### PR TITLE
Fetch available IPs for network profiles in NDB

### DIFF
--- a/plugins/module_utils/ndb/profiles/profile_types.py
+++ b/plugins/module_utils/ndb/profiles/profile_types.py
@@ -96,6 +96,11 @@ class NetworkProfile(Profile):
         super(NetworkProfile, self).__init__(module)
         self._type = NDB.ProfileTypes.NETWORK
 
+    def get_available_ips(self, uuid):
+        endpoint = "{0}/get-available-ips".format(uuid)
+        resp = self.read(endpoint=endpoint)
+        return resp
+
     def get_default_version_update_spec(self, override_spec=None):
         spec = {
             "name": "",

--- a/plugins/modules/ntnx_ndb_profiles_info.py
+++ b/plugins/modules/ntnx_ndb_profiles_info.py
@@ -48,8 +48,9 @@ options:
                 choices: ["Software","Compute","Network","Database_Parameter",]
         include_available_ips:
           description:
-            - include available ips in response
+            - include available ips for each subnet in response
             - only to be used for network profiles having NDB managed subnets
+            - only to be used for fetching profile using C(name) or C(uuid)
           default: false
           type: bool
 extends_documentation_fragment:

--- a/plugins/modules/ntnx_ndb_profiles_info.py
+++ b/plugins/modules/ntnx_ndb_profiles_info.py
@@ -46,13 +46,13 @@ options:
                     - filter as per profile type
                 type: str
                 choices: ["Software","Compute","Network","Database_Parameter",]
-        include_available_ips:
-          description:
-            - include available ips for each subnet in response
-            - only to be used for network profiles having NDB managed subnets
-            - only to be used for fetching profile using C(name) or C(uuid)
-          default: false
-          type: bool
+      include_available_ips:
+        description:
+          - include available ips for each subnet in response
+          - only to be used for network profiles having NDB managed subnets
+          - only to be used for fetching profile using C(name) or C(uuid)
+        default: false
+        type: bool
 extends_documentation_fragment:
     - nutanix.ncp.ntnx_ndb_info_base_module
 author:

--- a/plugins/modules/ntnx_ndb_profiles_info.py
+++ b/plugins/modules/ntnx_ndb_profiles_info.py
@@ -185,9 +185,9 @@ response:
 """
 
 from ..module_utils.ndb.base_info_module import NdbBaseInfoModule  # noqa: E402
+from ..module_utils.ndb.profiles.profile_types import NetworkProfile  # noqa: E402
 from ..module_utils.ndb.profiles.profiles import Profile  # noqa: E402
 from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
-from ..module_utils.ndb.profiles.profile_types import NetworkProfile
 
 
 def get_module_spec():

--- a/plugins/modules/ntnx_ndb_profiles_info.py
+++ b/plugins/modules/ntnx_ndb_profiles_info.py
@@ -46,6 +46,12 @@ options:
                     - filter as per profile type
                 type: str
                 choices: ["Software","Compute","Network","Database_Parameter",]
+        include_available_ips:
+          description:
+            - include available ips in response
+            - only to be used for network profiles having NDB managed subnets
+          default: false
+          type: bool
 extends_documentation_fragment:
     - nutanix.ncp.ntnx_ndb_info_base_module
 author:
@@ -180,6 +186,7 @@ response:
 from ..module_utils.ndb.base_info_module import NdbBaseInfoModule  # noqa: E402
 from ..module_utils.ndb.profiles.profiles import Profile  # noqa: E402
 from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.ndb.profiles.profile_types import NetworkProfile
 
 
 def get_module_spec():
@@ -217,6 +224,7 @@ def get_module_spec():
             type="dict",
             options=filters_spec,
         ),
+        include_available_ips=dict(type="bool", default=False),
     )
 
     return module_args
@@ -229,6 +237,11 @@ def get_profile(module, result):
     resp = profile.get_profiles(uuid, name)
 
     result["response"] = resp
+
+    if module.params.get("include_available_ips", False):
+        uuid = resp.get("id")
+        ntw_profile = NetworkProfile(module)
+        result["response"]["available_ips"] = ntw_profile.get_available_ips(uuid=uuid)
 
 
 def get_profiles(module, result):

--- a/tests/integration/targets/ntnx_ndb_profiles_info/tasks/info.yml
+++ b/tests/integration/targets/ntnx_ndb_profiles_info/tasks/info.yml
@@ -68,6 +68,44 @@
       - result.response[0].type == "Network"
     fail_msg: "Unable to list all Network NDB profile"
     success_msg: "Network NDB profiles listed successfully"
+
+################################################################
+- name: get network profile with available IPs
+  ntnx_ndb_profiles_info:
+    name: "{{static_network_profile.name}}"
+    include_available_ips: true
+  register: result
+  ignore_errors: true
+
+- name: check listing status
+  assert:
+    that:
+      - result.response is defined
+      - result.failed == false
+      - result.changed == false
+      - result.response.available_ips | length == 1
+      - result.response.id == "{{static_network_profile.uuid}}"
+
+    fail_msg: "Unable to list network profile with available IPs"
+    success_msg: "Network NDB profiles along with available IPs obtained successfully" 
+
+- name: get network profile with available IPs
+  ntnx_ndb_profiles_info:
+    uuid: "{{postgres_ha_profiles.multicluster_network_profile.uuid}}"
+    include_available_ips: true
+  register: result
+  ignore_errors: true
+
+- name: check listing status
+  assert:
+    that:
+      - result.response is defined
+      - result.failed == false
+      - result.changed == false
+      - result.response.available_ips | length == 2
+      - result.response.id == "{{postgres_ha_profiles.multicluster_network_profile.uuid}}"
+    fail_msg: "Unable to list network profile with available IPs"
+    success_msg: "Network NDB profiles along with available IPs obtained successfully"
 ################################################################
 - name: List Compute profiles
   ntnx_ndb_profiles_info:


### PR DESCRIPTION
- added "include_available_ips" flag for fetching available IPs for each network in network profile.
- response will have attribute "available_ips" for same.