### PR TITLE
Adding fix for updating empty CD ROM with clone image attribute (#505)

### DIFF
--- a/examples/vm_update_cdrom.yml
+++ b/examples/vm_update_cdrom.yml
@@ -1,0 +1,41 @@
+########################### UPDATE_VM_CDROM ################################
+---
+- name: Create a VM with empty CD ROM and Update that disk with image
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        vm_uuid: ""
+        disk_uuid: ""
+
+    - name: Create VM with empty CD ROM
+      nutanix.ncp.ntnx_vms:
+        name: "VM with empty CD ROM"
+        cluster:
+          name: "{{ cluster.name }}"
+        categories:
+          Environment:
+            - Production
+        disks:
+          - type: "CDROM"
+            bus: "IDE"
+            empty_cdrom: true
+      register: result
+
+    - name: Update VM by cloning image into CD ROM
+      nutanix.ncp.ntnx_vms:
+        vm_uuid: "{{ result.vm_uuid }}"
+        name: "VM with CD ROM updated"
+        disks:
+          - type: "CDROM"
+            uuid: "{{ result.response.spec.resources.disk_list[0].uuid }}"
+            clone_image:
+              name: "{{ iso_image_name }}"
+      register: result

--- a/examples/vm_update_cdrom.yml
+++ b/examples/vm_update_cdrom.yml
@@ -12,8 +12,9 @@
   tasks:
     - name: Setting Variables
       ansible.builtin.set_fact:
-        vm_uuid: ""
-        disk_uuid: ""
+        cluster:
+          name: "auto_cluster_prod_f660be0f6925"
+        iso_image_name: "Nutanix-VirtIO"
 
     - name: Create VM with empty CD ROM
       nutanix.ncp.ntnx_vms:

--- a/plugins/module_utils/v3/prism/vms.py
+++ b/plugins/module_utils/v3/prism/vms.py
@@ -497,7 +497,8 @@ class VM(Prism):
                 if error:
                     return None, error
 
-                disk["data_source_reference"]["uuid"] = uuid
+                disk.setdefault("data_source_reference", {})["uuid"] = uuid
+                disk.setdefault("data_source_reference", {})["kind"] = "image"
 
         if (
             not disk.get("storage_config", {})

--- a/tests/integration/targets/nutanix_vms/tasks/vm_update.yml
+++ b/tests/integration/targets/nutanix_vms/tasks/vm_update.yml
@@ -347,9 +347,9 @@
 
 - name: Get UUID of CDROM
   ansible.builtin.set_fact:
-    cdrom_uuid: "{{ result.response.spec.resources.disk_list | json_query(query) }}"
+    cdrom_uuid: "{{ result.response.spec.resources.disk_list | json_query(cdrom_query) }}"
   vars:
-    query: "[?device_properties.device_type == 'CDROM'].uuid"
+    cdrom_query: "[?device_properties.device_type == 'CDROM'].uuid"
   ignore_errors: true
   register: result
 

--- a/tests/integration/targets/nutanix_vms/tasks/vm_update.yml
+++ b/tests/integration/targets/nutanix_vms/tasks/vm_update.yml
@@ -351,11 +351,13 @@
   vars:
     query: "[?device_properties.device_type == 'CDROM'].uuid"
   ignore_errors: true
+  register: result
 
 - name: Get number of disks attached to VM
   ansible.builtin.set_fact:
     disk_count: "{{ result.response.spec.resources.disk_list | length }}"
   ignore_errors: true
+  register: result
 
 - name: Update VM by cloning image into CD ROM
   ntnx_vms:

--- a/tests/integration/targets/nutanix_vms/tasks/vm_update.yml
+++ b/tests/integration/targets/nutanix_vms/tasks/vm_update.yml
@@ -351,13 +351,11 @@
   vars:
     cdrom_query: "[?device_properties.device_type == 'CDROM'].uuid"
   ignore_errors: true
-  register: result
 
 - name: Get number of disks attached to VM
   ansible.builtin.set_fact:
     disk_count: "{{ result.response.spec.resources.disk_list | length }}"
   ignore_errors: true
-  register: result
 
 - name: Update VM by cloning image into CD ROM
   ntnx_vms:

--- a/tests/integration/targets/nutanix_vms/tasks/vm_update.yml
+++ b/tests/integration/targets/nutanix_vms/tasks/vm_update.yml
@@ -23,8 +23,8 @@
       - result.response.status.state == 'COMPLETE'
       - result.vm_uuid
       - result.task_uuid
-    fail_msg: " Unable to create VM with minimum requiremnts "
-    success_msg: " VM with minimum requiremnts created successfully "
+    fail_msg: " Unable to create VM with minimum requirements "
+    success_msg: " VM with minimum requirements created successfully "
 ####################################################################
 - name: Update vm by set owner by uuid
   ntnx_vms:
@@ -299,7 +299,7 @@
       - result.response.status.state == "COMPLETE"
     fail_msg: " Unable to update vm by removing PCI disks with force_power_off "
     success_msg: " VM updated successfully by removing PCI disks with force_power_off "
-##### CRUD opperation for IDE disks
+##### CRUD operation for IDE disks
 - name: Update VM by adding  IDE disks with force_power_off
   ntnx_vms:
     vm_uuid: "{{ result.vm_uuid }}"
@@ -344,6 +344,52 @@
       - result.response.status.state == "COMPLETE"
     fail_msg: " Unable to update vm by increasing the size of the IDE  disks with force_power_off "
     success_msg: " VM updated successfully by increasing the size of the IDE  disks with force_power_off "
+
+- name: Get UUID of CDROM
+  ansible.builtin.set_fact:
+    cdrom_uuid: "{{ result.response.spec.resources.disk_list | json_query(query) }}"
+  vars:
+    query: "[?device_properties.device_type == 'CDROM'].uuid"
+  ignore_errors: true
+
+- name: Get number of disks attached to VM
+  ansible.builtin.set_fact:
+    disk_count: "{{ result.response.spec.resources.disk_list | length }}"
+  ignore_errors: true
+
+- name: Update VM by cloning image into CD ROM
+  ntnx_vms:
+    vm_uuid: "{{ result.vm_uuid }}"
+    disks:
+      - type: "CDROM"
+        uuid: "{{ cdrom_uuid[0] }}"
+        clone_image:
+          name: "{{ centos }}"
+  register: result
+  ignore_errors: true
+
+- name: Get index of CDROM
+  ansible.builtin.set_fact:
+    item_index: "{{ index }}"
+  loop: "{{ result.response.spec.resources.disk_list }}"
+  loop_control:
+    index_var: index
+  when: item.uuid == cdrom_uuid[0]
+  no_log: true
+
+- name: Update Status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.vm_uuid
+      - result.task_uuid
+      - result.response.spec.resources.disk_list[item_index].device_properties.device_type == "CDROM"
+      - result.response.spec.resources.disk_list[item_index].data_source_reference.kind == "image"
+      - result.response.spec.resources.disk_list[item_index].data_source_reference.uuid is defined
+      - result.response.spec.resources.disk_list | length == {{ disk_count }}
+      - result.response.status.state == "COMPLETE"
+    fail_msg: " Unable to update vm by cloning image into CD ROM "
+    success_msg: " VM updated successfully by cloning image into CD ROM"
 
 - name: Update VM by removing IDE disks with force_power_off
   ntnx_vms:

--- a/tests/integration/targets/nutanix_vms/tasks/vm_update.yml
+++ b/tests/integration/targets/nutanix_vms/tasks/vm_update.yml
@@ -351,11 +351,13 @@
   vars:
     cdrom_query: "[?device_properties.device_type == 'CDROM'].uuid"
   ignore_errors: true
+  register: result1
 
 - name: Get number of disks attached to VM
   ansible.builtin.set_fact:
     disk_count: "{{ result.response.spec.resources.disk_list | length }}"
   ignore_errors: true
+  register: result2
 
 - name: Update VM by cloning image into CD ROM
   ntnx_vms:


### PR DESCRIPTION
* Adding fix for updating empty CD ROM with clone image attribute

* Adding example and test for updating VM with cloning image into CD ROM

* refactoring examples

* Creating seperate example file for updating empty CD ROM Moving update empty CD ROM test to CRUD operation for IDE disks section

* minor lint fix

* resolving comments

* Adding disk count assertion to assert that number of disks does not change when updating empty CD ROM

* Cherry-picked from https://github.com/nutanix/nutanix.ansible/pull/505 to apply the same changes to the main branch.