### PR TITLE
Fix mismatch of virtual switch in subnet creation

### DIFF
--- a/plugins/module_utils/prism/groups.py
+++ b/plugins/module_utils/prism/groups.py
@@ -14,17 +14,19 @@ class Groups(Prism):
 
     def get_uuid(
         self,
-        value,
+        value="",
         key="name",
         data=None,
         entity_type="",
         raise_error=True,
         no_response=False,
     ):
-        data = {
-            "entity_type": entity_type,
-            "filter_criteria": "{0}=={1}".format(key, value),
-        }
+        if not data:
+            data = {
+                "entity_type": entity_type,
+                "filter_criteria": "{0}=={1}".format(key, value),
+            }
+
         resp = self.list(
             data, use_base_url=True, raise_error=raise_error, no_response=no_response
         )

--- a/plugins/module_utils/prism/subnets.py
+++ b/plugins/module_utils/prism/subnets.py
@@ -46,14 +46,17 @@ class Subnet(Prism):
         payload["spec"]["resources"]["vlan_id"] = config["vlan_id"]
         payload["spec"]["resources"]["is_external"] = False
 
-        dvs_uuid, error = get_dvs_uuid(config["virtual_switch"], self.module)
-        if error:
-            return None, error
-        payload["spec"]["resources"]["virtual_switch_uuid"] = dvs_uuid
         cluster_uuid, error = get_cluster_uuid(config["cluster"], self.module)
         if error:
             return None, error
         payload["spec"]["cluster_reference"] = self._get_cluster_ref_spec(cluster_uuid)
+
+        dvs_uuid, error = get_dvs_uuid(
+            config["virtual_switch"], self.module, cluster_uuid=cluster_uuid
+        )
+        if error:
+            return None, error
+        payload["spec"]["resources"]["virtual_switch_uuid"] = dvs_uuid
 
         if "ipam" in config:
             payload["spec"]["resources"]["ip_config"] = self._get_ipam_spec(config)

--- a/plugins/module_utils/prism/virtual_switches.py
+++ b/plugins/module_utils/prism/virtual_switches.py
@@ -5,15 +5,25 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from .groups import Groups
+from ..utils import create_filter_criteria_string
 
 # Helper functions
 
 
-def get_dvs_uuid(config, module):
+def get_dvs_uuid(config, module, cluster_uuid=None):
     if "name" in config:
         groups = Groups(module)
         name = config["name"]
-        uuid = groups.get_uuid(value=name, entity_type="distributed_virtual_switch")
+        filters = {
+            "name": name,
+            "cluster_configuration_list.cluster_uuid": cluster_uuid,
+        }
+
+        data = {
+            "entity_type": "distributed_virtual_switch",
+            "filter_criteria": create_filter_criteria_string(filters),
+        }
+        uuid = groups.get_uuid(data=data)
         if not uuid:
             error = "Virtual Switch {0} not found.".format(name)
             return None, error

--- a/plugins/module_utils/prism/virtual_switches.py
+++ b/plugins/module_utils/prism/virtual_switches.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from .groups import Groups
 from ..utils import create_filter_criteria_string
+from .groups import Groups
 
 # Helper functions
 

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -109,3 +109,22 @@ def format_filters_map(filters, except_keys=None):
                 mapped_filters.update({key: value})
         filters = mapped_filters
     return filters
+
+
+def create_filter_criteria_string(filters):
+    """
+    This method creates filter criteria string as per filters map for v3 apis
+    example filter criteria format: "name==test_name;cluster_uuid=test_uuid"
+    """
+    filter_criteria = ""
+    if not filters:
+        return filter_criteria
+
+    for key, val in filters.items():
+        if val:
+            filter_criteria = filter_criteria + "{0}=={1};".format(key, val)
+
+    # remove ";" from ending
+    filter_criteria = filter_criteria[:-1]
+
+    return filter_criteria


### PR DESCRIPTION
Have added cluster reference in groups call for distributed virtual switch because multiple cluster can have virtual switches with same name.