### PR TITLE
Consider cluster reference as well for getting subnet uuid

### DIFF
--- a/plugins/module_utils/prism/subnets.py
+++ b/plugins/module_utils/prism/subnets.py
@@ -154,7 +154,23 @@ def get_subnet_uuid(config, module):
     if "name" in config or "subnet_name" in config:
         subnet = Subnet(module)
         name = config.get("name") or config.get("subnet_name")
-        uuid = subnet.get_uuid(name)
+        uuid = ""
+
+        # incase subnet of particular cluster is needed
+        if config.get("cluster_uuid"):
+            filter_spec = {"filter": "{0}=={1}".format("name", name)}
+            resp = subnet.list(
+                data=filter_spec
+            )
+            entities = resp.get("entities") if resp else None
+            if entities:
+                for entity in entities:
+                    if entity["status"]["cluster_reference"]["uuid"] == config["cluster_uuid"]:
+                        uuid = entity["metadata"]["uuid"]
+                        break
+        else:       
+            uuid = subnet.get_uuid(name)
+
         if not uuid:
             error = "Subnet {0} not found.".format(name)
             return None, error

--- a/plugins/module_utils/prism/vms.py
+++ b/plugins/module_utils/prism/vms.py
@@ -248,8 +248,14 @@ class VM(Prism):
                 elif network.get("subnet", {}).get("name"):
                     name = network["subnet"]["name"]
 
-                    # consider cluster as well to get correct subnet
-                    cluster_uuid, err = get_cluster_uuid(self.module.params.get("cluster"), self.module)
+                    # consider cluster as well to get subnet from given cluster only
+                    cluster_ref = None
+                    if self.module.params.get("cluster"):
+                        cluster_ref = self.module.params["cluster"]
+                    else:
+                        cluster_ref = payload["spec"]["cluster_reference"]
+
+                    cluster_uuid, err = get_cluster_uuid(cluster_ref, self.module)
                     if err:
                         return None, err
 


### PR DESCRIPTION
Approach:
User cluster reference of vm for getting subnet uuid from that particular cluster only when querying subnet using name. This is for case when there are subnets with same name across various PE clusters.