### PR TITLE
issue#385 functionality to handle issue when size of new disk is absent

### DIFF
--- a/plugins/module_utils/prism/vms.py
+++ b/plugins/module_utils/prism/vms.py
@@ -443,6 +443,11 @@ class VM(Prism):
                         msg="Unsupported operation: Unable to decrease disk size.",
                         disk=disk,
                     )
+            elif not vdisk.get("uuid"):
+                self.module.fail_json(
+                    msg="Unsupported operation: Unable to create disk, 'size_gb' is required.",
+                    disk=disk,
+                )
 
             if vdisk.get("storage_container"):
                 disk.pop("data_source_reference", None)


### PR DESCRIPTION
When size of new disk is not provided API raises internal server error without any message.