### PR TITLE
Workaround for saml ipds test cases.

### DIFF
--- a/tests/integration/targets/ntnx_saml_identity_providers_v2/tasks/all_operation.yml
+++ b/tests/integration/targets/ntnx_saml_identity_providers_v2/tasks/all_operation.yml
@@ -56,6 +56,10 @@
     fail_msg: " Unable to Verify spec generation for identity providers with check_mode "
     success_msg: " Verify spec generation for identity providers with check_mode finished successfully "
 
+- name: Read content from file
+  set_fact:
+    xml_file_content: "{{ lookup('file', xml_content.dest + '/content.txt') }}"
+
 - name: Create saml
   ntnx_saml_identity_providers_v2:
     name: "{{ full_name }}1"
@@ -63,7 +67,7 @@
     email_attribute: email
     groups_attribute: groups
     groups_delim: ","
-    idp_metadata_xml: "{{ xml_content }}"
+    idp_metadata_xml: "{{ xml_file_content }}"
     state: present
   register: result
   ignore_errors: true

--- a/tests/integration/targets/ntnx_saml_identity_providers_v2/tasks/all_operation.yml
+++ b/tests/integration/targets/ntnx_saml_identity_providers_v2/tasks/all_operation.yml
@@ -57,7 +57,7 @@
     success_msg: " Verify spec generation for identity providers with check_mode finished successfully "
 
 - name: Read content from file
-  set_fact:
+  ansible.builtin.set_fact:
     xml_file_content: "{{ lookup('file', xml_content.dest + '/content.txt') }}"
 
 - name: Create saml

--- a/tests/integration/targets/prepare_env/playbooks/prepare_env.yml
+++ b/tests/integration/targets/prepare_env/playbooks/prepare_env.yml
@@ -202,11 +202,17 @@
         mode: "0644"
         url: "{{ disk_image.url }}"
         dest: "{{ disk_image.dest }}"
-#   # - name: create address group for network security policy related tests
-#   #   nutanix.ncp.ntnx_address_groups:
-#   #     state: present
-#   #     name: dest
-#   #     desc: dest
-#   #     subnets:
-#   #       - network_ip: "10.1.1.0"
-#   #         network_prefix: 24
+    #   # - name: create address group for network security policy related tests
+    #   #   nutanix.ncp.ntnx_address_groups:
+    #   #     state: present
+    #   #     name: dest
+    #   #     desc: dest
+    #   #     subnets:
+    #   #       - network_ip: "10.1.1.0"
+    #   #         network_prefix: 24
+
+    - name: Downloading xml content for saml tests
+      ansible.builtin.get_url:
+        mode: "0644"
+        url: "{{ xml_content.url }}"
+        dest: "{{ xml_content.dest }}"


### PR DESCRIPTION
Fetching the xml_content from slave machine.
Need to add this in main.yml vars file:
```
xml_content:
  url: http://filer.calm.nutanix.com/Users/abhinav_bansal/xml_content/content.txt
  dest: /home/ubuntu/.ansible/collections/ansible_collections/nutanix/ncp/tests/integration/targets/prepare_env/playbooks
```