### PR TITLE
Adding fix for protection policies examples V2

### DIFF
--- a/examples/protection_policies_v2/promote_restore_vgs.yml
+++ b/examples/protection_policies_v2/promote_restore_vgs.yml
@@ -44,96 +44,6 @@
         availability_zone_pc_uuid: "bd32fb09-8005-4655-a3a8-086b8ec1b1ea"
         domain_manager_ext_id: "1e9a1996-50e2-485f-a67c-22355cb43055"
 
-    - name: Setting Variables
-      ansible.builtin.set_fact:
-        replication_location_1:
-          label: "ansible-label-{{label1}}"
-          domain_manager_ext_id: "{{domain_manager_ext_id}}"
-          is_primary: true
-          replication_sub_location:
-            nutanix_cluster:
-              cluster_ext_ids:
-                - "{{ cluster.uuid }}"
-
-        replication_location_2:
-          label: "ansible-label-{{label2}}"
-          domain_manager_ext_id: "{{availability_zone_pc_uuid}}"
-          is_primary: false
-          replication_sub_location:
-            nutanix_cluster:
-              cluster_ext_ids:
-                - "{{ cluster_availability_zone.uuid }}"
-
-        replication_location_1_local_clusters:
-          label: "ansible-label-local-clusters-{{label1}}"
-          domain_manager_ext_id: "{{domain_manager_ext_id}}"
-          is_primary: true
-          replication_sub_location:
-            nutanix_cluster:
-              cluster_ext_ids:
-                - "{{ cluster.uuid }}"
-
-        replication_location_2_local_clusters:
-          label: "ansible-label-local-clusters-{{label2}}"
-          domain_manager_ext_id: "{{domain_manager_ext_id}}"
-          is_primary: false
-          replication_sub_location:
-            nutanix_cluster:
-              cluster_ext_ids:
-                - "{{ cluster_ext_id }}"
-
-        replication_configuration_auto_1:
-          source_location_label: "ansible-label-{{label1}}"
-          remote_location_label: "ansible-label-{{label2}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 60
-            retention:
-              local:
-                snapshot_interval_type: "DAILY"
-                frequency: 1
-              remote:
-                snapshot_interval_type: "DAILY"
-                frequency: 1
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 300
-
-        replication_configuration_auto_2:
-          source_location_label: "ansible-label-{{label2}}"
-          remote_location_label: "ansible-label-{{label1}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 60
-            retention:
-              local:
-                snapshot_interval_type: "DAILY"
-                frequency: 1
-              remote:
-                snapshot_interval_type: "DAILY"
-                frequency: 1
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 300
-
-        replication_configuration_sync_local_clusters_1:
-          source_location_label: "ansible-label-local-clusters-{{label1}}"
-          remote_location_label: "ansible-label-local-clusters-{{label2}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            retention: null
-            recovery_point_objective_time_seconds: 0
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 10
-
-        replication_configuration_sync_local_clusters_2:
-          source_location_label: "ansible-label-local-clusters-{{label2}}"
-          remote_location_label: "ansible-label-local-clusters-{{label1}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            retention: null
-            recovery_point_objective_time_seconds: 0
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 10
-
     - name: Set ansible keys and values
       ansible.builtin.set_fact:
         keys:
@@ -151,7 +61,6 @@
         value: "{{ values[item] }}"
         description: "ansible-category"
       register: output
-      ignore_errors: true
       loop: "{{ range(0, 2) }}"
       loop_control:
         label: "{{ item }}"
@@ -181,15 +90,15 @@
                 cluster_ext_ids:
                   - "{{ cluster.uuid }}"
           - label: "ansible-label-local-clusters-{{label2}}"
-            domain_manager_ext_id: "{{domain_manager_ext_id}}"
+            domain_manager_ext_id: "{{availability_zone_pc_uuid}}"
             is_primary: false
             replication_sub_location:
               nutanix_cluster:
                 cluster_ext_ids:
-                  - "{{ cluster_ext_id }}"
+                  - "{{ cluster_availability_zone.uuid }}"
         replication_configurations:
-          - source_location_label: "ansible-label-{{label1}}"
-            remote_location_label: "ansible-label-{{label2}}"
+          - source_location_label: "ansible-label-local-clusters-{{label1}}"
+            remote_location_label: "ansible-label-local-clusters-{{label2}}"
             schedule:
               recovery_point_type: "CRASH_CONSISTENT"
               recovery_point_objective_time_seconds: 60
@@ -202,8 +111,8 @@
                     snapshot_interval_type: "DAILY"
                     frequency: 1
               sync_replication_auto_suspend_timeout_seconds: 300
-          - source_location_label: "ansible-label-{{label2}}"
-            remote_location_label: "ansible-label-{{label1}}"
+          - source_location_label: "ansible-label-local-clusters-{{label2}}"
+            remote_location_label: "ansible-label-local-clusters-{{label1}}"
             schedule:
               recovery_point_type: "CRASH_CONSISTENT"
               recovery_point_objective_time_seconds: 60
@@ -219,7 +128,6 @@
         category_ids:
           - "{{ category_ext_id_1 }}"
       register: result
-      ignore_errors: true
 
     - name: Add auto retention protection policy external ID to todelete list
       ansible.builtin.set_fact:
@@ -227,7 +135,7 @@
 
     ########################################################################################
 
-    - name: Create Synchronous replication protection policy for VG using category3
+    - name: Create Synchronous replication protection policy for VG using category2
       nutanix.ncp.ntnx_protection_policies_v2:
         name: "ansible-name-sync-vg-{{random_name}}"
         description: "ansible-description-sync-vg-{{random_name}}"
@@ -262,7 +170,6 @@
         category_ids:
           - "{{ category_ext_id_2 }}"
       register: result
-      ignore_errors: true
 
     - name: Add synchronous protection policy external ID to todelete list
       ansible.builtin.set_fact:
@@ -276,7 +183,6 @@
         description: "Volume group for promote"
         cluster_reference: "{{ cluster.uuid }}"
       register: result
-      ignore_errors: true
 
     - name: Set VG UUID
       ansible.builtin.set_fact:
@@ -288,7 +194,6 @@
         description: "Volume group for restore"
         cluster_reference: "{{ cluster.uuid }}"
       register: result
-      ignore_errors: true
 
     - name: Set VG UUID
       ansible.builtin.set_fact:
@@ -301,7 +206,6 @@
           - ext_id: "{{ category_ext_id_2 }}"
             entity_type: "CATEGORY"
       register: result
-      ignore_errors: true
 
     - name: Associate category with second VG
       nutanix.ncp.ntnx_volume_groups_categories_v2:
@@ -310,7 +214,6 @@
           - ext_id: "{{ category_ext_id_1 }}"
             entity_type: "CATEGORY"
       register: result
-      ignore_errors: true
 
     - name: Sleep for 5 minutes until VGs are protected
       ansible.builtin.pause:
@@ -320,13 +223,11 @@
       nutanix.ncp.ntnx_protected_resources_info_v2:
         ext_id: "{{ vg1_uuid }}"
       register: result
-      ignore_errors: true
 
     - name: Promote VG
       nutanix.ncp.ntnx_promote_protected_resources_v2:
         ext_id: "{{ vg1_uuid }}"
       register: result
-      ignore_errors: true
 
     - name: Restore VG
       nutanix.ncp.ntnx_restore_protected_resources_v2:
@@ -334,7 +235,6 @@
         ext_id: "{{ vg2_uuid }}"
         cluster_ext_id: "{{ cluster_availability_zone.uuid }}"
       register: result
-      ignore_errors: true
 
     ########################################################################################
 
@@ -350,7 +250,6 @@
           - ext_id: "{{ category_ext_id_2 }}"
             entity_type: "CATEGORY"
       register: result
-      ignore_errors: true
 
     - name: Disassociate category from second VG
       nutanix.ncp.ntnx_volume_groups_categories_v2:
@@ -360,12 +259,10 @@
           - ext_id: "{{ category_ext_id_1 }}"
             entity_type: "CATEGORY"
       register: result
-      ignore_errors: true
 
     - name: Fetch all VGs on local cluster
       nutanix.ncp.ntnx_volume_groups_info_v2:
       register: result
-      ignore_errors: true
 
     - name: Filter only protected VGs
       ansible.builtin.set_fact:
@@ -386,7 +283,6 @@
       nutanix.ncp.ntnx_volume_groups_info_v2:
         nutanix_host: "{{ availability_zone_pc_ip }}"
       register: result
-      ignore_errors: true
 
     - name: Filter only protected VGs
       ansible.builtin.set_fact:
@@ -411,7 +307,6 @@
         state: absent
       loop: "{{ todelete }}"
       register: result
-      ignore_errors: true
 
     ########################################################################################
 
@@ -421,4 +316,3 @@
         state: absent
       register: result
       loop: "{{ todelete_categories }}"
-      ignore_errors: true

--- a/examples/protection_policies_v2/promote_restore_vms.yml
+++ b/examples/protection_policies_v2/promote_restore_vms.yml
@@ -35,78 +35,6 @@
         availability_zone_pc_uuid: "bd32fb09-8005-4655-a3a8-086b8ec1b1ea"
         domain_manager_ext_id: "1e9a1996-50e2-485f-a67c-22355cb43055"
 
-    - name: Setting Variables
-      ansible.builtin.set_fact:
-        replication_location_1:
-          label: "ansible-label-{{label1}}"
-          domain_manager_ext_id: "{{domain_manager_ext_id}}"
-          is_primary: true
-          replication_sub_location:
-            nutanix_cluster:
-              cluster_ext_ids:
-                - "{{ cluster.uuid }}"
-
-        replication_location_2:
-          label: "ansible-label-{{label2}}"
-          domain_manager_ext_id: "{{availability_zone_pc_uuid}}"
-          is_primary: false
-          replication_sub_location:
-            nutanix_cluster:
-              cluster_ext_ids:
-                - "{{ cluster_availability_zone.uuid }}"
-
-        replication_configuration_auto_1:
-          source_location_label: "ansible-label-{{label1}}"
-          remote_location_label: "ansible-label-{{label2}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 60
-            retention:
-              local:
-                snapshot_interval_type: "DAILY"
-                frequency: 1
-              remote:
-                snapshot_interval_type: "DAILY"
-                frequency: 1
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 300
-
-        replication_configuration_auto_2:
-          source_location_label: "ansible-label-{{label2}}"
-          remote_location_label: "ansible-label-{{label1}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 60
-            retention:
-              local:
-                snapshot_interval_type: "DAILY"
-                frequency: 1
-              remote:
-                snapshot_interval_type: "DAILY"
-                frequency: 1
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 300
-
-        replication_configuration_sync_1:
-          source_location_label: "ansible-label-{{label1}}"
-          remote_location_label: "ansible-label-{{label2}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            retention: null
-            recovery_point_objective_time_seconds: 0
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 10
-
-        replication_configuration_sync_2:
-          source_location_label: "ansible-label-{{label2}}"
-          remote_location_label: "ansible-label-{{label1}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            retention: null
-            recovery_point_objective_time_seconds: 0
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 10
-
     - name: Set ansible keys and values
       ansible.builtin.set_fact:
         keys:
@@ -124,7 +52,6 @@
         value: "{{ values[item] }}"
         description: "ansible-category"
       register: output
-      ignore_errors: true
       loop: "{{ range(0, 2) }}"
       loop_control:
         label: "{{ item }}"
@@ -192,7 +119,6 @@
         category_ids:
           - "{{category_ext_id_1}}"
       register: result
-      ignore_errors: true
 
     - name: Add auto retention protection policy external ID to todelete list
       ansible.builtin.set_fact:
