### PR TITLE
[FIX] Data type mismatch between module spec and V4 API SDK spec

### DIFF
--- a/plugins/module_utils/v4/clusters_mgmt/spec/clusters.py
+++ b/plugins/module_utils/v4/clusters_mgmt/spec/clusters.py
@@ -252,7 +252,7 @@ class ClusterSpecs:
             obj=clusters_sdk.ClusterNetworkReference,
         ),
         container_name=dict(type="str"),
-        categories=dict(type="dict"),
+        categories=dict(type="list", elements="str"),
     )
 
     @classmethod

--- a/plugins/modules/ntnx_clusters_v2.py
+++ b/plugins/modules/ntnx_clusters_v2.py
@@ -742,7 +742,7 @@ options:
   categories:
     description:
       - The categories of the cluster.
-    type: dict
+    type: list
   container_name:
     description:
       - The name of the container.


### PR DESCRIPTION
This PR fixes #759 

Changes:

- Changed data type of categories attribute inside `cluster_mgmt` spec to match with the one expected by the V4 API spec