### PR TITLE
Dev, Tests, Examples and Docs for Certificate Authentication Providers

### DIFF
--- a/examples/iam_v2/certificate_auth_providers_v2.yml
+++ b/examples/iam_v2/certificate_auth_providers_v2.yml
@@ -2,10 +2,10 @@
 # Summary:
 # This playbook will do:
 # 1. Create certificate authentication provider with CAC enabled
-# 3. Update certificate authentication provider
-# 4. List all certificate authentication providers
-# 5. Get specific certificate authentication provider
-# 7. Delete created certificate authentication providers
+# 2. Update certificate authentication provider
+# 3. List all certificate authentication providers
+# 4. Get specific certificate authentication provider
+# 5. Delete created certificate authentication providers
 
 - name: Certificate Authentication Providers playbook
   hosts: localhost
@@ -27,7 +27,7 @@
         ca_cert_file_name: "test_ca_chain.pem"
         directory_service_ext_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
-    - name: Create certificate auth provider with CAC enabled
+    - name: Create certificate authentication provider with CAC enabled
       nutanix.ncp.ntnx_certificate_auth_providers_v2:
         state: present
         name: "CAC"
@@ -39,11 +39,11 @@
       register: result_cac
       ignore_errors: true
 
-    - name: Set cert auth provider ext_id for CAC
+    - name: Set cert authentication provider ext_id for CAC
       ansible.builtin.set_fact:
         cert_auth_ext_id_cac: "{{ result_cac.ext_id }}"
 
-    - name: Update certificate auth provider
+    - name: Update certificate authentication provider
       nutanix.ncp.ntnx_certificate_auth_providers_v2:
         state: present
         ext_id: "{{ cert_auth_ext_id_cac }}"
@@ -51,18 +51,18 @@
       register: result
       ignore_errors: true
 
-    - name: List all certificate auth providers (returns list containing only one certificate auth provider)
+    - name: List all certificate authentication providers (returns list containing only one certificate authentication provider)
       nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
       register: result
       ignore_errors: true
 
-    - name: Get specific certificate auth provider
+    - name: Get specific certificate authentication provider
       nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
         ext_id: "{{ cert_auth_ext_id_cac }}"
       register: result
       ignore_errors: true
 
-    - name: Delete certificate auth provider
+    - name: Delete certificate authentication provider
       nutanix.ncp.ntnx_certificate_auth_providers_v2:
         state: absent
         ext_id: "{{ cert_auth_ext_id_cac }}"

--- a/examples/iam_v2/certificate_auth_providers_v2.yml
+++ b/examples/iam_v2/certificate_auth_providers_v2.yml
@@ -1,0 +1,70 @@
+---
+# Summary:
+# This playbook will do:
+# 1. Create certificate authentication provider with CAC enabled
+# 3. Update certificate authentication provider
+# 4. List all certificate authentication providers
+# 5. Get specific certificate authentication provider
+# 7. Delete created certificate authentication providers
+
+- name: Certificate Authentication Providers playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        ca_chain_content: |
+          -----BEGIN CERTIFICATE-----
+          MIIDXTCCAkWgAwIBAgIJAJC1HiIAZAiUMA0GCSqGSIb3Qa2sdfasdfasdfsadfsd
+          ... (certificate content) ...
+          -----END CERTIFICATE-----
+        ca_cert_file_name: "test_ca_chain.pem"
+        directory_service_ext_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+    - name: Create certificate auth provider with CAC enabled
+      nutanix.ncp.ntnx_certificate_auth_providers_v2:
+        state: present
+        name: "CAC"
+        client_ca_chain: "{{ ca_chain_content }}"
+        ca_cert_file_name: "{{ ca_cert_file_name }}"
+        is_cert_auth_enabled: true
+        is_cac_enabled: true
+        dir_svc_ext_id: "{{ directory_service_ext_id }}"
+      register: result_cac
+      ignore_errors: true
+
+    - name: Set cert auth provider ext_id for CAC
+      ansible.builtin.set_fact:
+        cert_auth_ext_id_cac: "{{ result_cac.ext_id }}"
+
+    - name: Update certificate auth provider
+      nutanix.ncp.ntnx_certificate_auth_providers_v2:
+        state: present
+        ext_id: "{{ cert_auth_ext_id_cac }}"
+        is_cac_enabled: false
+      register: result
+      ignore_errors: true
+
+    - name: List all certificate auth providers (returns list containing only one certificate auth provider)
+      nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
+      register: result
+      ignore_errors: true
+
+    - name: Get specific certificate auth provider
+      nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
+        ext_id: "{{ cert_auth_ext_id_cac }}"
+      register: result
+      ignore_errors: true
+
+    - name: Delete certificate auth provider
+      nutanix.ncp.ntnx_certificate_auth_providers_v2:
+        state: absent
+        ext_id: "{{ cert_auth_ext_id_cac }}"
+      register: result
+      ignore_errors: true

--- a/examples/iam_v2/certificate_auth_providers_v2.yml
+++ b/examples/iam_v2/certificate_auth_providers_v2.yml
@@ -5,9 +5,9 @@
 # 2. Update certificate authentication provider
 # 3. List all certificate authentication providers
 # 4. Get specific certificate authentication provider
-# 5. Delete created certificate authentication providers
+# 5. Delete created certificate authentication provider
 
-- name: Certificate Authentication Providers playbook
+- name: Certificate Authentication Provider playbook
   hosts: localhost
   gather_facts: false
   module_defaults:
@@ -28,7 +28,7 @@
         directory_service_ext_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
     - name: Create certificate authentication provider with CAC enabled
-      nutanix.ncp.ntnx_certificate_auth_providers_v2:
+      nutanix.ncp.ntnx_certificate_auth_provider_v2:
         state: present
         name: "CAC"
         client_ca_chain: "{{ ca_chain_content }}"
@@ -44,7 +44,7 @@
         cert_auth_ext_id_cac: "{{ result_cac.ext_id }}"
 
     - name: Update certificate authentication provider
-      nutanix.ncp.ntnx_certificate_auth_providers_v2:
+      nutanix.ncp.ntnx_certificate_auth_provider_v2:
         state: present
         ext_id: "{{ cert_auth_ext_id_cac }}"
         is_cac_enabled: false
@@ -56,6 +56,13 @@
       register: result
       ignore_errors: true
 
+    - name: List all certificate authentication providers with page and limit
+      nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
+        page: 0
+        limit: 1
+      register: result
+      ignore_errors: true
+
     - name: Get specific certificate authentication provider
       nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
         ext_id: "{{ cert_auth_ext_id_cac }}"
@@ -63,7 +70,7 @@
       ignore_errors: true
 
     - name: Delete certificate authentication provider
-      nutanix.ncp.ntnx_certificate_auth_providers_v2:
+      nutanix.ncp.ntnx_certificate_auth_provider_v2:
         state: absent
         ext_id: "{{ cert_auth_ext_id_cac }}"
       register: result

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -240,5 +240,5 @@ action_groups:
     - ntnx_clusters_profile_association_v2
     - ntnx_eula_accept_v2
     - ntnx_eula_info_v2
-    - ntnx_certificate_auth_providers_v2
+    - ntnx_certificate_auth_provider_v2
     - ntnx_certificate_auth_providers_info_v2

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -240,3 +240,5 @@ action_groups:
     - ntnx_clusters_profile_association_v2
     - ntnx_eula_accept_v2
     - ntnx_eula_info_v2
+    - ntnx_certificate_auth_providers_v2
+    - ntnx_certificate_auth_providers_info_v2

