### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For <font color=royalblue>Developers</font>, please follow [this install guide](
 
 **4. Install the collection**
 
-```ansible-galaxy collection install nutanix-ncp-<version>.tar.gz```
+```ansible-galaxy collection install nutanix.ncp```
 
 **Note** Add <font color=red>`--force`</font> option for rebuilding or reinstalling to overwrite existing data
 


### PR DESCRIPTION
galaxy install needs different syntax; 
> ansible-galaxy collection install nutanix-ncp-v1.0.2.tar.gz:
#12 1.237 Process install dependency map
#12 1.238 ERROR! Invalid collection name 'nutanix-ncp-v1.0.2.tar.gz', name must be in the format <namespace>.<collection>. Please make sure namespace and collection name contains characters from [a-zA-Z0-9_] only.