### PR TITLE
Bug/fix backward compatibility in vm disks

### DIFF
--- a/plugins/module_utils/prism/vms.py
+++ b/plugins/module_utils/prism/vms.py
@@ -473,11 +473,6 @@ class VM(Prism):
                         msg="Unsupported operation: Unable to decrease disk size.",
                         disk=disk,
                     )
-            elif not vdisk.get("uuid"):
-                self.module.fail_json(
-                    msg="Unsupported operation: Unable to create disk, 'size_gb' is required.",
-                    disk=disk,
-                )
 
             if vdisk.get("storage_container"):
                 disk.pop("data_source_reference", None)
@@ -491,6 +486,11 @@ class VM(Prism):
                     return None, error
 
                 disk["storage_config"]["storage_container_reference"]["uuid"] = uuid
+                if not vdisk.get("uuid") and not vdisk.get("size_gb"):
+                    self.module.fail_json(
+                        msg="Unsupported operation: Unable to create disk, 'size_gb' is required for using storage container.",
+                        disk=disk,
+                    )
 
             elif vdisk.get("clone_image"):
                 uuid, error = get_image_uuid(vdisk["clone_image"], self.module)

--- a/tests/integration/targets/nutanix_vms/tasks/negtaive_scenarios.yml
+++ b/tests/integration/targets/nutanix_vms/tasks/negtaive_scenarios.yml
@@ -28,6 +28,36 @@
         - result.error == "Project project not found."
       success_msg: ' Success: returned error as expected '
 #############################################################
+  - name: Check if error is produced when disk size is not given for storage container
+    check_mode: yes
+    ntnx_vms:
+      state: present
+      name: VM with storage container
+      timezone: GMT
+      cluster:
+        name: "{{ cluster.name }}"
+      categories:
+        AppType:
+          - Apache_Spark
+      disks:
+        - type: DISK
+          bus: SCSI
+          storage_container:
+            name: "{{ storage_container.name }}"
+      vcpus: 1
+      cores_per_vcpu: 1
+      memory_gb: 1
+    register: result
+    ignore_errors: True
+    
+  - name: Creation Status
+    assert:
+      that:
+        - result.msg == "Unsupported operation: Unable to create disk, 'size_gb' is required for using storage container."
+        - result.failed == True
+        - result.failed is defined
+      success_msg: ' Success: returned error as expected '
+##################################################################################
   - name: Unknown Cluster
     ntnx_vms:
       state: present


### PR DESCRIPTION
https://github.com/nutanix/nutanix.ansible/pull/393/files This introduced a backward compatibiltiy issue where absence of size gb in disks using image is not allowed from module but ideally it is allowed from API server.

So have added the above PR fix for only storage container case. 