--- a/plugins/module_utils/v4/iam/api_client.py
+++ b/plugins/module_utils/v4/iam/api_client.py
@@ -145,3 +145,17 @@ def get_identity_provider_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_iam_py_client.SAMLIdentityProvidersApi(api_client=api_client)
+
+
+def get_certificate_auth_provider_api_instance(module):
+    """
+    This method will return CertAuthProvidersApi instance.
+    Args:
+        module (object): Ansible module object
+    Returns:
+        api_instance (object): Certificate auth provider api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_iam_py_client.CertificateAuthenticationProvidersApi(
+        api_client=api_client
+    )

--- a/plugins/module_utils/v4/iam/api_client.py
+++ b/plugins/module_utils/v4/iam/api_client.py
@@ -156,7 +156,7 @@ def get_certificate_auth_provider_api_instance(module):
     Args:
         module (object): Ansible module object
     Returns:
-        api_instance (object): Certificate auth provider api instance
+        api_instance (object): Certificate authentication provider api instance
     """
     api_client = get_api_client(module)
     return ntnx_iam_py_client.CertificateAuthenticationProvidersApi(

--- a/plugins/module_utils/v4/iam/helpers.py
+++ b/plugins/module_utils/v4/iam/helpers.py
@@ -223,13 +223,13 @@ def get_requested_key(module, api_instance, ext_id, user_ext_id):
 
 def get_certificate_auth_provider(module, api_instance, ext_id):
     """
-    This method will return certificate auth provider info using ext_id.
+    This method will return certificate authentication provider info using ext_id.
     Args:
         module (object): Ansible module object
         api_instance (object): CertAuthProvidersApi instance from ntnx_iam_py_client sdk
-        ext_id (str): External id of certificate auth provider
+        ext_id (str): External id of certificate authentication provider
     Returns:
-        cert_auth_provider_info (obj): Certificate auth provider info object
+        cert_auth_provider_info (obj): Certificate authentication provider info object
     """
     try:
         return api_instance.get_cert_auth_provider_by_id(extId=ext_id).data
@@ -237,5 +237,5 @@ def get_certificate_auth_provider(module, api_instance, ext_id):
         raise_api_exception(
             module=module,
             exception=e,
-            msg="Api Exception raised while fetching certificate auth provider info",
+            msg="Api Exception raised while fetching certificate authentication provider info",
         )

--- a/plugins/module_utils/v4/iam/helpers.py
+++ b/plugins/module_utils/v4/iam/helpers.py
@@ -8,58 +8,6 @@ __metaclass__ = type
 from ..utils import raise_api_exception  # noqa: E402
 
 
-def snake_to_camel(snake_str, special_cases=None):
-    """
-    Convert snake_case string to camelCase.
-
-    Args:
-        snake_str: The snake_case string to convert
-        special_cases: Optional dict mapping snake_case keys to their camelCase equivalents
-                      for cases where standard conversion doesn't apply
-                      (e.g., {'dir_svc_ext_id': 'dirSvcExtID'} for uppercase acronyms)
-
-    Returns:
-        str: The camelCase version of the input string
-    """
-    if special_cases and snake_str in special_cases:
-        return special_cases[snake_str]
-
-    # Standard snake_case to camelCase conversion
-    components = snake_str.split("_")
-    return components[0] + "".join(x.title() for x in components[1:])
-
-
-def get_api_params_from_spec(
-    spec, module_spec, exclude_params=None, special_cases=None
-):
-    """
-    Get parameters from a spec object converted to camelCase for API calls.
-    Dynamically extracts all parameters from the provided module_spec.
-    Only includes parameters that are not None.
-
-    Args:
-        spec: SDK spec object with snake_case attributes
-        module_spec: Dictionary of module argument spec (from get_module_spec())
-        exclude_params: List of parameter names to exclude (e.g., ['ext_id'])
-        special_cases: Dict mapping snake_case keys to camelCase for special conversions
-
-    Returns:
-        dict: Dictionary with camelCase keys and their values
-    """
-    if exclude_params is None:
-        exclude_params = []
-
-    api_params = {}
-    for param in module_spec.keys():
-        if param in exclude_params:
-            continue
-        value = getattr(spec, param, None)
-        if value is not None:
-            camel_key = snake_to_camel(param, special_cases)
-            api_params[camel_key] = value
-    return api_params
-
-
 def get_authorization_policy(module, api_instance, ext_id):
     """
     This method will return authorization policy info using ext_id.

--- a/plugins/module_utils/v4/utils.py
+++ b/plugins/module_utils/v4/utils.py
@@ -159,3 +159,55 @@ def remove_fields_from_spec(obj, fields_to_remove, deep=False):
         if deep:
             for item in obj:
                 remove_fields_from_spec(item, fields_to_remove, deep=True)
+
+
+def snake_to_camel(snake_str, special_cases=None):
+    """
+    Convert snake_case string to camelCase.
+
+    Args:
+        snake_str: The snake_case string to convert
+        special_cases: Optional dict mapping snake_case keys to their camelCase equivalents
+                      for cases where standard conversion doesn't apply
+                      (e.g., {'dir_svc_ext_id': 'dirSvcExtID'} for uppercase acronyms)
+
+    Returns:
+        str: The camelCase version of the input string
+    """
+    if special_cases and snake_str in special_cases:
+        return special_cases[snake_str]
+
+    # Standard snake_case to camelCase conversion
+    components = snake_str.split("_")
+    return components[0] + "".join(x.title() for x in components[1:])
+
+
+def get_api_params_from_spec(
+    spec, module_spec, exclude_params=None, special_cases=None
+):
+    """
+    Get parameters from a spec object converted to camelCase for API calls.
+    Dynamically extracts all parameters from the provided module_spec.
+    Only includes parameters that are not None.
+
+    Args:
+        spec: SDK spec object with snake_case attributes
+        module_spec: Dictionary of module argument spec (from get_module_spec())
+        exclude_params: List of parameter names to exclude (e.g., ['ext_id'])
+        special_cases: Dict mapping snake_case keys to camelCase for special conversions
+
+    Returns:
+        dict: Dictionary with camelCase keys and their values
+    """
+    if exclude_params is None:
+        exclude_params = []
+
+    api_params = {}
+    for param in module_spec.keys():
+        if param in exclude_params:
+            continue
+        value = getattr(spec, param, None)
+        if value is not None:
+            camel_key = snake_to_camel(param, special_cases)
+            api_params[camel_key] = value
+    return api_params

--- a/plugins/modules/ntnx_certificate_auth_provider_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_provider_v2.py
@@ -204,9 +204,8 @@ from ..module_utils.v4.iam.api_client import (  # noqa: E402
     get_etag,
 )
 from ..module_utils.v4.iam.helpers import get_certificate_auth_provider  # noqa: E402
-from ..module_utils.v4.utils import get_api_params_from_spec  # noqa: E402
-
 from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import get_api_params_from_spec  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402
     raise_api_exception,
     strip_internal_attributes,

--- a/plugins/modules/ntnx_certificate_auth_provider_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_provider_v2.py
@@ -256,10 +256,8 @@ def create_certificate_auth_provider(module, api_instance, result):
 
     if err:
         result["error"] = err
-        module.fail_json(
-            msg="Failed generating create certificate authentication provider spec",
-            **result,
-        )
+        result["msg"] = "Failed generating create certificate authentication provider spec"
+        module.fail_json(**result)
 
     if module.check_mode:
         result["response"] = strip_internal_attributes(spec.to_dict())
@@ -303,10 +301,8 @@ def update_certificate_auth_provider(module, api_instance, result):
 
     etag = get_etag(data=current_spec)
     if not etag:
-        return module.fail_json(
-            "Unable to fetch etag for updating certificate authentication provider",
-            **result,
-        )
+        result["msg"] = "Unable to fetch etag for updating certificate authentication provider"
+        module.fail_json(**result)
 
     kwargs = {"if_match": etag}
 
@@ -315,10 +311,8 @@ def update_certificate_auth_provider(module, api_instance, result):
 
     if err:
         result["error"] = err
-        module.fail_json(
-            msg="Failed generating certificate authentication provider update spec",
-            **result,
-        )
+        result["msg"] = "Failed generating certificate authentication provider update spec"
+        module.fail_json(**result)
 
     if module.check_mode:
         result["response"] = strip_internal_attributes(update_spec.to_dict())
@@ -371,10 +365,8 @@ def delete_certificate_auth_provider(module, api_instance, result):
 
     etag = get_etag(data=current_spec)
     if not etag:
-        return module.fail_json(
-            "Unable to fetch etag for deleting certificate authentication provider",
-            **result,
-        )
+        result["msg"] = "Unable to fetch etag for deleting certificate authentication provider"
+        module.fail_json(**result)
 
     kwargs = {"if_match": etag}
 

--- a/plugins/modules/ntnx_certificate_auth_provider_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_provider_v2.py
@@ -256,10 +256,8 @@ def create_certificate_auth_provider(module, api_instance, result):
 
     if err:
         result["error"] = err
-        result[
-            "msg"
-        ] = "Failed generating create certificate authentication provider spec"
-        module.fail_json(**result)
+        msg = "Failed generating create certificate authentication provider spec"
+        module.fail_json(msg, **result)
 
     if module.check_mode:
         result["response"] = strip_internal_attributes(spec.to_dict())
@@ -303,10 +301,8 @@ def update_certificate_auth_provider(module, api_instance, result):
 
     etag = get_etag(data=current_spec)
     if not etag:
-        result[
-            "msg"
-        ] = "Unable to fetch etag for updating certificate authentication provider"
-        module.fail_json(**result)
+        msg = "Unable to fetch etag for updating certificate authentication provider"
+        module.fail_json(msg, **result)
 
     kwargs = {"if_match": etag}
 
@@ -315,10 +311,8 @@ def update_certificate_auth_provider(module, api_instance, result):
 
     if err:
         result["error"] = err
-        result[
-            "msg"
-        ] = "Failed generating certificate authentication provider update spec"
-        module.fail_json(**result)
+        msg = "Failed generating certificate authentication provider update spec"
+        module.fail_json(msg, **result)
 
     if module.check_mode:
         result["response"] = strip_internal_attributes(update_spec.to_dict())
@@ -360,10 +354,10 @@ def delete_certificate_auth_provider(module, api_instance, result):
     result["ext_id"] = ext_id
 
     if module.check_mode:
-        result[
-            "msg"
-        ] = "Certificate authentication provider with ext_id:{0} will be deleted.".format(
-            ext_id
+        result["msg"] = (
+            "Certificate authentication provider with ext_id:{0} will be deleted.".format(
+                ext_id
+            )
         )
         return
 
@@ -371,10 +365,8 @@ def delete_certificate_auth_provider(module, api_instance, result):
 
     etag = get_etag(data=current_spec)
     if not etag:
-        result[
-            "msg"
-        ] = "Unable to fetch etag for deleting certificate authentication provider"
-        module.fail_json(**result)
+        msg = "Unable to fetch etag for deleting certificate authentication provider"
+        module.fail_json(msg, **result)
 
     kwargs = {"if_match": etag}
 
@@ -390,10 +382,10 @@ def delete_certificate_auth_provider(module, api_instance, result):
     # Delete API may return None or empty response
     result["changed"] = True
     if resp is None:
-        result[
-            "msg"
-        ] = "Certificate authentication provider with ext_id: {} deleted successfully".format(
-            ext_id
+        result["msg"] = (
+            "Certificate authentication provider with ext_id: {} deleted successfully".format(
+                ext_id
+            )
         )
     else:
         result["response"] = strip_internal_attributes(resp.to_dict())

--- a/plugins/modules/ntnx_certificate_auth_provider_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_provider_v2.py
@@ -205,8 +205,9 @@ from ..module_utils.v4.iam.api_client import (  # noqa: E402
 )
 from ..module_utils.v4.iam.helpers import get_certificate_auth_provider  # noqa: E402
 from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
-from ..module_utils.v4.utils import get_api_params_from_spec  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402
+    get_api_params_from_spec,
+    validate_required_params,
     raise_api_exception,
     strip_internal_attributes,
 )
@@ -250,6 +251,17 @@ CAMEL_CASE_SPECIAL_CASES = {
 
 
 def create_certificate_auth_provider(module, api_instance, result):
+    validate_required_params(
+        module,
+        [
+            "name",
+            "client_ca_chain",
+            "ca_cert_file_name",
+            "is_cert_auth_enabled",
+            "is_cac_enabled",
+            "dir_svc_ext_id",
+        ],
+    )
     sg = SpecGenerator(module)
     default_spec = iam_sdk.CertAuthProvider()
     spec, err = sg.generate_spec(obj=default_spec)

--- a/plugins/modules/ntnx_certificate_auth_provider_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_provider_v2.py
@@ -207,9 +207,9 @@ from ..module_utils.v4.iam.helpers import get_certificate_auth_provider  # noqa:
 from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402
     get_api_params_from_spec,
-    validate_required_params,
     raise_api_exception,
     strip_internal_attributes,
+    validate_required_params,
 )
 
 SDK_IMP_ERROR = None

--- a/plugins/modules/ntnx_certificate_auth_provider_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_provider_v2.py
@@ -256,7 +256,9 @@ def create_certificate_auth_provider(module, api_instance, result):
 
     if err:
         result["error"] = err
-        result["msg"] = "Failed generating create certificate authentication provider spec"
+        result[
+            "msg"
+        ] = "Failed generating create certificate authentication provider spec"
         module.fail_json(**result)
 
     if module.check_mode:
@@ -301,7 +303,9 @@ def update_certificate_auth_provider(module, api_instance, result):
 
     etag = get_etag(data=current_spec)
     if not etag:
-        result["msg"] = "Unable to fetch etag for updating certificate authentication provider"
+        result[
+            "msg"
+        ] = "Unable to fetch etag for updating certificate authentication provider"
         module.fail_json(**result)
 
     kwargs = {"if_match": etag}
@@ -311,7 +315,9 @@ def update_certificate_auth_provider(module, api_instance, result):
 
     if err:
         result["error"] = err
-        result["msg"] = "Failed generating certificate authentication provider update spec"
+        result[
+            "msg"
+        ] = "Failed generating certificate authentication provider update spec"
         module.fail_json(**result)
 
     if module.check_mode:
@@ -354,10 +360,10 @@ def delete_certificate_auth_provider(module, api_instance, result):
     result["ext_id"] = ext_id
 
     if module.check_mode:
-        result["msg"] = (
-            "Certificate authentication provider with ext_id:{0} will be deleted.".format(
-                ext_id
-            )
+        result[
+            "msg"
+        ] = "Certificate authentication provider with ext_id:{0} will be deleted.".format(
+            ext_id
         )
         return
 
@@ -365,7 +371,9 @@ def delete_certificate_auth_provider(module, api_instance, result):
 
     etag = get_etag(data=current_spec)
     if not etag:
-        result["msg"] = "Unable to fetch etag for deleting certificate authentication provider"
+        result[
+            "msg"
+        ] = "Unable to fetch etag for deleting certificate authentication provider"
         module.fail_json(**result)
 
     kwargs = {"if_match": etag}
@@ -382,10 +390,10 @@ def delete_certificate_auth_provider(module, api_instance, result):
     # Delete API may return None or empty response
     result["changed"] = True
     if resp is None:
-        result["msg"] = (
-            "Certificate authentication provider with ext_id: {} deleted successfully".format(
-                ext_id
-            )
+        result[
+            "msg"
+        ] = "Certificate authentication provider with ext_id: {} deleted successfully".format(
+            ext_id
         )
     else:
         result["response"] = strip_internal_attributes(resp.to_dict())

--- a/plugins/modules/ntnx_certificate_auth_provider_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_provider_v2.py
@@ -10,12 +10,12 @@ __metaclass__ = type
 
 DOCUMENTATION = r"""
 ---
-module: ntnx_certificate_auth_providers_v2
-short_description: Manage certificate-based authentication providers in Nutanix Prism Central
+module: ntnx_certificate_auth_provider_v2
+short_description: Manage certificate-based authentication provider in Nutanix Prism Central
 version_added: "2.5.0"
 description:
-  - Create, Update, Delete certificate-based authentication providers in Nutanix Prism Central.
-  - Certificate Authentication Providers enable mutual TLS (mTLS) authentication.
+  - Create, Update, Delete certificate-based authentication provider in Nutanix Prism Central.
+  - Certificate Authentication Provider enable mutual TLS (mTLS) authentication.
   - Allows users to log in using a client certificate instead of username/password.
   - This module uses PC v4 APIs based SDKs.
 options:
@@ -89,7 +89,7 @@ author:
 
 EXAMPLES = r"""
 - name: Create certificate authentication provider with CAC enabled
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     nutanix_host: "{{ ip }}"
     nutanix_username: "{{ username }}"
     nutanix_password: "{{ password }}"
@@ -105,7 +105,7 @@ EXAMPLES = r"""
   ignore_errors: true
 
 - name: Update certificate authentication provider
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     nutanix_host: "{{ ip }}"
     nutanix_username: "{{ username }}"
     nutanix_password: "{{ password }}"
@@ -118,7 +118,7 @@ EXAMPLES = r"""
   ignore_errors: true
 
 - name: Delete certificate authentication provider
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     nutanix_host: "{{ ip }}"
     nutanix_username: "{{ username }}"
     nutanix_password: "{{ password }}"
@@ -203,10 +203,9 @@ from ..module_utils.v4.iam.api_client import (  # noqa: E402
     get_certificate_auth_provider_api_instance,
     get_etag,
 )
-from ..module_utils.v4.iam.helpers import (  # noqa: E402
-    get_api_params_from_spec,
-    get_certificate_auth_provider,
-)
+from ..module_utils.v4.iam.helpers import get_certificate_auth_provider  # noqa: E402
+from ..module_utils.v4.utils import get_api_params_from_spec  # noqa: E402
+
 from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402
     raise_api_exception,
@@ -259,7 +258,8 @@ def create_certificate_auth_provider(module, api_instance, result):
     if err:
         result["error"] = err
         module.fail_json(
-            msg="Failed generating create certificate authentication provider spec", **result
+            msg="Failed generating create certificate authentication provider spec",
+            **result,
         )
 
     if module.check_mode:
@@ -305,7 +305,8 @@ def update_certificate_auth_provider(module, api_instance, result):
     etag = get_etag(data=current_spec)
     if not etag:
         return module.fail_json(
-            "Unable to fetch etag for updating certificate authentication provider", **result
+            "Unable to fetch etag for updating certificate authentication provider",
+            **result,
         )
 
     kwargs = {"if_match": etag}
@@ -316,7 +317,8 @@ def update_certificate_auth_provider(module, api_instance, result):
     if err:
         result["error"] = err
         module.fail_json(
-            msg="Failed generating certificate authentication provider update spec", **result
+            msg="Failed generating certificate authentication provider update spec",
+            **result,
         )
 
     if module.check_mode:
@@ -360,7 +362,9 @@ def delete_certificate_auth_provider(module, api_instance, result):
 
     if module.check_mode:
         result["msg"] = (
-            "Certificate authentication provider with ext_id:{0} will be deleted.".format(ext_id)
+            "Certificate authentication provider with ext_id:{0} will be deleted.".format(
+                ext_id
+            )
         )
         return
 
@@ -369,7 +373,8 @@ def delete_certificate_auth_provider(module, api_instance, result):
     etag = get_etag(data=current_spec)
     if not etag:
         return module.fail_json(
-            "Unable to fetch etag for deleting certificate authentication provider", **result
+            "Unable to fetch etag for deleting certificate authentication provider",
+            **result,
         )
 
     kwargs = {"if_match": etag}

--- a/plugins/modules/ntnx_certificate_auth_providers_info_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_providers_info_v2.py
@@ -15,15 +15,15 @@ short_description: Fetch information about certificate-based authentication prov
 version_added: "2.5.0"
 description:
   - This module fetches information about Nutanix certificate-based authentication provider(s).
-  - Fetch specific certificate auth provider using external ID.
-  - Fetch list containing only one certificate auth provider if external ID is not provided.
+  - Fetch specific certificate authentication provider using external ID.
+  - Fetch list containing only one certificate authentication provider if external ID is not provided.
   - This module uses PC v4 APIs based SDKs.
 options:
   ext_id:
     description:
       - The external ID of the certificate authentication provider.
-      - If provided, returns single certificate auth provider.
-      - If not provided, returns list containing only one certificate auth provider.
+      - If provided, returns single certificate authentication provider.
+      - If not provided, returns list containing only one certificate authentication provider.
     type: str
     required: false
 author:
@@ -35,7 +35,7 @@ extends_documentation_fragment:
 """
 
 EXAMPLES = r"""
-- name: Get details of a specific certificate auth provider
+- name: Get details of a specific certificate authentication provider
   nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
     nutanix_host: "{{ ip }}"
     nutanix_username: "{{ username }}"
@@ -57,8 +57,8 @@ RETURN = r"""
 response:
   description:
     - The response for fetching certificate authentication provider(s).
-    - Single certificate auth provider if external ID is provided.
-    - List containing only one certificate auth provider if external ID is provided.
+    - Single certificate authentication provider if external ID is provided.
+    - List containing only one certificate authentication provider if external ID is provided.
   type: dict
   returned: always
   sample:
@@ -98,20 +98,20 @@ msg:
   description: This indicates the message if any message occurred.
   returned: When there is an error
   type: str
-  sample: "Api Exception raised while fetching certificate auth providers info"
+  sample: "Api Exception raised while fetching certificate authentication providers info"
 error:
   description: Error message if something goes wrong.
   type: str
   returned: always
 ext_id:
-  description: The external ID of the certificate auth provider that was fetched.
+  description: The external ID of the certificate authentication provider that was fetched.
   type: str
-  returned: when fetching a specific certificate auth provider
+  returned: when fetching a specific certificate authentication provider
   sample: "a3265671-de53-41be-af9b-f06241b95356"
 total_available_results:
-  description: The total number of available certificate auth providers in PC.
+  description: The total number of available certificate authentication providers in PC.
   type: int
-  returned: when all certificate auth providers are fetched
+  returned: when all certificate authentication providers are fetched
   sample: 5
 """
 
@@ -154,7 +154,7 @@ def get_certificate_auth_providers(module, api_instance, result):
     if err:
         result["error"] = err
         module.fail_json(
-            msg="Failed generating certificate auth providers info Spec", **result
+            msg="Failed generating certificate authentication providers info Spec", **result
         )
 
     try:
@@ -163,7 +163,7 @@ def get_certificate_auth_providers(module, api_instance, result):
         raise_api_exception(
             module=module,
             exception=e,
-            msg="Api Exception raised while fetching certificate auth providers info",
+            msg="Api Exception raised while fetching certificate authentication providers info",
         )
     total_available_results = resp.metadata.total_available_results
     result["total_available_results"] = total_available_results

--- a/plugins/modules/ntnx_certificate_auth_providers_info_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_providers_info_v2.py
@@ -172,10 +172,8 @@ def get_certificate_auth_providers(module, api_instance, result):
 
     if err:
         result["error"] = err
-        module.fail_json(
-            msg="Failed generating certificate authentication provider info Spec",
-            **result,
-        )
+        result["msg"] = "Failed generating certificate authentication provider info Spec"
+        module.fail_json(**result)
 
     try:
         resp = api_instance.list_cert_auth_providers(**kwargs)

--- a/plugins/modules/ntnx_certificate_auth_providers_info_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_providers_info_v2.py
@@ -172,10 +172,8 @@ def get_certificate_auth_providers(module, api_instance, result):
 
     if err:
         result["error"] = err
-        result[
-            "msg"
-        ] = "Failed generating certificate authentication provider info Spec"
-        module.fail_json(**result)
+        msg = "Failed generating certificate authentication provider info Spec"
+        module.fail_json(msg, **result)
 
     try:
         resp = api_instance.list_cert_auth_providers(**kwargs)

--- a/plugins/modules/ntnx_certificate_auth_providers_info_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_providers_info_v2.py
@@ -172,7 +172,9 @@ def get_certificate_auth_providers(module, api_instance, result):
 
     if err:
         result["error"] = err
-        result["msg"] = "Failed generating certificate authentication provider info Spec"
+        result[
+            "msg"
+        ] = "Failed generating certificate authentication provider info Spec"
         module.fail_json(**result)
 
     try:

--- a/plugins/modules/ntnx_certificate_auth_providers_info_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_providers_info_v2.py
@@ -1,0 +1,197 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_certificate_auth_providers_info_v2
+short_description: Fetch information about certificate-based authentication provider(s)
+version_added: "2.5.0"
+description:
+  - This module fetches information about Nutanix certificate-based authentication provider(s).
+  - Fetch specific certificate auth provider using external ID.
+  - Fetch list containing only one certificate auth provider if external ID is not provided.
+  - This module uses PC v4 APIs based SDKs.
+options:
+  ext_id:
+    description:
+      - The external ID of the certificate authentication provider.
+      - If provided, returns single certificate auth provider.
+      - If not provided, returns list containing only one certificate auth provider.
+    type: str
+    required: false
+author:
+  - George Ghawali (@george-ghawali)
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+"""
+
+EXAMPLES = r"""
+- name: Get details of a specific certificate auth provider
+  nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "a3265671-de53-41be-af9b-f06241b95356"
+  register: result
+
+- name: List all certificate authentication providers
+  nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response for fetching certificate authentication provider(s).
+    - Single certificate auth provider if external ID is provided.
+    - List containing only one certificate auth provider if external ID is provided.
+  type: dict
+  returned: always
+  sample:
+    {
+      "ca_cert_file_name": "ca_cert_chain.pem",
+      "cert_revocation_info": {
+          "crl_dps": null,
+          "global_crl_refresh_interval": 86400,
+          "is_crl_enabled": false,
+          "is_ocsp_enabled": true,
+          "ocsp_responder": ""
+      },
+      "client_ca_chain": "-----BEGIN CERTIFICATE-----\nMIIGuzCCBKOgIBAgICEAEwDQYDVEK0/s84n\n-----END CERTIFICATE-----\n",
+      "created_by": "00000000-0000-0000-0000-000000000000",
+      "created_time": null,
+      "dir_svc_ext_id": "6cd7a803-a0ae-5a23-92be-e7a27573b363",
+      "ext_id": "10c4bab1-2d88-540e-a602-92f723b44c73",
+      "is_cac_enabled": true,
+      "is_cert_auth_enabled": true,
+      "last_updated_time": null,
+      "links": null,
+      "name": "CAC",
+      "tenant_id": null
+    }
+
+changed:
+  description: Indicates if any changes were made during the operation.
+  type: bool
+  returned: always
+  sample: false
+failed:
+  description: Indicates if the operation failed.
+  type: bool
+  returned: always
+  sample: false
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching certificate auth providers info"
+error:
+  description: Error message if something goes wrong.
+  type: str
+  returned: always
+ext_id:
+  description: The external ID of the certificate auth provider that was fetched.
+  type: str
+  returned: when fetching a specific certificate auth provider
+  sample: "a3265671-de53-41be-af9b-f06241b95356"
+total_available_results:
+  description: The total number of available certificate auth providers in PC.
+  type: int
+  returned: when all certificate auth providers are fetched
+  sample: 5
+"""
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.iam.api_client import (  # noqa: E402
+    get_certificate_auth_provider_api_instance,
+)
+from ..module_utils.v4.iam.helpers import get_certificate_auth_provider  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def get_certificate_auth_provider_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+
+    resp = get_certificate_auth_provider(
+        module=module,
+        api_instance=api_instance,
+        ext_id=ext_id,
+    )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_certificate_auth_providers(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating certificate auth providers info Spec", **result
+        )
+
+    try:
+        resp = api_instance.list_cert_auth_providers(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching certificate auth providers info",
+        )
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "error": None, "response": None}
+    api_instance = get_certificate_auth_provider_api_instance(module)
+    if module.params.get("ext_id"):
+        get_certificate_auth_provider_using_ext_id(module, api_instance, result)
+    else:
+        get_certificate_auth_providers(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_certificate_auth_providers_info_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_providers_info_v2.py
@@ -26,11 +26,18 @@ options:
       - If not provided, returns list containing only one certificate authentication provider.
     type: str
     required: false
+  page:
+    description:
+      - The number of page
+    type: int
+  limit:
+    description:
+      - The number of records
+    type: int
 author:
   - George Ghawali (@george-ghawali)
 extends_documentation_fragment:
   - nutanix.ncp.ntnx_credentials
-  - nutanix.ncp.ntnx_info_v2
   - nutanix.ncp.ntnx_logger
 """
 
@@ -50,6 +57,16 @@ EXAMPLES = r"""
     nutanix_username: "{{ username }}"
     nutanix_password: "{{ password }}"
     validate_certs: false
+  register: result
+
+- name: List all certificate authentication providers with page and limit
+  nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    page: 0
+    limit: 1
   register: result
 """
 
@@ -98,7 +115,7 @@ msg:
   description: This indicates the message if any message occurred.
   returned: When there is an error
   type: str
-  sample: "Api Exception raised while fetching certificate authentication providers info"
+  sample: "Api Exception raised while fetching certificate authentication provider info"
 error:
   description: Error message if something goes wrong.
   type: str
@@ -131,6 +148,8 @@ from ..module_utils.v4.utils import (  # noqa: E402
 def get_module_spec():
     module_args = dict(
         ext_id=dict(type="str"),
+        limit=dict(type="int"),
+        page=dict(type="int"),
     )
     return module_args
 
@@ -154,7 +173,8 @@ def get_certificate_auth_providers(module, api_instance, result):
     if err:
         result["error"] = err
         module.fail_json(
-            msg="Failed generating certificate authentication providers info Spec", **result
+            msg="Failed generating certificate authentication provider info Spec",
+            **result,
         )
 
     try:
@@ -163,7 +183,7 @@ def get_certificate_auth_providers(module, api_instance, result):
         raise_api_exception(
             module=module,
             exception=e,
-            msg="Api Exception raised while fetching certificate authentication providers info",
+            msg="Api Exception raised while fetching certificate authentication provider info",
         )
     total_available_results = resp.metadata.total_available_results
     result["total_available_results"] = total_available_results
@@ -175,6 +195,7 @@ def get_certificate_auth_providers(module, api_instance, result):
 
 def run_module():
     module = BaseInfoModule(
+        skip_info_args=True,
         argument_spec=get_module_spec(),
         supports_check_mode=False,
     )

--- a/plugins/modules/ntnx_certificate_auth_providers_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_providers_v2.py
@@ -16,21 +16,21 @@ version_added: "2.5.0"
 description:
   - Create, Update, Delete certificate-based authentication providers in Nutanix Prism Central.
   - Certificate Authentication Providers enable mutual TLS (mTLS) authentication.
-  - Allows users to log in using a client certificate (e.g., Smart Card, DoD CAC, PIV card) instead of username/password.
+  - Allows users to log in using a client certificate instead of username/password.
   - This module uses PC v4 APIs based SDKs.
 options:
   state:
     description:
       - Specify state of the certificate authentication provider.
-      - If C(state) is set to C(present) then module will create certificate auth provider.
-      - If C(state) is set to C(present) and C(ext_id) is given, then module will update certificate auth provider.
-      - If C(state) is set to C(absent) with C(ext_id), then module will delete certificate auth provider.
+      - If C(state) is set to C(present) then module will create certificate authentication provider.
+      - If C(state) is set to C(present) and C(ext_id) is given, then module will update certificate authentication provider.
+      - If C(state) is set to C(absent) with C(ext_id), then module will delete certificate authentication provider.
     type: str
     choices: ["present", "absent"]
   ext_id:
     description:
       - External ID of the certificate authentication provider.
-      - Required for updating or deleting the certificate auth provider.
+      - Required for updating or deleting the certificate authentication provider.
     type: str
   name:
     description:
@@ -43,11 +43,11 @@ options:
     type: str
   is_cert_auth_enabled:
     description:
-      - Flag to enable/disable certificate authentication for the current provider.
+      - Flag to enable/disable CAC for the current certificate-based authentication provider.
     type: bool
   is_cac_enabled:
     description:
-      - Flag to enable/disable Common Access Card (CAC).
+      - Flag to enable/disable certificate authentication for the current certificate-based authentication provider.
     type: bool
   dir_svc_ext_id:
     description:
@@ -133,8 +133,8 @@ RETURN = r"""
 response:
   description:
     - Response for the certificate authentication provider operations.
-    - For create and update operations, it returns the certificate auth provider details.
-    - For delete operation, it returns the message indicating the certificate auth provider is deleted successfully.
+    - For create and update operations, it returns the certificate authentication provider details.
+    - For delete operation, it returns the message indicating the certificate authentication provider is deleted successfully.
   returned: always
   type: dict
   sample:
@@ -168,7 +168,7 @@ msg:
   description: This indicates the message if any message occurred
   returned: When there is an error, module is idempotent or in delete operation
   type: str
-  sample: "Api Exception raised while creating certificate auth provider"
+  sample: "Api Exception raised while creating certificate authentication provider"
 error:
   description: This field typically holds information about if the task have errors that occurred during the task execution
   type: str
@@ -182,7 +182,7 @@ ext_id:
 skipped:
   description: Indicates if the operation was skipped
   type: bool
-  returned: always
+  returned: When the operation is skipped
   sample: false
 failed:
   description: Indicates if the operation failed
@@ -259,7 +259,7 @@ def create_certificate_auth_provider(module, api_instance, result):
     if err:
         result["error"] = err
         module.fail_json(
-            msg="Failed generating create certificate auth provider spec", **result
+            msg="Failed generating create certificate authentication provider spec", **result
         )
 
     if module.check_mode:
@@ -281,7 +281,7 @@ def create_certificate_auth_provider(module, api_instance, result):
         raise_api_exception(
             module=module,
             exception=e,
-            msg="Api Exception raised while creating certificate auth provider",
+            msg="Api Exception raised while creating certificate authentication provider",
         )
 
     # API returns entity directly, not a task
@@ -305,7 +305,7 @@ def update_certificate_auth_provider(module, api_instance, result):
     etag = get_etag(data=current_spec)
     if not etag:
         return module.fail_json(
-            "Unable to fetch etag for updating certificate auth provider", **result
+            "Unable to fetch etag for updating certificate authentication provider", **result
         )
 
     kwargs = {"if_match": etag}
@@ -316,7 +316,7 @@ def update_certificate_auth_provider(module, api_instance, result):
     if err:
         result["error"] = err
         module.fail_json(
-            msg="Failed generating certificate auth provider update spec", **result
+            msg="Failed generating certificate authentication provider update spec", **result
         )
 
     if module.check_mode:
@@ -346,7 +346,7 @@ def update_certificate_auth_provider(module, api_instance, result):
         raise_api_exception(
             module=module,
             exception=e,
-            msg="Api Exception raised while updating certificate auth provider",
+            msg="Api Exception raised while updating certificate authentication provider",
         )
 
     # API returns entity directly, not a task
@@ -360,7 +360,7 @@ def delete_certificate_auth_provider(module, api_instance, result):
 
     if module.check_mode:
         result["msg"] = (
-            "Certificate auth provider with ext_id:{0} will be deleted.".format(ext_id)
+            "Certificate authentication provider with ext_id:{0} will be deleted.".format(ext_id)
         )
         return
 
@@ -369,7 +369,7 @@ def delete_certificate_auth_provider(module, api_instance, result):
     etag = get_etag(data=current_spec)
     if not etag:
         return module.fail_json(
-            "Unable to fetch etag for deleting certificate auth provider", **result
+            "Unable to fetch etag for deleting certificate authentication provider", **result
         )
 
     kwargs = {"if_match": etag}
@@ -380,14 +380,14 @@ def delete_certificate_auth_provider(module, api_instance, result):
         raise_api_exception(
             module=module,
             exception=e,
-            msg="Api Exception raised while deleting certificate auth provider",
+            msg="Api Exception raised while deleting certificate authentication provider",
         )
 
     # Delete API may return None or empty response
     result["changed"] = True
     if resp is None:
         result["msg"] = (
-            "Certificate auth provider with ext_id: {} deleted successfully".format(
+            "Certificate authentication provider with ext_id: {} deleted successfully".format(
                 ext_id
             )
         )

--- a/plugins/modules/ntnx_certificate_auth_providers_v2.py
+++ b/plugins/modules/ntnx_certificate_auth_providers_v2.py
@@ -1,0 +1,436 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_certificate_auth_providers_v2
+short_description: Manage certificate-based authentication providers in Nutanix Prism Central
+version_added: "2.5.0"
+description:
+  - Create, Update, Delete certificate-based authentication providers in Nutanix Prism Central.
+  - Certificate Authentication Providers enable mutual TLS (mTLS) authentication.
+  - Allows users to log in using a client certificate (e.g., Smart Card, DoD CAC, PIV card) instead of username/password.
+  - This module uses PC v4 APIs based SDKs.
+options:
+  state:
+    description:
+      - Specify state of the certificate authentication provider.
+      - If C(state) is set to C(present) then module will create certificate auth provider.
+      - If C(state) is set to C(present) and C(ext_id) is given, then module will update certificate auth provider.
+      - If C(state) is set to C(absent) with C(ext_id), then module will delete certificate auth provider.
+    type: str
+    choices: ["present", "absent"]
+  ext_id:
+    description:
+      - External ID of the certificate authentication provider.
+      - Required for updating or deleting the certificate auth provider.
+    type: str
+  name:
+    description:
+      - Unique name of the certificate-based authentication provider.
+      - Used to identify this specific provider in the Prism Central UI or API lists.
+    type: str
+  client_ca_chain:
+    description:
+      - The full chain of Certificate Authority (CA) certificates (Root CA and Intermediate CAs).
+    type: str
+  is_cert_auth_enabled:
+    description:
+      - Flag to enable/disable certificate authentication for the current provider.
+    type: bool
+  is_cac_enabled:
+    description:
+      - Flag to enable/disable Common Access Card (CAC).
+    type: bool
+  dir_svc_ext_id:
+    description:
+      - UUID of an existing Directory Service (e.g., Active Directory) configured in Prism Central.
+    type: str
+  ca_cert_file_name:
+    description:
+      - Name of the uploaded CA chain file.
+      - The original filename of the clientCaChain you uploaded.
+    type: str
+  is_ocsp_enabled:
+    description:
+      - Flag to enable/disable Online Certificate Status Protocol (OCSP) revocation check.
+    type: bool
+  ocsp_responder:
+    description:
+      - URL of the OCSP responder used to override the URL from AIA extension.
+    type: str
+  is_crl_enabled:
+    description:
+      - Flag to enable/disable Certificate Revocation List (CRL) checking.
+    type: bool
+  crl_dps:
+    description:
+      - List of CRL Distribution Points URLs where the CRL file can be downloaded.
+    type: list
+    elements: str
+  global_crl_refresh_interval:
+    description:
+      - Interval in seconds at which the CRL should be fetched from the CRL Distribution Points.
+    type: int
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create certificate authentication provider with CAC enabled
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "CAC"
+    client_ca_chain: "<ca_cert_chain_string>"
+    ca_cert_file_name: "ca_cert_chain.pem"
+    is_cert_auth_enabled: true
+    is_cac_enabled: true
+    dir_svc_ext_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+  register: result
+  ignore_errors: true
+
+- name: Update certificate authentication provider
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "a3265671-de53-41be-af9b-f06241b95356"
+    name: "CAC"
+    is_cert_auth_enabled: false
+  register: result
+  ignore_errors: true
+
+- name: Delete certificate authentication provider
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "a3265671-de53-41be-af9b-f06241b95356"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for the certificate authentication provider operations.
+    - For create and update operations, it returns the certificate auth provider details.
+    - For delete operation, it returns the message indicating the certificate auth provider is deleted successfully.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ca_cert_file_name": "ca_cert_chain.pem",
+      "cert_revocation_info": {
+          "crl_dps": null,
+          "global_crl_refresh_interval": 86400,
+          "is_crl_enabled": false,
+          "is_ocsp_enabled": true,
+          "ocsp_responder": ""
+      },
+      "client_ca_chain": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
+      "created_by": "00000000-0000-0000-0000-000000000000",
+      "created_time": null,
+      "dir_svc_ext_id": "6cd7a803-a0ae-5a23-92be-e7a27573b363",
+      "ext_id": "10c4bab1-2d88-540e-a602-92f723b44c73",
+      "is_cac_enabled": true,
+      "is_cert_auth_enabled": true,
+      "last_updated_time": null,
+      "links": null,
+      "name": "CAC",
+      "tenant_id": null
+    }
+changed:
+  description: Indicates if any changes were made during the operation.
+  returned: always
+  type: bool
+  sample: true
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or in delete operation
+  type: str
+  sample: "Api Exception raised while creating certificate auth provider"
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: When an error occurs
+  sample: "BAD REQUEST"
+ext_id:
+  description: External ID of the certificate authentication provider.
+  type: str
+  returned: always
+  sample: "a3265671-de53-41be-af9b-f06241b95356"
+skipped:
+  description: Indicates if the operation was skipped
+  type: bool
+  returned: always
+  sample: false
+failed:
+  description: Indicates if the operation failed
+  type: bool
+  returned: always
+  sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.base_module import BaseModule  # noqa: E402
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.iam.api_client import (  # noqa: E402
+    get_certificate_auth_provider_api_instance,
+    get_etag,
+)
+from ..module_utils.v4.iam.helpers import (  # noqa: E402
+    get_api_params_from_spec,
+    get_certificate_auth_provider,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_iam_py_client as iam_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as iam_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        client_ca_chain=dict(type="str", no_log=True),
+        is_cert_auth_enabled=dict(type="bool"),
+        is_cac_enabled=dict(type="bool"),
+        dir_svc_ext_id=dict(type="str"),
+        ca_cert_file_name=dict(type="str"),
+        is_ocsp_enabled=dict(type="bool"),
+        ocsp_responder=dict(type="str"),
+        is_crl_enabled=dict(type="bool"),
+        crl_dps=dict(type="list", elements="str"),
+        global_crl_refresh_interval=dict(type="int"),
+    )
+    return module_args
+
+
+# Special case mappings for snake_case to camelCase conversion
+# dir_svc_ext_id -> API expects 'dirSvcExtID' (uppercase ID), not 'dirSvcExtId'
+CAMEL_CASE_SPECIAL_CASES = {
+    "dir_svc_ext_id": "dirSvcExtID",
+}
+
+
+def create_certificate_auth_provider(module, api_instance, result):
+    sg = SpecGenerator(module)
+    default_spec = iam_sdk.CertAuthProvider()
+    spec, err = sg.generate_spec(obj=default_spec)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating create certificate auth provider spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    # Get API parameters dynamically from spec (exclude ext_id as it's not used in create)
+    api_params = get_api_params_from_spec(
+        spec,
+        module_spec=get_module_spec(),
+        exclude_params=["ext_id"],
+        special_cases=CAMEL_CASE_SPECIAL_CASES,
+    )
+
+    resp = None
+    try:
+        resp = api_instance.create_cert_auth_provider(**api_params)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating certificate auth provider",
+        )
+
+    # API returns entity directly, not a task
+    result["ext_id"] = resp.data.ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    result["changed"] = True
+
+
+def check_certificate_auth_provider_idempotency(current_spec, update_spec):
+    if current_spec != update_spec:
+        return False
+    return True
+
+
+def update_certificate_auth_provider(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    current_spec = get_certificate_auth_provider(module, api_instance, ext_id=ext_id)
+
+    etag = get_etag(data=current_spec)
+    if not etag:
+        return module.fail_json(
+            "Unable to fetch etag for updating certificate auth provider", **result
+        )
+
+    kwargs = {"if_match": etag}
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(current_spec))
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating certificate auth provider update spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    # check for idempotency
+    if check_certificate_auth_provider_idempotency(
+        strip_internal_attributes(current_spec.to_dict()),
+        strip_internal_attributes(update_spec.to_dict()),
+    ):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    # Get API parameters dynamically from update spec (exclude ext_id as it's passed separately)
+    api_params = get_api_params_from_spec(
+        update_spec,
+        module_spec=get_module_spec(),
+        special_cases=CAMEL_CASE_SPECIAL_CASES,
+    )
+    api_params.update(kwargs)
+
+    resp = None
+    try:
+        resp = api_instance.update_cert_auth_provider_by_id(**api_params)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating certificate auth provider",
+        )
+
+    # API returns entity directly, not a task
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    result["changed"] = True
+
+
+def delete_certificate_auth_provider(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "Certificate auth provider with ext_id:{0} will be deleted.".format(ext_id)
+        )
+        return
+
+    current_spec = get_certificate_auth_provider(module, api_instance, ext_id=ext_id)
+
+    etag = get_etag(data=current_spec)
+    if not etag:
+        return module.fail_json(
+            "Unable to fetch etag for deleting certificate auth provider", **result
+        )
+
+    kwargs = {"if_match": etag}
+
+    try:
+        resp = api_instance.delete_cert_auth_provider_by_id(extId=ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting certificate auth provider",
+        )
+
+    # Delete API may return None or empty response
+    result["changed"] = True
+    if resp is None:
+        result["msg"] = (
+            "Certificate auth provider with ext_id: {} deleted successfully".format(
+                ext_id
+            )
+        )
+    else:
+        result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def run_module():
+    module = BaseModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "present", ("name", "ext_id"), True),
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_iam_py_client"), exception=SDK_IMP_ERROR
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+    }
+    state = module.params["state"]
+    api_instance = get_certificate_auth_provider_api_instance(module)
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_certificate_auth_provider(module, api_instance, result)
+        else:
+            create_certificate_auth_provider(module, api_instance, result)
+    else:
+        delete_certificate_auth_provider(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/ntnx_certificate_auth_providers_v2/aliases
+++ b/tests/integration/targets/ntnx_certificate_auth_providers_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_certificate_auth_providers_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_certificate_auth_providers_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_certificate_auth_providers_v2/tasks/certificate_auth_providers.yml
+++ b/tests/integration/targets/ntnx_certificate_auth_providers_v2/tasks/certificate_auth_providers.yml
@@ -14,7 +14,7 @@
 
 - name: Set variables
   ansible.builtin.set_fact:
-    directory_service: "{{ random_name }}ansible-ag"
+    directory_service: "{{ random_name }}ansible-ds"
 
 ##############################################################################
 # Create ACTIVE_DIRECTORY service
@@ -38,9 +38,9 @@
 - name: Status of ACTIVE_DIRECTORY service creation
   ansible.builtin.assert:
     that:
-      - result.response is defined
       - result.changed == true
-      - result.failed == False
+      - result.failed == false
+      - result.response is defined
       - result.response.name == "{{ directory_service }}"
       - result.response.directory_type == "ACTIVE_DIRECTORY"
       - result.response.url == "{{ active_directory.url }}"
@@ -48,6 +48,8 @@
       - result.response.service_account.username == "{{ active_directory.username }}"
       - result.response.service_account.password is defined
       - result.response.ext_id is defined
+      - result.response.white_listed_groups | length == 1
+      - result.response.white_listed_groups[0] == "{{ white_listed_groups[0] }}"
       - result.ext_id is defined
       - result.response.ext_id == result.ext_id
     fail_msg: "Unable to create ACTIVE_DIRECTORY service "
@@ -61,7 +63,7 @@
 # Check Mode - Generate spec with all attributes
 ##############################################################################
 
-- name: Generate spec for creating certificate auth provider using check mode with all attributes
+- name: Generate spec for creating certificate authentication provider using check mode with all attributes
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     name: "CAC"
     client_ca_chain: "{{ ca_cert_chain }}"
@@ -88,8 +90,8 @@
       - result.response.is_cert_auth_enabled == true
       - result.response.ca_cert_file_name == "test_ca_chain.pem"
       - result.response.dir_svc_ext_id == "00000000-0000-0000-0000-000000000000"
-    fail_msg: "Creating spec with check mode failed"
-    success_msg: "Creating spec with check mode passed with expected values"
+    fail_msg: "Generating create spec with check mode failed"
+    success_msg: "Generating create spec with check mode passed with expected values"
 
 ##############################################################################
 # Create - Success
@@ -106,11 +108,11 @@
   register: result
   ignore_errors: true
 
-- name: Debug certificate auth provider creation result
+- name: Debug certificate authentication provider creation result
   ansible.builtin.debug:
     var: result
 
-- name: Verify creating certificate auth provider with CAC enabled
+- name: Verify creating certificate authentication provider with CAC enabled
   ansible.builtin.assert:
     that:
       - result.changed == true
@@ -122,10 +124,10 @@
       - result.response.is_cert_auth_enabled == true
       - result.response.ca_cert_file_name == "ca_cert_chain.pem"
       - result.response.dir_svc_ext_id == "{{ directory_service_ext_id }}"
-    fail_msg: "Creating certificate auth provider with CAC enabled failed"
-    success_msg: "Creating certificate auth provider with CAC enabled passed"
+    fail_msg: "Creating certificate authentication provider with CAC enabled failed"
+    success_msg: "Creating certificate authentication provider with CAC enabled passed"
 
-- name: Save certificate auth provider ext_id for update and delete
+- name: Save certificate authentication provider ext_id for update and delete
   ansible.builtin.set_fact:
     cert_auth_provider_ext_id: "{{ result.ext_id }}"
 
@@ -133,7 +135,7 @@
 # Negative Scenarios - Create
 ##############################################################################
 
-- name: Create certificate auth provider with same name (should fail - max 1 allowed)
+- name: Create certificate authentication provider with same name (should fail - max 1 allowed)
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     name: "CAC"
     client_ca_chain: "{{ ca_cert_chain }}"
@@ -144,23 +146,23 @@
   register: result
   ignore_errors: true
 
-- name: Debug creating certificate auth provider with same name result
+- name: Debug creating certificate authentication provider with same name result
   ansible.builtin.debug:
     var: result
 
-- name: Verify creating certificate auth provider with same name failed
+- name: Verify creating certificate authentication provider with same name failed
   ansible.builtin.assert:
     that:
       - result.changed == false
       - result.failed == true
-      - result.msg == "Api Exception raised while creating certificate auth provider"
+      - result.msg == "Api Exception raised while creating certificate authentication provider"
       - result.response is defined
       - result.response.data.error | length > 0
       - result.status == 409
-    fail_msg: "Creating certificate auth provider with same name did not fail as expected"
-    success_msg: "Creating certificate auth provider with same name failed as expected (max 1 entity allowed)"
+    fail_msg: "Creating certificate authentication provider with same name did not fail as expected"
+    success_msg: "Creating certificate authentication provider with same name failed as expected (max 1 entity allowed)"
 
-- name: Create certificate auth provider without name (should fail)
+- name: Create certificate authentication provider without name (should fail)
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     client_ca_chain: "{{ ca_cert_chain }}"
     ca_cert_file_name: "ca_cert_chain.pem"
@@ -174,16 +176,16 @@
   ansible.builtin.debug:
     var: result
 
-- name: Verify creating certificate auth provider without name failed
+- name: Verify creating certificate authentication provider without name failed
   ansible.builtin.assert:
     that:
       - result.changed == false
       - result.failed == true
       - "'state is present but any of the following are missing: name, ext_id' in result.msg"
-    fail_msg: "Creating certificate auth provider without name did not fail as expected"
-    success_msg: "Creating certificate auth provider without name failed as expected"
+    fail_msg: "Creating certificate authentication provider without name did not fail as expected"
+    success_msg: "Creating certificate authentication provider without name failed as expected"
 
-- name: Create certificate auth provider with non-CAC name (should fail)
+- name: Create certificate authentication provider with non-CAC name (should fail)
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     name: "InvalidName"
     client_ca_chain: "{{ ca_cert_chain }}"
@@ -194,23 +196,23 @@
   register: result
   ignore_errors: true
 
-- name: Debug creating certificate auth provider with non-CAC name result
+- name: Debug creating certificate authentication provider with non-CAC name result
   ansible.builtin.debug:
     var: result
 
-- name: Verify creating certificate auth provider with non-CAC name failed
+- name: Verify creating certificate authentication provider with non-CAC name failed
   ansible.builtin.assert:
     that:
       - result.changed == false
       - result.failed == true
-      - result.msg == "Api Exception raised while creating certificate auth provider"
+      - result.msg == "Api Exception raised while creating certificate authentication provider"
       - result.response is defined
       - result.response.data.error | length > 0
       - result.status == 400
-    fail_msg: "Creating certificate auth provider with non-CAC name did not fail as expected"
-    success_msg: "Creating certificate auth provider with non-CAC name failed as expected"
+    fail_msg: "Creating certificate authentication provider with non-CAC name did not fail as expected"
+    success_msg: "Creating certificate authentication provider with non-CAC name failed as expected"
 
-- name: Create certificate auth provider with invalid certificate (should fail - SDK validation)
+- name: Create certificate authentication provider with invalid certificate (should fail - SDK validation)
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     name: "CAC"
     client_ca_chain: "invalid_certificate_data"
@@ -221,23 +223,23 @@
   register: result
   ignore_errors: true
 
-- name: Debug creating certificate auth provider with invalid certificate result
+- name: Debug creating certificate authentication provider with invalid certificate result
   ansible.builtin.debug:
     var: result
 
-- name: Verify creating certificate auth provider with invalid certificate failed
+- name: Verify creating certificate authentication provider with invalid certificate failed
   ansible.builtin.assert:
     that:
       - result.changed == false
       - result.failed == true
-    fail_msg: "Creating certificate auth provider with invalid certificate did not fail as expected"
-    success_msg: "Creating certificate auth provider with invalid certificate failed as expected (SDK validation)"
+    fail_msg: "Creating certificate authentication provider with invalid certificate did not fail as expected"
+    success_msg: "Creating certificate authentication provider with invalid certificate failed as expected (SDK validation)"
 
 ##############################################################################
 # Update - Check Mode
 ##############################################################################
 
-- name: Generate spec for updating certificate auth provider using check mode
+- name: Generate spec for updating certificate authentication provider using check mode
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
     client_ca_chain: "{{ ca_cert_chain }}_updated"
@@ -270,7 +272,7 @@
 # Update - Success
 ##############################################################################
 
-- name: Update certificate auth provider - disable CAC
+- name: Update certificate authentication provider - disable CAC
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
     is_cac_enabled: false
@@ -281,7 +283,7 @@
   ansible.builtin.debug:
     var: result
 
-- name: Verify updating certificate auth provider - disable CAC
+- name: Verify updating certificate authentication provider - disable CAC
   ansible.builtin.assert:
     that:
       - result.changed == true
@@ -291,10 +293,10 @@
       - result.response.is_cert_auth_enabled == true
       - result.response.ca_cert_file_name == "ca_cert_chain.pem"
       - result.response.dir_svc_ext_id == "{{ directory_service_ext_id }}"
-    fail_msg: "Updating certificate auth provider - disable CAC failed"
-    success_msg: "Updating certificate auth provider - disable CAC passed with expected values"
+    fail_msg: "Updating certificate authentication provider - disable CAC failed"
+    success_msg: "Updating certificate authentication provider - disable CAC passed with expected values"
 
-- name: Update certificate auth provider - enable CAC back
+- name: Update certificate authentication provider - enable CAC back
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
     is_cac_enabled: true
@@ -305,7 +307,7 @@
   ansible.builtin.debug:
     var: result
 
-- name: Verify updating certificate auth provider - enable CAC back
+- name: Verify updating certificate authentication provider - enable CAC back
   ansible.builtin.assert:
     that:
       - result.changed == true
@@ -315,25 +317,25 @@
       - result.response.is_cert_auth_enabled == true
       - result.response.ca_cert_file_name == "ca_cert_chain.pem"
       - result.response.dir_svc_ext_id == "{{ directory_service_ext_id }}"
-    fail_msg: "Updating certificate auth provider - enable CAC back failed"
-    success_msg: "Updating certificate auth provider - enable CAC back passed with expected values"
+    fail_msg: "Updating certificate authentication provider - enable CAC back failed"
+    success_msg: "Updating certificate authentication provider - enable CAC back passed with expected values"
 
 ##############################################################################
 # Idempotency Check
 ##############################################################################
 
-- name: Update certificate auth provider with same values (idempotency check)
+- name: Update certificate authentication provider with same values (idempotency check)
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
     is_cac_enabled: true
   register: result
   ignore_errors: true
 
-- name: Debug idempotency check result for updating certificate auth provider with same values
+- name: Debug idempotency check result for updating certificate authentication provider with same values
   ansible.builtin.debug:
     var: result
 
-- name: Verify idempotency check for updating certificate auth provider with same values - no changes made
+- name: Verify idempotency check for updating certificate authentication provider with same values - no changes made
   ansible.builtin.assert:
     that:
       - result.changed == false
@@ -341,95 +343,95 @@
       - result.skipped == true
       - result.msg == "Nothing to change."
       - result.ext_id == "{{ cert_auth_provider_ext_id }}"
-    fail_msg: "Idempotency check for updating certificate auth provider with same values failed"
-    success_msg: "Idempotency check for updating certificate auth provider with same values passed - no changes made"
+    fail_msg: "Idempotency check for updating certificate authentication provider with same values failed"
+    success_msg: "Idempotency check for updating certificate authentication provider with same values passed - no changes made"
 
 ##############################################################################
 # Update - Negative Scenario
 ##############################################################################
 
-- name: Update certificate auth provider with wrong ext_id (should fail)
+- name: Update certificate authentication provider with wrong ext_id (should fail)
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     ext_id: "00000000-0000-0000-0000-000000000000"
     is_cac_enabled: false
   register: result
   ignore_errors: true
 
-- name: Debug updating certificate auth provider with wrong ext_id result
+- name: Debug updating certificate authentication provider with wrong ext_id result
   ansible.builtin.debug:
     var: result
 
-- name: Verify updating certificate auth provider with wrong ext_id failed as expected
+- name: Verify updating certificate authentication provider with wrong ext_id failed as expected
   ansible.builtin.assert:
     that:
       - result.changed == false
       - result.failed == true
       - result.response is defined
-      - result.msg == "Api Exception raised while fetching certificate auth provider info"
+      - result.msg == "Api Exception raised while fetching certificate authentication provider info"
       - result.response.data.error | length > 0
       - result.status == 404
-    fail_msg: "Updating certificate auth provider with wrong ext_id did not fail as expected"
-    success_msg: "Updating certificate auth provider with wrong ext_id failed as expected"
+    fail_msg: "Updating certificate authentication provider with wrong ext_id did not fail as expected"
+    success_msg: "Updating certificate authentication provider with wrong ext_id failed as expected"
 
-- name: Update certificate auth provider with wrong directory service ext_id (should fail)
+- name: Update certificate authentication provider with wrong directory service ext_id (should fail)
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
     dir_svc_ext_id: "00000000-0000-0000-0000-000000000000"
   register: result
   ignore_errors: true
 
-- name: Debug updating certificate auth provider with wrong directory service ext_id result
+- name: Debug updating certificate authentication provider with wrong directory service ext_id result
   ansible.builtin.debug:
     var: result
 
-- name: Verify updating certificate auth provider with wrong directory service ext_id failed as expected
+- name: Verify updating certificate authentication provider with wrong directory service ext_id failed as expected
   ansible.builtin.assert:
     that:
       - result.changed == false
       - result.failed == true
       - result.response is defined
-      - result.msg == "Api Exception raised while updating certificate auth provider"
+      - result.msg == "Api Exception raised while updating certificate authentication provider"
       - result.response.data.error | length > 0
-    fail_msg: "Updating certificate auth provider with wrong directory service ext_id did not fail as expected"
-    success_msg: "Updating certificate auth provider with wrong directory service ext_id failed as expected"
+    fail_msg: "Updating certificate authentication provider with wrong directory service ext_id did not fail as expected"
+    success_msg: "Updating certificate authentication provider with wrong directory service ext_id failed as expected"
 
-- name: Update certificate auth provider with non-CAC name (should fail)
+- name: Update certificate authentication provider with non-CAC name (should fail)
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
     name: "InvalidName"
   register: result
   ignore_errors: true
 
-- name: Debug updating certificate auth provider with non-CAC name result
+- name: Debug updating certificate authentication provider with non-CAC name result
   ansible.builtin.debug:
     var: result
 
-- name: Verify updating certificate auth provider with non-CAC name
+- name: Verify updating certificate authentication provider with non-CAC name
   ansible.builtin.assert:
     that:
       - result.changed == false
       - result.failed == true
       - result.response is defined
-      - result.msg == "Api Exception raised while updating certificate auth provider"
+      - result.msg == "Api Exception raised while updating certificate authentication provider"
       - result.response.data.error | length > 0
-    fail_msg: "Updating certificate auth provider with non-CAC name did not fail as expected"
-    success_msg: "Updating certificate auth provider with non-CAC name failed as expected"
+    fail_msg: "Updating certificate authentication provider with non-CAC name did not fail as expected"
+    success_msg: "Updating certificate authentication provider with non-CAC name failed as expected"
 
 ##############################################################################
 # Fetch - Success
 ##############################################################################
 
-- name: Fetch certificate auth provider using ext_id
+- name: Fetch certificate authentication provider using ext_id
   nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
   register: result
   ignore_errors: true
 
-- name: Debug fetch certificate auth provider result
+- name: Debug fetch certificate authentication provider result
   ansible.builtin.debug:
     var: result
 
-- name: Verify certificate auth provider fetched successfully
+- name: Verify certificate authentication provider fetched successfully
   ansible.builtin.assert:
     that:
       - result.changed == false
@@ -442,14 +444,14 @@
       - result.response.is_cert_auth_enabled == true
       - result.response.ca_cert_file_name == "ca_cert_chain.pem"
       - result.response.dir_svc_ext_id == "{{ directory_service_ext_id }}"
-    fail_msg: "Fetch certificate auth provider using ext_id failed"
-    success_msg: "Fetch certificate auth provider using ext_id passed"
+    fail_msg: "Fetch certificate authentication provider using ext_id failed"
+    success_msg: "Fetch certificate authentication provider using ext_id passed"
 
 ##############################################################################
 # Fetch - Negative Scenario
 ##############################################################################
 
-- name: Fetch certificate auth provider with wrong ext_id (should fail)
+- name: Fetch certificate authentication provider with wrong ext_id (should fail)
   nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
     ext_id: "00000000-0000-0000-0000-000000000000"
   register: result
@@ -459,32 +461,32 @@
   ansible.builtin.debug:
     var: result
 
-- name: Verify fetch certificate auth provider with wrong ext_id
+- name: Verify fetch certificate authentication provider with wrong ext_id
   ansible.builtin.assert:
     that:
       - result.changed == false
       - result.failed == true
       - result.response is defined
-      - result.msg == "Api Exception raised while fetching certificate auth provider info"
+      - result.msg == "Api Exception raised while fetching certificate authentication provider info"
       - result.response.data.error | length > 0
       - result.status == 404
-    fail_msg: "Fetch certificate auth provider with wrong ext_id did not fail as expected"
-    success_msg: "Fetch certificate auth provider with wrong ext_id failed as expected"
+    fail_msg: "Fetch certificate authentication provider with wrong ext_id did not fail as expected"
+    success_msg: "Fetch certificate authentication provider with wrong ext_id failed as expected"
 
 ##############################################################################
 # List All
 ##############################################################################
 
-- name: List all certificate auth providers
+- name: List all certificate authentication providers
   nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
   register: result
   ignore_errors: true
 
-- name: Debug list all certificate auth providers result
+- name: Debug list all certificate authentication providers result
   ansible.builtin.debug:
     var: result
 
-- name: Verify list all certificate auth providers
+- name: Verify list all certificate authentication providers
   ansible.builtin.assert:
     that:
       - result.changed == false
@@ -496,14 +498,14 @@
       - result.response[0].is_cert_auth_enabled == true
       - result.response[0].ca_cert_file_name == "ca_cert_chain.pem"
       - result.response[0].dir_svc_ext_id == "{{ directory_service_ext_id }}"
-    fail_msg: "List all certificate auth providers failed"
-    success_msg: "List all certificate auth providers passed"
+    fail_msg: "List all certificate authentication providers failed"
+    success_msg: "List all certificate authentication providers passed"
 
 ##############################################################################
 # Delete - Check Mode
 ##############################################################################
 
-- name: Delete certificate auth provider using check mode
+- name: Delete certificate authentication provider using check mode
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     state: absent
     ext_id: "{{ cert_auth_provider_ext_id }}"
@@ -511,71 +513,71 @@
   register: result
   ignore_errors: true
 
-- name: Debug delete certificate auth provider using check mode result
+- name: Debug delete certificate authentication provider using check mode result
   ansible.builtin.debug:
     var: result
 
-- name: Verify delete certificate auth provider using check mode
+- name: Verify delete certificate authentication provider using check mode
   ansible.builtin.assert:
     that:
       - result.changed == false
       - result.failed == false
       - result.ext_id == "{{ cert_auth_provider_ext_id }}"
-      - result.msg == "Certificate auth provider with ext_id:{{ cert_auth_provider_ext_id }} will be deleted."
-    fail_msg: "Delete certificate auth provider using check mode failed"
-    success_msg: "Delete certificate auth provider using check mode passed"
+      - result.msg == "Certificate authentication provider with ext_id:{{ cert_auth_provider_ext_id }} will be deleted."
+    fail_msg: "Delete certificate authentication provider using check mode failed"
+    success_msg: "Delete certificate authentication provider using check mode passed"
 
 ##############################################################################
 # Delete - Success
 ##############################################################################
 
-- name: Delete the certificate auth provider
+- name: Delete the certificate authentication provider
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     state: absent
     ext_id: "{{ cert_auth_provider_ext_id }}"
   register: result
   ignore_errors: true
 
-- name: Debug delete certificate auth provider result
+- name: Debug delete certificate authentication provider result
   ansible.builtin.debug:
     var: result
 
-- name: Verify certificate auth provider is deleted successfully
+- name: Verify certificate authentication provider is deleted successfully
   ansible.builtin.assert:
     that:
       - result.changed == true
       - result.failed == false
       - result.ext_id == "{{ cert_auth_provider_ext_id }}"
       - "'deleted successfully' in result.msg"
-    fail_msg: "Deleting certificate auth provider failed"
-    success_msg: "Deleting certificate auth provider passed with expected values"
+    fail_msg: "Deleting certificate authentication provider failed"
+    success_msg: "Deleting certificate authentication provider passed with expected values"
 
 ##############################################################################
 # Delete - Negative Scenario
 ##############################################################################
 
-- name: Delete certificate auth provider with wrong ext_id (should fail)
+- name: Delete certificate authentication provider with wrong ext_id (should fail)
   nutanix.ncp.ntnx_certificate_auth_providers_v2:
     state: absent
     ext_id: "00000000-0000-0000-0000-000000000000"
   register: result
   ignore_errors: true
 
-- name: Debug deleting certificate auth provider with wrong ext_id result
+- name: Debug deleting certificate authentication provider with wrong ext_id result
   ansible.builtin.debug:
     var: result
 
-- name: Verify deleting certificate auth provider with wrong ext_id
+- name: Verify deleting certificate authentication provider with wrong ext_id
   ansible.builtin.assert:
     that:
       - result.changed == false
       - result.failed == true
       - result.response is defined
-      - result.msg == "Api Exception raised while fetching certificate auth provider info"
+      - result.msg == "Api Exception raised while fetching certificate authentication provider info"
       - result.response.data.error | length > 0
       - result.status == 404
-    fail_msg: "Deleting certificate auth provider with wrong ext_id did not fail as expected"
-    success_msg: "Deleting certificate auth provider with wrong ext_id failed as expected"
+    fail_msg: "Deleting certificate authentication provider with wrong ext_id did not fail as expected"
+    success_msg: "Deleting certificate authentication provider with wrong ext_id failed as expected"
 
 ##############################################################################
 # Delete ACTIVE_DIRECTORY service

--- a/tests/integration/targets/ntnx_certificate_auth_providers_v2/tasks/certificate_auth_providers.yml
+++ b/tests/integration/targets/ntnx_certificate_auth_providers_v2/tasks/certificate_auth_providers.yml
@@ -1,0 +1,581 @@
+---
+# Variables required before running this playbook:
+# - ca_cert_chain
+# - active_directory
+# - white_listed_groups
+
+- name: Start ntnx_certificate_auth_providers_v2 tests
+  ansible.builtin.debug:
+    msg: start ntnx_certificate_auth_providers_v2 tests
+
+- name: Generate random category key & value
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set variables
+  ansible.builtin.set_fact:
+    directory_service: "{{ random_name }}ansible-ag"
+
+##############################################################################
+# Create ACTIVE_DIRECTORY service
+##############################################################################
+
+- name: Create ACTIVE_DIRECTORY service
+  nutanix.ncp.ntnx_directory_services_v2:
+    state: present
+    name: "{{ directory_service }}"
+    url: "{{ active_directory.url }}"
+    directory_type: ACTIVE_DIRECTORY
+    domain_name: "{{ active_directory.domain_name }}"
+    service_account:
+      username: "{{ active_directory.username }}"
+      password: "{{ active_directory.password }}"
+    white_listed_groups:
+      - "{{ white_listed_groups[0] }}"
+  register: result
+  ignore_errors: true
+
+- name: Status of ACTIVE_DIRECTORY service creation
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == False
+      - result.response.name == "{{ directory_service }}"
+      - result.response.directory_type == "ACTIVE_DIRECTORY"
+      - result.response.url == "{{ active_directory.url }}"
+      - result.response.domain_name == "{{ active_directory.domain_name }}"
+      - result.response.service_account.username == "{{ active_directory.username }}"
+      - result.response.service_account.password is defined
+      - result.response.ext_id is defined
+      - result.ext_id is defined
+      - result.response.ext_id == result.ext_id
+    fail_msg: "Unable to create ACTIVE_DIRECTORY service "
+    success_msg: "ACTIVE_DIRECTORY service created successfully  "
+
+- name: Set directory service external ID
+  ansible.builtin.set_fact:
+    directory_service_ext_id: "{{ result.response.ext_id }}"
+
+##############################################################################
+# Check Mode - Generate spec with all attributes
+##############################################################################
+
+- name: Generate spec for creating certificate auth provider using check mode with all attributes
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    name: "CAC"
+    client_ca_chain: "{{ ca_cert_chain }}"
+    ca_cert_file_name: "test_ca_chain.pem"
+    is_cert_auth_enabled: true
+    is_cac_enabled: true
+    dir_svc_ext_id: "00000000-0000-0000-0000-000000000000"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Debug check mode spec generation result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify generating create spec with check mode
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "CAC"
+      - result.response.is_cac_enabled == true
+      - result.response.is_cert_auth_enabled == true
+      - result.response.ca_cert_file_name == "test_ca_chain.pem"
+      - result.response.dir_svc_ext_id == "00000000-0000-0000-0000-000000000000"
+    fail_msg: "Creating spec with check mode failed"
+    success_msg: "Creating spec with check mode passed with expected values"
+
+##############################################################################
+# Create - Success
+##############################################################################
+
+- name: Create certificate authentication provider with CAC enabled
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    name: "CAC"
+    client_ca_chain: "{{ ca_cert_chain }}"
+    ca_cert_file_name: "ca_cert_chain.pem"
+    is_cert_auth_enabled: true
+    is_cac_enabled: true
+    dir_svc_ext_id: "{{ directory_service_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Debug certificate auth provider creation result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify creating certificate auth provider with CAC enabled
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.response is defined
+      - result.response.name == "CAC"
+      - result.response.is_cac_enabled == true
+      - result.response.is_cert_auth_enabled == true
+      - result.response.ca_cert_file_name == "ca_cert_chain.pem"
+      - result.response.dir_svc_ext_id == "{{ directory_service_ext_id }}"
+    fail_msg: "Creating certificate auth provider with CAC enabled failed"
+    success_msg: "Creating certificate auth provider with CAC enabled passed"
+
+- name: Save certificate auth provider ext_id for update and delete
+  ansible.builtin.set_fact:
+    cert_auth_provider_ext_id: "{{ result.ext_id }}"
+
+##############################################################################
+# Negative Scenarios - Create
+##############################################################################
+
+- name: Create certificate auth provider with same name (should fail - max 1 allowed)
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    name: "CAC"
+    client_ca_chain: "{{ ca_cert_chain }}"
+    ca_cert_file_name: "ca_cert_chain.pem"
+    is_cert_auth_enabled: true
+    is_cac_enabled: true
+    dir_svc_ext_id: "{{ directory_service_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Debug creating certificate auth provider with same name result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify creating certificate auth provider with same name failed
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while creating certificate auth provider"
+      - result.response is defined
+      - result.response.data.error | length > 0
+      - result.status == 409
+    fail_msg: "Creating certificate auth provider with same name did not fail as expected"
+    success_msg: "Creating certificate auth provider with same name failed as expected (max 1 entity allowed)"
+
+- name: Create certificate auth provider without name (should fail)
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    client_ca_chain: "{{ ca_cert_chain }}"
+    ca_cert_file_name: "ca_cert_chain.pem"
+    is_cert_auth_enabled: true
+    is_cac_enabled: true
+    dir_svc_ext_id: "{{ directory_service_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Debug create without name result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify creating certificate auth provider without name failed
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - "'state is present but any of the following are missing: name, ext_id' in result.msg"
+    fail_msg: "Creating certificate auth provider without name did not fail as expected"
+    success_msg: "Creating certificate auth provider without name failed as expected"
+
+- name: Create certificate auth provider with non-CAC name (should fail)
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    name: "InvalidName"
+    client_ca_chain: "{{ ca_cert_chain }}"
+    ca_cert_file_name: "ca_cert_chain.pem"
+    is_cert_auth_enabled: true
+    is_cac_enabled: true
+    dir_svc_ext_id: "{{ directory_service_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Debug creating certificate auth provider with non-CAC name result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify creating certificate auth provider with non-CAC name failed
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while creating certificate auth provider"
+      - result.response is defined
+      - result.response.data.error | length > 0
+      - result.status == 400
+    fail_msg: "Creating certificate auth provider with non-CAC name did not fail as expected"
+    success_msg: "Creating certificate auth provider with non-CAC name failed as expected"
+
+- name: Create certificate auth provider with invalid certificate (should fail - SDK validation)
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    name: "CAC"
+    client_ca_chain: "invalid_certificate_data"
+    ca_cert_file_name: "ca_cert_chain.pem"
+    is_cert_auth_enabled: true
+    is_cac_enabled: true
+    dir_svc_ext_id: "{{ directory_service_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Debug creating certificate auth provider with invalid certificate result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify creating certificate auth provider with invalid certificate failed
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+    fail_msg: "Creating certificate auth provider with invalid certificate did not fail as expected"
+    success_msg: "Creating certificate auth provider with invalid certificate failed as expected (SDK validation)"
+
+##############################################################################
+# Update - Check Mode
+##############################################################################
+
+- name: Generate spec for updating certificate auth provider using check mode
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    ext_id: "{{ cert_auth_provider_ext_id }}"
+    client_ca_chain: "{{ ca_cert_chain }}_updated"
+    ca_cert_file_name: "ca_cert_chain_updated.pem"
+    is_cert_auth_enabled: false
+    is_cac_enabled: false
+    dir_svc_ext_id: "11111111-1111-1111-1111-111111111111"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Debug generating update spec with check mode result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify generating update spec with check mode
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.is_cert_auth_enabled == false
+      - result.response.is_cac_enabled == false
+      - result.response.ca_cert_file_name == "ca_cert_chain_updated.pem"
+      - result.response.dir_svc_ext_id == "11111111-1111-1111-1111-111111111111"
+    fail_msg: "Generating update spec with check mode failed"
+    success_msg: "Generating update spec with check mode passed with expected values"
+
+##############################################################################
+# Update - Success
+##############################################################################
+
+- name: Update certificate auth provider - disable CAC
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    ext_id: "{{ cert_auth_provider_ext_id }}"
+    is_cac_enabled: false
+  register: result
+  ignore_errors: true
+
+- name: Debug update disable CAC result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify updating certificate auth provider - disable CAC
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.is_cac_enabled == false
+      - result.response.is_cert_auth_enabled == true
+      - result.response.ca_cert_file_name == "ca_cert_chain.pem"
+      - result.response.dir_svc_ext_id == "{{ directory_service_ext_id }}"
+    fail_msg: "Updating certificate auth provider - disable CAC failed"
+    success_msg: "Updating certificate auth provider - disable CAC passed with expected values"
+
+- name: Update certificate auth provider - enable CAC back
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    ext_id: "{{ cert_auth_provider_ext_id }}"
+    is_cac_enabled: true
+  register: result
+  ignore_errors: true
+
+- name: Debug update enable CAC back result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify updating certificate auth provider - enable CAC back
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.is_cac_enabled == true
+      - result.response.is_cert_auth_enabled == true
+      - result.response.ca_cert_file_name == "ca_cert_chain.pem"
+      - result.response.dir_svc_ext_id == "{{ directory_service_ext_id }}"
+    fail_msg: "Updating certificate auth provider - enable CAC back failed"
+    success_msg: "Updating certificate auth provider - enable CAC back passed with expected values"
+
+##############################################################################
+# Idempotency Check
+##############################################################################
+
+- name: Update certificate auth provider with same values (idempotency check)
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    ext_id: "{{ cert_auth_provider_ext_id }}"
+    is_cac_enabled: true
+  register: result
+  ignore_errors: true
+
+- name: Debug idempotency check result for updating certificate auth provider with same values
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify idempotency check for updating certificate auth provider with same values - no changes made
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.msg == "Nothing to change."
+      - result.ext_id == "{{ cert_auth_provider_ext_id }}"
+    fail_msg: "Idempotency check for updating certificate auth provider with same values failed"
+    success_msg: "Idempotency check for updating certificate auth provider with same values passed - no changes made"
+
+##############################################################################
+# Update - Negative Scenario
+##############################################################################
+
+- name: Update certificate auth provider with wrong ext_id (should fail)
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    is_cac_enabled: false
+  register: result
+  ignore_errors: true
+
+- name: Debug updating certificate auth provider with wrong ext_id result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify updating certificate auth provider with wrong ext_id failed as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.response is defined
+      - result.msg == "Api Exception raised while fetching certificate auth provider info"
+      - result.response.data.error | length > 0
+      - result.status == 404
+    fail_msg: "Updating certificate auth provider with wrong ext_id did not fail as expected"
+    success_msg: "Updating certificate auth provider with wrong ext_id failed as expected"
+
+- name: Update certificate auth provider with wrong directory service ext_id (should fail)
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    ext_id: "{{ cert_auth_provider_ext_id }}"
+    dir_svc_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Debug updating certificate auth provider with wrong directory service ext_id result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify updating certificate auth provider with wrong directory service ext_id failed as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.response is defined
+      - result.msg == "Api Exception raised while updating certificate auth provider"
+      - result.response.data.error | length > 0
+    fail_msg: "Updating certificate auth provider with wrong directory service ext_id did not fail as expected"
+    success_msg: "Updating certificate auth provider with wrong directory service ext_id failed as expected"
+
+##############################################################################
+# Fetch - Success
+##############################################################################
+
+- name: Fetch certificate auth provider using ext_id
+  nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
+    ext_id: "{{ cert_auth_provider_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Debug fetch certificate auth provider result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify certificate auth provider fetched successfully
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ cert_auth_provider_ext_id }}"
+      - result.response is defined
+      - result.response.ext_id == "{{ cert_auth_provider_ext_id }}"
+      - result.response.name == "CAC"
+      - result.response.is_cac_enabled == true
+      - result.response.is_cert_auth_enabled == true
+      - result.response.ca_cert_file_name == "ca_cert_chain.pem"
+      - result.response.dir_svc_ext_id == "{{ directory_service_ext_id }}"
+    fail_msg: "Fetch certificate auth provider using ext_id failed"
+    success_msg: "Fetch certificate auth provider using ext_id passed"
+
+##############################################################################
+# Fetch - Negative Scenario
+##############################################################################
+
+- name: Fetch certificate auth provider with wrong ext_id (should fail)
+  nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Debug fetch with wrong ext_id result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify fetch certificate auth provider with wrong ext_id
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.response is defined
+      - result.msg == "Api Exception raised while fetching certificate auth provider info"
+      - result.response.data.error | length > 0
+      - result.status == 404
+    fail_msg: "Fetch certificate auth provider with wrong ext_id did not fail as expected"
+    success_msg: "Fetch certificate auth provider with wrong ext_id failed as expected"
+
+##############################################################################
+# List All
+##############################################################################
+
+- name: List all certificate auth providers
+  nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: Debug list all certificate auth providers result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify list all certificate auth providers
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 1
+      - result.response[0].name == "CAC"
+      - result.response[0].is_cac_enabled == true
+      - result.response[0].is_cert_auth_enabled == true
+      - result.response[0].ca_cert_file_name == "ca_cert_chain.pem"
+      - result.response[0].dir_svc_ext_id == "{{ directory_service_ext_id }}"
+    fail_msg: "List all certificate auth providers failed"
+    success_msg: "List all certificate auth providers passed"
+
+##############################################################################
+# Delete - Check Mode
+##############################################################################
+
+- name: Delete certificate auth provider using check mode
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    state: absent
+    ext_id: "{{ cert_auth_provider_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Debug delete certificate auth provider using check mode result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify delete certificate auth provider using check mode
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ cert_auth_provider_ext_id }}"
+      - result.msg == "Certificate auth provider with ext_id:{{ cert_auth_provider_ext_id }} will be deleted."
+    fail_msg: "Delete certificate auth provider using check mode failed"
+    success_msg: "Delete certificate auth provider using check mode passed"
+
+##############################################################################
+# Delete - Success
+##############################################################################
+
+- name: Delete the certificate auth provider
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    state: absent
+    ext_id: "{{ cert_auth_provider_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Debug delete certificate auth provider result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify certificate auth provider is deleted successfully
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == "{{ cert_auth_provider_ext_id }}"
+      - "'deleted successfully' in result.msg"
+    fail_msg: "Deleting certificate auth provider failed"
+    success_msg: "Deleting certificate auth provider passed with expected values"
+
+##############################################################################
+# Delete - Negative Scenario
+##############################################################################
+
+- name: Delete certificate auth provider with wrong ext_id (should fail)
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    state: absent
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Debug deleting certificate auth provider with wrong ext_id result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify deleting certificate auth provider with wrong ext_id
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.response is defined
+      - result.msg == "Api Exception raised while fetching certificate auth provider info"
+      - result.response.data.error | length > 0
+      - result.status == 404
+    fail_msg: "Deleting certificate auth provider with wrong ext_id did not fail as expected"
+    success_msg: "Deleting certificate auth provider with wrong ext_id failed as expected"
+
+##############################################################################
+# Delete ACTIVE_DIRECTORY service
+##############################################################################
+
+- name: Delete directory service
+  nutanix.ncp.ntnx_directory_services_v2:
+    state: absent
+    ext_id: "{{ directory_service_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Debug delete directory service result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify directory service is deleted successfully
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == "{{ directory_service_ext_id }}"
+      - "'deleted successfully' in result.msg"
+    fail_msg: "Deleting directory service failed"
+    success_msg: "Deleting directory service passed with expected values"

