### PR TITLE
add msg if API response can't be converted

### DIFF
--- a/plugins/module_utils/entity.py
+++ b/plugins/module_utils/entity.py
@@ -412,7 +412,7 @@ class Entity(object):
 
         if resp_json is None:
             try:
-                if len(info.get("msg")) > 2:
+                if len(info.get("msg")) > 0:
                     resp_json_msg = "{}".format(info.get("msg"))
                 else:
                     resp_json_msg = "Failed to convert API response to json"

--- a/plugins/module_utils/entity.py
+++ b/plugins/module_utils/entity.py
@@ -411,8 +411,13 @@ class Entity(object):
             return {"status_code": status_code}
 
         if resp_json is None:
+            if len(info.get("msg")) > 0:
+                resp_json_msg = "{0}".format(info.get("msg"))
+            else:
+                resp_json_msg = "Failed to convert API response to json"
+
             self.module.fail_json(
-                msg="{0}".format(info.get("msg")),
+                msg=resp_json_msg,
                 status_code=status_code,
                 error=body,
                 response=resp_json,

--- a/plugins/module_utils/entity.py
+++ b/plugins/module_utils/entity.py
@@ -411,12 +411,9 @@ class Entity(object):
             return {"status_code": status_code}
 
         if resp_json is None:
-            try:
-                if info.get("msg"):
-                    resp_json_msg = "{}".format(info.get("msg"))
-                else:
-                    resp_json_msg = "Failed to convert API response to json"
-            except ValueError:
+            if info.get("msg"):
+                resp_json_msg = "{}".format(info.get("msg"))
+            else:
                 resp_json_msg = "Failed to convert API response to json"
 
             self.module.fail_json(

--- a/plugins/module_utils/entity.py
+++ b/plugins/module_utils/entity.py
@@ -411,9 +411,12 @@ class Entity(object):
             return {"status_code": status_code}
 
         if resp_json is None:
-            if len(info.get("msg")) > 0:
-                resp_json_msg = "{0}".format(info.get("msg"))
-            else:
+            try:
+                if len(info.get("msg")) > 2:
+                    resp_json_msg = "{}".format(info.get("msg"))
+                else:
+                    resp_json_msg = "Failed to convert API response to json"
+            except ValueError:
                 resp_json_msg = "Failed to convert API response to json"
 
             self.module.fail_json(

--- a/plugins/module_utils/entity.py
+++ b/plugins/module_utils/entity.py
@@ -412,7 +412,7 @@ class Entity(object):
 
         if resp_json is None:
             self.module.fail_json(
-                msg="Failed to convert API response to json",
+                msg="{0}".format(info.get("msg")),
                 status_code=status_code,
                 error=body,
                 response=resp_json,

--- a/plugins/module_utils/entity.py
+++ b/plugins/module_utils/entity.py
@@ -412,7 +412,7 @@ class Entity(object):
 
         if resp_json is None:
             try:
-                if info.get("msg")):
+                if info.get("msg"):
                     resp_json_msg = "{}".format(info.get("msg"))
                 else:
                     resp_json_msg = "Failed to convert API response to json"

--- a/plugins/module_utils/entity.py
+++ b/plugins/module_utils/entity.py
@@ -412,7 +412,7 @@ class Entity(object):
 
         if resp_json is None:
             try:
-                if len(info.get("msg")) > 0:
+                if info.get("msg")):
                     resp_json_msg = "{}".format(info.get("msg"))
                 else:
                     resp_json_msg = "Failed to convert API response to json"


### PR DESCRIPTION
This PR makes the return msg a bit more helpful when the API response can't be converted to json.

Pre- and post-patch:

```sh
$ ansible-playbook -ihosts cert.yml 2>/dev/null

PLAY [Clusters_Info playbook] **********************************************************************************************************************

TASK [Getting all clusters - validate_certs True] ***********************************************************************************************************************
fatal: [prism]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false, "error": null, "msg": "Failed to convert API response to json", "response": null, "status_code": -1}
...ignoring

TASK [Print clusters] ******************************************************************************************************
ok: [prism] => {
    "msg": {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/bin/python"
        },
        "changed": false,
        "error": null,
        "failed": true,
        "msg": "Failed to convert API response to json",
        "response": null,
        "status_code": -1
    }
}

TASK [Getting all clusters - validate_certs False] *******************************************************************************************************************
ok: [prism]

TASK [Print clusters] *********************************************************************************************
ok: [prism] => {
    "msg": "API version: 3.1"
}

PLAY RECAP **************************************************************************************************************
prism                      : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1
```

```sh
$ ansible-playbook -ihosts cert.yml 2>/dev/null

PLAY [Clusters_Info playbook] ****************************************************************************************************************************

TASK [Getting all clusters - validate_certs True] ****************************************************************************************************************************
fatal: [prism]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python"}, "changed": false, "error": null, "msg": "Request failed: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:618)>", "response": null, "status_code": -1}
...ignoring

TASK [Print clusters] *****************************************************************************************************************************
ok: [prism] => {
    "msg": {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/bin/python"
        },
        "changed": false,
        "error": null,
        "failed": true,
        "msg": "Request failed: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:618)>",
        "response": null,
        "status_code": -1
    }
}

TASK [Getting all clusters - validate_certs False] *************************************************************************************************************************
ok: [prism]

TASK [Print clusters] *****************************************************************************************************
ok: [prism] => {
    "msg": "API version: 3.1"
}

PLAY RECAP **************************************************************************************************************
prism                      : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1
```