### PR TITLE
Add proxy use support in modules for API v4

### DIFF
--- a/plugins/doc_fragments/ntnx_credentials.py
+++ b/plugins/doc_fragments/ntnx_credentials.py
@@ -44,4 +44,23 @@ options:
         - C(validate_certs). If not set then the value of the C(VALIDATE_CERTS), environment variable is used.
     type: bool
     default: true
+  proxy_scheme:
+    description:
+      - Protocol to use to communicate with the proxy server.
+      - Use for modules which use api v4 only.
+    type: str
+    default: http
+    choices:
+      - http
+      - https
+  proxy_host:
+    description:
+      - Proxy host use to connect to C(nutanix_host).
+      - Use for modules which use api v4 only.
+    type: str
+  proxy_port:
+    description:
+      - Proxy port of C(proxy_host).
+      - Use for modules which use api v4 only.
+    type: int
 """

--- a/plugins/doc_fragments/ntnx_credentials.py
+++ b/plugins/doc_fragments/ntnx_credentials.py
@@ -47,7 +47,7 @@ options:
   proxy_scheme:
     description:
       - Protocol to use to communicate with the proxy server.
-      - Use for modules which use api v4 only.
+      - Use for modules which use v4 APIs based SDKs.
     type: str
     default: http
     choices:
@@ -56,11 +56,11 @@ options:
   proxy_host:
     description:
       - Proxy host use to connect to C(nutanix_host).
-      - Use for modules which use api v4 only.
+      - Use for modules which use v4 APIs based SDKs.
     type: str
   proxy_port:
     description:
       - Proxy port of C(proxy_host).
-      - Use for modules which use api v4 only.
+      - Use for modules which use v4 APIs based SDKs.
     type: int
 """

--- a/plugins/module_utils/base_module.py
+++ b/plugins/module_utils/base_module.py
@@ -32,9 +32,6 @@ class BaseModule(AnsibleModule):
         validate_certs=dict(
             type="bool", default=True, fallback=(env_fallback, ["VALIDATE_CERTS"])
         ),
-        validate_certs=dict(
-            type="bool", default=True, fallback=(env_fallback, ["VALIDATE_CERTS"])
-        ),
         state=dict(type="str", choices=["present", "absent"], default="present"),
         wait=dict(type="bool", default=True),
         proxy_scheme=dict(type="str", default="http", choices=["http", "https"]),

--- a/plugins/module_utils/base_module.py
+++ b/plugins/module_utils/base_module.py
@@ -32,8 +32,14 @@ class BaseModule(AnsibleModule):
         validate_certs=dict(
             type="bool", default=True, fallback=(env_fallback, ["VALIDATE_CERTS"])
         ),
+        validate_certs=dict(
+            type="bool", default=True, fallback=(env_fallback, ["VALIDATE_CERTS"])
+        ),
         state=dict(type="str", choices=["present", "absent"], default="present"),
         wait=dict(type="bool", default=True),
+        proxy_scheme=dict(type="str", default="http", choices=["http", "https"]),
+        proxy_host=dict(type="str", default=None),
+        proxy_port=dict(type="int", default=None),
     )
 
     def __init__(self, **kwargs):

--- a/plugins/module_utils/v4/clusters_mgmt/api_client.py
+++ b/plugins/module_utils/v4/clusters_mgmt/api_client.py
@@ -34,6 +34,9 @@ def get_api_client(module):
     config.username = module.params.get("nutanix_username")
     config.password = module.params.get("nutanix_password")
     config.verify_ssl = module.params.get("validate_certs")
+    config.proxy_scheme = module.params.get("proxy_scheme")
+    config.proxy_host = module.params.get("proxy_host")
+    config.proxy_port = module.params.get("proxy_port")
     client = ntnx_clustermgmt_py_client.ApiClient(configuration=config)
 
     cred = "{0}:{1}".format(config.username, config.password)

--- a/plugins/module_utils/v4/data_protection/api_client.py
+++ b/plugins/module_utils/v4/data_protection/api_client.py
@@ -34,6 +34,9 @@ def get_api_client(module):
     config.username = module.params.get("nutanix_username")
     config.password = module.params.get("nutanix_password")
     config.verify_ssl = module.params.get("validate_certs")
