### PR TITLE
Adding new parameter fetch_all_vms to inventory plugin - Imprv#651

### DIFF
--- a/plugins/inventory/ntnx_prism_vm_inventory.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory.py
@@ -50,6 +50,11 @@ DOCUMENTATION = r"""
             type: str
             env:
                 - name: NUTANIX_PORT
+        fetch_all_vms:
+            description:
+                - Set to C(True) to fetch all VMs
+                - Set to C(False) to fetch specified number of VMs based on offset and length
+                - If set to C(True), offset and length will be ignored
         data:
             description:
                 - Pagination support for listing VMs
@@ -85,7 +90,9 @@ from ..module_utils.v3.prism import vms  # noqa: E402
 
 
 class Mock_Module:
-    def __init__(self, host, port, username, password, validate_certs=False):
+    def __init__(
+        self, host, port, username, password, validate_certs=False, fetch_all_vms=False
+    ):
         self.tmpdir = tempfile.gettempdir()
         self.params = {
             "nutanix_host": host,
@@ -93,6 +100,7 @@ class Mock_Module:
             "nutanix_username": username,
             "nutanix_password": password,
             "validate_certs": validate_certs,
+            "fetch_all_vms": fetch_all_vms,
             "load_params_without_defaults": False,
         }
 
@@ -196,6 +204,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self.nutanix_port = self.get_option("nutanix_port")
         self.data = self.get_option("data")
         self.validate_certs = self.get_option("validate_certs")
+        self.fetch_all_vms = self.get_option("fetch_all_vms")
         # Determines if composed variables or groups using nonexistent variables is an error
         strict = self.get_option("strict")
         host_filters = self.get_option("filters")
@@ -206,11 +215,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.nutanix_username,
             self.nutanix_password,
             self.validate_certs,
+            self.fetch_all_vms,
         )
         vm = vms.VM(module)
         self.data["offset"] = self.data.get("offset", 0)
-        resp = vm.list(self.data)
-
+        resp = vm.list(data=self.data, fetch_all_vms=self.fetch_all_vms)
         for entity in resp.get("entities", []):
             host_vars = self._build_host_vars(entity)
 

--- a/plugins/module_utils/v3/prism/vms.py
+++ b/plugins/module_utils/v3/prism/vms.py
@@ -56,14 +56,18 @@ class VM(Prism):
         no_response=False,
         timeout=30,
         max_length=500,
+        fetch_all_vms=False,
     ):
-        if data.get("length", 0) > max_length:
+        if fetch_all_vms or data.get("length", 0) > max_length:
             spec = deepcopy(data)
             resp = {"entities": []}
             total_matches = None
             total_length = spec["length"]
             spec["length"] = max_length
             spec["offset"] = spec.get("offset", 0)
+            if fetch_all_vms:
+                sub_resp = super(VM, self).list(spec)
+                total_length = sub_resp["metadata"].get("total_matches")
             while True:
                 sub_resp = super(VM, self).list(spec)
                 resp["entities"].extend(sub_resp["entities"])


### PR DESCRIPTION
- This PR enhances the inventory plugin by adding support for retrieving all VMs without requiring the user to manually specify the length parameter.
- The new parameter is fetch_all_vms
- Set it to True to fetch all VMs
- Set it to False to fetch specified number of VMs based on offset and length
- If set to True, offset and length will be ignored