--- a/tests/integration/targets/ntnx_certificate_auth_providers_v2/tasks/certificate_auth_providers.yml
+++ b/tests/integration/targets/ntnx_certificate_auth_providers_v2/tasks/certificate_auth_providers.yml
@@ -393,6 +393,28 @@
     fail_msg: "Updating certificate auth provider with wrong directory service ext_id did not fail as expected"
     success_msg: "Updating certificate auth provider with wrong directory service ext_id failed as expected"
 
+- name: Update certificate auth provider with non-CAC name (should fail)
+  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+    ext_id: "{{ cert_auth_provider_ext_id }}"
+    name: "InvalidName"
+  register: result
+  ignore_errors: true
+
+- name: Debug updating certificate auth provider with non-CAC name result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify updating certificate auth provider with non-CAC name
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.response is defined
+      - result.msg == "Api Exception raised while updating certificate auth provider"
+      - result.response.data.error | length > 0
+    fail_msg: "Updating certificate auth provider with non-CAC name did not fail as expected"
+    success_msg: "Updating certificate auth provider with non-CAC name failed as expected"
+
 ##############################################################################
 # Fetch - Success
 ##############################################################################

--- a/tests/integration/targets/ntnx_certificate_auth_providers_v2/tasks/certificate_auth_providers.yml
+++ b/tests/integration/targets/ntnx_certificate_auth_providers_v2/tasks/certificate_auth_providers.yml
@@ -4,9 +4,9 @@
 # - active_directory
 # - white_listed_groups
 