@@ -235,7 +161,6 @@
         category_ids:
           - "{{category_ext_id_2}}"
       register: result
-      ignore_errors: true
 
     - name: Add synchronous protection policy external ID to todelete list
       ansible.builtin.set_fact:
@@ -252,7 +177,6 @@
         categories:
           - ext_id: "{{ category_ext_id_2 }}"
       register: result
-      ignore_errors: true
 
     - name: Set VM external ID
       ansible.builtin.set_fact:
@@ -267,7 +191,6 @@
         categories:
           - ext_id: "{{ category_ext_id_1 }}"
       register: result
-      ignore_errors: true
 
     - name: Set VM external ID
       ansible.builtin.set_fact:
@@ -281,7 +204,6 @@
       until: result.response.protection_type == "RULE_PROTECTED"
       retries: 60
       delay: 10
-      ignore_errors: true
 
     # Wait for the second VM to be protected
     - name: Fetch VM using ext_id
@@ -291,7 +213,6 @@
       until: result.response.protection_type == "RULE_PROTECTED"
       retries: 60
       delay: 10
-      ignore_errors: true
 
     - name: Sleep for 5 minutes until VMs are protected
       ansible.builtin.pause:
@@ -301,14 +222,12 @@
       nutanix.ncp.ntnx_protected_resources_info_v2:
         ext_id: "{{ vm_ext_id_1 }}"
       register: result
-      ignore_errors: true
 
     - name: Promote VM
       nutanix.ncp.ntnx_promote_protected_resources_v2:
         nutanix_host: "{{ availability_zone_pc_ip }}"
         ext_id: "{{ vm_ext_id_1 }}"
       register: result
-      ignore_errors: true
 
     - name: Restore VM
       nutanix.ncp.ntnx_restore_protected_resources_v2:
@@ -316,7 +235,6 @@
         ext_id: "{{ vm_ext_id_2 }}"
         cluster_ext_id: "{{ cluster_availability_zone.uuid }}"
       register: result
-      ignore_errors: true
 
     ########################################################################################
 
@@ -327,7 +245,6 @@
     - name: Fetch all VMs on local cluster
       nutanix.ncp.ntnx_vms_info_v2:
       register: result
-      ignore_errors: true
 
     - name: Filter only protected VMs
       ansible.builtin.set_fact:
@@ -348,7 +265,6 @@
       nutanix.ncp.ntnx_vms_info_v2:
         nutanix_host: "{{ availability_zone_pc_ip }}"
       register: result
-      ignore_errors: true
 
     - name: Filter only protected VMs
       ansible.builtin.set_fact:
@@ -365,7 +281,6 @@
         ext_id: "{{ item }}"
       register: result
       loop: "{{ protected_vms_ext_ids }}"
-      ignore_errors: true
 
     ########################################################################################
 
@@ -375,7 +290,6 @@
         state: absent
       loop: "{{ todelete }}"
       register: result
-      ignore_errors: true
 
     ########################################################################################
 
@@ -385,4 +299,3 @@
         state: absent
       register: result
       loop: "{{ todelete_categories }}"
-      ignore_errors: true

--- a/examples/protection_policies_v2/protection_policies_crud_v2.yml
+++ b/examples/protection_policies_v2/protection_policies_crud_v2.yml
@@ -40,230 +40,12 @@
         todelete_categories: []
         todelete: []
         cluster:
-          uuid: "00062fe7-4b68-e710-0000-000000028f57"
+          uuid: "00062db4-a450-e685-0fda-cdf9ca935bfd"
         cluster_availability_zone:
-          uuid: "00062ef8-a0a4-5120-0bce-6793cff236de"
-        availability_zone_pc_ip: "10.96.76.110"
-        availability_zone_pc_uuid: "b791a896-232e-474e-955b-39cd0a0d8d3c"
-        domain_manager_ext_id: "236acacc-209c-440c-bf99-7d7c67a7a260"
-
-    - name: Setting Variables
-      ansible.builtin.set_fact:
-        replication_location_1:
-          label: "ansible-label-{{label1}}"
-          domain_manager_ext_id: "{{domain_manager_ext_id}}"
-          is_primary: true
-          replication_sub_location:
-            nutanix_cluster:
-              cluster_ext_ids:
-                - "{{ cluster.uuid }}"
-
-        replication_location_2:
-          label: "ansible-label-{{label2}}"
-          domain_manager_ext_id: "{{availability_zone_pc_uuid}}"
-          is_primary: false
-          replication_sub_location:
-            nutanix_cluster:
-              cluster_ext_ids:
-                - "{{ cluster_availability_zone.uuid }}"
-
-        replication_location_1_updated:
-          label: "ansible-label-{{label1}}_updated"
-          domain_manager_ext_id: "{{domain_manager_ext_id}}"
-          is_primary: true
-          replication_sub_location:
-            nutanix_cluster:
-              cluster_ext_ids:
-                - "{{ cluster.uuid }}"
-
-        replication_location_2_updated:
-          label: "ansible-label-{{label2}}_updated"
-          domain_manager_ext_id: "{{availability_zone_pc_uuid}}"
-          is_primary: false
-          replication_sub_location:
-            nutanix_cluster:
-              cluster_ext_ids:
-                - "{{ cluster_availability_zone.uuid }}"
-
-        replication_configuration_linear_1:
-          source_location_label: "ansible-label-{{label1}}"
-          remote_location_label: "ansible-label-{{label2}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 3600
-            retention:
-              local: 1
-              remote: 1
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 300
-
-        replication_configuration_linear_1_check_mode:
-          source_location_label: "ansible-label-{{label1}}"
-          remote_location_label: "ansible-label-{{label2}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 3600
-            retention:
-              local: 1
-              remote: 1
-            start_time: "13h:11m"
-            sync_replication_auto_suspend_timeout_seconds: 300
-
-        replication_configuration_linear_2:
-          source_location_label: "ansible-label-{{label2}}"
-          remote_location_label: "ansible-label-{{label1}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 3600
-            retention:
-              local: 1
-              remote: 1
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 300
-
-        replication_configuration_linear_2_check_mode:
-          source_location_label: "ansible-label-{{label2}}"
-          remote_location_label: "ansible-label-{{label1}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 3600
-            retention:
-              local: 1
-              remote: 1
-            start_time: "13h:11m"
-            sync_replication_auto_suspend_timeout_seconds: 300
-
-        replication_configuration_linear_1_updated:
-          source_location_label: "ansible-label-{{label1}}_updated"
-          remote_location_label: "ansible-label-{{label2}}_updated"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 7200
-            retention:
-              local: 2
-              remote: 2
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 90
-
-        replication_configuration_linear_1_updated_check_mode:
-          source_location_label: "ansible-label-{{label1}}_updated"
-          remote_location_label: "ansible-label-{{label2}}_updated"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 7200
-            retention:
-              local: 2
-              remote: 2
-            start_time: "14h:26m"
-            sync_replication_auto_suspend_timeout_seconds: 90
-
-        replication_configuration_linear_2_updated:
-          source_location_label: "ansible-label-{{label2}}_updated"
-          remote_location_label: "ansible-label-{{label1}}_updated"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 7200
-            retention:
-              local: 2
-              remote: 2
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 90
-
-        replication_configuration_linear_2_updated_check_mode:
-          source_location_label: "ansible-label-{{label2}}_updated"
-          remote_location_label: "ansible-label-{{label1}}_updated"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 7200
-            retention:
-              local: 2
-              remote: 2
-            start_time: "14h:26m"
-            sync_replication_auto_suspend_timeout_seconds: 90
-
-        replication_configuration_auto_1:
-          source_location_label: "ansible-label-{{label1}}"
-          remote_location_label: "ansible-label-{{label2}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 60
-            retention:
-              local:
-                snapshot_interval_type: "DAILY"
-                frequency: 1
-              remote:
-                snapshot_interval_type: "DAILY"
-                frequency: 1
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 300
-
-        replication_configuration_auto_2:
-          source_location_label: "ansible-label-{{label2}}"
-          remote_location_label: "ansible-label-{{label1}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 60
-            retention:
-              local:
-                snapshot_interval_type: "DAILY"
-                frequency: 1
-              remote:
-                snapshot_interval_type: "DAILY"
-                frequency: 1
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 300
-
-        replication_configuration_auto_1_updated:
-          source_location_label: "ansible-label-{{label1}}_updated"
-          remote_location_label: "ansible-label-{{label2}}_updated"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 3600
-            retention:
-              local:
-                snapshot_interval_type: "DAILY"
-                frequency: 2
-              remote:
-                snapshot_interval_type: "DAILY"
-                frequency: 2
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 90
-
-        replication_configuration_auto_2_updated:
-          source_location_label: "ansible-label-{{label2}}_updated"
-          remote_location_label: "ansible-label-{{label1}}_updated"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            recovery_point_objective_time_seconds: 3600
-            retention:
-              local:
-                snapshot_interval_type: "DAILY"
-                frequency: 2
-              remote:
-                snapshot_interval_type: "DAILY"
-                frequency: 2
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 90
-
-        replication_configuration_sync_1:
-          source_location_label: "ansible-label-{{label1}}"
-          remote_location_label: "ansible-label-{{label2}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            retention: null
-            recovery_point_objective_time_seconds: 0
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 10
-
-        replication_configuration_sync_2:
-          source_location_label: "ansible-label-{{label2}}"
-          remote_location_label: "ansible-label-{{label1}}"
-          schedule:
-            recovery_point_type: "CRASH_CONSISTENT"
-            retention: null
-            recovery_point_objective_time_seconds: 0
-            start_time:
-            sync_replication_auto_suspend_timeout_seconds: 10
+          uuid: "00062df3-0a98-93d3-0654-e452ba9c0c25"
+        availability_zone_pc_ip: "10.2.0.0"
+        availability_zone_pc_uuid: "bd32fb09-8005-4655-a3a8-086b8ec1b1ea"
+        domain_manager_ext_id: "1e9a1996-50e2-485f-a67c-22355cb43055"
 
     - name: Set ansible keys and values
       ansible.builtin.set_fact:
@@ -284,7 +66,6 @@
         value: "{{ values[item] }}"
         description: "ansible-category"
       register: output
-      ignore_errors: true
       loop: "{{ range(0, 3) }}"
       loop_control:
         label: "{{ item }}"
@@ -307,37 +88,46 @@
         name: "ansible-create-protection-policy-name"
         description: "ansible-create-protection-policy-description"
         replication_locations:
-          - "{{ replication_location_1}}"
-          - "{{ replication_location_2}}"
+          - label: "ansible-label-{{label1}}"
+            domain_manager_ext_id: "{{domain_manager_ext_id}}"
+            is_primary: true
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster.uuid }}"
+          - label: "ansible-label-{{label2}}"
+            domain_manager_ext_id: "{{availability_zone_pc_uuid}}"
+            is_primary: false
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster_availability_zone.uuid }}"
         replication_configurations:
-          - source_location_label: "{{ replication_configuration_linear_1_check_mode.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_linear_1_check_mode.remote_location_label }}"
+          - source_location_label: "ansible-label-{{label1}}"
+            remote_location_label: "ansible-label-{{label2}}"
             schedule:
-              recovery_point_type: "{{ replication_configuration_linear_1_check_mode.schedule.recovery_point_type }}"
-              recovery_point_objective_time_seconds: "{{ replication_configuration_linear_1_check_mode.schedule.recovery_point_objective_time_seconds | int }}"
+              recovery_point_type: "CRASH_CONSISTENT"
+              recovery_point_objective_time_seconds: 3600
               retention:
                 linear_retention:
