### PR TITLE
Add custom header support to all v4 APIs and inventory plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 nutanix-ncp-*
 .ansible/
+
+# Claude Code
+.claude/
+
+# Python
+__pycache__/
+*.pyc
+*.pyo

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,6 @@ nutanix-ncp-*
 .ansible/
 py3.12_virt
 
-# Claude Code
-.claude/
-
 # Python
 __pycache__/
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+
+# Claude Code
+.claude/
+
+# Python
+__pycache__/
+*.pyc
+*.pyo

--- a/README.md
+++ b/README.md
@@ -258,6 +258,66 @@ ansible-playbook <playbook_name>
 ansible-playbook examples/iaas/iaas.yml
 ```
 
+# Authentication
+
+## Username and Password
+
+The standard authentication method uses `nutanix_username` and `nutanix_password`:
+
+```yaml
+module_defaults:
+  group/nutanix.ncp.ntnx:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    validate_certs: true
+```
+
+## API Key
+
+All v2 modules and inventory plugins support API key authentication as an alternative to username and password. Set `nutanix_api_key` in your playbook or inventory config, or export the `NUTANIX_API_KEY` environment variable:
+
+```yaml
+module_defaults:
+  group/nutanix.ncp.ntnx:
+    nutanix_host: <pc_ip>
+    nutanix_api_key: <api_key>
+    validate_certs: true
+```
+
+```bash
+export NUTANIX_API_KEY=<api_key>
+```
+
+## Custom Headers
+
+All v2 modules and inventory plugins support injecting custom HTTP headers into every API request. This is useful in environments that sit behind a proxy or access gateway requiring additional headers (e.g. Cloudflare Access service tokens).
+
+Headers can be set in two ways:
+
+**1. In your playbook or inventory config** (takes precedence):
+```yaml
+module_defaults:
+  group/nutanix.ncp.ntnx:
+    nutanix_host: <pc_ip>
+    nutanix_api_key: <api_key>
+    validate_certs: true
+    custom_headers:
+      CF-Access-Client-Id: <client-id>
+      CF-Access-Client-Secret: <client-secret>
+```
+
+**2. Via environment variables** using the `NUTANIX_HEADER_` prefix:
+
+The prefix is stripped, underscores are converted to hyphens, and each segment is title-cased. For example:
+- `NUTANIX_HEADER_CF_ACCESS_CLIENT_ID` → `Cf-Access-Client-Id`
+- `NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET` → `Cf-Access-Client-Secret`
+
+```bash
+export NUTANIX_HEADER_CF_ACCESS_CLIENT_ID=<client-id>
+export NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET=<client-secret>
+```
+
 # Included Content
 
 Note: v1 are based on legacy APIs (v0.8,v1,v2 and v3 APIs) and v2 are based on prism central v4 APIs.

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ export NUTANIX_HEADER_CF_ACCESS_CLIENT_ID=<client-id>
 export NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET=<client-secret>
 ```
 
+> **Cloudflare ETag note:** Cloudflare strips `ETag` response headers by default. The Nutanix v4 API requires ETags for power actions and updates (via the `If-Match` request header). If you are proxying through Cloudflare, add a cache rule to your Cloudflare zone that preserves `ETag` headers, otherwise these operations will fail.
+
 # Included Content
 
 Note: v1 are based on legacy APIs (v0.8,v1,v2 and v3 APIs) and v2 are based on prism central v4 APIs.

--- a/plugins/doc_fragments/ntnx_credentials.py
+++ b/plugins/doc_fragments/ntnx_credentials.py
@@ -51,6 +51,9 @@ options:
       - Headers can also be supplied via environment variables using the C(NUTANIX_HEADER_) prefix
         (e.g. C(NUTANIX_HEADER_CF_ACCESS_CLIENT_ID) becomes C(Cf-Access-Client-Id)).
         Config values take precedence over environment variables.
+      - When proxying through Cloudflare, add a cache rule to your Cloudflare zone that preserves
+        C(ETag) response headers. The Nutanix v4 API requires ETags for power actions and updates
+        (via the C(If-Match) request header), and Cloudflare strips them by default.
     type: dict
     required: false
   validate_certs:

--- a/plugins/doc_fragments/ntnx_credentials.py
+++ b/plugins/doc_fragments/ntnx_credentials.py
@@ -44,6 +44,15 @@ options:
       - This field is only supported for Prism Central.
     type: str
     required: false
+  custom_headers:
+    description:
+      - Custom HTTP headers to add to all API requests. Useful for environments that require
+        additional headers such as Cloudflare Access service tokens.
+      - Headers can also be supplied via environment variables using the C(NUTANIX_HEADER_) prefix
+        (e.g. C(NUTANIX_HEADER_CF_ACCESS_CLIENT_ID) becomes C(Cf-Access-Client-Id)).
+        Config values take precedence over environment variables.
+    type: dict
+    required: false
   validate_certs:
     description:
         - Set value to C(False) to skip validation for self signed certificates

--- a/plugins/inventory/ntnx_prism_host_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_host_inventory_v2.py
@@ -66,6 +66,15 @@ DOCUMENTATION = r"""
             type: str
             env:
                 - name: NUTANIX_API_KEY
+        custom_headers:
+            description:
+                - Custom HTTP headers to add to all API requests. Useful for environments that
+                  require additional headers such as Cloudflare Access service tokens.
+                - Headers can also be supplied via environment variables using the NUTANIX_HEADER_
+                  prefix (e.g. NUTANIX_HEADER_CF_ACCESS_CLIENT_ID becomes Cf-Access-Client-Id).
+                  Config values take precedence over environment variables.
+            required: false
+            type: dict
         fetch_all_hosts:
             description:
                 - Set to C(True) to fetch all hosts
@@ -192,6 +201,7 @@ EXAMPLES = r"""
 import json  # noqa: E402
 import os  # noqa: E402
 import tempfile  # noqa: E402
+from urllib.parse import urlparse  # noqa: E402
 
 from ansible.errors import AnsibleError  # noqa: E402
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable  # noqa: E402
@@ -216,6 +226,7 @@ class Mock_Module:
         nutanix_debug=False,
         nutanix_log_file=None,
         nutanix_api_key=None,
+        custom_headers=None,
     ):
         self.tmpdir = tempfile.gettempdir()
         self.params = {
@@ -229,6 +240,7 @@ class Mock_Module:
             "nutanix_debug": nutanix_debug,
             "nutanix_log_file": nutanix_log_file,
             "nutanix_api_key": nutanix_api_key,
+            "custom_headers": custom_headers,
         }
 
     def jsonify(self, data):
@@ -433,23 +445,34 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             or os.environ.get("NUTANIX_HOSTNAME")
             or os.environ.get("NUTANIX_HOST")
         )
+        self.nutanix_port = self.get_option("nutanix_port") or os.environ.get(
+            "NUTANIX_PORT", "9440"
+        )
+
+        # Fall back to parsing NUTANIX_ENDPOINT (e.g. https://prism.example.com:9440)
+        if not self.nutanix_host:
+            endpoint = os.environ.get("NUTANIX_ENDPOINT")
+            if endpoint:
+                parsed = urlparse(endpoint)
+                self.nutanix_host = parsed.hostname
+                if parsed.port:
+                    self.nutanix_port = str(parsed.port)
+
         self.nutanix_username = self.get_option("nutanix_username") or os.environ.get(
             "NUTANIX_USERNAME"
         )
         self.nutanix_password = self.get_option("nutanix_password") or os.environ.get(
             "NUTANIX_PASSWORD"
         )
-        self.nutanix_port = self.get_option("nutanix_port") or os.environ.get(
-            "NUTANIX_PORT", "9440"
-        )
         self.nutanix_api_key = self.get_option("nutanix_api_key") or os.environ.get(
             "NUTANIX_API_KEY"
         )
+        self.custom_headers = self.get_option("custom_headers")
 
         # Validate required parameters
         if not self.nutanix_host:
             raise AnsibleError(
-                "nutanix_host must be provided either in inventory file or as NUTANIX_HOSTNAME environment variable or NUTANIX_HOST environment variable"
+                "nutanix_host must be provided either in inventory file or as NUTANIX_HOSTNAME, NUTANIX_HOST, or NUTANIX_ENDPOINT environment variable"
             )
         if (
             not self.nutanix_username or not self.nutanix_password
@@ -493,6 +516,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.nutanix_debug,
             self.nutanix_log_file,
             self.nutanix_api_key,
+            self.custom_headers,
         )
 
         # Get Host API instance

--- a/plugins/inventory/ntnx_prism_host_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_host_inventory_v2.py
@@ -24,9 +24,11 @@ DOCUMENTATION = r"""
             choices: ['ntnx_prism_host_inventory_v2', 'nutanix.ncp.ntnx_prism_host_inventory_v2']
         nutanix_host:
             description:
-                - Prism central hostname or IP address
-                - If not provided, values will be taken from environment variables NUTANIX_HOSTNAME or NUTANIX_HOST
-                - If both are set, NUTANIX_HOSTNAME is preferred over NUTANIX_HOST
+                - Prism Central hostname or IP address
+                - If not provided, values will be taken from environment variables NUTANIX_HOSTNAME, NUTANIX_HOST,
+                  or NUTANIX_ENDPOINT (in that order of preference)
+                - NUTANIX_ENDPOINT is supported for alignment with the Nutanix Terraform provider and should be
+                  set to just the hostname or IP (e.g. C(prism.example.com)), not a full URL
             required: false
             type: str
             env:
@@ -36,6 +38,8 @@ DOCUMENTATION = r"""
             description:
                 - Prism central username
                 - If not provided, values will be taken from environment variable NUTANIX_USERNAME
+                - Supports Jinja2 expressions including lookup plugins
+                  (e.g. C({{ lookup('community.general.onepassword', 'Nutanix', field='username') }}))
             required: false
             type: str
             env:
@@ -44,6 +48,7 @@ DOCUMENTATION = r"""
             description:
                 - Prism central password
                 - If not provided, values will be taken from environment variable NUTANIX_PASSWORD
+                - Supports Jinja2 expressions including lookup plugins
             required: false
             type: str
             env:
@@ -62,6 +67,8 @@ DOCUMENTATION = r"""
             description:
                 - Prism central API key
                 - If not provided, values will be taken from environment variable NUTANIX_API_KEY
+                - Supports Jinja2 expressions including lookup plugins
+                  (e.g. C({{ lookup('community.general.onepassword', 'Nutanix', field='api_key') }}))
             required: false
             type: str
             env:
@@ -73,6 +80,8 @@ DOCUMENTATION = r"""
                 - Headers can also be supplied via environment variables using the NUTANIX_HEADER_
                   prefix (e.g. NUTANIX_HEADER_CF_ACCESS_CLIENT_ID becomes Cf-Access-Client-Id).
                   Config values take precedence over environment variables.
+                - Supports Jinja2 expressions including lookup plugins for secret management.
+                  Inventory file values take precedence over environment variables.
             required: false
             type: dict
         fetch_all_hosts:
@@ -407,6 +416,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
 
         return host_vars
 
+    def _template_option(self, option_name):
+        raw = self.get_option(option_name)
+        if raw and self.templar:
+            return self.templar.template(raw)
+        return raw
+
     def _should_add_host(self, host_vars, host, host_filters, strict):
         """
         Evaluate filter expressions against host_vars and raw host data.
@@ -458,16 +473,19 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 if parsed.port:
                     self.nutanix_port = str(parsed.port)
 