-- name: Start ntnx_certificate_auth_providers_v2 tests
+- name: Start ntnx_certificate_auth_provider_v2 tests
   ansible.builtin.debug:
-    msg: start ntnx_certificate_auth_providers_v2 tests
+    msg: start ntnx_certificate_auth_provider_v2 tests
 
 - name: Generate random category key & value
   ansible.builtin.set_fact:
@@ -64,7 +64,7 @@
 ##############################################################################
 
 - name: Generate spec for creating certificate authentication provider using check mode with all attributes
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     name: "CAC"
     client_ca_chain: "{{ ca_cert_chain }}"
     ca_cert_file_name: "test_ca_chain.pem"
@@ -98,7 +98,7 @@
 ##############################################################################
 
 - name: Create certificate authentication provider with CAC enabled
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     name: "CAC"
     client_ca_chain: "{{ ca_cert_chain }}"
     ca_cert_file_name: "ca_cert_chain.pem"
@@ -136,7 +136,7 @@
 ##############################################################################
 
 - name: Create certificate authentication provider with same name (should fail - max 1 allowed)
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     name: "CAC"
     client_ca_chain: "{{ ca_cert_chain }}"
     ca_cert_file_name: "ca_cert_chain.pem"
@@ -163,7 +163,7 @@
     success_msg: "Creating certificate authentication provider with same name failed as expected (max 1 entity allowed)"
 
 - name: Create certificate authentication provider without name (should fail)
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     client_ca_chain: "{{ ca_cert_chain }}"
     ca_cert_file_name: "ca_cert_chain.pem"
     is_cert_auth_enabled: true
