### PR TITLE
Update recovery_plans.py to include kind: cluster in JSON request

### DIFF
--- a/plugins/module_utils/prism/recovery_plans.py
+++ b/plugins/module_utils/prism/recovery_plans.py
@@ -160,7 +160,7 @@ class RecoveryPlan(Prism):
             }
             if self.module.params["primary_location"].get("cluster"):
                 primary_location["cluster_reference_list"] = [
-                    {"uuid": self.module.params["primary_location"]["cluster"]}
+                    {"uuid": self.module.params["primary_location"]["cluster"], "kind": "cluster"}
                 ]
         else:
             primary_location_index = payload["spec"]["resources"]["parameters"][
@@ -176,7 +176,7 @@ class RecoveryPlan(Prism):
             }
             if self.module.params["recovery_location"].get("cluster"):
                 recovery_location["cluster_reference_list"] = [
-                    {"uuid": self.module.params["recovery_location"]["cluster"]}
+                    {"uuid": self.module.params["recovery_location"]["cluster"], "kind": "cluster"}
                 ]
         else:
             recovery_location_index = (
@@ -243,7 +243,7 @@ class RecoveryPlan(Prism):
         spec = {"availability_zone_url": primary_location["url"]}
 
         if primary_location.get("cluster"):
-            spec["cluster_reference_list"] = [{"uuid": primary_location["cluster"]}]
+            spec["cluster_reference_list"] = [{"uuid": primary_location["cluster"], "kind": "cluster"}]
 
         payload["spec"]["resources"]["parameters"]["availability_zone_list"][
             primary_location_index
@@ -257,7 +257,7 @@ class RecoveryPlan(Prism):
         spec = {"availability_zone_url": recovery_location["url"]}
 
         if recovery_location.get("cluster"):
-            spec["cluster_reference_list"] = [{"uuid": recovery_location["cluster"]}]
+            spec["cluster_reference_list"] = [{"uuid": recovery_location["cluster"], "kind": "cluster"}]
 
         payload["spec"]["resources"]["parameters"]["availability_zone_list"][
             recovery_location_index


### PR DESCRIPTION
Update recovery_plans.py in plugins/module_utils/prism/ to include "kind": "cluster" in the cluster reference along with the cluster UUID.  Without this addition the recovery plan is not created as the API rejects the request