### PR TITLE
functionality fixes

### DIFF
--- a/plugins/module_utils/prism/spec/vms.py
+++ b/plugins/module_utils/prism/spec/vms.py
@@ -58,7 +58,7 @@ class DefaultVMSpec:
         ),
         vcpus=dict(type="int"),
         cores_per_vcpu=dict(type="int"),
-        memory_gb=dict(type="int"),
+        memory_gb=dict(type="float"),
         networks=dict(type="list", elements="dict", options=network_spec),
         boot_config=dict(type="dict", options=boot_config_spec),
         guest_customization=dict(type="dict", options=gc_spec),

--- a/plugins/module_utils/prism/subnets.py
+++ b/plugins/module_utils/prism/subnets.py
@@ -45,6 +45,7 @@ class Subnet(Prism):
         payload["spec"]["resources"]["subnet_type"] = "VLAN"
         payload["spec"]["resources"]["vlan_id"] = config["vlan_id"]
         payload["spec"]["resources"]["is_external"] = False
+        payload["spec"]["resources"]["advanced_networking"] = False
 
         cluster_uuid, error = get_cluster_uuid(config["cluster"], self.module)
         if error:

--- a/plugins/module_utils/prism/vms.py
+++ b/plugins/module_utils/prism/vms.py
@@ -264,7 +264,7 @@ class VM(Prism):
         return payload, None
 
     def _build_spec_mem(self, payload, mem_gb):
-        mem_mib = mem_gb * 1024
+        mem_mib = int(mem_gb * 1024)
         current_mem_mib = payload["spec"]["resources"].get("memory_size_mib", 0)
         self._check_and_set_require_vm_restart(current_mem_mib, mem_mib)
         payload["spec"]["resources"]["memory_size_mib"] = mem_mib
@@ -452,7 +452,8 @@ class VM(Prism):
         if vdisk.get("empty_cdrom", None):
             disk.pop("data_source_reference", None)
             disk.pop("storage_config", None)
-
+            disk.pop("disk_size_bytes", None)
+            disk.pop("disk_size_mib", None)
         else:
             if vdisk.get("size_gb"):
                 disk_size_bytes = int(vdisk["size_gb"]) * 1024 * 1024 * 1024


### PR DESCRIPTION
- Allow VM GB memory as float.   

Module is already taking GB format memory and converting it to MB to meet the API Spec.   Using Float instead of INT allows values outside of whole numbers.   (Example: When you need to set 6.5 GB of RAM for VMs)

- Default Subnet Creation as Basic Subnets.  

This covers Subnet creation outside of External Networks and Overlays.   This can be further updated with a new argument the subnet module allowing the user to set the bool. 

- Fix "Eject CDROM" operation.  

Updating VM disks with "empty_cdrom: true" was not fully vacating the attached ISO.   Updated API call to match spec that needs popped during post. 