-        self.nutanix_username = self.get_option("nutanix_username") or os.environ.get(
+        self.nutanix_username = self._template_option("nutanix_username") or os.environ.get(
             "NUTANIX_USERNAME"
         )
-        self.nutanix_password = self.get_option("nutanix_password") or os.environ.get(
+        self.nutanix_password = self._template_option("nutanix_password") or os.environ.get(
             "NUTANIX_PASSWORD"
         )
-        self.nutanix_api_key = self.get_option("nutanix_api_key") or os.environ.get(
+        _raw_api_key = self._template_option("nutanix_api_key") or os.environ.get(
             "NUTANIX_API_KEY"
         )
-        self.custom_headers = self.get_option("custom_headers")
+        # Convert to plain str: Ansible's get_option() may return _AnsibleTaggedStr
+        # subclasses which fail strict type(key) is str checks in some SDK clients.
+        self.nutanix_api_key = str(_raw_api_key) if _raw_api_key else None
+        self.custom_headers = self._template_option("custom_headers")
 
         # Validate required parameters
         if not self.nutanix_host:

--- a/plugins/inventory/ntnx_prism_host_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_host_inventory_v2.py
@@ -27,8 +27,8 @@ DOCUMENTATION = r"""
                 - Prism Central hostname or IP address
                 - If not provided, values will be taken from environment variables NUTANIX_HOSTNAME, NUTANIX_HOST,
                   or NUTANIX_ENDPOINT (in that order of preference)
-                - NUTANIX_ENDPOINT is supported for alignment with the Nutanix Terraform provider and should be
-                  set to just the hostname or IP (e.g. C(prism.example.com)), not a full URL
+                - NUTANIX_ENDPOINT is supported for alignment with the Nutanix Terraform provider and accepts
+                  a hostname, IP, or URL (e.g. C(prism.example.com) or C(https://prism.example.com:9440))
             required: false
             type: str
             env:
@@ -469,7 +469,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             endpoint = os.environ.get("NUTANIX_ENDPOINT")
             if endpoint:
                 parsed = urlparse(endpoint)
-                self.nutanix_host = parsed.hostname
+                self.nutanix_host = parsed.hostname or endpoint.split(":")[0]
                 if parsed.port:
                     self.nutanix_port = str(parsed.port)
 

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -25,9 +25,11 @@ DOCUMENTATION = r"""
             choices: ['ntnx_prism_vm_inventory_v2', 'nutanix.ncp.ntnx_prism_vm_inventory_v2']
         nutanix_host:
             description:
-                - Prism central hostname or IP address
-                - If not provided, values will be taken from environment variables NUTANIX_HOSTNAME or NUTANIX_HOST
-                - If both are set, NUTANIX_HOSTNAME is preferred over NUTANIX_HOST
+                - Prism Central hostname or IP address
+                - If not provided, values will be taken from environment variables NUTANIX_HOSTNAME, NUTANIX_HOST,
+                  or NUTANIX_ENDPOINT (in that order of preference)
+                - NUTANIX_ENDPOINT is supported for alignment with the Nutanix Terraform provider and should be
+                  set to just the hostname or IP (e.g. C(prism.example.com)), not a full URL
             required: false
             type: str
             env:
@@ -67,6 +69,15 @@ DOCUMENTATION = r"""
             type: str
             env:
                 - name: NUTANIX_API_KEY
+        custom_headers:
+            description:
+                - Custom HTTP headers to add to all API requests. Useful for environments that
+                  require additional headers such as Cloudflare Access service tokens.
+                - Headers can also be supplied via environment variables using the NUTANIX_HEADER_
+                  prefix (e.g. NUTANIX_HEADER_CF_ACCESS_CLIENT_ID becomes Cf-Access-Client-Id).
+                  Config values take precedence over environment variables.
+            required: false
+            type: dict
         fetch_all_vms:
             description:
                 - Set to C(True) to fetch all VMs
@@ -266,6 +277,7 @@ class Mock_Module:
         nutanix_debug=False,
         nutanix_log_file=None,
         nutanix_api_key=None,
+        custom_headers=None,
     ):
         self.tmpdir = tempfile.gettempdir()
         self.params = {
@@ -280,6 +292,7 @@ class Mock_Module:
             "nutanix_debug": nutanix_debug,
             "nutanix_log_file": nutanix_log_file,
             "nutanix_api_key": nutanix_api_key,
+            "custom_headers": custom_headers,
         }
 
     def jsonify(self, data):
@@ -541,28 +554,36 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self._read_config_data(path)
 
         # Get configuration options from inventory file or environment variables
+        # NUTANIX_ENDPOINT is supported for alignment with the Nutanix Terraform provider.
+        # The value should be a plain hostname or IP (e.g. prism.example.com), not a URL.
         self.nutanix_host = (
             self.get_option("nutanix_host")
             or os.environ.get("NUTANIX_HOSTNAME")
             or os.environ.get("NUTANIX_HOST")
+            or os.environ.get("NUTANIX_ENDPOINT")
         )
+        self.nutanix_port = self.get_option("nutanix_port") or os.environ.get(
+            "NUTANIX_PORT", "9440"
+        )
+
         self.nutanix_username = self.get_option("nutanix_username") or os.environ.get(
             "NUTANIX_USERNAME"
         )
         self.nutanix_password = self.get_option("nutanix_password") or os.environ.get(
             "NUTANIX_PASSWORD"
         )
-        self.nutanix_port = self.get_option("nutanix_port") or os.environ.get(
-            "NUTANIX_PORT", "9440"
-        )
-        self.nutanix_api_key = self.get_option("nutanix_api_key") or os.environ.get(
+        _raw_api_key = self.get_option("nutanix_api_key") or os.environ.get(
             "NUTANIX_API_KEY"
         )
+        # Convert to plain str: Ansible's get_option() may return _AnsibleTaggedStr
+        # subclasses which fail strict type(key) is str checks in some SDK clients.
+        self.nutanix_api_key = str(_raw_api_key) if _raw_api_key else None
+        self.custom_headers = self.get_option("custom_headers")
 
         # Validate required parameters
         if not self.nutanix_host:
             raise AnsibleError(
-                "nutanix_host must be provided either in inventory file or as NUTANIX_HOSTNAME environment variable or NUTANIX_HOST environment variable"
+                "nutanix_host must be provided either in inventory file or as NUTANIX_HOSTNAME, NUTANIX_HOST, or NUTANIX_ENDPOINT environment variable"
             )
         if (
             not self.nutanix_username or not self.nutanix_password
@@ -609,6 +630,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.nutanix_debug,
             self.nutanix_log_file,
             self.nutanix_api_key,
+            self.custom_headers,
         )
 
         # Get VM API instance

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -549,6 +549,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 return False
         return True
 
+    def _template_option(self, option_name):
+        raw = self.get_option(option_name)
+        if raw and self.templar:
+            return self.templar.template(raw)
+        return raw
+
     def parse(self, inventory, loader, path, cache=True):
         super().parse(inventory, loader, path, cache=cache)
         self._read_config_data(path)
@@ -566,19 +572,19 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             "NUTANIX_PORT", "9440"
         )
 
-        self.nutanix_username = self.get_option("nutanix_username") or os.environ.get(
+        self.nutanix_username = self._template_option("nutanix_username") or os.environ.get(
             "NUTANIX_USERNAME"
         )
-        self.nutanix_password = self.get_option("nutanix_password") or os.environ.get(
+        self.nutanix_password = self._template_option("nutanix_password") or os.environ.get(
             "NUTANIX_PASSWORD"
         )
-        _raw_api_key = self.get_option("nutanix_api_key") or os.environ.get(
+        _raw_api_key = self._template_option("nutanix_api_key") or os.environ.get(
             "NUTANIX_API_KEY"
         )
         # Convert to plain str: Ansible's get_option() may return _AnsibleTaggedStr
         # subclasses which fail strict type(key) is str checks in some SDK clients.
         self.nutanix_api_key = str(_raw_api_key) if _raw_api_key else None
-        self.custom_headers = self.get_option("custom_headers")
+        self.custom_headers = self._template_option("custom_headers")
 
         # Validate required parameters
         if not self.nutanix_host:

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -39,6 +39,8 @@ DOCUMENTATION = r"""
             description:
                 - Prism central username
                 - If not provided, values will be taken from environment variable NUTANIX_USERNAME
+                - Supports Jinja2 expressions including lookup plugins
+                  (e.g. C({{ lookup('community.general.onepassword', 'Nutanix', field='username') }}))
             required: false
             type: str
             env:
@@ -47,6 +49,7 @@ DOCUMENTATION = r"""
             description:
                 - Prism central password
                 - If not provided, values will be taken from environment variable NUTANIX_PASSWORD
+                - Supports Jinja2 expressions including lookup plugins
             required: false
             type: str
             env:
@@ -65,6 +68,8 @@ DOCUMENTATION = r"""
             description:
                 - Prism central API key
                 - If not provided, values will be taken from environment variable NUTANIX_API_KEY
+                - Supports Jinja2 expressions including lookup plugins
+                  (e.g. C({{ lookup('community.general.onepassword', 'Nutanix', field='api_key') }}))
             required: false
             type: str
             env:
@@ -76,6 +81,8 @@ DOCUMENTATION = r"""
                 - Headers can also be supplied via environment variables using the NUTANIX_HEADER_
                   prefix (e.g. NUTANIX_HEADER_CF_ACCESS_CLIENT_ID becomes Cf-Access-Client-Id).
                   Config values take precedence over environment variables.
+                - Supports Jinja2 expressions including lookup plugins for secret management.
+                  Inventory file values take precedence over environment variables.
             required: false
             type: dict
         fetch_all_vms:
@@ -245,6 +252,15 @@ EXAMPLES = r"""
   nutanix_host: 10.x.x.x
   nutanix_api_key: api_key
   validate_certs: false
+
+# Using a secrets manager lookup plugin for credentials
+- plugin: nutanix.ncp.ntnx_prism_vm_inventory_v2
+  nutanix_host: 10.x.x.x
+  nutanix_api_key: "{{ lookup('community.general.onepassword', 'Nutanix', field='api_key') }}"
+  custom_headers:
+    CF-Access-Client-Id: "{{ lookup('community.general.onepassword', 'Cloudflare', field='client_id') }}"
+    CF-Access-Client-Secret: "{{ lookup('community.general.onepassword', 'Cloudflare', field='client_secret') }}"
+  validate_certs: true
 """
 
 import json  # noqa: E402

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -28,8 +28,8 @@ DOCUMENTATION = r"""
                 - Prism Central hostname or IP address
                 - If not provided, values will be taken from environment variables NUTANIX_HOSTNAME, NUTANIX_HOST,
                   or NUTANIX_ENDPOINT (in that order of preference)
-                - NUTANIX_ENDPOINT is supported for alignment with the Nutanix Terraform provider and should be
-                  set to just the hostname or IP (e.g. C(prism.example.com)), not a full URL
+                - NUTANIX_ENDPOINT is supported for alignment with the Nutanix Terraform provider and accepts
+                  a hostname, IP, or URL (e.g. C(prism.example.com) or C(https://prism.example.com:9440))
             required: false
             type: str
             env:
@@ -681,7 +681,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             endpoint = os.environ.get("NUTANIX_ENDPOINT")
             if endpoint:
                 parsed = urlparse(endpoint)
-                self.nutanix_host = parsed.hostname
+                self.nutanix_host = parsed.hostname or endpoint.split(":")[0]
                 if parsed.port:
                     self.nutanix_port = str(parsed.port)
 

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -39,6 +39,8 @@ DOCUMENTATION = r"""
             description:
                 - Prism central username
                 - If not provided, values will be taken from environment variable NUTANIX_USERNAME
+                - Supports Jinja2 expressions including lookup plugins
+                  (e.g. C({{ lookup('community.general.onepassword', 'Nutanix', field='username') }}))
             required: false
             type: str
             env:
@@ -47,6 +49,7 @@ DOCUMENTATION = r"""
             description:
                 - Prism central password
                 - If not provided, values will be taken from environment variable NUTANIX_PASSWORD
+                - Supports Jinja2 expressions including lookup plugins
             required: false
             type: str
             env:
@@ -65,6 +68,8 @@ DOCUMENTATION = r"""
             description:
                 - Prism central API key
                 - If not provided, values will be taken from environment variable NUTANIX_API_KEY
+                - Supports Jinja2 expressions including lookup plugins
+                  (e.g. C({{ lookup('community.general.onepassword', 'Nutanix', field='api_key') }}))
             required: false
             type: str
             env:
@@ -92,6 +97,8 @@ DOCUMENTATION = r"""
                 - Headers can also be supplied via environment variables using the NUTANIX_HEADER_
                   prefix (e.g. NUTANIX_HEADER_CF_ACCESS_CLIENT_ID becomes Cf-Access-Client-Id).
                   Config values take precedence over environment variables.
+                - Supports Jinja2 expressions including lookup plugins for secret management.
+                  Inventory file values take precedence over environment variables.
             required: false
             type: dict
         fetch_all_vms:
@@ -282,6 +289,15 @@ EXAMPLES = r"""
   nutanix_host: 10.x.x.x
   nutanix_api_key: api_key
   validate_certs: false
+
+# Using a secrets manager lookup plugin for credentials
+- plugin: nutanix.ncp.ntnx_prism_vm_inventory_v2
+  nutanix_host: 10.x.x.x
+  nutanix_api_key: "{{ lookup('community.general.onepassword', 'Nutanix', field='api_key') }}"
+  custom_headers:
+    CF-Access-Client-Id: "{{ lookup('community.general.onepassword', 'Cloudflare', field='client_id') }}"
+    CF-Access-Client-Secret: "{{ lookup('community.general.onepassword', 'Cloudflare', field='client_secret') }}"
+  validate_certs: true
 """
 
 import json  # noqa: E402

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -18,6 +18,7 @@ DOCUMENTATION = r"""
     requirements:
         - "ntnx_vmm_py_client"
         - "ntnx_clustermgmt_py_client"
+        - "ntnx_prism_py_client"
     options:
         plugin:
             description: Name of the plugin
@@ -685,12 +686,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 if parsed.port:
                     self.nutanix_port = str(parsed.port)
 
-        self.nutanix_username = self._template_option("nutanix_username") or os.environ.get(
-            "NUTANIX_USERNAME"
-        )
-        self.nutanix_password = self._template_option("nutanix_password") or os.environ.get(
-            "NUTANIX_PASSWORD"
-        )
+        self.nutanix_username = self._template_option(
+            "nutanix_username"
+        ) or os.environ.get("NUTANIX_USERNAME")
+        self.nutanix_password = self._template_option(
+            "nutanix_password"
+        ) or os.environ.get("NUTANIX_PASSWORD")
         _raw_api_key = self._template_option("nutanix_api_key") or os.environ.get(
             "NUTANIX_API_KEY"
         )

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -639,6 +639,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             )
         return result
 
+    def _template_option(self, option_name):
+        raw = self.get_option(option_name)
+        if raw and self.templar:
+            return self.templar.template(raw)
+        return raw
+
     def parse(self, inventory, loader, path, cache=True):
         super().parse(inventory, loader, path, cache=cache)
         self._read_config_data(path)
@@ -656,19 +662,19 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             "NUTANIX_PORT", "9440"
         )
 
-        self.nutanix_username = self.get_option("nutanix_username") or os.environ.get(
+        self.nutanix_username = self._template_option("nutanix_username") or os.environ.get(
             "NUTANIX_USERNAME"
         )
-        self.nutanix_password = self.get_option("nutanix_password") or os.environ.get(
+        self.nutanix_password = self._template_option("nutanix_password") or os.environ.get(
             "NUTANIX_PASSWORD"
         )
-        _raw_api_key = self.get_option("nutanix_api_key") or os.environ.get(
+        _raw_api_key = self._template_option("nutanix_api_key") or os.environ.get(
             "NUTANIX_API_KEY"
         )
         # Convert to plain str: Ansible's get_option() may return _AnsibleTaggedStr
         # subclasses which fail strict type(key) is str checks in some SDK clients.
         self.nutanix_api_key = str(_raw_api_key) if _raw_api_key else None
-        self.custom_headers = self.get_option("custom_headers")
+        self.custom_headers = self._template_option("custom_headers")
 
         # Validate required parameters
         if not self.nutanix_host:

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -25,9 +25,11 @@ DOCUMENTATION = r"""
             choices: ['ntnx_prism_vm_inventory_v2', 'nutanix.ncp.ntnx_prism_vm_inventory_v2']
         nutanix_host:
             description:
-                - Prism central hostname or IP address
-                - If not provided, values will be taken from environment variables NUTANIX_HOSTNAME or NUTANIX_HOST
-                - If both are set, NUTANIX_HOSTNAME is preferred over NUTANIX_HOST
+                - Prism Central hostname or IP address
+                - If not provided, values will be taken from environment variables NUTANIX_HOSTNAME, NUTANIX_HOST,
+                  or NUTANIX_ENDPOINT (in that order of preference)
+                - NUTANIX_ENDPOINT is supported for alignment with the Nutanix Terraform provider and should be
+                  set to just the hostname or IP (e.g. C(prism.example.com)), not a full URL
             required: false
             type: str
             env:
@@ -83,6 +85,15 @@ DOCUMENTATION = r"""
                   in keyed_groups, compose, or groups expressions.
             default: true
             type: bool
+        custom_headers:
+            description:
+                - Custom HTTP headers to add to all API requests. Useful for environments that
+                  require additional headers such as Cloudflare Access service tokens.
+                - Headers can also be supplied via environment variables using the NUTANIX_HEADER_
+                  prefix (e.g. NUTANIX_HEADER_CF_ACCESS_CLIENT_ID becomes Cf-Access-Client-Id).
+                  Config values take precedence over environment variables.
+            required: false
+            type: dict
         fetch_all_vms:
             description:
                 - Set to C(True) to fetch all VMs
@@ -309,6 +320,7 @@ class Mock_Module:
         nutanix_debug=False,
         nutanix_log_file=None,
         nutanix_api_key=None,
+        custom_headers=None,
     ):
         self.tmpdir = tempfile.gettempdir()
         self.params = {
@@ -323,6 +335,7 @@ class Mock_Module:
             "nutanix_debug": nutanix_debug,
             "nutanix_log_file": nutanix_log_file,
             "nutanix_api_key": nutanix_api_key,
+            "custom_headers": custom_headers,
         }
 
     def jsonify(self, data):
@@ -631,28 +644,36 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self._read_config_data(path)
 
         # Get configuration options from inventory file or environment variables
+        # NUTANIX_ENDPOINT is supported for alignment with the Nutanix Terraform provider.
+        # The value should be a plain hostname or IP (e.g. prism.example.com), not a URL.
         self.nutanix_host = (
             self.get_option("nutanix_host")
             or os.environ.get("NUTANIX_HOSTNAME")
             or os.environ.get("NUTANIX_HOST")
+            or os.environ.get("NUTANIX_ENDPOINT")
         )
+        self.nutanix_port = self.get_option("nutanix_port") or os.environ.get(
+            "NUTANIX_PORT", "9440"
+        )
+
         self.nutanix_username = self.get_option("nutanix_username") or os.environ.get(
             "NUTANIX_USERNAME"
         )
         self.nutanix_password = self.get_option("nutanix_password") or os.environ.get(
             "NUTANIX_PASSWORD"
         )
-        self.nutanix_port = self.get_option("nutanix_port") or os.environ.get(
-            "NUTANIX_PORT", "9440"
-        )
-        self.nutanix_api_key = self.get_option("nutanix_api_key") or os.environ.get(
+        _raw_api_key = self.get_option("nutanix_api_key") or os.environ.get(
             "NUTANIX_API_KEY"
         )
+        # Convert to plain str: Ansible's get_option() may return _AnsibleTaggedStr
+        # subclasses which fail strict type(key) is str checks in some SDK clients.
+        self.nutanix_api_key = str(_raw_api_key) if _raw_api_key else None
+        self.custom_headers = self.get_option("custom_headers")
 
         # Validate required parameters
         if not self.nutanix_host:
             raise AnsibleError(
-                "nutanix_host must be provided either in inventory file or as NUTANIX_HOSTNAME environment variable or NUTANIX_HOST environment variable"
+                "nutanix_host must be provided either in inventory file or as NUTANIX_HOSTNAME, NUTANIX_HOST, or NUTANIX_ENDPOINT environment variable"
             )
         if (
             not self.nutanix_username or not self.nutanix_password
@@ -701,6 +722,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.nutanix_debug,
             self.nutanix_log_file,
             self.nutanix_api_key,
+            self.custom_headers,
         )
 
         # Get API instances

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -304,6 +304,7 @@ import json  # noqa: E402
 import os  # noqa: E402
 import re  # noqa: E402
 import tempfile  # noqa: E402
+from urllib.parse import urlparse  # noqa: E402
 
 from ansible.errors import AnsibleError  # noqa: E402
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable  # noqa: E402
@@ -666,17 +667,23 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         self._read_config_data(path)
 
         # Get configuration options from inventory file or environment variables
-        # NUTANIX_ENDPOINT is supported for alignment with the Nutanix Terraform provider.
-        # The value should be a plain hostname or IP (e.g. prism.example.com), not a URL.
         self.nutanix_host = (
             self.get_option("nutanix_host")
             or os.environ.get("NUTANIX_HOSTNAME")
             or os.environ.get("NUTANIX_HOST")
-            or os.environ.get("NUTANIX_ENDPOINT")
         )
         self.nutanix_port = self.get_option("nutanix_port") or os.environ.get(
             "NUTANIX_PORT", "9440"
         )
+
+        # Fall back to parsing NUTANIX_ENDPOINT (e.g. https://prism.example.com:9440)
+        if not self.nutanix_host:
+            endpoint = os.environ.get("NUTANIX_ENDPOINT")
+            if endpoint:
+                parsed = urlparse(endpoint)
+                self.nutanix_host = parsed.hostname
+                if parsed.port:
+                    self.nutanix_port = str(parsed.port)
 
         self.nutanix_username = self._template_option("nutanix_username") or os.environ.get(
             "NUTANIX_USERNAME"

--- a/plugins/module_utils/base_module.py
+++ b/plugins/module_utils/base_module.py
@@ -37,6 +37,11 @@ class BaseModule(AnsibleModule):
             fallback=(env_fallback, ["NUTANIX_API_KEY"]),
             required=False,
         ),
+        custom_headers=dict(
+            type="dict",
+            no_log=True,
+            required=False,
+        ),
         validate_certs=dict(
             type="bool", default=True, fallback=(env_fallback, ["VALIDATE_CERTS"])
         ),

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -3,7 +3,34 @@
 
 from __future__ import absolute_import, division, print_function
 
+import os
+
 __metaclass__ = type
+
+
+def get_custom_headers(module_params):
+    """
+    Build a dict of custom HTTP headers from environment variables and module parameters.
+
+    Environment variables with the NUTANIX_HEADER_ prefix are converted to headers by
+    stripping the prefix, replacing underscores with dashes, and title-casing each segment
+    (e.g. NUTANIX_HEADER_CF_ACCESS_CLIENT_ID becomes Cf-Access-Client-Id).
+
+    Config values (module_params['custom_headers']) take precedence over environment variables.
+    """
+    custom_headers = {}
+    header_prefix = "NUTANIX_HEADER_"
+    for key, value in os.environ.items():
+        if key.startswith(header_prefix):
+            header_name = key[len(header_prefix) :]
+            header_name = "-".join(
+                part[0].upper() + part[1:].lower() if part else part
+                for part in header_name.split("_")
+            )
+            custom_headers[header_name] = value
+    config_headers = module_params.get("custom_headers") or {}
+    custom_headers.update(config_headers)
+    return custom_headers
 
 
 def remove_param_with_none_value(d):

--- a/plugins/module_utils/v4/clusters_mgmt/api_client.py
+++ b/plugins/module_utils/v4/clusters_mgmt/api_client.py
@@ -69,6 +69,13 @@ def get_api_client(module):
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
 
+    if api_key:
+        default_headers = getattr(client, "_ApiClient__default_headers", {})
+        if "X-ntnx-api-key" not in default_headers:
+            client.add_default_header(
+                header_name="X-ntnx-api-key", header_value=api_key
+            )
+
     _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled

--- a/plugins/module_utils/v4/clusters_mgmt/api_client.py
+++ b/plugins/module_utils/v4/clusters_mgmt/api_client.py
@@ -12,7 +12,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
 from ..api_logger import setup_api_logging
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 SDK_IMP_ERROR = None
 try:
@@ -68,6 +68,8 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled
     setup_api_logging(module, client)

--- a/plugins/module_utils/v4/clusters_mgmt/api_client.py
+++ b/plugins/module_utils/v4/clusters_mgmt/api_client.py
@@ -69,6 +69,8 @@ def get_api_client(module):
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
 
+    # Ensure X-ntnx-api-key header is present — set_api_key() silently fails
+    # in some SDK clients.
     if api_key:
         default_headers = getattr(client, "_ApiClient__default_headers", {})
         if "X-ntnx-api-key" not in default_headers:

--- a/plugins/module_utils/v4/data_policies/api_client.py
+++ b/plugins/module_utils/v4/data_policies/api_client.py
@@ -12,7 +12,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
 from ..api_logger import setup_api_logging
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 SDK_IMP_ERROR = None
 try:
@@ -68,6 +68,8 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled
     setup_api_logging(module, client)

--- a/plugins/module_utils/v4/data_protection/api_client.py
+++ b/plugins/module_utils/v4/data_protection/api_client.py
@@ -12,7 +12,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
 from ..api_logger import setup_api_logging
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 SDK_IMP_ERROR = None
 try:
@@ -68,6 +68,8 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled
     setup_api_logging(module, client)

--- a/plugins/module_utils/v4/flow/api_client.py
+++ b/plugins/module_utils/v4/flow/api_client.py
@@ -12,7 +12,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
 from ..api_logger import setup_api_logging
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 SDK_IMP_ERROR = None
 try:
@@ -67,6 +67,8 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled
     setup_api_logging(module, client)

--- a/plugins/module_utils/v4/iam/api_client.py
+++ b/plugins/module_utils/v4/iam/api_client.py
@@ -12,7 +12,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
 from ..api_logger import setup_api_logging
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 SDK_IMP_ERROR = None
 try:
@@ -67,6 +67,8 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled
     setup_api_logging(module, client)

--- a/plugins/module_utils/v4/lcm/api_client.py
+++ b/plugins/module_utils/v4/lcm/api_client.py
@@ -12,7 +12,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
 from ..api_logger import setup_api_logging
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 SDK_IMP_ERROR = None
 try:
@@ -71,6 +71,8 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled
     setup_api_logging(module, client)

--- a/plugins/module_utils/v4/licensing/api_client.py
+++ b/plugins/module_utils/v4/licensing/api_client.py
@@ -11,7 +11,7 @@ from base64 import b64encode
 from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 SDK_IMP_ERROR = None
 try:
@@ -71,6 +71,7 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+    _apply_custom_headers(client, module)
     return client
 
 

--- a/plugins/module_utils/v4/licensing/api_client.py
+++ b/plugins/module_utils/v4/licensing/api_client.py
@@ -71,6 +71,7 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
     _apply_custom_headers(client, module)
     return client
 

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -12,7 +12,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
 from ..api_logger import setup_api_logging
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 SDK_IMP_ERROR = None
 try:
@@ -71,6 +71,8 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled
     setup_api_logging(module, client)

--- a/plugins/module_utils/v4/objects/api_client.py
+++ b/plugins/module_utils/v4/objects/api_client.py
@@ -72,6 +72,13 @@ def get_api_client(module):
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
 
+    if api_key:
+        default_headers = getattr(client, "_ApiClient__default_headers", {})
+        if "X-ntnx-api-key" not in default_headers:
+            client.add_default_header(
+                header_name="X-ntnx-api-key", header_value=api_key
+            )
+
     _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled

--- a/plugins/module_utils/v4/objects/api_client.py
+++ b/plugins/module_utils/v4/objects/api_client.py
@@ -12,7 +12,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
 from ..api_logger import setup_api_logging
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 objects_SDK_IMP_ERROR = None
 try:
@@ -71,6 +71,8 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled
     setup_api_logging(module, client)

--- a/plugins/module_utils/v4/objects/api_client.py
+++ b/plugins/module_utils/v4/objects/api_client.py
@@ -72,6 +72,8 @@ def get_api_client(module):
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
 
+    # Ensure X-ntnx-api-key header is present — set_api_key() silently fails
+    # in some SDK clients.
     if api_key:
         default_headers = getattr(client, "_ApiClient__default_headers", {})
         if "X-ntnx-api-key" not in default_headers:

--- a/plugins/module_utils/v4/prism/pc_api_client.py
+++ b/plugins/module_utils/v4/prism/pc_api_client.py
@@ -12,7 +12,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
 from ..api_logger import setup_api_logging
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 PRISM_SDK_IMP_ERROR = None
 try:
@@ -67,6 +67,8 @@ def get_pc_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled
     setup_api_logging(module, client)

--- a/plugins/module_utils/v4/prism/pc_api_client.py
+++ b/plugins/module_utils/v4/prism/pc_api_client.py
@@ -68,6 +68,13 @@ def get_pc_api_client(module):
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
 
+    if api_key:
+        default_headers = getattr(client, "_ApiClient__default_headers", {})
+        if "X-ntnx-api-key" not in default_headers:
+            client.add_default_header(
+                header_name="X-ntnx-api-key", header_value=api_key
+            )
+
     _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled

--- a/plugins/module_utils/v4/prism/pc_api_client.py
+++ b/plugins/module_utils/v4/prism/pc_api_client.py
@@ -68,6 +68,8 @@ def get_pc_api_client(module):
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
 
+    # Ensure X-ntnx-api-key header is present — set_api_key() silently fails
+    # in some SDK clients.
     if api_key:
         default_headers = getattr(client, "_ApiClient__default_headers", {})
         if "X-ntnx-api-key" not in default_headers:

--- a/plugins/module_utils/v4/security/api_client.py
+++ b/plugins/module_utils/v4/security/api_client.py
@@ -67,6 +67,13 @@ def get_api_client(module):
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
 
+    if api_key:
+        default_headers = getattr(client, "_ApiClient__default_headers", {})
+        if "X-ntnx-api-key" not in default_headers:
+            client.add_default_header(
+                header_name="X-ntnx-api-key", header_value=api_key
+            )
+
     _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled

--- a/plugins/module_utils/v4/security/api_client.py
+++ b/plugins/module_utils/v4/security/api_client.py
@@ -67,6 +67,8 @@ def get_api_client(module):
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
 
+    # Ensure X-ntnx-api-key header is present — set_api_key() silently fails
+    # in some SDK clients.
     if api_key:
         default_headers = getattr(client, "_ApiClient__default_headers", {})
         if "X-ntnx-api-key" not in default_headers:

--- a/plugins/module_utils/v4/security/api_client.py
+++ b/plugins/module_utils/v4/security/api_client.py
@@ -12,7 +12,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
 from ..api_logger import setup_api_logging
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 SDK_IMP_ERROR = None
 try:
@@ -66,6 +66,8 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled
     setup_api_logging(module, client)

--- a/plugins/module_utils/v4/utils.py
+++ b/plugins/module_utils/v4/utils.py
@@ -198,6 +198,17 @@ def validate_required_params(module, required_params):
     return missing_params
 
 
+def _apply_custom_headers(client, module):
+    """
+    Apply custom headers from module params and NUTANIX_HEADER_ environment variables
+    to a v4 SDK ApiClient via add_default_header.
+    """
+    from ..utils import get_custom_headers
+
+    for key, value in get_custom_headers(module.params).items():
+        client.add_default_header(header_name=key, header_value=value)
+
+
 def _get_proxy_url(module=None):
     """
     Get proxy URL from module parameters (preferred) or environment variables.

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -12,7 +12,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
 from ..api_logger import setup_api_logging
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 SDK_IMP_ERROR = None
 try:
@@ -67,6 +67,16 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    # Workaround as set_api_key not working as expected for vmm api
+    if api_key:
+        default_headers = getattr(client, "_ApiClient__default_headers", {})
+        if "X-ntnx-api-key" not in default_headers:
+            client.add_default_header(
+                header_name="X-ntnx-api-key", header_value=api_key
+            )
+
+    _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled
     setup_api_logging(module, client)

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -68,7 +68,8 @@ def get_api_client(module):
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
 
-    # Workaround as set_api_key not working as expected for vmm api
+    # Ensure X-ntnx-api-key header is present — set_api_key() silently fails
+    # in some SDK clients.
     if api_key:
         default_headers = getattr(client, "_ApiClient__default_headers", {})
         if "X-ntnx-api-key" not in default_headers:

--- a/plugins/module_utils/v4/volumes/api_client.py
+++ b/plugins/module_utils/v4/volumes/api_client.py
@@ -12,7 +12,7 @@ from ansible.module_utils.basic import missing_required_lib
 
 from ...constants import ALLOW_VERSION_NEGOTIATION
 from ..api_logger import setup_api_logging
-from ..utils import _apply_proxy_from_env
+from ..utils import _apply_custom_headers, _apply_proxy_from_env
 
 SDK_IMP_ERROR = None
 try:
@@ -67,6 +67,8 @@ def get_api_client(module):
             encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
         auth_header = "Basic " + encoded_cred
         client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    _apply_custom_headers(client, module)
 
     # Setup API logging if debug is enabled
     setup_api_logging(module, client)

--- a/tests/unit/plugins/inventory/test_ntnx_prism_vm_inventory_v2.py
+++ b/tests/unit/plugins/inventory/test_ntnx_prism_vm_inventory_v2.py
@@ -1,0 +1,615 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for ntnx_prism_vm_inventory_v2 inventory plugin.
+
+Includes:
+  - Pure unit tests for get_custom_headers() env-var parsing and precedence.
+  - Unit tests verifying custom headers are applied to the API client.
+  - A live integration test (skipped unless NUTANIX_HOST + NUTANIX_API_KEY are set)
+    that retrieves VMs from Prism Central using API key auth and NUTANIX_HEADER_*
+    custom headers (e.g. Cloudflare Access tokens).
+
+Run unit tests only:
+    pytest tests/unit/plugins/inventory/test_ntnx_prism_vm_inventory_v2.py -v -m "not live"
+
+Run all tests (requires sourced .env with NUTANIX_HOST, NUTANIX_API_KEY,
+NUTANIX_HEADER_CF_ACCESS_CLIENT_ID, NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET):
+    source inventory/landscape/.env
+    pytest tests/unit/plugins/inventory/test_ntnx_prism_vm_inventory_v2.py -v -s
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import os
+import sys
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the ansible_collections namespace is importable.
+# The installed collection lives at:
+#   ~/.ansible/collections/ansible_collections/nutanix/ncp/
+# Adding ~/.ansible/collections to sys.path makes
+#   ansible_collections.nutanix.ncp  resolvable.
+# ---------------------------------------------------------------------------
+_COLLECTIONS_PATH = os.path.expanduser("~/.ansible/collections")
+if _COLLECTIONS_PATH not in sys.path:
+    sys.path.insert(0, _COLLECTIONS_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# 1. Unit tests: get_custom_headers()
+# ---------------------------------------------------------------------------
+
+
+class TestGetCustomHeaders:
+    """Tests for the get_custom_headers() utility that converts NUTANIX_HEADER_*
+    environment variables into HTTP header dicts."""
+
+    def _fn(self):
+        from ansible_collections.nutanix.ncp.plugins.module_utils.utils import (
+            get_custom_headers,
+        )
+
+        return get_custom_headers
+
+    def test_single_env_var_converted_to_header(self, monkeypatch):
+        """NUTANIX_HEADER_X_CUSTOM_TOKEN -> X-Custom-Token"""
+        monkeypatch.setenv("NUTANIX_HEADER_X_CUSTOM_TOKEN", "abc123")
+        headers = self._fn()({})
+        assert headers.get("X-Custom-Token") == "abc123"
+
+    def test_cf_access_client_id_conversion(self, monkeypatch):
+        """NUTANIX_HEADER_CF_ACCESS_CLIENT_ID -> Cf-Access-Client-Id"""
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "test-client-id")
+        headers = self._fn()({})
+        assert headers.get("Cf-Access-Client-Id") == "test-client-id"
+
+    def test_cf_access_client_secret_conversion(self, monkeypatch):
+        """NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET -> Cf-Access-Client-Secret"""
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET", "test-secret")
+        headers = self._fn()({})
+        assert headers.get("Cf-Access-Client-Secret") == "test-secret"
+
+    def test_multiple_env_vars_all_collected(self, monkeypatch):
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "id-val")
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET", "secret-val")
+        headers = self._fn()({})
+        assert headers.get("Cf-Access-Client-Id") == "id-val"
+        assert headers.get("Cf-Access-Client-Secret") == "secret-val"
+
+    def test_no_env_vars_returns_empty(self, monkeypatch):
+        for key in list(os.environ.keys()):
+            if key.startswith("NUTANIX_HEADER_"):
+                monkeypatch.delenv(key)
+        headers = self._fn()({})
+        assert headers == {}
+
+    def test_config_headers_take_precedence_over_env(self, monkeypatch):
+        """Explicitly set custom_headers in config override env vars."""
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "env-value")
+        headers = self._fn()(
+            {"custom_headers": {"Cf-Access-Client-Id": "config-value"}}
+        )
+        assert headers["Cf-Access-Client-Id"] == "config-value"
+
+    def test_env_and_config_headers_merged(self, monkeypatch):
+        """Env-var headers and config headers are merged; config wins on conflict."""
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "env-id")
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET", "env-secret")
+        headers = self._fn()({"custom_headers": {"Cf-Access-Client-Id": "config-id"}})
+        assert headers["Cf-Access-Client-Id"] == "config-id"
+        assert headers["Cf-Access-Client-Secret"] == "env-secret"
+
+    def test_non_nutanix_header_env_vars_ignored(self, monkeypatch):
+        monkeypatch.setenv("SOME_OTHER_VAR", "ignored")
+        monkeypatch.setenv("NUTANIX_HOST", "host-ignored")
+        for key in list(os.environ.keys()):
+            if key.startswith("NUTANIX_HEADER_"):
+                monkeypatch.delenv(key)
+        headers = self._fn()({})
+        assert headers == {}
+
+
+# ---------------------------------------------------------------------------
+# 2. Unit tests: custom headers applied to API client
+# ---------------------------------------------------------------------------
+
+
+class TestCustomHeadersAppliedToApiClient:
+    """Verify that _apply_custom_headers() adds all headers returned by
+    get_custom_headers() to the SDK ApiClient via add_default_header()."""
+
+    def test_headers_added_to_client(self, monkeypatch):
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "test-id")
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET", "test-secret")
+
+        from unittest.mock import MagicMock
+
+        mock_client = MagicMock()
+        mock_module = MagicMock()
+        mock_module.params = {"custom_headers": None}
+
+        from ansible_collections.nutanix.ncp.plugins.module_utils.v4.utils import (
+            _apply_custom_headers,
+        )
+
+        _apply_custom_headers(mock_client, mock_module)
+
+        added = {
+            call.kwargs.get("header_name")
+            or call.args[0]: call.kwargs.get("header_value")
+            or call.args[1]
+            for call in mock_client.add_default_header.call_args_list
+        }
+        assert added.get("Cf-Access-Client-Id") == "test-id"
+        assert added.get("Cf-Access-Client-Secret") == "test-secret"
+
+    def test_no_headers_added_when_env_empty(self, monkeypatch):
+        for key in list(os.environ.keys()):
+            if key.startswith("NUTANIX_HEADER_"):
+                monkeypatch.delenv(key)
+
+        from unittest.mock import MagicMock
+
+        mock_client = MagicMock()
+        mock_module = MagicMock()
+        mock_module.params = {"custom_headers": None}
+
+        from ansible_collections.nutanix.ncp.plugins.module_utils.v4.utils import (
+            _apply_custom_headers,
+        )
+
+        _apply_custom_headers(mock_client, mock_module)
+        mock_client.add_default_header.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 3. Parametrised unit tests: every v4 API client calls _apply_custom_headers
+# ---------------------------------------------------------------------------
+
+_V4_API_CLIENTS = [
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.vmm.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.clusters_mgmt.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.network.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.iam.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.flow.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.data_protection.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.data_policies.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.volumes.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.objects.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.security.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.lcm.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.licensing.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.prism.pc_api_client",
+]
+
+_SDK_MODULES = {
+    "vmm": "ntnx_vmm_py_client",
+    "clusters_mgmt": "ntnx_clustermgmt_py_client",
+    "network": "ntnx_networking_py_client",
+    "iam": "ntnx_iam_py_client",
+    "flow": "ntnx_microseg_py_client",
+    "data_protection": "ntnx_dataprotection_py_client",
+    "data_policies": "ntnx_datapolicies_py_client",
+    "volumes": "ntnx_volumes_py_client",
+    "objects": "ntnx_objects_py_client",
+    "security": "ntnx_security_py_client",
+    "lcm": "ntnx_lifecycle_py_client",
+    "licensing": "ntnx_licensing_py_client",
+    "prism": "ntnx_prism_py_client",
+}
+
+# Some clients use a name other than get_api_client
+_GET_API_CLIENT_FN = {
+    "prism": "get_pc_api_client",
+}
+
+
+def _client_id(module_path):
+    """Pytest ID: use the API area name (e.g. 'vmm', 'iam')."""
+    return module_path.split(".")[-2]
+
+
+@pytest.mark.parametrize("client_module_path", _V4_API_CLIENTS, ids=_client_id)
+class TestAllV4ClientsApplyCustomHeaders:
+    """For every v4 API client, verify that get_api_client() calls
+    _apply_custom_headers(), which adds NUTANIX_HEADER_* env vars as HTTP
+    headers on the SDK ApiClient instance.
+
+    The underlying SDK packages are mocked so no network access is needed.
+    """
+
+    def _make_mock_module(self):
+        from unittest.mock import MagicMock
+
+        module = MagicMock()
+        module.params = {
+            "nutanix_host": "10.0.0.1",
+            "nutanix_port": "9440",
+            "nutanix_username": None,
+            "nutanix_password": None,
+            "nutanix_api_key": "test-api-key",
+            "validate_certs": False,
+            "nutanix_debug": False,
+            "nutanix_log_file": None,
+            "custom_headers": None,
+            "load_params_without_defaults": False,
+            "https_proxy": None,
+            "http_proxy": None,
+            "all_proxy": None,
+            "no_proxy": None,
+        }
+        module.fail_json.side_effect = Exception("fail_json called")
+        return module
+
+    def test_custom_headers_applied(self, client_module_path, monkeypatch):
+        """get_api_client() must add NUTANIX_HEADER_* env vars to the client."""
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "test-cf-id")
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET", "test-cf-secret")
+
+        import importlib
+        from unittest.mock import MagicMock, patch
+
+        # Derive which SDK package this client imports
+        api_area = client_module_path.split(".")[-2]
+        sdk_name = _SDK_MODULES[api_area]
+
+        # Build a minimal mock SDK that satisfies get_api_client()
+        mock_sdk = MagicMock()
+        mock_config = MagicMock()
+        mock_client = MagicMock()
+        mock_sdk.Configuration.return_value = mock_config
+        mock_sdk.ApiClient.return_value = mock_client
+
+        with patch.dict("sys.modules", {sdk_name: mock_sdk}):
+            client_mod = importlib.import_module(client_module_path)
+            importlib.reload(client_mod)
+
+            fn_name = _GET_API_CLIENT_FN.get(api_area, "get_api_client")
+            module = self._make_mock_module()
+            getattr(client_mod, fn_name)(module)
+
+        added = {
+            call.kwargs.get("header_name")
+            or call.args[0]: (call.kwargs.get("header_value") or call.args[1])
+            for call in mock_client.add_default_header.call_args_list
+        }
+
+        assert (
+            "Cf-Access-Client-Id" in added
+        ), f"{client_module_path}: Cf-Access-Client-Id missing from default headers"
+        assert added["Cf-Access-Client-Id"] == "test-cf-id"
+        assert (
+            "Cf-Access-Client-Secret" in added
+        ), f"{client_module_path}: Cf-Access-Client-Secret missing from default headers"
+        assert added["Cf-Access-Client-Secret"] == "test-cf-secret"
+
+    def test_no_custom_headers_when_env_empty(self, client_module_path, monkeypatch):
+        """When no NUTANIX_HEADER_* env vars are set, no custom headers are added."""
+        for key in list(os.environ.keys()):
+            if key.startswith("NUTANIX_HEADER_"):
+                monkeypatch.delenv(key)
+
+        import importlib
+        from unittest.mock import MagicMock, patch
+
+        api_area = client_module_path.split(".")[-2]
+        sdk_name = _SDK_MODULES[api_area]
+
+        mock_sdk = MagicMock()
+        mock_config = MagicMock()
+        mock_client = MagicMock()
+        mock_sdk.Configuration.return_value = mock_config
+        mock_sdk.ApiClient.return_value = mock_client
+
+        with patch.dict("sys.modules", {sdk_name: mock_sdk}):
+            client_mod = importlib.import_module(client_module_path)
+            importlib.reload(client_mod)
+
+            fn_name = _GET_API_CLIENT_FN.get(api_area, "get_api_client")
+            module = self._make_mock_module()
+            getattr(client_mod, fn_name)(module)
+
+        added_names = [
+            call.kwargs.get("header_name") or call.args[0]
+            for call in mock_client.add_default_header.call_args_list
+        ]
+        custom = [h for h in added_names if h.startswith("Cf-")]
+        assert (
+            custom == []
+        ), f"{client_module_path}: unexpected custom headers added: {custom}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Unit tests: parse() strips Ansible tagged string types from api_key
+# ---------------------------------------------------------------------------
+
+
+class _AnsibleTaggedStr(str):
+    """Minimal stand-in for ansible.utils.unsafe_proxy.AnsibleUnsafeText /
+    ansible.parsing.yaml.objects.AnsibleTaggedStr.
+
+    Ansible's get_option() returns str *subclasses*, not plain str.  The VMM
+    SDK's Configuration.set_api_key() uses ``type(key) is str`` (strict check),
+    so a subclass value is treated as None and authentication silently breaks.
+    """
+
+
+class TestAnsibleTaggedStrApiKey:
+    """Prove that parse() correctly handles _AnsibleTaggedStr api_key values.
+
+    This test class captures the root cause of ansible-inventory --graph
+    failing even when NUTANIX_API_KEY is set: Ansible's config layer wraps
+    string option values in a str subclass (_AnsibleTaggedStr / AnsibleUnsafeText),
+    and the Nutanix VMM SDK's Configuration.set_api_key() uses a strict
+    ``type(key) is str`` check that rejects subclasses, silently setting the
+    key to None.  The fix is to convert the api_key to plain str in parse().
+    """
+
+    def test_sdk_set_api_key_rejects_str_subclass(self):
+        """Demonstrate the SDK bug: type(key) is str fails for str subclasses."""
+        import ntnx_vmm_py_client
+
+        config = ntnx_vmm_py_client.Configuration()
+        tagged = _AnsibleTaggedStr("my-secret-api-key")
+        config.set_api_key(tagged)
+
+        # The SDK silently sets None because type(tagged) is not str
+        assert (
+            config.api_key.get("X-ntnx-api-key") is None
+        ), "Expected SDK to reject str subclass (proving the known SDK limitation)"
+
+    def test_sdk_set_api_key_accepts_plain_str(self):
+        """Plain str always works with set_api_key."""
+        import ntnx_vmm_py_client
+
+        config = ntnx_vmm_py_client.Configuration()
+        config.set_api_key("my-secret-api-key")
+
+        assert config.api_key.get("X-ntnx-api-key") == "my-secret-api-key"
+
+    def test_parse_converts_tagged_api_key_to_plain_str(self, monkeypatch):
+        """parse() must call str() on the api_key so that the VMM SDK's strict
+        type check accepts it.  This is the regression test for the root cause
+        of ansible-inventory --graph failing silently.
+        """
+        from unittest.mock import patch as mock_patch
+
+        from ansible.inventory.data import InventoryData
+        from ansible.parsing.dataloader import DataLoader
+        from ansible_collections.nutanix.ncp.plugins.inventory.ntnx_prism_vm_inventory_v2 import (
+            InventoryModule,
+        )
+
+        # Use a str subclass (simulating Ansible's _AnsibleTaggedStr)
+        tagged_api_key = _AnsibleTaggedStr("test-api-key-12345")
+        assert isinstance(
+            tagged_api_key, _AnsibleTaggedStr
+        ), "Pre-condition: must be a str subclass"
+
+        captured_module = {}
+
+        def fake_get_vm_api_instance(module):
+            captured_module["module"] = module
+            raise Exception("stop-early")
+
+        with mock_patch(
+            "ansible_collections.nutanix.ncp.plugins.inventory.ntnx_prism_vm_inventory_v2.get_vm_api_instance",
+            side_effect=fake_get_vm_api_instance,
+        ):
+            options = {
+                "nutanix_host": "10.0.0.1",
+                "nutanix_port": "9440",
+                "nutanix_username": None,
+                "nutanix_password": None,
+                "nutanix_api_key": tagged_api_key,
+                "custom_headers": None,
+                "validate_certs": False,
+                "fetch_all_vms": False,
+                "page": 0,
+                "limit": 10,
+                "filter": None,
+                "custom_ansible_host": None,
+                "nutanix_debug": False,
+                "nutanix_log_file": None,
+                "filters": [],
+                "strict": False,
+                "compose": {},
+                "groups": {},
+                "keyed_groups": [],
+            }
+            plugin = InventoryModule()
+            with mock_patch.object(InventoryModule, "_read_config_data"):
+                plugin._options = options
+                try:
+                    plugin.parse(
+                        InventoryData(), DataLoader(), "nutanix.yaml", cache=False
+                    )
+                except Exception:
+                    pass  # expected: we raised "stop-early"
+
+        assert (
+            "module" in captured_module
+        ), "Mock_Module was not passed to get_vm_api_instance"
+        module = captured_module["module"]
+        stored_key = module.params.get("nutanix_api_key")
+        assert isinstance(stored_key, str) and not isinstance(
+            stored_key, _AnsibleTaggedStr
+        ), (
+            f"Expected plain str in Mock_Module.params['nutanix_api_key'], "
+            f"got {type(stored_key).__name__!r}. "
+            "parse() must convert get_option() results to plain str before "
+            "passing to Mock_Module to avoid VMM SDK's strict type check failing."
+        )
+        assert stored_key == "test-api-key-12345"
+
+
+# ---------------------------------------------------------------------------
+# 5. Live integration test: list VMs via real Prism Central API
+# ---------------------------------------------------------------------------
+
+_LIVE_SKIP_REASON = (
+    "Live test requires NUTANIX_HOST and NUTANIX_API_KEY environment variables. "
+    "Source inventory/landscape/.env before running."
+)
+
+
+@pytest.mark.live
+@pytest.mark.skipif(
+    not os.environ.get("NUTANIX_HOST") or not os.environ.get("NUTANIX_API_KEY"),
+    reason=_LIVE_SKIP_REASON,
+)
+class TestLiveListVms:
+    """Integration test: exercises the full path from Mock_Module -> API client
+    -> list_vms() against a real Prism Central instance.
+
+    Validates:
+    - API key authentication works.
+    - NUTANIX_HEADER_CF_ACCESS_CLIENT_ID / _SECRET are sent as Cloudflare
+      Access headers and the request is not rejected.
+    - At least one page of VMs (or an empty list) is returned without error.
+    """
+
+    def _build_module(self):
+        """Construct a Mock_Module using env vars from the sourced .env file."""
+        from ansible_collections.nutanix.ncp.plugins.inventory.ntnx_prism_vm_inventory_v2 import (
+            Mock_Module,
+        )
+
+        host = os.environ.get("NUTANIX_HOST") or os.environ.get("NUTANIX_HOSTNAME")
+        port = os.environ.get("NUTANIX_PORT", "9440")
+        api_key = os.environ.get("NUTANIX_API_KEY")
+
+        return Mock_Module(
+            hostname=host,
+            port=port,
+            username=None,
+            password=None,
+            validate_certs=False,
+            nutanix_api_key=api_key,
+            custom_headers=None,  # headers come from NUTANIX_HEADER_* env vars
+        )
+
+    def test_list_vms_returns_response(self):
+        """list_vms() succeeds and returns a valid SDK response object."""
+        from ansible_collections.nutanix.ncp.plugins.module_utils.v4.vmm.api_client import (
+            get_vm_api_instance,
+        )
+
+        module = self._build_module()
+        vmm = get_vm_api_instance(module)
+
+        resp = vmm.list_vms(_page=0, _limit=10)
+
+        assert resp is not None, "Expected a response object from list_vms()"
+        assert hasattr(resp, "data"), "Response should have a 'data' attribute"
+        print(
+            f"\n[live] list_vms returned {len(resp.data or [])} VMs "
+            f"(total_available={getattr(resp.metadata, 'total_available_results', 'N/A')})"
+        )
+
+    def test_custom_headers_present_on_client(self):
+        """Verify CF Access headers are set on the API client before any request."""
+        cf_id = os.environ.get("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID")
+        cf_secret = os.environ.get("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET")
+        if not cf_id or not cf_secret:
+            pytest.skip("CF Access env vars not set — skipping header presence check")
+
+        from ansible_collections.nutanix.ncp.plugins.module_utils.v4.vmm.api_client import (
+            get_api_client,
+        )
+
+        module = self._build_module()
+        client = get_api_client(module)
+
+        default_headers = getattr(client, "_ApiClient__default_headers", {})
+        assert (
+            "Cf-Access-Client-Id" in default_headers
+        ), "CF-Access-Client-Id header missing from API client default headers"
+        assert (
+            "Cf-Access-Client-Secret" in default_headers
+        ), "CF-Access-Client-Secret header missing from API client default headers"
+        assert default_headers["Cf-Access-Client-Id"] == cf_id
+        assert default_headers["Cf-Access-Client-Secret"] == cf_secret
+        print("\n[live] CF Access headers confirmed on API client")
+
+    def test_list_vms_with_filter(self):
+        """list_vms() with an OData filter returns only matching VMs."""
+        from ansible_collections.nutanix.ncp.plugins.module_utils.v4.vmm.api_client import (
+            get_vm_api_instance,
+        )
+
+        module = self._build_module()
+        vmm = get_vm_api_instance(module)
+
+        resp = vmm.list_vms(_page=0, _limit=10, _filter="startswith(name, 'frg-')")
+
+        assert resp is not None
+        assert hasattr(resp, "data")
+        vms = resp.data or []
+        print(f"\n[live] list_vms(filter='frg-') returned {len(vms)} VMs")
+        for vm in vms:
+            vm_dict = vm.to_dict() if hasattr(vm, "to_dict") else {}
+            assert vm_dict.get("name", "").startswith(
+                "frg-"
+            ), f"VM '{vm_dict.get('name')}' does not match filter startswith(name, 'frg-')"
+
+    def test_inventory_plugin_parse_returns_hosts(self):
+        """Full end-to-end: InventoryModule.parse() populates hosts via the
+        same code path that ansible-inventory --graph uses."""
+        from unittest.mock import patch as mock_patch
+
+        from ansible.inventory.data import InventoryData
+        from ansible.parsing.dataloader import DataLoader
+        from ansible_collections.nutanix.ncp.plugins.inventory.ntnx_prism_vm_inventory_v2 import (
+            InventoryModule,
+        )
+
+        inventory = InventoryData()
+        loader = DataLoader()
+
+        options = {
+            "nutanix_host": os.environ.get("NUTANIX_HOST"),
+            "nutanix_port": os.environ.get("NUTANIX_PORT", "9440"),
+            "nutanix_username": None,
+            "nutanix_password": None,
+            "nutanix_api_key": os.environ.get("NUTANIX_API_KEY"),
+            "custom_headers": None,
+            "validate_certs": False,
+            "fetch_all_vms": False,
+            "page": 0,
+            "limit": 10,
+            "filter": None,
+            "custom_ansible_host": None,
+            "nutanix_debug": False,
+            "nutanix_log_file": None,
+            "filters": [],
+            "strict": False,
+            "compose": {},
+            "groups": {},
+            "keyed_groups": [],
+        }
+
+        plugin = InventoryModule()
+
+        # Patch _read_config_data to a no-op and inject options directly,
+        # bypassing Ansible's config manager (not available outside ansible-test).
+        with mock_patch.object(InventoryModule, "_read_config_data"):
+            plugin._options = options
+            plugin.parse(inventory, loader, "nutanix.yaml", cache=False)
+
+        hosts = list(inventory.hosts.keys())
+        print(f"\n[live] inventory parse() added {len(hosts)} hosts: {hosts[:5]}")
+        assert len(hosts) > 0, "Expected at least one host from inventory parse()"