+    config.proxy_scheme = module.params.get("proxy_scheme")
+    config.proxy_host = module.params.get("proxy_host")
+    config.proxy_port = module.params.get("proxy_port")
     client = ntnx_dataprotection_py_client.ApiClient(configuration=config)
 
     cred = "{0}:{1}".format(config.username, config.password)

--- a/plugins/module_utils/v4/flow/api_client.py
+++ b/plugins/module_utils/v4/flow/api_client.py
@@ -33,6 +33,9 @@ def get_api_client(module):
     config.username = module.params.get("nutanix_username")
     config.password = module.params.get("nutanix_password")
     config.verify_ssl = module.params.get("validate_certs")
+    config.proxy_scheme = module.params.get("proxy_scheme")
+    config.proxy_host = module.params.get("proxy_host")
+    config.proxy_port = module.params.get("proxy_port")
     client = ntnx_microseg_py_client.ApiClient(configuration=config)
 
     cred = "{0}:{1}".format(config.username, config.password)

--- a/plugins/module_utils/v4/iam/api_client.py
+++ b/plugins/module_utils/v4/iam/api_client.py
@@ -33,6 +33,9 @@ def get_api_client(module):
     config.username = module.params.get("nutanix_username")
     config.password = module.params.get("nutanix_password")
     config.verify_ssl = module.params.get("validate_certs")
+    config.proxy_scheme = module.params.get("proxy_scheme")
+    config.proxy_host = module.params.get("proxy_host")
+    config.proxy_port = module.params.get("proxy_port")
     client = ntnx_iam_py_client.ApiClient(configuration=config)
 
     cred = "{0}:{1}".format(config.username, config.password)

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -38,6 +38,9 @@ def get_api_client(module):
     config.username = module.params.get("nutanix_username")
     config.password = module.params.get("nutanix_password")
     config.verify_ssl = module.params.get("validate_certs")
+    config.proxy_scheme = module.params.get("proxy_scheme")
+    config.proxy_host = module.params.get("proxy_host")
+    config.proxy_port = module.params.get("proxy_port")
     client = ntnx_networking_py_client.ApiClient(configuration=config)
 
     cred = "{0}:{1}".format(config.username, config.password)

--- a/plugins/module_utils/v4/prism/pc_api_client.py
+++ b/plugins/module_utils/v4/prism/pc_api_client.py
@@ -33,6 +33,9 @@ def get_pc_api_client(module):
     config.username = module.params.get("nutanix_username")
     config.password = module.params.get("nutanix_password")
     config.verify_ssl = module.params.get("validate_certs")
+    config.proxy_scheme = module.params.get("proxy_scheme")
+    config.proxy_host = module.params.get("proxy_host")
+    config.proxy_port = module.params.get("proxy_port")
     client = ntnx_prism_py_client.ApiClient(configuration=config)
 
     cred = "{0}:{1}".format(config.username, config.password)

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -33,6 +33,9 @@ def get_api_client(module):
     config.username = module.params.get("nutanix_username")
     config.password = module.params.get("nutanix_password")
     config.verify_ssl = module.params.get("validate_certs")
+    config.proxy_scheme = module.params.get("proxy_scheme")
+    config.proxy_host = module.params.get("proxy_host")
+    config.proxy_port = module.params.get("proxy_port")
     client = ntnx_vmm_py_client.ApiClient(configuration=config)
 
     cred = "{0}:{1}".format(config.username, config.password)

--- a/plugins/module_utils/v4/volumes/api_client.py
+++ b/plugins/module_utils/v4/volumes/api_client.py
@@ -33,6 +33,9 @@ def get_api_client(module):
     config.username = module.params.get("nutanix_username")
     config.password = module.params.get("nutanix_password")
     config.verify_ssl = module.params.get("validate_certs")
+    config.proxy_scheme = module.params.get("proxy_scheme")
+    config.proxy_host = module.params.get("proxy_host")
+    config.proxy_port = module.params.get("proxy_port")
     client = ntnx_volumes_py_client.ApiClient(configuration=config)
 
     cred = "{0}:{1}".format(config.username, config.password)


### PR DESCRIPTION
It's not possible to use proxy with api_client v4, environment variables http_proxy and https_proxy are not compatible.
It's possibles with modules which api v3.
This pull requests is created to add support proxy config on api v4 modules.

- Add proxy arguments (proxy_scheme, proxy_host, proxy_port)
- Only compatible with modules which used api v4