### PR TITLE
[Bug] fix(ntnx_subnets_v2): only run remove_empty_ip_config if ip_config isn’t empty

### DIFF
--- a/plugins/modules/ntnx_subnets_v2.py
+++ b/plugins/modules/ntnx_subnets_v2.py
@@ -755,7 +755,8 @@ def update_subnet(module, result):
     result["ext_id"] = ext_id
     subnets = get_subnet_api_instance(module)
     current_spec = get_subnet(module, subnets, ext_id=ext_id)
-    remove_empty_ip_config(current_spec)
+    if current_spec.to_dict()['ip_config'] is not None:
+        remove_empty_ip_config(current_spec)
 
     sg = SpecGenerator(module)
     update_spec, err = sg.generate_spec(obj=deepcopy(current_spec))


### PR DESCRIPTION
## Summary:
On update_subnet() in ntnx_subnets_v2.py, previously remove_empty_ip_config(current_spec) was always invoked—even when current_spec.ip_config was None, which triggers errors when subnet does not IPAM features enabled. This commit ensures we only perform this clean‑up when ip_config actually exists.

## Changes
- Wrapped the call to remove_empty_ip_config(current_spec) in an if current_spec.to_dict()['ip_config'] is not None: guard.
- Removed the unconditional call from the previous implementation.
- No new logic added beyond safety check, so behavior should remain identical in valid cases.
