### PR TITLE
Support multi-tiers target in application network security rule

### DIFF
--- a/plugins/module_utils/prism/security_rules.py
+++ b/plugins/module_utils/prism/security_rules.py
@@ -119,8 +119,8 @@ class SecurityRule(Prism):
                     ]
             if categories.get("apptype"):
                 params["AppType"] = [categories["apptype"]]
-            if categories.get("apptier"):
-                params["AppTier"] = [categories.get("apptier")]
+            if categories.get("apptiers"):
+                params["AppTier"] = categories.get("apptiers")
                 if value["target_group"].get("default_internal_policy"):
                     target_group["default_internal_policy"] = value["target_group"][
                         "default_internal_policy"

--- a/plugins/modules/ntnx_security_rules.py
+++ b/plugins/modules/ntnx_security_rules.py
@@ -106,7 +106,8 @@ options:
                 description:
                   - List of AppTier category values
                   - C(apptier) is deprecated
-                type: str
+                type: list
+                elements: str
               adgroup:
                 description:
                     - A category value.
@@ -363,7 +364,8 @@ options:
                 description:
                   - List of AppTier category values
                   - C(apptier) is deprecated
-                type: str
+                type: list
+                elements: str
               adgroup:
                 description:
                     - A category value.
@@ -620,7 +622,8 @@ options:
                 description:
                   - List of AppTier category values
                   - C(apptier) is deprecated
-                type: str
+                type: list
+                elements: str
               adgroup:
                 description:
                     - A category value.

--- a/plugins/modules/ntnx_security_rules.py
+++ b/plugins/modules/ntnx_security_rules.py
@@ -102,8 +102,10 @@ options:
               apptype_filter_by_category:
                 description: A category key and value.
                 type: dict
-              apptier:
-                description: A category value.
+              apptiers:
+                description: 
+                  - List of AppTier category values
+                  - C(apptier) is deprecated
                 type: str
               adgroup:
                 description:

--- a/plugins/modules/ntnx_security_rules.py
+++ b/plugins/modules/ntnx_security_rules.py
@@ -359,8 +359,10 @@ options:
               apptype_filter_by_category:
                 description: A category key and value.
                 type: dict
-              apptier:
-                description: A category value.
+              apptiers:
+                description: 
+                  - List of AppTier category values
+                  - C(apptier) is deprecated
                 type: str
               adgroup:
                 description:
@@ -614,8 +616,10 @@ options:
               apptype_filter_by_category:
                 description: A category key and value.
                 type: dict
-              apptier:
-                description: A category value.
+              apptiers:
+                description: 
+                  - List of AppTier category values
+                  - C(apptier) is deprecated
                 type: str
               adgroup:
                 description:

--- a/plugins/modules/ntnx_security_rules.py
+++ b/plugins/modules/ntnx_security_rules.py
@@ -103,7 +103,7 @@ options:
                 description: A category key and value.
                 type: dict
               apptiers:
-                description: 
+                description:
                   - List of AppTier category values
                   - C(apptier) is deprecated
                 type: str
@@ -360,7 +360,7 @@ options:
                 description: A category key and value.
                 type: dict
               apptiers:
-                description: 
+                description:
                   - List of AppTier category values
                   - C(apptier) is deprecated
                 type: str
@@ -617,7 +617,7 @@ options:
                 description: A category key and value.
                 type: dict
               apptiers:
-                description: 
+                description:
                   - List of AppTier category values
                   - C(apptier) is deprecated
                 type: str

--- a/plugins/modules/ntnx_security_rules.py
+++ b/plugins/modules/ntnx_security_rules.py
@@ -1105,7 +1105,7 @@ def get_module_spec():
     categories_spec = dict(
         apptype=dict(type="str"),
         apptype_filter_by_category=dict(type="dict"),
-        apptier=dict(type="str"),
+        apptiers=dict(type="list", elements="str"),
         adgroup=dict(type="str"),
     )
 

--- a/tests/integration/targets/ntnx_security_rules/tasks/app_rule.yml
+++ b/tests/integration/targets/ntnx_security_rules/tasks/app_rule.yml
@@ -8,7 +8,10 @@
             apptype_filter_by_category:
               AppFamily:
                 - Backup
-            apptier: Default
+            apptiers: 
+              - "{{categories.apptiers[0]}}"
+              - "{{categories.apptiers[1]}}"
+
           default_internal_policy: DENY_ALL
 
       inbounds:
@@ -72,13 +75,15 @@
   register: result
   ignore_errors: true
 
+
 - name: Creation Status
   assert:
     that:
       - result.response is defined
       - result.failed == false
       - result.response.status.state == 'COMPLETE'
-      - result.response.spec.name=="test_app_rule"
+      - result.response.status.name=="test_app_rule"
+      - result.response.status.resources.app_rule.target_group.filter.params.AppTier | length == 2
     fail_msg: ' fail: unable to create app security rule with inbound and outbound list'
     success_msg: 'pass: create app security rule with inbound and outbound list successfully'
 
@@ -140,7 +145,9 @@
             apptype_filter_by_category:
               AppFamily:
                 - Backup
-            apptier: Default
+            apptiers: 
+              - "{{categories.apptiers[0]}}"
+              - "{{categories.apptiers[1]}}"
           default_internal_policy: DENY_ALL
       allow_all_outbounds: true
       allow_all_inbounds: true
@@ -157,6 +164,8 @@
       - result.failed == false
       - result.response.status.state == 'COMPLETE'
       - result.response.spec.name=="test_app_rule"
+      - result.response.status.resources.app_rule.target_group.filter.params.AppTier | length == 2
+
     fail_msg: ' fail: unable to create app security rule with allow all inbound and outbound list'
     success_msg: 'pass: create app security rule with allow all inbound and outbound list successfully'
 - name: delete app security rule


### PR DESCRIPTION
- created a new spec field "apptiers" in target category for application network security rules
- modified tests for same

Notes:
Deprecated "apptier" field in ntw_security_rules categories