--- a/tests/unit/plugins/inventory/test_ntnx_prism_vm_inventory_v2.py
+++ b/tests/unit/plugins/inventory/test_ntnx_prism_vm_inventory_v2.py
@@ -395,7 +395,9 @@ class TestAnsibleTaggedStrApiKey:
 
         # Use a str subclass (simulating Ansible's _AnsibleTaggedStr)
         tagged_api_key = _AnsibleTaggedStr("test-api-key-12345")
-        assert type(tagged_api_key) is not str, "Pre-condition: must be a str subclass"
+        assert isinstance(
+            tagged_api_key, _AnsibleTaggedStr
+        ), "Pre-condition: must be a str subclass"
 
         captured_module = {}
 
@@ -443,7 +445,9 @@ class TestAnsibleTaggedStrApiKey:
         ), "Mock_Module was not passed to get_vm_api_instance"
         module = captured_module["module"]
         stored_key = module.params.get("nutanix_api_key")
-        assert type(stored_key) is str, (
+        assert isinstance(stored_key, str) and not isinstance(
+            stored_key, _AnsibleTaggedStr
+        ), (
             f"Expected plain str in Mock_Module.params['nutanix_api_key'], "
             f"got {type(stored_key).__name__!r}. "
             "parse() must convert get_option() results to plain str before "

--- a/tests/unit/plugins/inventory/test_ntnx_prism_vm_inventory_v2.py
+++ b/tests/unit/plugins/inventory/test_ntnx_prism_vm_inventory_v2.py
@@ -1,0 +1,611 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for ntnx_prism_vm_inventory_v2 inventory plugin.
+
+Includes:
+  - Pure unit tests for get_custom_headers() env-var parsing and precedence.
+  - Unit tests verifying custom headers are applied to the API client.
+  - A live integration test (skipped unless NUTANIX_HOST + NUTANIX_API_KEY are set)
+    that retrieves VMs from Prism Central using API key auth and NUTANIX_HEADER_*
+    custom headers (e.g. Cloudflare Access tokens).
+
+Run unit tests only:
+    pytest tests/unit/plugins/inventory/test_ntnx_prism_vm_inventory_v2.py -v -m "not live"
+
+Run all tests (requires sourced .env with NUTANIX_HOST, NUTANIX_API_KEY,
+NUTANIX_HEADER_CF_ACCESS_CLIENT_ID, NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET):
+    source inventory/landscape/.env
+    pytest tests/unit/plugins/inventory/test_ntnx_prism_vm_inventory_v2.py -v -s
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import os
+import sys
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the ansible_collections namespace is importable.
+# The installed collection lives at:
+#   ~/.ansible/collections/ansible_collections/nutanix/ncp/
+# Adding ~/.ansible/collections to sys.path makes
+#   ansible_collections.nutanix.ncp  resolvable.
+# ---------------------------------------------------------------------------
+_COLLECTIONS_PATH = os.path.expanduser("~/.ansible/collections")
+if _COLLECTIONS_PATH not in sys.path:
+    sys.path.insert(0, _COLLECTIONS_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# 1. Unit tests: get_custom_headers()
+# ---------------------------------------------------------------------------
+
+
+class TestGetCustomHeaders:
+    """Tests for the get_custom_headers() utility that converts NUTANIX_HEADER_*
+    environment variables into HTTP header dicts."""
+
+    def _fn(self):
+        from ansible_collections.nutanix.ncp.plugins.module_utils.utils import (
+            get_custom_headers,
+        )
+
+        return get_custom_headers
+
+    def test_single_env_var_converted_to_header(self, monkeypatch):
+        """NUTANIX_HEADER_X_CUSTOM_TOKEN -> X-Custom-Token"""
+        monkeypatch.setenv("NUTANIX_HEADER_X_CUSTOM_TOKEN", "abc123")
+        headers = self._fn()({})
+        assert headers.get("X-Custom-Token") == "abc123"
+
+    def test_cf_access_client_id_conversion(self, monkeypatch):
+        """NUTANIX_HEADER_CF_ACCESS_CLIENT_ID -> Cf-Access-Client-Id"""
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "test-client-id")
+        headers = self._fn()({})
+        assert headers.get("Cf-Access-Client-Id") == "test-client-id"
+
+    def test_cf_access_client_secret_conversion(self, monkeypatch):
+        """NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET -> Cf-Access-Client-Secret"""
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET", "test-secret")
+        headers = self._fn()({})
+        assert headers.get("Cf-Access-Client-Secret") == "test-secret"
+
+    def test_multiple_env_vars_all_collected(self, monkeypatch):
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "id-val")
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET", "secret-val")
+        headers = self._fn()({})
+        assert headers.get("Cf-Access-Client-Id") == "id-val"
+        assert headers.get("Cf-Access-Client-Secret") == "secret-val"
+
+    def test_no_env_vars_returns_empty(self, monkeypatch):
+        for key in list(os.environ.keys()):
+            if key.startswith("NUTANIX_HEADER_"):
+                monkeypatch.delenv(key)
+        headers = self._fn()({})
+        assert headers == {}
+
+    def test_config_headers_take_precedence_over_env(self, monkeypatch):
+        """Explicitly set custom_headers in config override env vars."""
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "env-value")
+        headers = self._fn()(
+            {"custom_headers": {"Cf-Access-Client-Id": "config-value"}}
+        )
+        assert headers["Cf-Access-Client-Id"] == "config-value"
+
+    def test_env_and_config_headers_merged(self, monkeypatch):
+        """Env-var headers and config headers are merged; config wins on conflict."""
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "env-id")
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET", "env-secret")
+        headers = self._fn()({"custom_headers": {"Cf-Access-Client-Id": "config-id"}})
+        assert headers["Cf-Access-Client-Id"] == "config-id"
+        assert headers["Cf-Access-Client-Secret"] == "env-secret"
+
+    def test_non_nutanix_header_env_vars_ignored(self, monkeypatch):
+        monkeypatch.setenv("SOME_OTHER_VAR", "ignored")
+        monkeypatch.setenv("NUTANIX_HOST", "host-ignored")
+        for key in list(os.environ.keys()):
+            if key.startswith("NUTANIX_HEADER_"):
+                monkeypatch.delenv(key)
+        headers = self._fn()({})
+        assert headers == {}
+
+
+# ---------------------------------------------------------------------------
+# 2. Unit tests: custom headers applied to API client
+# ---------------------------------------------------------------------------
+
+
+class TestCustomHeadersAppliedToApiClient:
+    """Verify that _apply_custom_headers() adds all headers returned by
+    get_custom_headers() to the SDK ApiClient via add_default_header()."""
+
+    def test_headers_added_to_client(self, monkeypatch):
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "test-id")
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET", "test-secret")
+
+        from unittest.mock import MagicMock
+
+        mock_client = MagicMock()
+        mock_module = MagicMock()
+        mock_module.params = {"custom_headers": None}
+
+        from ansible_collections.nutanix.ncp.plugins.module_utils.v4.utils import (
+            _apply_custom_headers,
+        )
+
+        _apply_custom_headers(mock_client, mock_module)
+
+        added = {
+            call.kwargs.get("header_name")
+            or call.args[0]: call.kwargs.get("header_value")
+            or call.args[1]
+            for call in mock_client.add_default_header.call_args_list
+        }
+        assert added.get("Cf-Access-Client-Id") == "test-id"
+        assert added.get("Cf-Access-Client-Secret") == "test-secret"
+
+    def test_no_headers_added_when_env_empty(self, monkeypatch):
+        for key in list(os.environ.keys()):
+            if key.startswith("NUTANIX_HEADER_"):
+                monkeypatch.delenv(key)
+
+        from unittest.mock import MagicMock
+
+        mock_client = MagicMock()
+        mock_module = MagicMock()
+        mock_module.params = {"custom_headers": None}
+
+        from ansible_collections.nutanix.ncp.plugins.module_utils.v4.utils import (
+            _apply_custom_headers,
+        )
+
+        _apply_custom_headers(mock_client, mock_module)
+        mock_client.add_default_header.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 3. Parametrised unit tests: every v4 API client calls _apply_custom_headers
+# ---------------------------------------------------------------------------
+
+_V4_API_CLIENTS = [
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.vmm.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.clusters_mgmt.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.network.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.iam.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.flow.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.data_protection.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.data_policies.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.volumes.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.objects.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.security.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.lcm.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.licensing.api_client",
+    "ansible_collections.nutanix.ncp.plugins.module_utils.v4.prism.pc_api_client",
+]
+
+_SDK_MODULES = {
+    "vmm": "ntnx_vmm_py_client",
+    "clusters_mgmt": "ntnx_clustermgmt_py_client",
+    "network": "ntnx_networking_py_client",
+    "iam": "ntnx_iam_py_client",
+    "flow": "ntnx_microseg_py_client",
+    "data_protection": "ntnx_dataprotection_py_client",
+    "data_policies": "ntnx_datapolicies_py_client",
+    "volumes": "ntnx_volumes_py_client",
+    "objects": "ntnx_objects_py_client",
+    "security": "ntnx_security_py_client",
+    "lcm": "ntnx_lifecycle_py_client",
+    "licensing": "ntnx_licensing_py_client",
+    "prism": "ntnx_prism_py_client",
+}
+
+# Some clients use a name other than get_api_client
+_GET_API_CLIENT_FN = {
+    "prism": "get_pc_api_client",
+}
+
+
+def _client_id(module_path):
+    """Pytest ID: use the API area name (e.g. 'vmm', 'iam')."""
+    return module_path.split(".")[-2]
+
+
+@pytest.mark.parametrize("client_module_path", _V4_API_CLIENTS, ids=_client_id)
+class TestAllV4ClientsApplyCustomHeaders:
+    """For every v4 API client, verify that get_api_client() calls
+    _apply_custom_headers(), which adds NUTANIX_HEADER_* env vars as HTTP
+    headers on the SDK ApiClient instance.
+
+    The underlying SDK packages are mocked so no network access is needed.
+    """
+
+    def _make_mock_module(self):
+        from unittest.mock import MagicMock
+
+        module = MagicMock()
+        module.params = {
+            "nutanix_host": "10.0.0.1",
+            "nutanix_port": "9440",
+            "nutanix_username": None,
+            "nutanix_password": None,
+            "nutanix_api_key": "test-api-key",
+            "validate_certs": False,
+            "nutanix_debug": False,
+            "nutanix_log_file": None,
+            "custom_headers": None,
+            "load_params_without_defaults": False,
+            "https_proxy": None,
+            "http_proxy": None,
+            "all_proxy": None,
+            "no_proxy": None,
+        }
+        module.fail_json.side_effect = Exception("fail_json called")
+        return module
+
+    def test_custom_headers_applied(self, client_module_path, monkeypatch):
+        """get_api_client() must add NUTANIX_HEADER_* env vars to the client."""
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID", "test-cf-id")
+        monkeypatch.setenv("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET", "test-cf-secret")
+
+        import importlib
+        from unittest.mock import MagicMock, patch
+
+        # Derive which SDK package this client imports
+        api_area = client_module_path.split(".")[-2]
+        sdk_name = _SDK_MODULES[api_area]
+
+        # Build a minimal mock SDK that satisfies get_api_client()
+        mock_sdk = MagicMock()
+        mock_config = MagicMock()
+        mock_client = MagicMock()
+        mock_sdk.Configuration.return_value = mock_config
+        mock_sdk.ApiClient.return_value = mock_client
+
+        with patch.dict("sys.modules", {sdk_name: mock_sdk}):
+            client_mod = importlib.import_module(client_module_path)
+            importlib.reload(client_mod)
+
+            fn_name = _GET_API_CLIENT_FN.get(api_area, "get_api_client")
+            module = self._make_mock_module()
+            getattr(client_mod, fn_name)(module)
+
+        added = {
+            call.kwargs.get("header_name")
+            or call.args[0]: (call.kwargs.get("header_value") or call.args[1])
+            for call in mock_client.add_default_header.call_args_list
+        }
+
+        assert (
+            "Cf-Access-Client-Id" in added
+        ), f"{client_module_path}: Cf-Access-Client-Id missing from default headers"
+        assert added["Cf-Access-Client-Id"] == "test-cf-id"
+        assert (
+            "Cf-Access-Client-Secret" in added
+        ), f"{client_module_path}: Cf-Access-Client-Secret missing from default headers"
+        assert added["Cf-Access-Client-Secret"] == "test-cf-secret"
+
+    def test_no_custom_headers_when_env_empty(self, client_module_path, monkeypatch):
+        """When no NUTANIX_HEADER_* env vars are set, no custom headers are added."""
+        for key in list(os.environ.keys()):
+            if key.startswith("NUTANIX_HEADER_"):
+                monkeypatch.delenv(key)
+
+        import importlib
+        from unittest.mock import MagicMock, patch
+
+        api_area = client_module_path.split(".")[-2]
+        sdk_name = _SDK_MODULES[api_area]
+
+        mock_sdk = MagicMock()
+        mock_config = MagicMock()
+        mock_client = MagicMock()
+        mock_sdk.Configuration.return_value = mock_config
+        mock_sdk.ApiClient.return_value = mock_client
+
+        with patch.dict("sys.modules", {sdk_name: mock_sdk}):
+            client_mod = importlib.import_module(client_module_path)
+            importlib.reload(client_mod)
+
+            fn_name = _GET_API_CLIENT_FN.get(api_area, "get_api_client")
+            module = self._make_mock_module()
+            getattr(client_mod, fn_name)(module)
+
+        added_names = [
+            call.kwargs.get("header_name") or call.args[0]
+            for call in mock_client.add_default_header.call_args_list
+        ]
+        custom = [h for h in added_names if h.startswith("Cf-")]
+        assert (
+            custom == []
+        ), f"{client_module_path}: unexpected custom headers added: {custom}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Unit tests: parse() strips Ansible tagged string types from api_key
+# ---------------------------------------------------------------------------
+
+
+class _AnsibleTaggedStr(str):
+    """Minimal stand-in for ansible.utils.unsafe_proxy.AnsibleUnsafeText /
+    ansible.parsing.yaml.objects.AnsibleTaggedStr.
+
+    Ansible's get_option() returns str *subclasses*, not plain str.  The VMM
+    SDK's Configuration.set_api_key() uses ``type(key) is str`` (strict check),
+    so a subclass value is treated as None and authentication silently breaks.
+    """
+
+
+class TestAnsibleTaggedStrApiKey:
+    """Prove that parse() correctly handles _AnsibleTaggedStr api_key values.
+
+    This test class captures the root cause of ansible-inventory --graph
+    failing even when NUTANIX_API_KEY is set: Ansible's config layer wraps
+    string option values in a str subclass (_AnsibleTaggedStr / AnsibleUnsafeText),
+    and the Nutanix VMM SDK's Configuration.set_api_key() uses a strict
+    ``type(key) is str`` check that rejects subclasses, silently setting the
+    key to None.  The fix is to convert the api_key to plain str in parse().
+    """
+
+    def test_sdk_set_api_key_rejects_str_subclass(self):
+        """Demonstrate the SDK bug: type(key) is str fails for str subclasses."""
+        import ntnx_vmm_py_client
+
+        config = ntnx_vmm_py_client.Configuration()
+        tagged = _AnsibleTaggedStr("my-secret-api-key")
+        config.set_api_key(tagged)
+
+        # The SDK silently sets None because type(tagged) is not str
+        assert (
+            config.api_key.get("X-ntnx-api-key") is None
+        ), "Expected SDK to reject str subclass (proving the known SDK limitation)"
+
+    def test_sdk_set_api_key_accepts_plain_str(self):
+        """Plain str always works with set_api_key."""
+        import ntnx_vmm_py_client
+
+        config = ntnx_vmm_py_client.Configuration()
+        config.set_api_key("my-secret-api-key")
+
+        assert config.api_key.get("X-ntnx-api-key") == "my-secret-api-key"
+
+    def test_parse_converts_tagged_api_key_to_plain_str(self, monkeypatch):
+        """parse() must call str() on the api_key so that the VMM SDK's strict
+        type check accepts it.  This is the regression test for the root cause
+        of ansible-inventory --graph failing silently.
+        """
+        from unittest.mock import patch as mock_patch
+
+        from ansible.inventory.data import InventoryData
+        from ansible.parsing.dataloader import DataLoader
+        from ansible_collections.nutanix.ncp.plugins.inventory.ntnx_prism_vm_inventory_v2 import (
+            InventoryModule,
+        )
+
+        # Use a str subclass (simulating Ansible's _AnsibleTaggedStr)
+        tagged_api_key = _AnsibleTaggedStr("test-api-key-12345")
+        assert type(tagged_api_key) is not str, "Pre-condition: must be a str subclass"
+
+        captured_module = {}
+
+        def fake_get_vm_api_instance(module):
+            captured_module["module"] = module
+            raise Exception("stop-early")
+
+        with mock_patch(
+            "ansible_collections.nutanix.ncp.plugins.inventory.ntnx_prism_vm_inventory_v2.get_vm_api_instance",
+            side_effect=fake_get_vm_api_instance,
+        ):
+            options = {
+                "nutanix_host": "10.0.0.1",
+                "nutanix_port": "9440",
+                "nutanix_username": None,
+                "nutanix_password": None,
+                "nutanix_api_key": tagged_api_key,
+                "custom_headers": None,
+                "validate_certs": False,
+                "fetch_all_vms": False,
+                "page": 0,
+                "limit": 10,
+                "filter": None,
+                "custom_ansible_host": None,
+                "nutanix_debug": False,
+                "nutanix_log_file": None,
+                "filters": [],
+                "strict": False,
+                "compose": {},
+                "groups": {},
+                "keyed_groups": [],
+            }
+            plugin = InventoryModule()
+            with mock_patch.object(InventoryModule, "_read_config_data"):
+                plugin._options = options
+                try:
+                    plugin.parse(
+                        InventoryData(), DataLoader(), "nutanix.yaml", cache=False
+                    )
+                except Exception:
+                    pass  # expected: we raised "stop-early"
+
+        assert (
+            "module" in captured_module
+        ), "Mock_Module was not passed to get_vm_api_instance"
+        module = captured_module["module"]
+        stored_key = module.params.get("nutanix_api_key")
+        assert type(stored_key) is str, (
+            f"Expected plain str in Mock_Module.params['nutanix_api_key'], "
+            f"got {type(stored_key).__name__!r}. "
+            "parse() must convert get_option() results to plain str before "
+            "passing to Mock_Module to avoid VMM SDK's strict type check failing."
+        )
+        assert stored_key == "test-api-key-12345"
+
+
+# ---------------------------------------------------------------------------
+# 5. Live integration test: list VMs via real Prism Central API
+# ---------------------------------------------------------------------------
+
+_LIVE_SKIP_REASON = (
+    "Live test requires NUTANIX_HOST and NUTANIX_API_KEY environment variables. "
+    "Source inventory/landscape/.env before running."
+)
+
+
+@pytest.mark.live
+@pytest.mark.skipif(
+    not os.environ.get("NUTANIX_HOST") or not os.environ.get("NUTANIX_API_KEY"),
+    reason=_LIVE_SKIP_REASON,
+)
+class TestLiveListVms:
+    """Integration test: exercises the full path from Mock_Module -> API client
+    -> list_vms() against a real Prism Central instance.
+
+    Validates:
+    - API key authentication works.
+    - NUTANIX_HEADER_CF_ACCESS_CLIENT_ID / _SECRET are sent as Cloudflare
+      Access headers and the request is not rejected.
+    - At least one page of VMs (or an empty list) is returned without error.
+    """
+
+    def _build_module(self):
+        """Construct a Mock_Module using env vars from the sourced .env file."""
+        from ansible_collections.nutanix.ncp.plugins.inventory.ntnx_prism_vm_inventory_v2 import (
+            Mock_Module,
+        )
+
+        host = os.environ.get("NUTANIX_HOST") or os.environ.get("NUTANIX_HOSTNAME")
+        port = os.environ.get("NUTANIX_PORT", "9440")
+        api_key = os.environ.get("NUTANIX_API_KEY")
+
+        return Mock_Module(
+            hostname=host,
+            port=port,
+            username=None,
+            password=None,
+            validate_certs=False,
+            nutanix_api_key=api_key,
+            custom_headers=None,  # headers come from NUTANIX_HEADER_* env vars
+        )
+
+    def test_list_vms_returns_response(self):
+        """list_vms() succeeds and returns a valid SDK response object."""
+        from ansible_collections.nutanix.ncp.plugins.module_utils.v4.vmm.api_client import (
+            get_vm_api_instance,
+        )
+
+        module = self._build_module()
+        vmm = get_vm_api_instance(module)
+
+        resp = vmm.list_vms(_page=0, _limit=10)
+
+        assert resp is not None, "Expected a response object from list_vms()"
+        assert hasattr(resp, "data"), "Response should have a 'data' attribute"
+        print(
+            f"\n[live] list_vms returned {len(resp.data or [])} VMs "
+            f"(total_available={getattr(resp.metadata, 'total_available_results', 'N/A')})"
+        )
+
+    def test_custom_headers_present_on_client(self):
+        """Verify CF Access headers are set on the API client before any request."""
+        cf_id = os.environ.get("NUTANIX_HEADER_CF_ACCESS_CLIENT_ID")
+        cf_secret = os.environ.get("NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET")
+        if not cf_id or not cf_secret:
+            pytest.skip("CF Access env vars not set — skipping header presence check")
+
+        from ansible_collections.nutanix.ncp.plugins.module_utils.v4.vmm.api_client import (
+            get_api_client,
+        )
+
+        module = self._build_module()
+        client = get_api_client(module)
+
+        default_headers = getattr(client, "_ApiClient__default_headers", {})
+        assert (
+            "Cf-Access-Client-Id" in default_headers
+        ), "CF-Access-Client-Id header missing from API client default headers"
+        assert (
+            "Cf-Access-Client-Secret" in default_headers
+        ), "CF-Access-Client-Secret header missing from API client default headers"
+        assert default_headers["Cf-Access-Client-Id"] == cf_id
+        assert default_headers["Cf-Access-Client-Secret"] == cf_secret
+        print("\n[live] CF Access headers confirmed on API client")
+
+    def test_list_vms_with_filter(self):
+        """list_vms() with an OData filter returns only matching VMs."""
+        from ansible_collections.nutanix.ncp.plugins.module_utils.v4.vmm.api_client import (
+            get_vm_api_instance,
+        )
+
+        module = self._build_module()
+        vmm = get_vm_api_instance(module)
+
+        resp = vmm.list_vms(_page=0, _limit=10, _filter="startswith(name, 'frg-')")
+
+        assert resp is not None
+        assert hasattr(resp, "data")
+        vms = resp.data or []
+        print(f"\n[live] list_vms(filter='frg-') returned {len(vms)} VMs")
+        for vm in vms:
+            vm_dict = vm.to_dict() if hasattr(vm, "to_dict") else {}
+            assert vm_dict.get("name", "").startswith(
+                "frg-"
+            ), f"VM '{vm_dict.get('name')}' does not match filter startswith(name, 'frg-')"
+
+    def test_inventory_plugin_parse_returns_hosts(self):
+        """Full end-to-end: InventoryModule.parse() populates hosts via the
+        same code path that ansible-inventory --graph uses."""
+        from unittest.mock import patch as mock_patch
+
+        from ansible.inventory.data import InventoryData
+        from ansible.parsing.dataloader import DataLoader
+        from ansible_collections.nutanix.ncp.plugins.inventory.ntnx_prism_vm_inventory_v2 import (
+            InventoryModule,
+        )
+
+        inventory = InventoryData()
+        loader = DataLoader()
+
+        options = {
+            "nutanix_host": os.environ.get("NUTANIX_HOST"),
+            "nutanix_port": os.environ.get("NUTANIX_PORT", "9440"),
+            "nutanix_username": None,
+            "nutanix_password": None,
+            "nutanix_api_key": os.environ.get("NUTANIX_API_KEY"),
+            "custom_headers": None,
+            "validate_certs": False,
+            "fetch_all_vms": False,
+            "page": 0,
+            "limit": 10,
+            "filter": None,
+            "custom_ansible_host": None,
+            "nutanix_debug": False,
+            "nutanix_log_file": None,
+            "filters": [],
+            "strict": False,
+            "compose": {},
+            "groups": {},
+            "keyed_groups": [],
+        }
+
+        plugin = InventoryModule()
+
+        # Patch _read_config_data to a no-op and inject options directly,
+        # bypassing Ansible's config manager (not available outside ansible-test).
+        with mock_patch.object(InventoryModule, "_read_config_data"):
+            plugin._options = options
+            plugin.parse(inventory, loader, "nutanix.yaml", cache=False)
+
+        hosts = list(inventory.hosts.keys())
+        print(f"\n[live] inventory parse() added {len(hosts)} hosts: {hosts[:5]}")
+        assert len(hosts) > 0, "Expected at least one host from inventory parse()"