-                  local: "{{ replication_configuration_linear_1_check_mode.schedule.retention.local }}"
-                  remote: "{{ replication_configuration_linear_1_check_mode.schedule.retention.remote }}"
-              start_time: "{{ replication_configuration_linear_1_check_mode.schedule.start_time }}"
-              sync_replication_auto_suspend_timeout_seconds: >
-                {{ replication_configuration_linear_1_check_mode.schedule.sync_replication_auto_suspend_timeout_seconds | int }}
-          - source_location_label: "{{  replication_configuration_linear_2_check_mode.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_linear_2_check_mode.remote_location_label }}"
+                  local: 1
+                  remote: 1
+              start_time: "13h:11m"
+              sync_replication_auto_suspend_timeout_seconds: 300
+          - source_location_label: "ansible-label-{{label2}}"
+            remote_location_label: "ansible-label-{{label1}}"
             schedule:
-              recovery_point_type: "{{ replication_configuration_linear_2_check_mode.schedule.recovery_point_type }}"
-              recovery_point_objective_time_seconds: "{{ replication_configuration_linear_2_check_mode.schedule.recovery_point_objective_time_seconds | int }}"
+              recovery_point_type: "CRASH_CONSISTENT"
+              recovery_point_objective_time_seconds: 3600
               retention:
                 linear_retention:
-                  local: "{{ replication_configuration_linear_2_check_mode.schedule.retention.local }}"
-                  remote: "{{ replication_configuration_linear_2_check_mode.schedule.retention.remote }}"
-              start_time: "{{ replication_configuration_linear_2_check_mode.schedule.start_time }}"
-              sync_replication_auto_suspend_timeout_seconds: >
-                {{ replication_configuration_linear_2_check_mode.schedule.sync_replication_auto_suspend_timeout_seconds | int }}
+                  local: 1
+                  remote: 1
+              start_time: "13h:11m"
+              sync_replication_auto_suspend_timeout_seconds: 300
         category_ids:
           - "00000000-0000-0000-0000-000000000000"
       register: result
-      ignore_errors: true
       check_mode: true
 
     ########################################################################################
@@ -347,33 +137,46 @@
         name: "ansible-name-linear-{{random_name}}"
         description: "ansible-description-linear-{{random_name}}"
         replication_locations:
-          - "{{ replication_location_1 }}"
-          - "{{ replication_location_2 }}"
+          - label: "ansible-label-{{label1}}"
+            domain_manager_ext_id: "{{domain_manager_ext_id}}"
+            is_primary: true
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster.uuid }}"
+          - label: "ansible-label-{{label2}}"
+            domain_manager_ext_id: "{{availability_zone_pc_uuid}}"
+            is_primary: false
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster_availability_zone.uuid }}"
         replication_configurations:
-          - source_location_label: "{{ replication_configuration_linear_1.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_linear_1.remote_location_label }}"
+          - source_location_label: "ansible-label-{{label1}}"
+            remote_location_label: "ansible-label-{{label2}}"
             schedule:
-              recovery_point_type: "{{ replication_configuration_linear_1.schedule.recovery_point_type }}"
-              recovery_point_objective_time_seconds: "{{ replication_configuration_linear_1.schedule.recovery_point_objective_time_seconds | int }}"
+              recovery_point_type: "CRASH_CONSISTENT"
+              recovery_point_objective_time_seconds: 3600
               retention:
                 linear_retention:
-                  local: "{{ replication_configuration_linear_1.schedule.retention.local }}"
-                  remote: "{{ replication_configuration_linear_1.schedule.retention.remote }}"
-              sync_replication_auto_suspend_timeout_seconds: "{{ replication_configuration_linear_1.schedule.sync_replication_auto_suspend_timeout_seconds }}"
-          - source_location_label: "{{ replication_configuration_linear_2.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_linear_2.remote_location_label }}"
+                  local: 1
+                  remote: 1
+              start_time:
+              sync_replication_auto_suspend_timeout_seconds: 300
+          - source_location_label: "ansible-label-{{label2}}"
+            remote_location_label: "ansible-label-{{label1}}"
             schedule:
-              recovery_point_type: "{{ replication_configuration_linear_2.schedule.recovery_point_type }}"
-              recovery_point_objective_time_seconds: "{{ replication_configuration_linear_2.schedule.recovery_point_objective_time_seconds | int }}"
+              recovery_point_type: "CRASH_CONSISTENT"
+              recovery_point_objective_time_seconds: 3600
               retention:
                 linear_retention:
-                  local: "{{ replication_configuration_linear_2.schedule.retention.local }}"
-                  remote: "{{ replication_configuration_linear_2.schedule.retention.remote }}"
-              sync_replication_auto_suspend_timeout_seconds: "{{ replication_configuration_linear_2.schedule.sync_replication_auto_suspend_timeout_seconds }}"
+                  local: 1
+                  remote: 1
+              start_time:
+              sync_replication_auto_suspend_timeout_seconds: 300
         category_ids:
           - "{{category_ext_id_1}}"
       register: result
-      ignore_errors: true
 
     - name: Add linear retention protection policy external ID to todelete list
       ansible.builtin.set_fact:
@@ -386,41 +189,54 @@
         name: "ansible-name-auto-{{random_name}}"
         description: "ansible-description-auto-{{random_name}}"
         replication_locations:
-          - "{{ replication_location_1 }}"
-          - "{{ replication_location_2 }}"
+          - label: "ansible-label-{{label1}}"
+            domain_manager_ext_id: "{{domain_manager_ext_id}}"
+            is_primary: true
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster.uuid }}"
+          - label: "ansible-label-{{label2}}"
+            domain_manager_ext_id: "{{availability_zone_pc_uuid}}"
+            is_primary: false
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster_availability_zone.uuid }}"
         replication_configurations:
-          - source_location_label: "{{ replication_configuration_auto_1.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_auto_1.remote_location_label }}"
+          - source_location_label: "ansible-label-{{label1}}"
+            remote_location_label: "ansible-label-{{label2}}"
             schedule:
-              recovery_point_type: "{{ replication_configuration_auto_1.schedule.recovery_point_type }}"
-              recovery_point_objective_time_seconds: "{{ replication_configuration_auto_1.schedule.recovery_point_objective_time_seconds | int }}"
+              recovery_point_type: "CRASH_CONSISTENT"
+              recovery_point_objective_time_seconds: 60
               retention:
                 auto_rollup_retention:
                   local:
-                    snapshot_interval_type: "{{ replication_configuration_auto_1.schedule.retention.local.snapshot_interval_type }}"
-                    frequency: "{{ replication_configuration_auto_1.schedule.retention.local.frequency }}"
+                    snapshot_interval_type: "DAILY"
+                    frequency: 1
                   remote:
-                    snapshot_interval_type: "{{ replication_configuration_auto_1.schedule.retention.remote.snapshot_interval_type }}"
-                    frequency: "{{ replication_configuration_auto_1.schedule.retention.remote.frequency }}"
-              sync_replication_auto_suspend_timeout_seconds: "{{ replication_configuration_auto_1.schedule.sync_replication_auto_suspend_timeout_seconds }}"
-          - source_location_label: "{{ replication_configuration_auto_2.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_auto_2.remote_location_label }}"
+                    snapshot_interval_type: "DAILY"
+                    frequency: 1
+              start_time:
+              sync_replication_auto_suspend_timeout_seconds: 300
+          - source_location_label: "ansible-label-{{label2}}"
+            remote_location_label: "ansible-label-{{label1}}"
             schedule:
-              recovery_point_type: "{{ replication_configuration_auto_2.schedule.recovery_point_type }}"
-              recovery_point_objective_time_seconds: "{{ replication_configuration_auto_2.schedule.recovery_point_objective_time_seconds | int }}"
+              recovery_point_type: "CRASH_CONSISTENT"
+              recovery_point_objective_time_seconds: 60
               retention:
                 auto_rollup_retention:
                   local:
-                    snapshot_interval_type: "{{ replication_configuration_auto_2.schedule.retention.local.snapshot_interval_type }}"
-                    frequency: "{{ replication_configuration_auto_2.schedule.retention.local.frequency }}"
+                    snapshot_interval_type: "DAILY"
+                    frequency: 1
                   remote:
-                    snapshot_interval_type: "{{ replication_configuration_auto_2.schedule.retention.remote.snapshot_interval_type }}"
-                    frequency: "{{ replication_configuration_auto_2.schedule.retention.remote.frequency }}"
-              sync_replication_auto_suspend_timeout_seconds: "{{ replication_configuration_auto_2.schedule.sync_replication_auto_suspend_timeout_seconds }}"
+                    snapshot_interval_type: "DAILY"
+                    frequency: 1
+              start_time:
+              sync_replication_auto_suspend_timeout_seconds: 300
         category_ids:
           - "{{category_ext_id_2}}"
       register: result
-      ignore_errors: true
 
     - name: Add auto retention protection policy external ID to todelete list
       ansible.builtin.set_fact:
@@ -433,25 +249,40 @@
         name: "ansible-name-sync-vm-{{random_name}}"
         description: "ansible-description-sync-vm-{{random_name}}"
         replication_locations:
-          - "{{ replication_location_1 }}"
-          - "{{ replication_location_2 }}"
+          - label: "ansible-label-{{label1}}"
+            domain_manager_ext_id: "{{domain_manager_ext_id}}"
+            is_primary: true
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster.uuid }}"
+          - label: "ansible-label-{{label2}}"
+            domain_manager_ext_id: "{{availability_zone_pc_uuid}}"
+            is_primary: false
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster_availability_zone.uuid }}"
         replication_configurations:
-          - source_location_label: "{{ replication_configuration_sync_1.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_sync_1.remote_location_label }}"
+          - source_location_label: "ansible-label-{{label1}}"
+            remote_location_label: "ansible-label-{{label2}}"
             schedule:
               recovery_point_type: "CRASH_CONSISTENT"
-              recovery_point_objective_time_seconds: "{{ replication_configuration_sync_1.schedule.recovery_point_objective_time_seconds | int }}"
-              sync_replication_auto_suspend_timeout_seconds: "{{ replication_configuration_sync_1.schedule.sync_replication_auto_suspend_timeout_seconds }}"
-          - source_location_label: "{{ replication_configuration_sync_2.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_sync_2.remote_location_label }}"
+              retention: null
+              recovery_point_objective_time_seconds: 0
+              start_time:
+              sync_replication_auto_suspend_timeout_seconds: 10
+          - source_location_label: "ansible-label-{{label2}}"
+            remote_location_label: "ansible-label-{{label1}}"
             schedule:
               recovery_point_type: "CRASH_CONSISTENT"
-              recovery_point_objective_time_seconds: "{{ replication_configuration_sync_2.schedule.recovery_point_objective_time_seconds | int }}"
-              sync_replication_auto_suspend_timeout_seconds: "{{ replication_configuration_sync_2.schedule.sync_replication_auto_suspend_timeout_seconds }}"
+              retention: null
+              recovery_point_objective_time_seconds: 0
+              start_time:
+              sync_replication_auto_suspend_timeout_seconds: 10
         category_ids:
           - "{{category_ext_id_3}}"
       register: result
-      ignore_errors: true
 
     - name: Add synchronous protection policy external ID to todelete list
       ansible.builtin.set_fact:
@@ -465,41 +296,46 @@
         name: "ansible-update-protection-policy-name"
         description: "ansible-update-protection-policy-description"
         replication_locations:
-          - "{{ replication_location_1_updated }}"
-          - "{{ replication_location_2_updated }}"
+          - label: "ansible-label-{{label1}}_updated"
+            domain_manager_ext_id: "{{domain_manager_ext_id}}"
+            is_primary: true
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster.uuid }}"
+          - label: "ansible-label-{{label2}}_updated"
+            domain_manager_ext_id: "{{availability_zone_pc_uuid}}"
+            is_primary: false
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster_availability_zone.uuid }}"
         replication_configurations:
