### PR TITLE
Don't push coverage files in integration tests as the remote location is down.

### DIFF
--- a/.github/workflows/ok-to-test-command.yml
+++ b/.github/workflows/ok-to-test-command.yml
@@ -69,7 +69,6 @@ jobs:
         run: |
           cd /home/${USER}/.ansible/collections/ansible_collections/${{ env.NAMESPACE }}/${{ env.COLLECTION_NAME }}
           ansible-test coverage html
-          sshpass -p '${{ secrets.FILER_PASSWORD }}' scp -r tests/output ${{ secrets.FILER_LOCATION }}
           echo "Code coverage: Checking if code coverage is above threshold..."
           export COVERAGE_THRESHOLD=70
           echo "Threshold: $COVERAGE_THRESHOLD %"


### PR DESCRIPTION
Removing this step for now so that tests are not blocked due to it. Will add again when its fixed.