### PR TITLE
issue#481 fix invalid dn check for OU vs group or user (#482)

### DIFF
--- a/plugins/module_utils/v3/prism/user_groups.py
+++ b/plugins/module_utils/v3/prism/user_groups.py
@@ -43,7 +43,7 @@ class UserGroup(Prism):
         return payload, None
 
     def _build_spec_user_distinguished_name(self, payload, config):
-        if "ou=" in config:
+        if config[0:3] == "ou=":
             payload["spec"]["resources"]["directory_service_ou"] = {
                 "distinguished_name": config
             }

--- a/plugins/modules/ntnx_protection_rules.py
+++ b/plugins/modules/ntnx_protection_rules.py
@@ -678,6 +678,10 @@ def check_rule_idempotency(rule_spec, update_spec):
         ):
             return False
 
+    #check if start_time has been updated
+    if rule_spec["spec"]["resources"].get("start_time") != update_spec["spec"]["resources"].get("start_time"):
+        return False
+  
     return True
 
 


### PR DESCRIPTION
* change config check to start with ou= for OU

groups don't start with ou= but may be within an OU so would contain ou= in the string. This change makes it so groups don't have to be in the root of the AD.

* Update ntnx_protection_rules.py with start_time check in idempotency check

* update to use get function of dict in case start_time is undefined