### PR TITLE
feat(ntnx_prism_vm_inventory): add jinja filtering support and refactor

### DIFF
--- a/plugins/inventory/ntnx_prism_vm_inventory.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory.py
@@ -64,6 +64,11 @@ DOCUMENTATION = r"""
             type: boolean
             env:
                 - name: VALIDATE_CERTS
+        filters:
+            description: A list of Jinja2 expressions used to filter the inventory
+            default: []
+            elements: str
+            type: list
     extends_documentation_fragment:
         - constructed
 """
@@ -72,6 +77,7 @@ import json  # noqa: E402
 import tempfile  # noqa: E402
 
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable  # noqa: E402
+from ansible.errors import AnsibleError  # noqa: E402
 
 from ..module_utils.v3.prism import vms  # noqa: E402
 
@@ -110,6 +116,74 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         )
         return path.endswith(inventory_file_fmts)
 
+    def _build_host_vars(self, entity):
+        """
+        Build a dictionary of host variables from the raw entity.
+        """
+        cluster = entity.get("status", {}).get("cluster_reference", {}).get("name")
+        vm_name = entity.get("status", {}).get("name")
+        vm_uuid = entity.get("metadata", {}).get("uuid")
+        vm_ip = None
+
+        vm_resources = entity.get("status", {}).get("resources", {}).copy()
+        for nics in vm_resources.get("nic_list", []):
+            if nics.get("nic_type") == "NORMAL_NIC":
+                for endpoint in nics.get("ip_endpoint_list", []):
+                    if endpoint.get("type") in ["ASSIGNED", "LEARNED"]:
+                        vm_ip = endpoint.get("ip")
+                        break
+                if vm_ip:
+                    break
+
+        # Remove unwanted keys.
+        for key in [
+            "disk_list",
+            "vnuma_config",
+            "nic_list",
+            "power_state_mechanism",
+            "host_reference",
+            "serial_port_list",
+            "gpu_list",
+            "storage_config",
+            "boot_config",
+            "guest_customization",
+        ]:
+            vm_resources.pop(key, None)
+
+        host_vars = {
+            "ansible_host": vm_ip,
+            "uuid": vm_uuid,
+            "name": vm_name,
+            "cluster": cluster,
+        }
+        host_vars.update(vm_resources)
+
+        # Incorporate ntnx_categories if available.
+        if "metadata" in entity and "categories" in entity["metadata"]:
+            host_vars["ntnx_categories"] = entity["metadata"]["categories"]
+
+        return host_vars
+
+    def _should_add_host(self, host_vars, host_filters, strict):
+        """
+        Evaluate filter expressions against host_vars.
+        Returns True if the host should be added, False otherwise.
+        """
+        if not host_filters:
+            return True
+
+        for host_filter in host_filters:
+            try:
+                if not self._compose(host_filter, host_vars):
+                    return False
+            except Exception as e:
+                if strict:
+                    raise AnsibleError(
+                        "Could not evaluate filter '%s' - %s" % (host_filter, str(e))
+                    )
+                return False
+        return True
+
     def parse(self, inventory, loader, path, cache=True):
         super().parse(inventory, loader, path, cache=cache)
         self._read_config_data(path)
@@ -122,6 +196,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.validate_certs = self.get_option("validate_certs")
         # Determines if composed variables or groups using nonexistent variables is an error
         strict = self.get_option("strict")
+        host_filters = self.get_option("filters")
 
         module = Mock_Module(
             self.nutanix_hostname,
@@ -133,77 +208,46 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         vm = vms.VM(module)
         self.data["offset"] = self.data.get("offset", 0)
         resp = vm.list(self.data)
-        keys_to_strip_from_resp = [
-            "disk_list",
-            "vnuma_config",
-            "nic_list",
-            "power_state_mechanism",
-            "host_reference",
-            "serial_port_list",
-            "gpu_list",
-            "storage_config",
-            "boot_config",
-            "guest_customization",
-        ]
 
-        for entity in resp["entities"]:
-            cluster = entity["status"]["cluster_reference"]["name"]
-            vm_name = entity["status"]["name"]
-            vm_uuid = entity["metadata"]["uuid"]
-            vm_ip = None
+        for entity in resp.get("entities", []):
+            host_vars = self._build_host_vars(entity)
 
-            # Get VM IP
-            nic_count = 0
-            for nics in entity["status"]["resources"]["nic_list"]:
-                if nics["nic_type"] == "NORMAL_NIC" and nic_count == 0:
-                    for endpoint in nics["ip_endpoint_list"]:
-                        if endpoint["type"] in ["ASSIGNED", "LEARNED"]:
-                            vm_ip = endpoint["ip"]
-                            nic_count += 1
-                            continue
+            if not self._should_add_host(host_vars, host_filters, strict):
+                continue
 
-            # Add inventory groups and hosts to inventory groups
-            self.inventory.add_group(cluster)
-            self.inventory.add_child("all", cluster)
-            self.inventory.add_host(vm_name, group=cluster)
-            self.inventory.set_variable(vm_name, "ansible_host", vm_ip)
-            self.inventory.set_variable(vm_name, "uuid", vm_uuid)
-            self.inventory.set_variable(vm_name, "name", vm_name)
+            # Add host to inventory.
+            vm_name = host_vars.get("name")
+            cluster = host_vars.get("cluster")
+            vm_ip = host_vars.get("ansible_host")
+            vm_uuid = host_vars.get("uuid")
 
-            # Add hostvars
-            for key in keys_to_strip_from_resp:
-                try:
-                    del entity["status"]["resources"][key]
-                except KeyError:
-                    pass
+            if cluster:
+                self.inventory.add_group(cluster)
+                self.inventory.add_child("all", cluster)
+            if vm_name:
+                self.inventory.add_host(vm_name, group=cluster)
+                self.inventory.set_variable(vm_name, "ansible_host", vm_ip)
+                self.inventory.set_variable(vm_name, "uuid", vm_uuid)
+                self.inventory.set_variable(vm_name, "name", vm_name)
+                # Set all host_vars as variables.
+                for key, value in host_vars.items():
+                    self.inventory.set_variable(vm_name, key, value)
 
-            for key, value in entity["status"]["resources"].items():
-                self.inventory.set_variable(vm_name, key, value)
-
-            if "metadata" in entity and "categories" in entity["metadata"]:
-                self.inventory.set_variable(
-                    vm_name, "ntnx_categories", entity["metadata"]["categories"]
-                )
-
-            # Add variables created by the user's Jinja2 expressions to the host
             self._set_composite_vars(
                 self.get_option("compose"),
-                entity["status"]["resources"],
+                host_vars,
                 vm_name,
                 strict=strict,
             )
-
-            # The following two methods combine the provided variables dictionary with the latest host variables
-            # Using these methods after _set_composite_vars() allows groups to be created with the composed variables
             self._add_host_to_composed_groups(
                 self.get_option("groups"),
-                entity["status"]["resources"],
+                host_vars,
                 vm_name,
                 strict=strict,
             )
             self._add_host_to_keyed_groups(
                 self.get_option("keyed_groups"),
-                entity["status"]["resources"],
+                host_vars,
                 vm_name,
                 strict=strict,
             )


### PR DESCRIPTION
This pull request adds support for applying Jinja2 filter expressions directly to the inventory hosts in the Nutanix Prism VM Inventory plugin. With this enhancement, users can define filter criteria in their inventory configuration to select hosts based on properties like categories.

```yaml
filters:
  - "'Demonstration' in ntnx_categories"
  - "hardware_clock_timezone == 'UTC'"
  - "power_state == 'OFF'"
  - "'demo' in name"
```