### PR TITLE
Installing community.general in the pipeline

### DIFF
--- a/.github/workflows/ok-to-test-command.yml
+++ b/.github/workflows/ok-to-test-command.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r tests/integration/requirements.txt
+          ansible-galaxy collection install community.general --force
       - name: Build and install the collection
         run: |
           NAMESPACE=$(cat galaxy.yml | shyaml get-value namespace)


### PR DESCRIPTION
This is required in our integration tests.