@@ -186,7 +186,7 @@
     success_msg: "Creating certificate authentication provider without name failed as expected"
 
 - name: Create certificate authentication provider with non-CAC name (should fail)
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     name: "InvalidName"
     client_ca_chain: "{{ ca_cert_chain }}"
     ca_cert_file_name: "ca_cert_chain.pem"
@@ -213,9 +213,9 @@
     success_msg: "Creating certificate authentication provider with non-CAC name failed as expected"
 
 - name: Create certificate authentication provider with invalid certificate (should fail - SDK validation)
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     name: "CAC"
-    client_ca_chain: "invalid_certificate_data"
+    client_ca_chain: "j5TF5Q3gStdsi81j5TF5Q3gStdsi81j5TF5Q3gStdsi81j5TF5Q3gStdsi81j5TF5Q3gStdsi81"
     ca_cert_file_name: "ca_cert_chain.pem"
     is_cert_auth_enabled: true
     is_cac_enabled: true
@@ -232,6 +232,8 @@
     that:
       - result.changed == false
       - result.failed == true
+      - result.msg == "Api Exception raised while creating certificate authentication provider"
+      - result.response.data.error | length > 0
     fail_msg: "Creating certificate authentication provider with invalid certificate did not fail as expected"
     success_msg: "Creating certificate authentication provider with invalid certificate failed as expected (SDK validation)"
 