### PR DESCRIPTION
Closes #922

Adds custom HTTP header support to all v4 API clients and the VM inventory plugin, enabling Nutanix behind reverse proxies like Cloudflare Access.

This is complementary to the PR I have for the Terraform provider: https://github.com/nutanix/terraform-provider-nutanix/pull/1062 that has already been merged.

## Changes

**Custom headers**
- New custom_headers parameter on all modules and inventory plugin
- Environment variable support via NUTANIX_HEADER_* prefix (e.g. NUTANIX_HEADER_CF_ACCESS_CLIENT_ID → Cf-Access-Client-Id)
- Config values take precedence over environment variables

**API key auth workaround**
- 5 of 13 Python SDKs (clustermgmt, objects, prism, security, vmm) hardcode auth_settings=['basicAuthScheme'] and never include apiKeyAuthScheme, making config.set_api_key() ineffective
- Workaround explicitly adds X-ntnx-api-key as a default header on the ApiClient

**Jinja2 lookup support in inventory plugins**
- Credential options (nutanix_api_key, nutanix_username, nutanix_password, custom_headers) now support Jinja2 expressions in both VM and host inventory plugin YAML configs
- Enables secrets manager integration (e.g. 1Password, Keeper, HashiCorp Vault) without hardcoding credentials

**Inventory plugin improvements**
- NUTANIX_ENDPOINT environment variable added to host resolution chain for both inventory plugins. The Nutanix Terraform provider uses NUTANIX_ENDPOINT as its standard connection variable, so this allows users running both Terraform and Ansible in the same environment to share a single variable instead of setting NUTANIX_HOST separately. Both plugins use urlparse to handle full URLs (e.g. https://prism.example.com:9440) as well as plain hostnames.
- Fixed _AnsibleTaggedStr type mismatch that caused SDK to reject API keys from get_option() — applied to both VM and host inventory plugins
- Guarded list_clusters.data iteration against None responses

**Documentation fixes**
- Added `ntnx_prism_py_client` to the VM inventory plugin DOCUMENTATION `requirements` list — the categories resolution feature (merged in #964) uses the prism SDK but the dependency was not declared
- Cloudflare ETag cache rule note added to custom_headers docs and README — Cloudflare strips ETag headers by default, which breaks v4 API power actions

## Test plan

- Unit tests: 39 passed, 4 skipped (live-only)
- End-to-end: ansible-inventory with API key + Cloudflare Access headers
- End-to-end: ntnx_vms_v2 create/delete/power-on through Cloudflare proxy
- Jinja2 lookups in inventory config (Keeper Secrets Manager)
- Sanity tests pass (pylint)

 The following environment variables were set when running the tests:

```bash
export NUTANIX_HOST="xxx.xxx.com"
export NUTANIX_PORT="443"

# Nutanix API Key for authentication
export NUTANIX_API_KEY="xxx"

# Cloudflare Access headers
export NUTANIX_HEADER_CF_ACCESS_CLIENT_ID="xxx"
export NUTANIX_HEADER_CF_ACCESS_CLIENT_SECRET="xxx"
```

The NUTANIX_HEADER_* variables demonstrate the custom header feature in action — CF_ACCESS_CLIENT_ID and CF_ACCESS_CLIENT_SECRET are automatically converted to Cf-Access-Client-Id and Cf-Access-Client-Secret HTTP headers on all API requests.

### Unit Tests
```bash
  $ pytest tests/unit/plugins/inventory/test_ntnx_prism_vm_inventory_v2.py
  platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
  collected 43 items

  .......................................ssss                                                                              [100%]

  39 passed, 4 skipped, 1 warning in 5.17s
```

## Ansible Inventory Test

Confirms working end-to-end.

```bash
  $ ansible-inventory -i inventory/forge2 --graph
  @all:
    |--@ungrouped:
    |--@cluster_00061126_4a0b_6fa4_223d_b83fd25e8fd6:
    |  |--poc-monitor01
    |--@linux:
    |  |--poc-monitor01
    |--@monitoringservers:
    |  |--poc-monitor01
```