### PR TITLE
Handle overlay subnet case while filtering subnets in vms based on cluster

### DIFF
--- a/plugins/module_utils/prism/spec/vms.py
+++ b/plugins/module_utils/prism/spec/vms.py
@@ -11,12 +11,18 @@ class DefaultVMSpec:
     mutually_exclusive = [("name", "uuid")]
 
     entity_by_spec = dict(name=dict(type="str"), uuid=dict(type="str"))
-
+    subnet_spec = dict(
+        name=dict(type="str"),
+        uuid=dict(type="str"),
+        cluster=dict(
+            type="dict", options=entity_by_spec, mutually_exclusive=mutually_exclusive
+        ),
+    )
     network_spec = dict(
         uuid=dict(type="str"),
         state=dict(type="str", choices=["absent"]),
         subnet=dict(
-            type="dict", options=entity_by_spec, mutually_exclusive=mutually_exclusive
+            type="dict", options=subnet_spec, mutually_exclusive=mutually_exclusive
         ),
         mac_address=dict(type="str", required=False),
         private_ip=dict(type="str", required=False),

--- a/plugins/module_utils/prism/vms.py
+++ b/plugins/module_utils/prism/vms.py
@@ -223,7 +223,7 @@ class VM(Prism):
     def _build_spec_cluster(self, payload, param):
         uuid, err = get_cluster_uuid(param, self.module)
         if err:
-            return err
+            return None, err
         payload["spec"]["cluster_reference"]["uuid"] = uuid
         return payload, None
 

--- a/plugins/module_utils/prism/vms.py
+++ b/plugins/module_utils/prism/vms.py
@@ -10,7 +10,7 @@ from copy import deepcopy
 
 from ansible.module_utils.basic import _load_params
 
-from .clusters import get_cluster_uuid
+from .clusters import Cluster, get_cluster_uuid
 from .groups import get_entity_uuid
 from .images import get_image_uuid
 from .prism import Prism
@@ -246,18 +246,7 @@ class VM(Prism):
         return payload, None
 
     def _build_spec_networks(self, payload, networks):
-        # consider cluster as well to get subnet from given cluster only
-        cluster_ref = None
-        if self.module.params.get("cluster"):
-            cluster_ref = self.module.params["cluster"]
-        elif payload["spec"].get("cluster_reference"):
-            cluster_ref = payload["spec"]["cluster_reference"]
-
-        cluster_uuid = ""
-        if cluster_ref:
-            cluster_uuid, err = get_cluster_uuid(cluster_ref, self.module)
-            if err:
-                return None, err
+        cluster_name_uuid_map = {}
 
         nics = []
         for network in networks:
@@ -290,9 +279,28 @@ class VM(Prism):
                     uuid = network["subnet"]["uuid"]
 
                 elif network.get("subnet", {}).get("name"):
-                    name = network["subnet"]["name"]
+                    config = {"name": network["subnet"]["name"]}
+                    uuid = ""
 
-                    config = {"name": name, "cluster_uuid": cluster_uuid}
+                    # check if cluster given for filtering subnet
+                    cluster_uuid = ""
+                    if network.get("subnet", {}).get("cluster"):
+                        if network["subnet"]["cluster"].get("uuid"):
+                            cluster_uuid = network["subnet"]["cluster"].get("uuid")
+                        else:
+                            if not cluster_name_uuid_map:
+                                cluster = Cluster(self.module)
+                                cluster_name_uuid_map = (
+                                    cluster.get_all_clusters_name_uuid_map()
+                                )
+                            cluster_uuid = cluster_name_uuid_map.get(
+                                network["subnet"]["cluster"]["name"]
+                            )
+                        
+                            if not cluster_uuid:
+                                return None, "Cluster {0} not found".format(network["subnet"]["cluster"]["name"])
+                        config["cluster_uuid"] = cluster_uuid
+
                     uuid, err = get_subnet_uuid(config, self.module)
                     if err:
                         return None, err

--- a/tests/integration/targets/nutanix_vms/tasks/create.yml
+++ b/tests/integration/targets/nutanix_vms/tasks/create.yml
@@ -391,10 +391,14 @@
       networks:
         - is_connected: true
           subnet:
-            uuid: "{{ network.dhcp.uuid }}"
+            name: "{{ network.dhcp.name }}"
+            cluster:
+              name: "{{ cluster.name }}"
         - is_connected: true
           subnet:
             uuid: "{{ static.uuid }}"
+            cluster:
+              uuid: "{{ cluster.uuid }}"
       disks:
         - type: DISK
           size_gb: 1


### PR DESCRIPTION
Fix provider by https://github.com/nutanix/nutanix.ansible/pull/266 only deals with vlan subnets.
Incase of overlay subnets we cannot filter based on cluster reference of vm. So added new field in subnet spec in vm networks to provide cluster instead of picking from vm cluster reference. This will enable user to pass cluster reference in subnet when required.