@@ -240,10 +242,10 @@
 ##############################################################################
 
 - name: Generate spec for updating certificate authentication provider using check mode
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
-    client_ca_chain: "{{ ca_cert_chain }}_updated"
-    ca_cert_file_name: "ca_cert_chain_updated.pem"
+    client_ca_chain: "j5TF5Q3gStdsi81j5TF5Q3gStdsi81j5TF5Q3gStdsi81j5TF5Q3gStdsi81j5TF5Q3gStdsi81j5TF5Q3gStdsi81"
+    ca_cert_file_name: "ca_cert_chain_updated_updated.pem"
     is_cert_auth_enabled: false
     is_cac_enabled: false
     dir_svc_ext_id: "11111111-1111-1111-1111-111111111111"
@@ -260,10 +262,11 @@
     that:
       - result.changed == false
       - result.failed == false
+      - result.ext_id == "{{ cert_auth_provider_ext_id }}"
       - result.response is defined
       - result.response.is_cert_auth_enabled == false
       - result.response.is_cac_enabled == false
-      - result.response.ca_cert_file_name == "ca_cert_chain_updated.pem"
+      - result.response.ca_cert_file_name == "ca_cert_chain_updated_updated.pem"
       - result.response.dir_svc_ext_id == "11111111-1111-1111-1111-111111111111"
     fail_msg: "Generating update spec with check mode failed"
     success_msg: "Generating update spec with check mode passed with expected values"
