### PR TITLE
Add templating support in some inventory field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 nutanix-ncp-*
+__pycache__/

--- a/examples/inventory/templating_1_nutanix.yaml
+++ b/examples/inventory/templating_1_nutanix.yaml
@@ -1,0 +1,13 @@
+plugin: nutanix.ncp.ntnx_prism_vm_inventory
+nutanix_hostname: "{{ lookup('ansible.builtin.env', 'PC_1_HOSTNAME') }}"
+nutanix_username: "{{ lookup('ansible.builtin.env', 'PC_1_USERNAME') }}"
+nutanix_password: "{{ lookup('ansible.builtin.env', 'PC_1_PASSWORD') }}"
+validate_certs: false
+data: {"offset": 0, "length": 1000}
+groups:
+  group_1: "'<name_prefix>' in name"
+  group_2: "'<vm_name>'==name"
+keyed_groups:
+  - prefix: "host"
+    separator: ':'
+    key: "ansible_host"

--- a/examples/inventory/templating_2_nutanix.yaml
+++ b/examples/inventory/templating_2_nutanix.yaml
@@ -1,0 +1,13 @@
+plugin: nutanix.ncp.ntnx_prism_vm_inventory
+nutanix_hostname: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=path/to/pc/secret:hostname') }}"
+nutanix_username: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=path/to/pc/secret:username') }}"
+nutanix_password: "{{ lookup('community.hashi_vault.hashi_vault', 'secret=path/to/pc/secret:password') }}"
+validate_certs: false
+data: {"offset": 0, "length": 1000}
+groups:
+  group_1: "'<name_prefix>' in name"
+  group_2: "'<vm_name>'==name"
+keyed_groups:
+  - prefix: "host"
+    separator: ':'
+    key: "ansible_host"

--- a/plugins/inventory/ntnx_prism_vm_inventory.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory.py
@@ -122,6 +122,15 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         # Determines if composed variables or groups using nonexistent variables is an error
         strict = self.get_option("strict")
 
+        if self.templar.is_template(self.nutanix_hostname):
+            self.nutanix_hostname=self.templar.template(variable=self.nutanix_hostname,disable_lookups=False)
+        
+        if self.templar.is_template(self.nutanix_username):
+            self.nutanix_username=self.templar.template(variable=self.nutanix_username,disable_lookups=False)
+        
+        if self.templar.is_template(self.nutanix_password):
+            self.nutanix_password=self.templar.template(variable=self.nutanix_password,disable_lookups=False)            
+
         module = Mock_Module(
             self.nutanix_hostname,
             self.nutanix_port,

--- a/plugins/inventory/ntnx_prism_vm_inventory.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory.py
@@ -24,25 +24,33 @@ DOCUMENTATION = r"""
             required: true
             choices: ['ntnx_prism_vm_inventory', 'nutanix.ncp.ntnx_prism_vm_inventory']
         nutanix_hostname:
-            description: Prism central hostname or IP address
+            description:
+              - Prism central hostname or IP address
+              - Accepts Jinja to template the value
             required: true
             type: str
             env:
                 - name: NUTANIX_HOSTNAME
         nutanix_username:
-            description: Prism central username
+            description:
+              - Prism central username
+              - Accepts Jinja to template the value
             required: true
             type: str
             env:
                 - name: NUTANIX_USERNAME
         nutanix_password:
-            description: Prism central password
+            description: 
+              - Prism central password
+              - Accepts Jinja to template the value
             required: true
             type: str
             env:
                 - name: NUTANIX_PASSWORD
         nutanix_port:
-            description: Prism central port
+            description: 
+              - Prism central port
+                - Accepts Jinja to template the value
             default: 9440
             type: str
             env:
@@ -129,7 +137,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.nutanix_username=self.templar.template(variable=self.nutanix_username,disable_lookups=False)
         
         if self.templar.is_template(self.nutanix_password):
-            self.nutanix_password=self.templar.template(variable=self.nutanix_password,disable_lookups=False)            
+            self.nutanix_password=self.templar.template(variable=self.nutanix_password,disable_lookups=False)
+
+        if self.templar.is_template(self.nutanix_port):
+            self.nutanix_port=self.templar.template(variable=self.nutanix_port,disable_lookups=False)
+
 
         module = Mock_Module(
             self.nutanix_hostname,


### PR DESCRIPTION
Hi,
I submit this PR in order to add Jinja templating support in inventory for these fields:
- hostname
- username
- password
- port

I think that it can be very useful based on my scenarios. You already have the support for environment variables but I have scenarios where I have to query 2 (or more) Prism Central because I have to target distributed applications (I have a PC for site).
In my configuration:
```bash
./inventory
├── 00_pc01.nutanix.yaml
├── 00_pc01.nutanix.yaml
└── 99_final.yml
```
in `00_pc01.nutanix.yaml` I have:
```YAML
plugin: nutanix.ncp.ntnx_prism_vm_inventory
nutanix_hostname: "{{ lookup('ansible.builtin.env', 'PC_1_HOSTNAME') }}"
nutanix_username: "{{ lookup('ansible.builtin.env', 'PC_1_USERNAME') }}"
nutanix_password: "{{ lookup('ansible.builtin.env', 'PC_1_PASSWORD') }}"
```
When I run
```bash
$ ansible-inventory --list -y --output test.yml
```
I have PCs Inventory merged.

I hope it hepls

bye
