### PR TITLE
[Bug] Fix errors when TRANSFORM_INVALID_GROUP_CHARS is always

### DIFF
--- a/plugins/inventory/ntnx_prism_vm_inventory.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory.py
@@ -162,7 +162,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                             continue
 
             # Add inventory groups and hosts to inventory groups
-            self.inventory.add_group(cluster)
+            cluster = self.inventory.add_group(cluster)
             self.inventory.add_child("all", cluster)
             self.inventory.add_host(vm_name, group=cluster)
             self.inventory.set_variable(vm_name, "ansible_host", vm_ip)


### PR DESCRIPTION
Cluster names can contain invalid characters (according to Ansible standards for group names) and when the Ansible setting TRANSFORM_INVALID_GROUP_CHARS is set to "always" the inventory script will throw exceptions and fail.  The add_group method will return the sanitized name, so this will fix the error.  It should cause no change in behavior when TRANSFORM_INVALID_GROUP_CHARS is set to the default of "never".

https://docs.ansible.com/ansible/latest/reference_appendices/config.html#transform-invalid-group-chars