@@ -273,7 +276,7 @@
 ##############################################################################
 
 - name: Update certificate authentication provider - disable CAC
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
     is_cac_enabled: false
   register: result
@@ -297,7 +300,7 @@
     success_msg: "Updating certificate authentication provider - disable CAC passed with expected values"
 
 - name: Update certificate authentication provider - enable CAC back
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
     is_cac_enabled: true
   register: result
@@ -325,7 +328,7 @@
 ##############################################################################
 
 - name: Update certificate authentication provider with same values (idempotency check)
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
     is_cac_enabled: true
   register: result
@@ -351,7 +354,7 @@
 ##############################################################################
 
 - name: Update certificate authentication provider with wrong ext_id (should fail)
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     ext_id: "00000000-0000-0000-0000-000000000000"
     is_cac_enabled: false
   register: result
@@ -374,7 +377,7 @@
     success_msg: "Updating certificate authentication provider with wrong ext_id failed as expected"
 
 - name: Update certificate authentication provider with wrong directory service ext_id (should fail)
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
     dir_svc_ext_id: "00000000-0000-0000-0000-000000000000"
   register: result
@@ -396,7 +399,7 @@
     success_msg: "Updating certificate authentication provider with wrong directory service ext_id failed as expected"
 
 - name: Update certificate authentication provider with non-CAC name (should fail)
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
     name: "InvalidName"
   register: result