-          - source_location_label: "{{ replication_configuration_linear_1_updated_check_mode.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_linear_1_updated_check_mode.remote_location_label }}"
+          - source_location_label: "ansible-label-{{label1}}_updated"
+            remote_location_label: "ansible-label-{{label2}}_updated"
             schedule:
-              recovery_point_type: "{{ replication_configuration_linear_1_updated_check_mode.schedule.recovery_point_type }}"
-              recovery_point_objective_time_seconds: >
-                {{ replication_configuration_linear_1_updated_check_mode.schedule.recovery_point_objective_time_seconds | int }}
+              recovery_point_type: "CRASH_CONSISTENT"
+              recovery_point_objective_time_seconds: 7200
               retention:
                 linear_retention:
-                  local: "{{ replication_configuration_linear_1_updated_check_mode.schedule.retention.local }}"
-                  remote: "{{ replication_configuration_linear_1_updated_check_mode.schedule.retention.remote }}"
-              start_time: "{{ replication_configuration_linear_1_updated_check_mode.schedule.start_time }}"
-              sync_replication_auto_suspend_timeout_seconds:
-                "{{ replication_configuration_linear_1_updated_check_mode.schedule.
-                sync_replication_auto_suspend_timeout_seconds }}"
-          - source_location_label: "{{ replication_configuration_linear_2_updated_check_mode.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_linear_2_updated_check_mode.remote_location_label }}"
+                  local: 2
+                  remote: 2
+              start_time: "14h:26m"
+              sync_replication_auto_suspend_timeout_seconds: 90
+          - source_location_label: "ansible-label-{{label2}}_updated"
+            remote_location_label: "ansible-label-{{label1}}_updated"
             schedule:
-              recovery_point_type: "{{ replication_configuration_linear_2_updated_check_mode.schedule.recovery_point_type }}"
-              recovery_point_objective_time_seconds: >
-                {{ replication_configuration_linear_2_updated_check_mode.schedule.recovery_point_objective_time_seconds | int }}
+              recovery_point_type: "CRASH_CONSISTENT"
+              recovery_point_objective_time_seconds: 7200
               retention:
                 linear_retention:
-                  local: "{{ replication_configuration_linear_2_updated_check_mode.schedule.retention.local }}"
-                  remote: "{{ replication_configuration_linear_2_updated_check_mode.schedule.retention.remote }}"
-              start_time: "{{ replication_configuration_linear_2_updated_check_mode.schedule.start_time }}"
-              sync_replication_auto_suspend_timeout_seconds:
-                "{{ replication_configuration_linear_2_updated_check_mode.schedule.
-                sync_replication_auto_suspend_timeout_seconds }}"
+                  local: 2
+                  remote: 2
+              start_time: "14h:26m"
+              sync_replication_auto_suspend_timeout_seconds: 90
         category_ids:
           - "{{category_ext_id_1}}"
       register: result
-      ignore_errors: true
       check_mode: true
 
     ########################################################################################
@@ -510,37 +346,46 @@
         name: "ansible-name-linear-{{random_name}}_updated"
         description: "ansible-description-linear-{{random_name}}_updated"
         replication_locations:
-          - "{{ replication_location_1_updated }}"
-          - "{{ replication_location_2_updated }}"
+          - label: "ansible-label-{{label1}}_updated"
+            domain_manager_ext_id: "{{domain_manager_ext_id}}"
+            is_primary: true
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster.uuid }}"
+          - label: "ansible-label-{{label2}}_updated"
+            domain_manager_ext_id: "{{availability_zone_pc_uuid}}"
+            is_primary: false
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster_availability_zone.uuid }}"
         replication_configurations:
-          - source_location_label: "{{ replication_configuration_linear_1_updated.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_linear_1_updated.remote_location_label }}"
+          - source_location_label: "ansible-label-{{label1}}_updated"
+            remote_location_label: "ansible-label-{{label2}}_updated"
             schedule:
-              recovery_point_type: "{{ replication_configuration_linear_1_updated.schedule.recovery_point_type }}"
-              recovery_point_objective_time_seconds: "{{ replication_configuration_linear_1_updated.schedule.recovery_point_objective_time_seconds | int }}"
+              recovery_point_type: "CRASH_CONSISTENT"
+              recovery_point_objective_time_seconds: 7200
               retention:
                 linear_retention:
-                  local: "{{ replication_configuration_linear_1_updated.schedule.retention.local }}"
-                  remote: "{{ replication_configuration_linear_1_updated.schedule.retention.remote }}"
-              sync_replication_auto_suspend_timeout_seconds:
-                "{{ replication_configuration_linear_1_updated.schedule.
-                sync_replication_auto_suspend_timeout_seconds }}"
-          - source_location_label: "{{ replication_configuration_linear_2_updated.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_linear_2_updated.remote_location_label }}"
+                  local: 2
+                  remote: 2
+              start_time:
+              sync_replication_auto_suspend_timeout_seconds: 90
+          - source_location_label: "ansible-label-{{label2}}_updated"
+            remote_location_label: "ansible-label-{{label1}}_updated"
             schedule:
-              recovery_point_type: "{{ replication_configuration_linear_2_updated.schedule.recovery_point_type }}"
-              recovery_point_objective_time_seconds: "{{ replication_configuration_linear_2_updated.schedule.recovery_point_objective_time_seconds | int }}"
+              recovery_point_type: "CRASH_CONSISTENT"
+              recovery_point_objective_time_seconds: 7200
               retention:
                 linear_retention:
-                  local: "{{ replication_configuration_linear_2_updated.schedule.retention.local }}"
-                  remote: "{{ replication_configuration_linear_2_updated.schedule.retention.remote }}"
-              sync_replication_auto_suspend_timeout_seconds:
-                "{{ replication_configuration_linear_2_updated.schedule.
-                sync_replication_auto_suspend_timeout_seconds }}"
+                  local: 2
+                  remote: 2
+              start_time:
+              sync_replication_auto_suspend_timeout_seconds: 90
         category_ids:
           - "{{category_ext_id_1}}"
       register: result
