### PR TITLE
Adding imprv where user can group VMs by project name to main branch

### DIFF
--- a/plugins/inventory/ntnx_prism_vm_inventory.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory.py
@@ -235,6 +235,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 for key, value in host_vars.items():
                     self.inventory.set_variable(vm_name, key, value)
 
+            self.inventory.set_variable(
+                vm_name,
+                "project_reference",
+                entity.get("metadata", {}).get("project_reference", {}),
+            )
+
+            # Add variables created by the user's Jinja2 expressions to the host
             self._set_composite_vars(
                 self.get_option("compose"),
                 host_vars,


### PR DESCRIPTION
Cherry-picked from [Adding imprv where user can group VMs by project name](https://github.com/nutanix/nutanix.ansible/pull/511) to apply the same changes to the main branch.