@@ -501,12 +504,32 @@
     fail_msg: "List all certificate authentication providers failed"
     success_msg: "List all certificate authentication providers passed"
 
+- name: List all certificate authentication providers with limit
+  nutanix.ncp.ntnx_certificate_auth_providers_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: Debug list all certificate authentication providers with limit result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify list all certificate authentication providers with limit
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    fail_msg: "List all certificate authentication providers with limit failed"
+    success_msg: "List all certificate authentication providers with limit passed"
+
 ##############################################################################
 # Delete - Check Mode
 ##############################################################################
 
 - name: Delete certificate authentication provider using check mode
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     state: absent
     ext_id: "{{ cert_auth_provider_ext_id }}"
   check_mode: true
@@ -532,7 +555,7 @@
 ##############################################################################
 
 - name: Delete the certificate authentication provider
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     state: absent
     ext_id: "{{ cert_auth_provider_ext_id }}"
   register: result
@@ -557,7 +580,7 @@
 ##############################################################################
 
 - name: Delete certificate authentication provider with wrong ext_id (should fail)
-  nutanix.ncp.ntnx_certificate_auth_providers_v2:
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
     state: absent
     ext_id: "00000000-0000-0000-0000-000000000000"
   register: result

--- a/tests/integration/targets/ntnx_certificate_auth_providers_v2/tasks/certificate_auth_providers.yml
+++ b/tests/integration/targets/ntnx_certificate_auth_providers_v2/tasks/certificate_auth_providers.yml
@@ -237,6 +237,26 @@
     fail_msg: "Creating certificate authentication provider with invalid certificate did not fail as expected"
     success_msg: "Creating certificate authentication provider with invalid certificate failed as expected (SDK validation)"
 
+- name: Create certificate authentication provider with missing required parameters (should fail)
+  nutanix.ncp.ntnx_certificate_auth_provider_v2:
+    client_ca_chain: "{{ ca_cert_chain }}"
+    name: CAC
+  register: result
+  ignore_errors: true
+
+- name: Debug creating certificate authentication provider with missing required parameters result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify creating certificate authentication provider with missing required parameters failed
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): ca_cert_file_name, is_cert_auth_enabled, is_cac_enabled, dir_svc_ext_id"
+    fail_msg: "Creating certificate authentication provider with missing required parameters did not fail as expected"
+    success_msg: "Creating certificate authentication provider with missing required parameters failed as expected"
+
 ##############################################################################
 # Update - Check Mode
 ##############################################################################
@@ -244,6 +264,7 @@
 - name: Generate spec for updating certificate authentication provider using check mode
   nutanix.ncp.ntnx_certificate_auth_provider_v2:
     ext_id: "{{ cert_auth_provider_ext_id }}"
+    name: "CAC"
     client_ca_chain: "j5TF5Q3gStdsi81j5TF5Q3gStdsi81j5TF5Q3gStdsi81j5TF5Q3gStdsi81j5TF5Q3gStdsi81j5TF5Q3gStdsi81"
     ca_cert_file_name: "ca_cert_chain_updated_updated.pem"
     is_cert_auth_enabled: false
@@ -264,6 +285,7 @@
       - result.failed == false
       - result.ext_id == "{{ cert_auth_provider_ext_id }}"
       - result.response is defined
+      - result.response.name == "CAC"
       - result.response.is_cert_auth_enabled == false
       - result.response.is_cac_enabled == false
       - result.response.ca_cert_file_name == "ca_cert_chain_updated_updated.pem"

--- a/tests/integration/targets/ntnx_certificate_auth_providers_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_certificate_auth_providers_v2/tasks/main.yml
@@ -1,0 +1,13 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username }}"
+      nutanix_password: "{{ password }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug }}"
+      nutanix_log_file: "{{ nutanix_log_file }}"
+  block:
+    - name: Import certificate_auth_providers.yml
+      ansible.builtin.import_tasks: certificate_auth_providers.yml


### PR DESCRIPTION
## Summary

- Add `ntnx_certificate_auth_providers_v2` (Create/Update/Delete) and
  `ntnx_certificate_auth_providers_info_v2` (read-only list/get) for PC v4 certificate-based authentication providers.
- Add v4 IAM helpers and API clients for certificate auth providers.
- Add runtime registration, examples, and integration tests.

## Behavior Notes

- `present` requires at least `name` or `ext_id`; `absent` requires `ext_id`. Updates and deletes use ETag.
- Enables CAC (Common Access Card / Smart Card) authentication via mTLS.
- Requires a linked Directory Service (e.g., Active Directory) for user lookup.
- `name` must be `"CAC"` when `is_cac_enabled` is true.
- PC allows only one certificate auth provider at a time.
- `client_ca_chain` is `no_log` (sensitive). Supports OCSP and CRL revocation checks.
- Idempotent updates; check mode is supported.
- Uses `snake_to_camel()` and `get_api_params_from_spec()` for dynamic parameter conversion.

## Files Changed

| File | Description |
|------|-------------|
| `plugins/modules/ntnx_certificate_auth_providers_v2.py` | CRUD module for certificate auth providers |
| `plugins/modules/ntnx_certificate_auth_providers_info_v2.py` | Info module |
| `plugins/module_utils/v4/iam/api_client.py` | Add `get_certificate_auth_provider_api_instance()` |
| `plugins/module_utils/v4/iam/helpers.py` | Add `get_certificate_auth_provider()`, `snake_to_camel()`, `get_api_params_from_spec()` helpers |
| `meta/runtime.yml` | Register modules in action groups |
| `examples/iam_v2/certificate_auth_providers_v2.yml` | Example playbook |
| `tests/integration/targets/ntnx_certificate_auth_providers_v2/` | Integration tests |

## Testing

- Create with CAC enabled, update with idempotency checks, delete
- Check mode for create/update/delete
- Info module list and get-by-id
- Error scenarios (duplicate name, missing name, non-CAC name, invalid cert, wrong ext_id, wrong dir_svc_ext_id)

## Compatibility / Risk

- No breaking changes (new modules only).
- PC allows only one certificate auth provider; create will fail if one already exists.

## Examples

See `examples/iam_v2/certificate_auth_providers_v2.yml` for usage examples.
