### PR TITLE
Changed Python version from 3.9 to 3.10 in ok-to-test-command.yml file

### DIFF
--- a/.github/workflows/ok-to-test-command.yml
+++ b/.github/workflows/ok-to-test-command.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     if: github.event_name == 'repository_dispatch'
     steps:
       - run: echo "🎉 The job was automatically triggered by a ${{ github.event_name }} event."


### PR DESCRIPTION
This is required as ansible-core 2.16.0 version is not available in Python 3.9.

Ref: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#:~:text=PowerShell%205.1-,2.16,-GA%3A%2006%20Nov