-      ignore_errors: true
 
     ########################################################################################
 
@@ -550,50 +395,60 @@
         name: "ansible-name-auto-{{random_name}}_updated"
         description: "ansible-description-auto-{{random_name}}_updated"
         replication_locations:
-          - "{{ replication_location_1_updated }}"
-          - "{{ replication_location_2_updated }}"
+          - label: "ansible-label-{{label1}}_updated"
+            domain_manager_ext_id: "{{domain_manager_ext_id}}"
+            is_primary: true
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster.uuid }}"
+          - label: "ansible-label-{{label2}}_updated"
+            domain_manager_ext_id: "{{availability_zone_pc_uuid}}"
+            is_primary: false
+            replication_sub_location:
+              nutanix_cluster:
+                cluster_ext_ids:
+                  - "{{ cluster_availability_zone.uuid }}"
         replication_configurations:
-          - source_location_label: "{{ replication_configuration_auto_1_updated.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_auto_1_updated.remote_location_label }}"
+          - source_location_label: "ansible-label-{{label1}}_updated"
+            remote_location_label: "ansible-label-{{label2}}_updated"
             schedule:
-              recovery_point_type: "{{ replication_configuration_auto_1_updated.schedule.recovery_point_type }}"
-              recovery_point_objective_time_seconds: "{{ replication_configuration_auto_1_updated.schedule.recovery_point_objective_time_seconds | int }}"
+              recovery_point_type: "CRASH_CONSISTENT"
+              recovery_point_objective_time_seconds: 3600
               retention:
                 auto_rollup_retention:
                   local:
-                    snapshot_interval_type: "{{ replication_configuration_auto_1_updated.schedule.retention.local.snapshot_interval_type }}"
-                    frequency: "{{ replication_configuration_auto_1_updated.schedule.retention.local.frequency }}"
+                    snapshot_interval_type: "DAILY"
+                    frequency: 2
                   remote:
-                    snapshot_interval_type: "{{ replication_configuration_auto_1_updated.schedule.retention.remote.snapshot_interval_type }}"
-                    frequency: "{{ replication_configuration_auto_1_updated.schedule.retention.remote.frequency }}"
-              sync_replication_auto_suspend_timeout_seconds: >
-                "{{ replication_configuration_auto_1_updated.schedule.sync_replication_auto_suspend_timeout_seconds }}"
-          - source_location_label: "{{ replication_configuration_auto_2_updated.source_location_label }}"
-            remote_location_label: "{{ replication_configuration_auto_2_updated.remote_location_label }}"
+                    snapshot_interval_type: "DAILY"
+                    frequency: 2
+              start_time:
+              sync_replication_auto_suspend_timeout_seconds: 90
+          - source_location_label: "ansible-label-{{label2}}_updated"
+            remote_location_label: "ansible-label-{{label1}}_updated"
             schedule:
-              recovery_point_type: "{{ replication_configuration_auto_2_updated.schedule.recovery_point_type }}"
-              recovery_point_objective_time_seconds: "{{ replication_configuration_auto_2_updated.schedule.recovery_point_objective_time_seconds | int }}"
+              recovery_point_type: "CRASH_CONSISTENT"
+              recovery_point_objective_time_seconds: 3600
               retention:
                 auto_rollup_retention:
                   local:
-                    snapshot_interval_type: "{{ replication_configuration_auto_2_updated.schedule.retention.local.snapshot_interval_type }}"
-                    frequency: "{{ replication_configuration_auto_2_updated.schedule.retention.local.frequency }}"
+                    snapshot_interval_type: "DAILY"
+                    frequency: 2
                   remote:
-                    snapshot_interval_type: "{{ replication_configuration_auto_2_updated.schedule.retention.remote.snapshot_interval_type }}"
-                    frequency: "{{ replication_configuration_auto_2_updated.schedule.retention.remote.frequency }}"
-              sync_replication_auto_suspend_timeout_seconds: >
-                "{{ replication_configuration_auto_2_updated.schedule.sync_replication_auto_suspend_timeout_seconds }}"
+                    snapshot_interval_type: "DAILY"
+                    frequency: 2
+              start_time:
+              sync_replication_auto_suspend_timeout_seconds: 90
         category_ids:
           - "{{category_ext_id_2}}"
       register: result
-      ignore_errors: true
 
     ########################################################################################
 
     - name: List all protection policies
       nutanix.ncp.ntnx_protection_policies_info_v2:
       register: result
-      ignore_errors: true
 
     ########################################################################################
 
@@ -601,7 +456,6 @@
       nutanix.ncp.ntnx_protection_policies_info_v2:
         filter: "name eq 'ansible-name-auto-{{random_name}}_updated'"
       register: result
-      ignore_errors: true
 
     ########################################################################################
 
@@ -609,7 +463,6 @@
       nutanix.ncp.ntnx_protection_policies_info_v2:
         limit: 1
       register: result
-      ignore_errors: true
 
     ########################################################################################
 
@@ -617,7 +470,6 @@
       nutanix.ncp.ntnx_protection_policies_info_v2:
         ext_id: "{{ todelete[0] }}"
       register: result
-      ignore_errors: true
 
     ########################################################################################
 
@@ -627,7 +479,6 @@
         state: absent
       loop: "{{ todelete }}"
       register: result
-      ignore_errors: true
 
     ########################################################################################
 
@@ -637,4 +488,3 @@
         state: absent
       register: result
       loop: "{{ todelete_categories }}"
-      ignore_errors: true


### PR DESCRIPTION
This PR includes improvements and cleanup for the v2 protection policies examples:

- Renamed variables for better clarity and consistency
- Updated replication configuration labels to align with replication location labels
- Removed unused and redundant variables