### PR TITLE
Add support for PC Categories

### DIFF
--- a/plugins/inventory/ntnx_prism_vm_inventory.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory.py
@@ -178,6 +178,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
             for key, value in entity["status"]["resources"].items():
                 self.inventory.set_variable(vm_name, key, value)
+            
+            if 'metadata' in entity and 'categories' in entity['metadata']:
+                self.inventory.set_variable(vm_name, 'ntnx_categories', entity['metadata']['categories'])
 
             # Add variables created by the user's Jinja2 expressions to the host
             self._set_composite_vars(


### PR DESCRIPTION
Hello,
I added a couple of lines in order to add the Prism Central categories to the inventory output.

Bye