### PR TITLE
Enable flag in integration tests to continue even during failures

### DIFF
--- a/.github/workflows/ok-to-test-command.yml
+++ b/.github/workflows/ok-to-test-command.yml
@@ -51,7 +51,7 @@ jobs:
           ansible-playbook tests/integration/targets/prepare_env/tasks/prepare_env.yml
           ansible-playbook tests/integration/targets/prepare_fc_env/tasks/prepare_fc_env.yml
           ansible-playbook tests/integration/targets/prepare_foundation_env/tasks/prepare_foundation_env.yml
-          ansible-test integration --python ${{ matrix.python-version }} --coverage $flag
+          ansible-test integration --continue-on-error --python ${{ matrix.python-version }} --coverage $flag
           ansible-test coverage report > coverage.txt
           ansible-playbook tests/integration/targets/prepare_env/tasks/cleanup.yml
           ansible-playbook tests/integration/targets/prepare_foundation_env/tasks/cleanup.yml


### PR DESCRIPTION
Used builtin flag "--continue-on-error"