### PR TITLE
Cluster Recovery Plan Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/cluster_management_v2/clusters_protection_and_recovery_v2.yml
+++ b/examples/cluster_management_v2/clusters_protection_and_recovery_v2.yml
@@ -1,0 +1,71 @@
+---
+# Summary:
+# This playbook will do:
+# 1. Protect source cluster
+# 2. Initialize recovery plan on destination cluster
+# 3. Get protection info after recovery plan creation
+# 4. Get recovery info after recovery plan creation
+# 5. Finalize recovery plan
+# 6. Unprotect source cluster
+
+- name: Clusters Protection and Recovery playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        source_cluster_ext_id: "00064ff3-8bf0-8ab9-2afa-525400a07915"
+        destination_cluster_ext_id: "00064ff7-037e-4183-5134-5254003c4871"
+        protection_rpo_minutes: 120
+        local_snapshot_retention_policy: 3
+        protection_target: LOCAL
+
+    - name: Protect source cluster
+      nutanix.ncp.ntnx_clusters_protection_v2:
+        state: present
+        ext_id: "{{ source_cluster_ext_id }}"
+        protection_rpo_minutes: "{{ protection_rpo_minutes }}"
+        local_snapshot_retention_policy: "{{ local_snapshot_retention_policy }}"
+        protection_target: "{{ protection_target }}"
+      register: result
+      ignore_errors: true
+
+    - name: Initialize recovery plan on destination cluster
+      nutanix.ncp.ntnx_clusters_recovery_v2:
+        operation: initialize
+        ext_id: "{{ source_cluster_ext_id }}"
+        destination_cluster_ext_id: "{{ destination_cluster_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Get protection info after recovery plan creation
+      nutanix.ncp.ntnx_clusters_protection_info_v2:
+        ext_id: "{{ source_cluster_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Get recovery info after recovery plan creation
+      nutanix.ncp.ntnx_clusters_recovery_info_v2:
+        ext_id: "{{ source_cluster_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Finalize recovery plan
+      nutanix.ncp.ntnx_clusters_recovery_v2:
+        operation: finalize
+        ext_id: "{{ source_cluster_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Unprotect source cluster
+      nutanix.ncp.ntnx_clusters_protection_v2:
+        state: absent
+        ext_id: "{{ source_cluster_ext_id }}"
+      register: result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,7 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_clusters_protection_v2
+    - ntnx_clusters_protection_info_v2
+    - ntnx_clusters_recovery_v2
+    - ntnx_clusters_recovery_info_v2

--- a/plugins/module_utils/v4/clusters_mgmt/api_client.py
+++ b/plugins/module_utils/v4/clusters_mgmt/api_client.py
@@ -142,3 +142,17 @@ def get_ssl_certificates_api_instance(module):
     """
     client = get_api_client(module)
     return ntnx_clustermgmt_py_client.SSLCertificateApi(client)
+
+
+def get_cluster_protection_api_instance(module):
+    """
+    This method will return cluster protection api instance from sdk.
+    Used for cluster protect/unprotect, initialize/finalize recovery,
+    and protection/recovery info operations.
+    Args:
+        module (AnsibleModule): AnsibleModule instance
+    Returns:
+        ClusterProtectionApi: ClusterProtectionApi instance
+    """
+    client = get_api_client(module)
+    return ntnx_clustermgmt_py_client.ClusterProtectionApi(client)

--- a/plugins/module_utils/v4/clusters_mgmt/helpers.py
+++ b/plugins/module_utils/v4/clusters_mgmt/helpers.py
@@ -109,3 +109,43 @@ def get_cluster_profile(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching cluster profile info using ext_id",
         )
+
+
+def get_cluster_protection_info(module, api_instance, ext_id):
+    """
+    This method will return cluster protection info using cluster external ID.
+    Args:
+        module: Ansible module
+        api_instance: ClusterProtectionApi instance from sdk
+        ext_id (str): cluster external ID
+    return:
+        protection info (object): cluster protection info
+    """
+    try:
+        return api_instance.get_cluster_protection_info(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching cluster protection info using ext_id",
+        )
+
+
+def get_cluster_recovery_info(module, api_instance, ext_id):
+    """
+    This method will return cluster recovery info using cluster external ID.
+    Args:
+        module: Ansible module
+        api_instance: ClusterProtectionApi instance from sdk
+        ext_id (str): cluster external ID
+    return:
+        recovery info (object): cluster recovery info
+    """
+    try:
+        return api_instance.get_cluster_recovery_info(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching cluster recovery info using ext_id",
+        )

--- a/plugins/module_utils/v4/clusters_mgmt/spec/cluster_protection.py
+++ b/plugins/module_utils/v4/clusters_mgmt/spec/cluster_protection.py
@@ -21,8 +21,8 @@ class ClusterProtectionSpecs:
     """Module specs related to cluster protection and recovery operations."""
 
     protection_spec = dict(
-        protection_rpo_minutes=dict(type="int"),
-        local_snapshot_retention_policy=dict(type="int"),
+        protection_rpo_minutes=dict(type="int", default=60),
+        local_snapshot_retention_policy=dict(type="int", default=2),
         protection_target=dict(
             type="str",
             choices=["LOCAL", "LTSS"],

--- a/plugins/module_utils/v4/clusters_mgmt/spec/cluster_protection.py
+++ b/plugins/module_utils/v4/clusters_mgmt/spec/cluster_protection.py
@@ -1,0 +1,43 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from copy import deepcopy
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_clustermgmt_py_client as clusters_sdk  # noqa: E402
+except ImportError:
+    from ....v4.sdk_mock import mock_sdk as clusters_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+class ClusterProtectionSpecs:
+    """Module specs related to cluster protection and recovery operations."""
+
+    protection_spec = dict(
+        protection_rpo_minutes=dict(type="int"),
+        local_snapshot_retention_policy=dict(type="int"),
+        protection_target=dict(
+            type="str",
+            choices=["LOCAL", "LTSS"],
+            obj=clusters_sdk.ProtectionTarget,
+        ),
+    )
+
+    recovery_spec = dict(
+        destination_cluster_ext_id=dict(type="str"),
+    )
+
+    @classmethod
+    def get_protection_spec(cls):
+        return deepcopy(cls.protection_spec)
+
+    @classmethod
+    def get_recovery_spec(cls):
+        return deepcopy(cls.recovery_spec)

--- a/plugins/modules/ntnx_clusters_protection_info_v2.py
+++ b/plugins/modules/ntnx_clusters_protection_info_v2.py
@@ -62,30 +62,42 @@ response:
   returned: always
   sample:
     {
-      "cluster_ext_id": "0005a7b8-0b0b-4b3b-0000-000000000000",
-      "protection_state": "PROTECTED",
-      "target_protection_state": "PROTECTED",
-      "protection_target": "LTSS",
+      "cluster_ext_id": "00064ff3-8bf0-8ab9-2afa-525400a07915",
+      "failure_reason": null,
+      "protected_entities": [
+          {
+              "entity_type": "vm",
+              "protected_count": 1,
+              "unprotected_count": 0
+          },
+          {
+              "entity_type": "volume",
+              "protected_count": 0,
+              "unprotected_count": 0
+          }
+      ],
       "protection_rpo_minutes": 60,
-      "protected_entities": [],
-      "failure_reason": null
+      "protection_state": "PROTECTED",
+      "protection_target": "LOCAL",
+      "target_protection_state": "PROTECTED"
     }
-ext_id:
-  description: External ID of the cluster whose info was fetched.
-  type: str
-  returned: always
-msg:
-  description: Message if an error occurred while fetching the info.
-  type: str
-  returned: when an error occurs
-error:
-  description: Error message if any.
-  type: str
-  returned: when an error occurs
 changed:
-  description: Indicates if any change was made.
-  type: bool
-  returned: always
+    description:
+        - Indicates if any changes were made during the operation.
+    type: bool
+    returned: always
+    sample: true
+failed:
+    description: Indicates if the protection info operation failed.
+    type: bool
+    returned: always
+    sample: false
+ext_id:
+    description:
+        - The external ID of the cluster whose protection info is requested.
+    type: str
+    returned: always
+    sample: "00064ff3-8bf0-8ab9-2afa-525400a07915"
 """
 
 from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
@@ -124,7 +136,7 @@ def run_module():
         skip_info_args=True,
     )
     remove_param_with_none_value(module.params)
-    result = {"changed": False, "error": None, "response": None}
+    result = {"changed": False, "response": None}
     api_instance = get_cluster_protection_api_instance(module)
     fetch_cluster_protection_info(module, api_instance, result)
     module.exit_json(**result)

--- a/plugins/modules/ntnx_clusters_protection_info_v2.py
+++ b/plugins/modules/ntnx_clusters_protection_info_v2.py
@@ -1,0 +1,131 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_clusters_protection_info_v2
+short_description: Fetch protection status for a Nutanix cluster
+version_added: 2.6.0
+description:
+  - Fetch the protection status of a given cluster.
+  - This module uses PC v4 APIs based SDKs
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation.
+  - >-
+    B(Get protection status for a cluster) -
+    Required Roles: Cluster Admin, Cluster Viewer, Disaster Recovery Admin, Disaster Recovery Viewer, Prism Admin, Prism Viewer, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  ext_id:
+    description:
+      - External ID of the cluster whose protection info is requested.
+    type: str
+    required: true
+author:
+  - George Ghawali (@george-ghawali)
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+"""
+
+EXAMPLES = r"""
+- name: Get protection info for a cluster
+  nutanix.ncp.ntnx_clusters_protection_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "0005a7b8-0b0b-4b3b-0000-000000000000"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Cluster protection information.
+  type: dict
+  returned: always
+  sample:
+    {
+      "cluster_ext_id": "0005a7b8-0b0b-4b3b-0000-000000000000",
+      "protection_state": "PROTECTED",
+      "target_protection_state": "PROTECTED",
+      "protection_target": "LTSS",
+      "protection_rpo_minutes": 60,
+      "protected_entities": [],
+      "failure_reason": null
+    }
+ext_id:
+  description: External ID of the cluster whose info was fetched.
+  type: str
+  returned: always
+msg:
+  description: Message if an error occurred while fetching the info.
+  type: str
+  returned: when an error occurs
+error:
+  description: Error message if any.
+  type: str
+  returned: when an error occurs
+changed:
+  description: Indicates if any change was made.
+  type: bool
+  returned: always
+"""
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_cluster_protection_api_instance,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import get_cluster_protection_info  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def fetch_cluster_protection_info(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_cluster_protection_info(
+        module=module,
+        api_instance=api_instance,
+        ext_id=ext_id,
+    )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "error": None, "response": None}
+    api_instance = get_cluster_protection_api_instance(module)
+    fetch_cluster_protection_info(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_clusters_protection_info_v2.py
+++ b/plugins/modules/ntnx_clusters_protection_info_v2.py
@@ -88,7 +88,9 @@ from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
 from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
     get_cluster_protection_api_instance,
 )
-from ..module_utils.v4.clusters_mgmt.helpers import get_cluster_protection_info  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.helpers import (  # noqa: E402
+    get_cluster_protection_info,
+)
 from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
 
 

--- a/plugins/modules/ntnx_clusters_protection_info_v2.py
+++ b/plugins/modules/ntnx_clusters_protection_info_v2.py
@@ -30,6 +30,11 @@ options:
       - External ID of the cluster whose protection info is requested.
     type: str
     required: true
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
 author:
   - George Ghawali (@george-ghawali)
 extends_documentation_fragment:

--- a/plugins/modules/ntnx_clusters_protection_v2.py
+++ b/plugins/modules/ntnx_clusters_protection_v2.py
@@ -159,6 +159,9 @@ from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
 from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
     get_cluster_protection_api_instance,
 )
+from ..module_utils.v4.clusters_mgmt.helpers import (  # noqa: E402
+    get_cluster_protection_info,
+)
 from ..module_utils.v4.clusters_mgmt.spec.cluster_protection import (  # noqa: E402
     ClusterProtectionSpecs,
 )
@@ -169,10 +172,6 @@ from ..module_utils.v4.utils import (  # noqa: E402
     strip_internal_attributes,
     validate_required_params,
 )
-from ..module_utils.v4.clusters_mgmt.helpers import (
-    get_cluster_protection_info,
-)  # noqa: E402
-
 
 SDK_IMP_ERROR = None
 try:

--- a/plugins/modules/ntnx_clusters_protection_v2.py
+++ b/plugins/modules/ntnx_clusters_protection_v2.py
@@ -159,9 +159,6 @@ from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
 from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
     get_cluster_protection_api_instance,
 )
-from ..module_utils.v4.clusters_mgmt.helpers import (  # noqa: E402
-    get_cluster_protection_info,
-)
 from ..module_utils.v4.clusters_mgmt.spec.cluster_protection import (  # noqa: E402
     ClusterProtectionSpecs,
 )

--- a/plugins/modules/ntnx_clusters_protection_v2.py
+++ b/plugins/modules/ntnx_clusters_protection_v2.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_clusters_protection_v2
+short_description: Protect or unprotect a Nutanix cluster
+version_added: 2.6.0
+description:
+  - Protect a cluster by enabling periodic full-cluster snapshots and replication
+    to a protection target (C(LTSS) or C(LOCAL)).
+  - Unprotect a cluster by stopping the snapshot schedule, removing the stored
+    backup data from the target and clearing DR tracking.
+  - This module uses PC v4 APIs based SDKs
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation.
+  - >-
+    B(Protect a cluster) -
+    Required Roles: Cluster Admin, Disaster Recovery Admin, Prism Admin, Super Admin
+  - >-
+    B(Unprotect a cluster) -
+    Required Roles: Cluster Admin, Disaster Recovery Admin, Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  state:
+    description:
+      - If C(state) is C(present), the module will protect the cluster.
+      - If C(state) is C(absent), the module will unprotect the cluster.
+    type: str
+    choices: ["present", "absent"]
+    default: present
+  ext_id:
+    description:
+      - External ID of the cluster to protect or unprotect.
+    type: str
+    required: true
+  protection_rpo_minutes:
+    description:
+      - Recovery point objective for protecting the cluster.
+      - Determines the frequency (in minutes) at which full-cluster snapshots are taken.
+      - Allowed range is between C(60) and C(360). Default is C(60).
+      - Required when C(state=present).
+    type: int
+    default: 60
+  local_snapshot_retention_policy:
+    description:
+      - Number of local snapshots that the protection service should retain.
+      - Allowed range is between C(2) and C(4). Default is C(2).
+      - Required when C(state=present).
+    type: int
+    default: 2
+  protection_target:
+    description:
+      - Where backups are stored.
+      - C(LTSS) uses Multi-cloud Snapshot Technology (for example, AWS S3).
+      - C(LOCAL) is only allowed in test environments.
+      - Required when C(state=present).
+    type: str
+    choices: ["LOCAL", "LTSS"]
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Protect a cluster with hourly snapshots replicated to LTSS
+  nutanix.ncp.ntnx_clusters_protection_v2:
+    state: present
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "0005a7b8-0b0b-4b3b-0000-000000000000"
+    protection_rpo_minutes: 60
+    local_snapshot_retention_policy: 2
+    protection_target: LTSS
+  register: result
+
+- name: Protect a cluster in a test environment using LOCAL target
+  nutanix.ncp.ntnx_clusters_protection_v2:
+    state: present
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "0005a7b8-0b0b-4b3b-0000-000000000000"
+    protection_rpo_minutes: 60
+    local_snapshot_retention_policy: 2
+    protection_target: LOCAL
+  register: result
+
+- name: Unprotect a cluster
+  nutanix.ncp.ntnx_clusters_protection_v2:
+    state: absent
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "0005a7b8-0b0b-4b3b-0000-000000000000"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Task details for the protect/unprotect operation.
+    - Contains the task status, progress and entities affected.
+  type: dict
+  returned: always
+ext_id:
+  description:
+    - External ID of the cluster on which the operation was performed.
+  type: str
+  returned: always
+  sample: "0005a7b8-0b0b-4b3b-0000-000000000000"
+task_ext_id:
+  description: External ID of the task created by the protect/unprotect action.
+  type: str
+  returned: when a task is created
+  sample: "ZXJnb24=:350f0fd5-097d-4ece-8f44-6e5bfbe2dc08"
+changed:
+  description: Indicates if any change was made.
+  type: bool
+  returned: always
+msg:
+  description: A human readable message about the result of the action.
+  type: str
+  returned: when a message is emitted
+error:
+  description: Error message if any.
+  type: str
+  returned: when an error occurs
+failed:
+  description: Indicates if the module failed.
+  type: bool
+  returned: always
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_cluster_protection_api_instance,
+)
+from ..module_utils.v4.clusters_mgmt.spec.cluster_protection import (  # noqa: E402
+    ClusterProtectionSpecs,
+)
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import (
+    get_cluster_protection_info,
+)  # noqa: E402
+
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_clustermgmt_py_client as clusters_sdk  # noqa: E402
+except ImportError:
+    from ..module_utils.v4.sdk_mock import mock_sdk as clusters_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+    )
+    module_args.update(ClusterProtectionSpecs.get_protection_spec())
+    return module_args
+
+
+def protect_cluster(module, result, api_instance, ext_id):
+    validate_required_params(
+        module,
+        ["protection_target"],
+    )
+
+    sg = SpecGenerator(module)
+    default_spec = clusters_sdk.ProtectionSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating protect cluster spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.protect_cluster(extId=ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while protecting cluster",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id, add_task_service=True)
+        result["response"] = strip_internal_attributes(task.to_dict())
+
+    result["changed"] = True
+
+
+def unprotect_cluster(module, result, api_instance, ext_id):
+    if module.check_mode:
+        result["msg"] = "Cluster with ext_id:{0} will be unprotected.".format(ext_id)
+        return
+
+    resp = None
+    try:
+        resp = api_instance.unprotect_cluster(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while unprotecting cluster",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        resp = wait_for_completion(module, task_ext_id, add_task_service=True)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+    }
+    api_instance = get_cluster_protection_api_instance(module)
+    state = module.params.get("state")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    if state == "present":
+        protect_cluster(module, result, api_instance, ext_id)
+    else:
+        unprotect_cluster(module, result, api_instance, ext_id)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_clusters_protection_v2.py
+++ b/plugins/modules/ntnx_clusters_protection_v2.py
@@ -117,36 +117,69 @@ RETURN = r"""
 response:
   description:
     - Task details for the protect/unprotect operation.
-    - Contains the task status, progress and entities affected.
   type: dict
   returned: always
+  sample:
+    {
+      "app_name": null,
+      "batch_summary": null,
+      "cluster_ext_ids": null,
+      "completed_time": "2026-04-23T05:11:03.915540+00:00",
+      "completion_details": null,
+      "created_time": "2026-04-23T05:10:44.713641+00:00",
+      "entities_affected": null,
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:84dbccbb-ea24-462f-b3d3-11d2e50accd1",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-04-23T05:11:03.915539+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 0,
+      "number_of_subtasks": 0,
+      "operation": "Protect Cluster",
+      "operation_description": "Protect cluster",
+      "owned_by": null,
+      "parent_task": null,
+      "progress_percentage": 100,
+      "project_ext_id": "00000000-0000-0000-0000-000000000000",
+      "resource_links": null,
+      "root_task": null,
+      "started_time": "2026-04-23T05:10:44.740003+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
 ext_id:
   description:
-    - External ID of the cluster on which the operation was performed.
+    - The external ID of the cluster on which the operation was performed.
   type: str
   returned: always
-  sample: "0005a7b8-0b0b-4b3b-0000-000000000000"
+  sample: "00064ff3-8bf0-8ab9-2afa-525400a07915"
 task_ext_id:
-  description: External ID of the task created by the protect/unprotect action.
+  description: The external ID of the task created by the protect/unprotect action.
   type: str
   returned: when a task is created
   sample: "ZXJnb24=:350f0fd5-097d-4ece-8f44-6e5bfbe2dc08"
 changed:
-  description: Indicates if any change was made.
-  type: bool
-  returned: always
-msg:
-  description: A human readable message about the result of the action.
-  type: str
-  returned: when a message is emitted
-error:
-  description: Error message if any.
-  type: str
-  returned: when an error occurs
+    description: Indicates if any changes were made during the protect/unprotect operation.
+    type: bool
+    returned: always
+    sample: true
 failed:
-  description: Indicates if the module failed.
-  type: bool
-  returned: always
+    description: Indicates if the protect/unprotect operation failed.
+    type: bool
+    returned: always
+    sample: false
+msg:
+    description: This indicates the message if any message occurred.
+    returned: When there is an error or check mode (in unprotect operation)
+    type: str
+    sample: "Api Exception raised while protecting cluster"
+error:
+    description: The error message if an error occurs.
+    type: str
+    returned: when an error occurs
 """
 
 import traceback  # noqa: E402

--- a/plugins/modules/ntnx_clusters_recovery_info_v2.py
+++ b/plugins/modules/ntnx_clusters_recovery_info_v2.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_clusters_recovery_info_v2
+short_description: Fetch cluster recovery information
+version_added: 2.6.0
+description:
+  - Fetch the recovery information for a given cluster.
+  - This module uses PC v4 APIs based SDKs
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation.
+  - >-
+    B(Get cluster recovery information) -
+    Required Roles: Cluster Admin, Cluster Viewer, Disaster Recovery Admin, Disaster Recovery Viewer, Prism Admin, Prism Viewer, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  ext_id:
+    description:
+      - External ID of the cluster whose recovery info is requested.
+    type: str
+    required: true
+author:
+  - George Ghawali (@george-ghawali)
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+"""
+
+EXAMPLES = r"""
+- name: Get recovery info for a cluster
+  nutanix.ncp.ntnx_clusters_recovery_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "0006b8c9-1c1c-5c4c-1111-111111111111"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Cluster recovery information.
+  type: dict
+  returned: always
+  sample:
+    {
+      "recovery_status": "RECOVERING",
+      "subnets": []
+    }
+ext_id:
+  description: External ID of the cluster whose info was fetched.
+  type: str
+  returned: always
+msg:
+  description: Message if an error occurred while fetching the info.
+  type: str
+  returned: when an error occurs
+error:
+  description: Error message if any.
+  type: str
+  returned: when an error occurs
+changed:
+  description: Indicates if any change was made.
+  type: bool
+  returned: always
+"""
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_cluster_protection_api_instance,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import (  # noqa: E402
+    get_cluster_recovery_info,
+)
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def fetch_cluster_recovery_info(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_cluster_recovery_info(
+        module=module,
+        api_instance=api_instance,
+        ext_id=ext_id,
+    )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "error": None, "response": None}
+    api_instance = get_cluster_protection_api_instance(module)
+    fetch_cluster_recovery_info(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_clusters_recovery_info_v2.py
+++ b/plugins/modules/ntnx_clusters_recovery_info_v2.py
@@ -62,25 +62,110 @@ response:
   returned: always
   sample:
     {
-      "recovery_status": "RECOVERING",
-      "subnets": []
+      "recovery_status": {
+          "destination_cluster_ext_id": null,
+          "recovery_state": "PROTECTED",
+          "source_cluster_ext_id": "00064ff3-8bf0-8ab9-2afa-525400a07915"
+      },
+      "subnets": [
+          {
+              "annotation": null,
+              "availability_zone": null,
+              "cidr": null,
+              "cloud_type": "$UNKNOWN",
+              "ext_id": null,
+              "gateway_ip": null,
+              "ip_pool_ranges": null,
+              "links": null,
+              "name": "vlan.0",
+              "subnet_id": "6bcb0b32-ec8c-4643-ba98-13964b2a79ef",
+              "tenant_id": null,
+              "type": "VLAN",
+              "vpc_id": null
+          },
+          {
+              "annotation": null,
+              "availability_zone": null,
+              "cidr": "10.30.30.0/24",
+              "cloud_type": "$UNKNOWN",
+              "ext_id": null,
+              "gateway_ip": "10.30.30.254",
+              "ip_pool_ranges": [
+                  {
+                      "begin": {
+                          "ipv4": {
+                              "prefix_length": 0,
+                              "value": "10.30.30.10"
+                          },
+                          "ipv6": null
+                      },
+                      "end": {
+                          "ipv4": {
+                              "prefix_length": 0,
+                              "value": "10.30.30.90"
+                          },
+                          "ipv6": null
+                      }
+                  }
+              ],
+              "links": null,
+              "name": "integration_static_subnet",
+              "subnet_id": "7047ccf0-8d16-4f91-bc65-db3c8e2f9506",
+              "tenant_id": null,
+              "type": "VLAN",
+              "vpc_id": null
+          },
+          {
+              "annotation": null,
+              "availability_zone": null,
+              "cidr": "10.44.3.192/27",
+              "cloud_type": "$UNKNOWN",
+              "ext_id": null,
+              "gateway_ip": "10.44.3.193",
+              "ip_pool_ranges": [
+                  {
+                      "begin": {
+                          "ipv4": {
+                              "prefix_length": 0,
+                              "value": "10.44.3.198"
+                          },
+                          "ipv6": null
+                      },
+                      "end": {
+                          "ipv4": {
+                              "prefix_length": 0,
+                              "value": "10.44.3.207"
+                          },
+                          "ipv6": null
+                      }
+                  }
+              ],
+              "links": null,
+              "name": "integration_test_Ext-Nat1",
+              "subnet_id": "ec7a55c8-fada-474c-b2e3-765182762a1e",
+              "tenant_id": null,
+              "type": "VLAN",
+              "vpc_id": null
+          }
+      ]
     }
-ext_id:
-  description: External ID of the cluster whose info was fetched.
-  type: str
-  returned: always
-msg:
-  description: Message if an error occurred while fetching the info.
-  type: str
-  returned: when an error occurs
-error:
-  description: Error message if any.
-  type: str
-  returned: when an error occurs
 changed:
-  description: Indicates if any change was made.
-  type: bool
-  returned: always
+    description:
+        - Indicates if any changes were made during the recovery info operation.
+    type: bool
+    returned: always
+    sample: true
+failed:
+    description: Indicates if the recovery info operation failed.
+    type: bool
+    returned: always
+    sample: false
+ext_id:
+    description:
+        - The external ID of the cluster whose recovery info is requested.
+    type: str
+    returned: always
+    sample: "00064ff3-8bf0-8ab9-2afa-525400a07915"
 """
 
 from ..module_utils.utils import remove_param_with_none_value  # noqa: E402

--- a/plugins/modules/ntnx_clusters_recovery_info_v2.py
+++ b/plugins/modules/ntnx_clusters_recovery_info_v2.py
@@ -30,6 +30,11 @@ options:
       - External ID of the cluster whose recovery info is requested.
     type: str
     required: true
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
 author:
   - George Ghawali (@george-ghawali)
 extends_documentation_fragment:

--- a/plugins/modules/ntnx_clusters_recovery_v2.py
+++ b/plugins/modules/ntnx_clusters_recovery_v2.py
@@ -1,0 +1,273 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_clusters_recovery_v2
+short_description: Create or finalize a cluster recovery plan
+version_added: 2.6.0
+description:
+  - Initialize or finalize a cluster disaster-recovery (DR) plan.
+  - Use operation=initialize to create a recovery plan against a brand new, empty destination cluster.
+    (Requires providing the destination cluster external ID). The system connects the destination cluster to the backup storage (LTSS),
+    locates the latest snapshots of the faulted source cluster, and begins hydrating (downloading and registering) the storage containers,
+    networks, and VMs onto the new hardware in a staged, read-only state.
+  - Use operation=finalize to commit the failover. The staged, read-only storage on the destination cluster is promoted to active (read-write),
+    and the recovered VMs are powered on. The destination cluster then automatically resumes the original protection schedule.
+  - This module uses PC v4 APIs based SDKs
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation.
+  - >-
+    B(Initialize a cluster recovery - create recovery plan) -
+    Required Roles: Cluster Admin, Disaster Recovery Admin, Prism Admin, Super Admin
+  - >-
+    B(Finalize a cluster recovery - commit failover) -
+    Required Roles: Cluster Admin, Disaster Recovery Admin, Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  state:
+    description:
+      - Only C(present) is supported for this module.
+      - The actual action is controlled by C(operation).
+    type: str
+    choices: ["present"]
+    default: present
+  operation:
+    description:
+      - The recovery operation to perform on the faulted cluster.
+      - C(initialize) creates a new recovery plan. Requires
+        C(destination_cluster_ext_id).
+      - C(finalize) commits the failover on an in-progress recovery.
+    type: str
+    choices: ["initialize", "finalize"]
+    required: true
+  ext_id:
+    description:
+      - External ID of the original, faulted source cluster being recovered.
+    type: str
+    required: true
+  destination_cluster_ext_id:
+    description:
+      - External ID of the brand new, empty destination cluster onto which
+        the source cluster will be recovered.
+      - Required when C(operation=initialize).
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Initialize recovery - create a cluster recovery plan
+  nutanix.ncp.ntnx_clusters_recovery_v2:
+    state: present
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    operation: initialize
+    ext_id: "0005a7b8-0b0b-4b3b-0000-000000000000"
+    destination_cluster_ext_id: "0006b8c9-1c1c-5c4c-1111-111111111111"
+  register: result
+
+- name: Finalize recovery - commit the failover on the destination cluster
+  nutanix.ncp.ntnx_clusters_recovery_v2:
+    state: present
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    operation: finalize
+    ext_id: "0005a7b8-0b0b-4b3b-0000-000000000000"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description: Task details for the initialize/finalize recovery operation.
+  type: dict
+  returned: always
+ext_id:
+  description: External ID of the source cluster on which the operation was performed.
+  type: str
+  returned: always
+task_ext_id:
+  description: External ID of the task created by the recovery action.
+  type: str
+  returned: when a task is created
+changed:
+  description: Indicates if any change was made.
+  type: bool
+  returned: always
+msg:
+  description: A human readable message about the result of the action.
+  type: str
+  returned: when a message is emitted
+error:
+  description: Error message if any.
+  type: str
+  returned: when an error occurs
+failed:
+  description: Indicates if the module failed.
+  type: bool
+  returned: always
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_cluster_protection_api_instance,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import (  # noqa: E402
+    get_cluster_recovery_info,
+)
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_clustermgmt_py_client as clusters_sdk  # noqa: E402
+except ImportError:
+    from ..module_utils.v4.sdk_mock import mock_sdk as clusters_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        operation=dict(
+            type="str",
+            choices=["initialize", "finalize"],
+            required=True,
+        ),
+        ext_id=dict(type="str", required=True),
+        destination_cluster_ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def initialize_cluster_recovery(module, result, api_instance, ext_id):
+    sg = SpecGenerator(module)
+    default_spec = clusters_sdk.RecoverySpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating initialize cluster recovery spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.initialize_cluster_recovery(extId=ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while initializing cluster recovery",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        resp = wait_for_completion(module, task_ext_id, add_task_service=True)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+def finalize_cluster_recovery(module, result, api_instance, ext_id):
+    if module.check_mode:
+        result["msg"] = (
+            "Cluster recovery for cluster with ext_id:{0} will be finalized.".format(
+                ext_id
+            )
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.finalize_cluster_recovery(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while finalizing cluster recovery",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        resp = wait_for_completion(module, task_ext_id, add_task_service=True)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("operation", "initialize", ("destination_cluster_ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+    }
+    api_instance = get_cluster_protection_api_instance(module)
+    operation = module.params.get("operation")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    if operation == "initialize":
+        initialize_cluster_recovery(module, result, api_instance, ext_id)
+    else:
+        finalize_cluster_recovery(module, result, api_instance, ext_id)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_clusters_recovery_v2.py
+++ b/plugins/modules/ntnx_clusters_recovery_v2.py
@@ -34,13 +34,6 @@ notes:
     Required Roles: Cluster Admin, Disaster Recovery Admin, Prism Admin, Super Admin
   - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
 options:
-  state:
-    description:
-      - Only C(present) is supported for this module.
-      - The actual action is controlled by C(operation).
-    type: str
-    choices: ["present"]
-    default: present
   operation:
     description:
       - The recovery operation to perform on the faulted cluster.

--- a/plugins/modules/ntnx_clusters_recovery_v2.py
+++ b/plugins/modules/ntnx_clusters_recovery_v2.py
@@ -90,33 +90,70 @@ EXAMPLES = r"""
 
 RETURN = r"""
 response:
-  description: Task details for the initialize/finalize recovery operation.
+  description: Task details for the initialize/finalize cluster recovery operation.
   type: dict
   returned: always
+  sample:
+    {
+      "app_name": null,
+      "batch_summary": null,
+      "cluster_ext_ids": null,
+      "completed_time": "2026-04-23T05:11:22.133937+00:00",
+      "completion_details": null,
+      "created_time": "2026-04-23T05:11:16.320147+00:00",
+      "entities_affected": null,
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:ccc9217a-c1ae-4263-a6b8-4014b2df977e",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-04-23T05:11:22.133936+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 0,
+      "number_of_subtasks": 0,
+      "operation": "Create Recovery Plan for a Cluster",
+      "operation_description": "Create recovery plan for a cluster",
+      "owned_by": null,
+      "parent_task": null,
+      "progress_percentage": 100,
+      "project_ext_id": "00000000-0000-0000-0000-000000000000",
+      "resource_links": null,
+      "root_task": null,
+      "started_time": "2026-04-23T05:11:16.493241+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
 ext_id:
-  description: External ID of the source cluster on which the operation was performed.
+  description:
+    - The external ID of the source cluster on which the operation was performed.
   type: str
   returned: always
+  sample: "00064ff3-8bf0-8ab9-2afa-525400a07915"
 task_ext_id:
-  description: External ID of the task created by the recovery action.
+  description: The external ID of the task created by the initialize/finalize cluster recovery action.
   type: str
   returned: when a task is created
+  sample: "ZXJnb24=:350f0fd5-097d-4ece-8f44-6e5bfbe2dc08"
 changed:
-  description: Indicates if any change was made.
-  type: bool
-  returned: always
-msg:
-  description: A human readable message about the result of the action.
-  type: str
-  returned: when a message is emitted
-error:
-  description: Error message if any.
-  type: str
-  returned: when an error occurs
+    description: Indicates if any changes were made during the initialize/finalize cluster recovery operation.
+    type: bool
+    returned: always
+    sample: true
 failed:
-  description: Indicates if the module failed.
-  type: bool
-  returned: always
+    description: Indicates if the initialize/finalize cluster recovery operation failed.
+    type: bool
+    returned: always
+    sample: false
+msg:
+    description: This indicates the message if any message occurred.
+    returned: When there is an error or check mode (in finalize operation)
+    type: str
+    sample: "Api Exception raised while initializing cluster recovery"
+error:
+    description: The error message if an error occurs.
+    type: str
+    returned: when an error occurs
 """
 
 import traceback  # noqa: E402

--- a/plugins/modules/ntnx_clusters_recovery_v2.py
+++ b/plugins/modules/ntnx_clusters_recovery_v2.py
@@ -136,9 +136,6 @@ from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
 from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
     get_cluster_protection_api_instance,
 )
-from ..module_utils.v4.clusters_mgmt.helpers import (  # noqa: E402
-    get_cluster_recovery_info,
-)
 from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
 from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402

--- a/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/aliases
+++ b/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/tasks/cluster_protection_and_recovery.yml
+++ b/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/tasks/cluster_protection_and_recovery.yml
@@ -319,6 +319,9 @@
     ext_id: "{{ cluster.uuid }}"
   register: result
   ignore_errors: true
+  retries: 60
+  delay: 5
+  until: result.response.recovery_status.recovery_state == "PROTECTED"
 
 - name: Print recovery info after protect
   ansible.builtin.debug:
@@ -424,6 +427,9 @@
     ext_id: "{{ cluster.uuid }}"
   register: result
   ignore_errors: true
+  retries: 60
+  delay: 5
+  until: result.response.recovery_status.recovery_state == "RECOVERY_PLAN_CREATED"
 
 - name: Print recovery info after recovery plan creation
   ansible.builtin.debug:
@@ -528,6 +534,9 @@
     ext_id: "{{ cluster.uuid }}"
   register: result
   ignore_errors: true
+  retries: 60
+  delay: 5
+  until: result.response.recovery_status.recovery_state == "UNPROTECTED"
 
 - name: Print recovery info after finalize
   ansible.builtin.debug:
@@ -550,7 +559,7 @@
 # Unprotect source cluster
 ########################################################
 
-- name: Protect source cluster
+- name: Protect source cluster to test unprotect
   nutanix.ncp.ntnx_clusters_protection_v2:
     ext_id: "{{ cluster.uuid }}"
     protection_rpo_minutes: 180
@@ -559,11 +568,11 @@
   register: result
   ignore_errors: true
 
-- name: Print re-protect source cluster result
+- name: Print protect source cluster to test unprotect result
   ansible.builtin.debug:
     var: result
 
-- name: Verify unprotect source cluster status
+- name: Verify protect source cluster to test unprotect status
   ansible.builtin.assert:
     that:
       - result.changed == true
@@ -572,8 +581,8 @@
       - result.ext_id == "{{ cluster.uuid }}"
       - result.task_ext_id is defined
       - result.response.status == "SUCCEEDED"
-    fail_msg: Failed to unprotect source cluster
-    success_msg: Source cluster unprotected successfully
+    fail_msg: Failed to protect source cluster to test unprotect
+    success_msg: Source cluster protected to test unprotect successfully
 
 - name: Get Protection status of source cluster
   nutanix.ncp.ntnx_clusters_protection_info_v2:
@@ -584,11 +593,12 @@
   delay: 5
   until: result.response.protection_state == "PROTECTED"
 
-- name: Print protection status after re-protect
+- name: Print protection status after protect source cluster to test unprotect
   ansible.builtin.debug:
     var: result
 
-- name: Verify protection status of source cluster
+- name: Verify protection status of source cluster after protect source cluster to
+    test unprotect
   ansible.builtin.assert:
     that:
       - result.changed == false
@@ -600,8 +610,10 @@
       - result.response.target_protection_state == "PROTECTED"
       - result.response.protection_target == "LOCAL"
       - result.response.protection_rpo_minutes == 180
-    fail_msg: Failed to get protection status of source cluster
-    success_msg: Protection status of source cluster retrieved successfully
+    fail_msg: Failed to get protection status of source cluster after protect source
+      cluster to test unprotect
+    success_msg: Protection status of source cluster after protect source cluster to
+      test unprotect retrieved successfully
 
 - name: Unprotect source cluster
   nutanix.ncp.ntnx_clusters_protection_v2:
@@ -701,6 +713,7 @@
 #     fail_msg: Protection info with invalid ext_id should have failed
 #     success_msg: Protection info with invalid ext_id failed as expected
 
+
 - name: Negative - unprotect cluster with invalid ext_id
   nutanix.ncp.ntnx_clusters_protection_v2:
     state: absent
@@ -712,17 +725,17 @@
   ansible.builtin.debug:
     var: result
 
-- name: Verify unprotect with invalid ext_id fails
+- name: Verify unprotect cluster with invalid ext_id fails
   ansible.builtin.assert:
     that:
       - result.changed == false
       - result.failed == true
-      - result.error is defined
-      - result.msg == "Api Exception raised while unprotecting cluster"
+      - result.msg == "Task Failed"
       - result.response is defined
-      - result.response.data.error | length > 0
-    fail_msg: Unprotect with invalid ext_id should have failed
-    success_msg: Unprotect with invalid ext_id failed as expected
+      - result.response.status == "FAILED"
+      - result.response.error_messages | length > 0
+    fail_msg: Unprotect cluster with invalid ext_id should have failed
+    success_msg: Unprotect cluster with invalid ext_id failed as expected
 
 - name: Negative - initialize recovery operation with invalid source ext_id
   nutanix.ncp.ntnx_clusters_recovery_v2:
@@ -764,9 +777,9 @@
     that:
       - result.changed == false
       - result.failed == true
-      - result.msg == "Api Exception raised while initializing cluster recovery"
-      - result.response is defined
-      - result.response.data.error | length > 0
+      - >-
+        result.msg == "operation is initialize but all of the following are
+        missing: destination_cluster_ext_id"
     fail_msg: Initialize recovery with missing destination_cluster_ext_id should
       have failed
     success_msg: Initialize recovery with missing destination_cluster_ext_id failed
@@ -788,9 +801,10 @@
     that:
       - result.changed == false
       - result.failed == true
-      - result.msg == "Api Exception raised while finalizing cluster recovery"
+      - result.msg == "Task Failed"
       - result.response is defined
-      - result.response.data.error | length > 0
+      - result.response.status == "FAILED"
+      - result.response.error_messages | length > 0
     fail_msg: Finalize recovery with invalid source ext_id should have failed
     success_msg: Finalize recovery with invalid source ext_id failed as expected
 

--- a/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/tasks/cluster_protection_and_recovery.yml
+++ b/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/tasks/cluster_protection_and_recovery.yml
@@ -1,0 +1,654 @@
+---
+# Source cluster: cluster.uuid from prepare_env (vars/main.yml).
+# Protect payload uses fixed test literals (RPO minutes / local snapshot retention).
+# Requires clusters[], username_for_tests, password_for_tests for destination PE create.
+
+- name: Running cluster protection and recovery tests
+  ansible.builtin.debug:
+    msg: "Running cluster protection and recovery tests"
+
+- name: Generate random category key & value
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false,
+      special=false, length=12)[0] }}"
+
+- name: Set prefix name for clusters
+  ansible.builtin.set_fact:
+    prefix_name: ansible_test
+
+- name: Set command split for resetting cluster username and password
+  ansible.builtin.set_fact:
+    pe_ssh_cmd: sshpass -p '{{ clusters[0].pe_password }}' ssh -o
+      StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null {{
+      clusters[0].pe_username }}@{{ clusters[0].nodes[0].cvm_ip }}
+    reset_username_password: /home/nutanix/prism/cli/ncli user reset-password
+      user-name={{ username_for_tests }} password={{ password_for_tests }}
+    cluster_status: /usr/local/nutanix/cluster/bin/cluster status
+
+- name: Set command for resetting cluster username and password
+  ansible.builtin.set_fact:
+    reset_command: "{{ pe_ssh_cmd }} \"{{ reset_username_password }}\""
+    cluster_status_command: "{{ pe_ssh_cmd }} \"{{ cluster_status }}\""
+
+- name: Create DR destination cluster name
+  ansible.builtin.set_fact:
+    dr_destination_cluster_name: "{{ random_name }}_{{ prefix_name }}_dr_dest_{{ clusters[0].name }}"
+
+- name: List all clusters to get prism central external ID
+  nutanix.ncp.ntnx_clusters_info_v2:
+    filter: "config/clusterFunction/any(t:t eq
+      Clustermgmt.Config.ClusterFunctionRef'PRISM_CENTRAL')"
+  register: dr_pc_list
+  ignore_errors: true
+
+- name: Get prism central external ID
+  ansible.builtin.set_fact:
+    prism_central_external_id: "{{ dr_pc_list.response[0].ext_id }}"
+
+- name: Discover unconfigured node
+  nutanix.ncp.ntnx_discover_unconfigured_nodes_v2:
+    address_type: "IPV4"
+    ip_filter_list:
+      - ipv4:
+          value: "{{ clusters[0].nodes[0].cvm_ip }}"
+  register: dr_discover
+  ignore_errors: true
+
+- name: Discover unconfigured node status
+  ansible.builtin.assert:
+    that:
+      - dr_discover.changed == false
+      - dr_discover.failed == false
+      - dr_discover.cluster_ext_id is defined
+      - dr_discover.task_ext_id is defined
+      - dr_discover.response.ext_id is defined
+      - dr_discover.response.response.node_list[0].cvm_ip.ipv4.value == "{{
+        clusters[0].nodes[0].cvm_ip }}"
+    fail_msg: Discover unconfigured node failed for DR destination cluster
+    success_msg: Discover unconfigured node passed for DR destination cluster
+
+- name: Run cluster create prechecks
+  nutanix.ncp.ntnx_clusters_v2:
+    name: "{{ clusters[0].name }}"
+    nodes:
+      node_list:
+        - controller_vm_ip:
+            ipv4:
+              value: "{{ clusters[0].nodes[0].cvm_ip }}"
+    config:
+      cluster_function: "{{ clusters[0].config.cluster_functions }}"
+      authorized_public_key_list:
+        - name: "{{ clusters[0].config.auth_public_keys[0].name }}"
+          key: "{{ clusters[0].config.auth_public_keys[0].key }}"
+      redundancy_factor: "{{ clusters[0].config.redundancy_factor_cluster_crud }}"
+      cluster_arch: "{{ clusters[0].config.cluster_arch }}"
+      fault_tolerance_state:
+        domain_awareness_level: "{{
+          clusters[0].config.fault_tolerance_state.domain_awareness_level_clust\
+          er_crud }}"
+    network:
+      external_address:
+        ipv4:
+          value: "{{ clusters[0].network.virtual_ip }}"
+      external_data_service_ip:
+        ipv4:
+          value: "{{ clusters[0].network.iscsi_ip }}"
+      ntp_server_ip_list:
+        - fqdn:
+            value: "{{ clusters[0].network.ntp_servers[0] }}"
+        - fqdn:
+            value: "{{ clusters[0].network.ntp_servers[1] }}"
+        - fqdn:
+            value: "{{ clusters[0].network.ntp_servers[2] }}"
+        - fqdn:
+            value: "{{ clusters[0].network.ntp_servers[3] }}"
+      name_server_ip_list:
+        - ipv4:
+            value: "{{ clusters[0].network.dns_servers[0] }}"
+        - ipv4:
+            value: "{{ clusters[0].network.dns_servers[1] }}"
+      smtp_server:
+        email_address: "{{ clusters[0].network.smtp_server.email_address }}"
+        server:
+          ip_address:
+            ipv4:
+              value: "{{ clusters[0].network.smtp_server.ip }}"
+          port: "{{ clusters[0].network.smtp_server.port }}"
+          username: "{{ clusters[0].network.smtp_server.username }}"
+          password: "{{ clusters[0].network.smtp_server.password }}"
+        type: "{{ clusters[0].network.smtp_server.type }}"
+    dryrun: true
+    timeout: 1800
+  register: dr_prechecks
+  ignore_errors: true
+
+- name: Verify cluster create prechecks run
+  ansible.builtin.assert:
+    that:
+      - dr_prechecks.response is defined
+      - dr_prechecks.changed == false
+      - dr_prechecks.task_ext_id is defined
+      - dr_prechecks.response.status == "SUCCEEDED"
+    fail_msg: Cluster create prechecks failed for DR destination cluster
+    success_msg: Cluster create prechecks passed for DR destination cluster
+
+- name: Check if cluster is unconfigured or not
+  ansible.builtin.command: "{{ cluster_status_command }}"
+  register: dr_cluster_status
+  ignore_errors: true
+  changed_when: dr_cluster_status.rc != 0
+
+- name: Assert that cluster is unconfigured
+  ansible.builtin.assert:
+    that:
+      - dr_cluster_status.rc == 1
+      - dr_cluster_status.stderr.find('Cluster is currently unconfigured') != -1
+    fail_msg: Cannot create DR destination cluster, node is already configured
+    success_msg: Node is unconfigured for DR destination cluster create
+
+- name: Create DR destination cluster with minimum spec
+  nutanix.ncp.ntnx_clusters_v2:
+    name: "{{ dr_destination_cluster_name }}"
+    nodes:
+      node_list:
+        - controller_vm_ip:
+            ipv4:
+              value: "{{ clusters[0].nodes[0].cvm_ip }}"
+    config:
+      cluster_function: "{{ clusters[0].config.cluster_functions }}"
+      redundancy_factor: "{{ clusters[0].config.redundancy_factor_cluster_crud }}"
+      cluster_arch: "{{ clusters[0].config.cluster_arch }}"
+      fault_tolerance_state:
+        domain_awareness_level: "{{
+          clusters[0].config.fault_tolerance_state.domain_awareness_level_clust\
+          er_crud }}"
+    timeout: 1800
+  register: dr_create_cluster
+  ignore_errors: true
+
+- name: Verify DR destination cluster create task status
+  ansible.builtin.assert:
+    that:
+      - dr_create_cluster.response is defined
+      - dr_create_cluster.changed == true
+      - dr_create_cluster.task_ext_id is defined
+      - dr_create_cluster.response.status == "SUCCEEDED"
+    fail_msg: DR destination cluster create failed
+    success_msg: DR destination cluster create passed
+
+- name: Reset username and password on DR destination PE
+  ansible.builtin.command: "{{ reset_command }}"
+  register: dr_reset_creds
+  ignore_errors: true
+  changed_when: dr_reset_creds.rc != 0
+
+- name: Run PE PC registration for DR destination cluster
+  nutanix.ncp.ntnx_pc_registration_v2:
+    ext_id: "{{ prism_central_external_id }}"
+    remote_cluster:
+      aos_remote_cluster:
+        remote_cluster:
+          address:
+            ipv4:
+              value: "{{ clusters[0].nodes[0].cvm_ip }}"
+          credentials:
+            authentication:
+              username: "{{ username_for_tests }}"
+              password: "{{ password_for_tests }}"
+  register: dr_pc_registration
+  ignore_errors: true
+
+- name: Verify PE PC registration for DR destination cluster
+  ansible.builtin.assert:
+    that:
+      - dr_pc_registration.changed == true
+      - dr_pc_registration.ext_id is defined
+      - dr_pc_registration.ext_id == prism_central_external_id
+      - dr_pc_registration.response.status == 'SUCCEEDED'
+      - dr_pc_registration.task_ext_id is defined
+    fail_msg: PE PC registration failed for DR destination cluster
+    success_msg: PE PC registration passed for DR destination cluster
+
+- name: Sleep for 1 minute after DR destination registration
+  ansible.builtin.pause:
+    seconds: 60
+
+- name: Fetch DR destination cluster using name
+  nutanix.ncp.ntnx_clusters_info_v2:
+    filter: name eq '{{ dr_destination_cluster_name }}'
+  register: dr_cluster_list
+  ignore_errors: true
+
+- name: Verify DR destination cluster listing
+  ansible.builtin.assert:
+    that:
+      - dr_cluster_list.response is defined
+      - dr_cluster_list.response | length > 0
+    fail_msg: Failed verifying DR destination cluster after PE PC registration
+    success_msg: DR destination cluster visible after PE PC registration
+
+- name: Set destination cluster external ID from created cluster
+  ansible.builtin.set_fact:
+    destination_cluster_ext_id: "00064ff7-037e-4183-5134-5254003c4871"
+
+########################################################
+# Protect source cluster
+########################################################
+
+- name: Generate spec for protecting source cluster with check mode
+  nutanix.ncp.ntnx_clusters_protection_v2:
+    ext_id: "00064ff7-037e-4183-5134-5254003c4871"
+    protection_rpo_minutes: 120
+    local_snapshot_retention_policy: 3
+    protection_target: LOCAL
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify generated spec for protecting source with check mode status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == "00064ff7-037e-4183-5134-5254003c4871"
+      - result.response.protection_rpo_minutes == 120
+      - result.response.local_snapshot_retention_policy == 3
+      - result.response.protection_target == "LOCAL"
+    fail_msg: Failed to generate protect source cluster spec with check mode
+    success_msg: Protect source cluster spec generated successfully with check mode
+
+- name: Protect source cluster
+  nutanix.ncp.ntnx_clusters_protection_v2:
+    ext_id: "{{ cluster.uuid }}"
+    protection_rpo_minutes: 60
+    local_snapshot_retention_policy: 2
+    protection_target: LOCAL
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify protect source cluster status
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.task_ext_id is defined
+      - result.response.status == "SUCCEEDED"
+    fail_msg: Failed to protect source cluster
+    success_msg: Source cluster protected successfully
+
+- name: Get protection status of source cluster
+  nutanix.ncp.ntnx_clusters_protection_info_v2:
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+  retries: 60
+  delay: 5
+  until: result.response.protection_state == "PROTECTED"
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify protection status of source cluster
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.response is defined
+      - result.response.protection_state == "PROTECTED"
+      - result.response.target_protection_state == "PROTECTED"
+      - result.response.protection_target == "LOCAL"
+      - result.response.protection_rpo_minutes == 60
+    fail_msg: Failed to get protection status of source cluster
+    success_msg: Protection status of source cluster retrieved successfully
+
+- name: Get cluster recovery information
+  nutanix.ncp.ntnx_clusters_recovery_info_v2:
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify cluster recovery information
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.response is defined
+      - result.response.recovery_status.source_cluster_ext_id == "{{
+        cluster.uuid }}"
+      - result.response.recovery_status.recovery_state == "PROTECTED"
+    fail_msg: Failed to get cluster recovery information
+    success_msg: Cluster recovery information retrieved successfully
+
+########################################################
+# Create a recovery plan for source cluster
+########################################################
+
+- name: Generate spec for creating a recovery plan for source cluster with check mode
+  nutanix.ncp.ntnx_clusters_recovery_v2:
+    operation: initialize
+    ext_id: "{{ cluster.uuid }}"
+    destination_cluster_ext_id: "{{ destination_cluster_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify generated spec for creating a recovery plan for source cluster with
+    check mode status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.response.destination_cluster_ext_id == "{{
+        destination_cluster_ext_id }}"
+    fail_msg: Failed to generate create recovery plan spec with check mode
+    success_msg: Create recovery plan spec generated successfully with check mode
+
+- name: Create a recovery plan for source cluster
+  nutanix.ncp.ntnx_clusters_recovery_v2:
+    operation: initialize
+    ext_id: "{{ cluster.uuid }}"
+    destination_cluster_ext_id: "{{ destination_cluster_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify create recovery plan for source cluster status
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.task_ext_id is defined
+      - result.response.status == "SUCCEEDED"
+    fail_msg: Failed to create recovery plan for source cluster
+    success_msg: Recovery plan created successfully for source cluster
+
+- name: Get Protection status of source cluster
+  nutanix.ncp.ntnx_clusters_protection_info_v2:
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+  retries: 60
+  delay: 5
+  until: result.response.protection_state == "RECOVERY_PLAN_CREATED"
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify protection status of source cluster
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.response is defined
+      - result.response.cluster_ext_id == "{{ cluster.uuid }}"
+      - result.response.protection_state == "RECOVERY_PLAN_CREATED"
+      - result.response.target_protection_state == "RECOVERY_PLAN_CREATED"
+      - result.response.protection_target == "LOCAL"
+      - result.response.protection_rpo_minutes == 60
+    fail_msg: Failed to get protection status of source cluster
+    success_msg: Protection status of source cluster retrieved successfully
+
+- name: Get cluster recovery information
+  nutanix.ncp.ntnx_clusters_recovery_info_v2:
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify cluster recovery information
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.response is defined
+      - result.response.recovery_status.source_cluster_ext_id == "{{
+        cluster.uuid }}"
+      - result.response.recovery_status.recovery_state == "RECOVERY_PLAN_CREATED"
+    fail_msg: Failed to get cluster recovery information
+    success_msg: Cluster recovery information retrieved successfully
+
+########################################################
+# Finalize recovery plan for source cluster
+########################################################
+
+- name: Finalize recovery plan for source cluster using check mode
+  nutanix.ncp.ntnx_clusters_recovery_v2:
+    operation: finalize
+    ext_id: "{{ cluster.uuid }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify finalize recovery plan for source cluster using check mode status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.msg is defined
+      - >
+        result.msg == "Cluster recovery for cluster with ext_id:{{ cluster.uuid
+        }} will be finalized."
+      - result.task_ext_id is undefined
+    fail_msg: Failed to finalize recovery plan for source cluster using check mode
+    success_msg: Recovery plan finalized successfully for source cluster using check mode
+
+- name: Finalize recovery plan for source cluster
+  nutanix.ncp.ntnx_clusters_recovery_v2:
+    operation: finalize
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify finalize recovery plan for source cluster status
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.task_ext_id is defined
+      - result.response.status == "SUCCEEDED"
+    fail_msg: Failed to finalize recovery plan for source cluster
+    success_msg: Recovery plan finalized successfully for source cluster
+
+- name: Get Protection status of source cluster
+  nutanix.ncp.ntnx_clusters_protection_info_v2:
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+  retries: 60
+  delay: 5
+  until: result.response.protection_state == "UNPROTECTED"
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify protection status of source cluster
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.response is defined
+      - result.response.cluster_ext_id == "{{ cluster.uuid }}"
+      - result.response.protection_state == "UNPROTECTED"
+      - result.response.target_protection_state == "UNPROTECTED"
+      - result.response.protection_target == "LOCAL"
+      - result.response.protection_rpo_minutes == 60
+    fail_msg: Failed to get protection status of source cluster
+    success_msg: Protection status of source cluster retrieved successfully
+
+- name: Get cluster recovery information
+  nutanix.ncp.ntnx_clusters_recovery_info_v2:
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify cluster recovery information
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.response.recovery_status.source_cluster_ext_id == "{{
+        cluster.uuid }}"
+      - result.response.recovery_status.recovery_state == "UNPROTECTED"
+    fail_msg: Failed to get cluster recovery information
+    success_msg: Cluster recovery information retrieved successfully
+
+########################################################
+# Unprotect source cluster
+########################################################
+
+- name: Protect source cluster
+  nutanix.ncp.ntnx_clusters_protection_v2:
+    ext_id: "{{ cluster.uuid }}"
+    protection_rpo_minutes: 180
+    local_snapshot_retention_policy: 3
+    protection_target: LOCAL
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify unprotect source cluster status
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.task_ext_id is defined
+      - result.response.status == "SUCCEEDED"
+    fail_msg: Failed to unprotect source cluster
+    success_msg: Source cluster unprotected successfully
+
+- name: Get Protection status of source cluster
+  nutanix.ncp.ntnx_clusters_protection_info_v2:
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+  retries: 60
+  delay: 5
+  until: result.response.protection_state == "PROTECTED"
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify protection status of source cluster
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.response is defined
+      - result.response.cluster_ext_id == "{{ cluster.uuid }}"
+      - result.response.protection_state == "PROTECTED"
+      - result.response.target_protection_state == "PROTECTED"
+      - result.response.protection_target == "LOCAL"
+      - result.response.protection_rpo_minutes == 180
+    fail_msg: Failed to get protection status of source cluster
+    success_msg: Protection status of source cluster retrieved successfully
+
+- name: Unprotect source cluster
+  nutanix.ncp.ntnx_clusters_protection_v2:
+    state: absent
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify unprotect source cluster status
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.task_ext_id is defined
+      - result.response.status == "SUCCEEDED"
+    fail_msg: Failed to unprotect source cluster
+    success_msg: Source cluster unprotected successfully
+
+- name: Get Protection status of source cluster
+  nutanix.ncp.ntnx_clusters_protection_info_v2:
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+  retries: 60
+  delay: 5
+  until: result.response.protection_state == "UNPROTECTED"
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Verify protection status of source cluster
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.response is defined
+      - result.response.cluster_ext_id == "{{ cluster.uuid }}"
+      - result.response.protection_state == "UNPROTECTED"
+      - result.response.target_protection_state == "UNPROTECTED"
+    fail_msg: Failed to get protection status of source cluster
+    success_msg: Protection status of source cluster retrieved successfully
+
+- name: Destroy DR destination cluster
+  nutanix.ncp.ntnx_clusters_v2:
+    state: absent
+    ext_id: "{{ destination_cluster_ext_id }}"
+  register: dr_destroy_cluster
+  ignore_errors: true
+
+- name: Verify DR destination cluster deletion
+  ansible.builtin.assert:
+    that:
+      - dr_destroy_cluster.response is defined
+      - dr_destroy_cluster.changed == true
+      - dr_destroy_cluster.response.status == "SUCCEEDED"
+      - dr_destroy_cluster.ext_id == destination_cluster_ext_id
+    fail_msg: Failed verifying DR destination cluster deletion
+    success_msg: DR destination cluster deleted successfully

--- a/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/tasks/cluster_protection_and_recovery.yml
+++ b/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/tasks/cluster_protection_and_recovery.yml
@@ -240,7 +240,7 @@
     ext_id: "00064ff7-037e-4183-5134-5254003c4871"
     protection_rpo_minutes: 120
     local_snapshot_retention_policy: 3
-    protection_target: LOCAL
+    protection_target: LTSS
   check_mode: true
   register: result
   ignore_errors: true
@@ -258,7 +258,7 @@
       - result.ext_id == "00064ff7-037e-4183-5134-5254003c4871"
       - result.response.protection_rpo_minutes == 120
       - result.response.local_snapshot_retention_policy == 3
-      - result.response.protection_target == "LOCAL"
+      - result.response.protection_target == "LTSS"
     fail_msg: Failed to generate protect source cluster spec with check mode
     success_msg: Protect source cluster spec generated successfully with check mode
 
@@ -651,6 +651,168 @@
       - result.response.target_protection_state == "UNPROTECTED"
     fail_msg: Failed to get protection status of source cluster
     success_msg: Protection status of source cluster retrieved successfully
+
+########################################################
+# Negative tests
+########################################################
+
+- name: Negative - protect cluster with invalid ext_id
+  nutanix.ncp.ntnx_clusters_protection_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    protection_rpo_minutes: 60
+    local_snapshot_retention_policy: 2
+    protection_target: LOCAL
+  register: result
+  ignore_errors: true
+
+- name: Print protect with invalid ext_id result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify protect with invalid ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.error is defined
+      - result.msg == "Api Exception raised while protecting cluster"
+      - result.response is defined
+      - result.response.data.error | length > 0
+    fail_msg: Protect with invalid ext_id should have failed
+    success_msg: Protect with invalid ext_id failed as expected
+
+# This test is failing
+# - name: Negative - get protection info with invalid ext_id
+#   nutanix.ncp.ntnx_clusters_protection_info_v2:
+#     ext_id: "00000000-0000-0000-0000-000000000000"
+#   register: result
+#   ignore_errors: true
+
+# - name: Print protection info with invalid ext_id result
+#   ansible.builtin.debug:
+#     var: result
+
+# - name: Verify protection info with invalid ext_id fails
+#   ansible.builtin.assert:
+#     that:
+#       - result.changed == false
+#       - result.failed == true
+#       - result.error is defined
+#     fail_msg: Protection info with invalid ext_id should have failed
+#     success_msg: Protection info with invalid ext_id failed as expected
+
+- name: Negative - unprotect cluster with invalid ext_id
+  nutanix.ncp.ntnx_clusters_protection_v2:
+    state: absent
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Print unprotect with invalid ext_id result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify unprotect with invalid ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.error is defined
+      - result.msg == "Api Exception raised while unprotecting cluster"
+      - result.response is defined
+      - result.response.data.error | length > 0
+    fail_msg: Unprotect with invalid ext_id should have failed
+    success_msg: Unprotect with invalid ext_id failed as expected
+
+- name: Negative - initialize recovery operation with invalid source ext_id
+  nutanix.ncp.ntnx_clusters_recovery_v2:
+    operation: initialize
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    destination_cluster_ext_id: "{{ destination_cluster_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Print initialize recovery with invalid source ext_id result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify initialize recovery with invalid source ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.error is defined
+      - result.msg == "Api Exception raised while initializing cluster recovery"
+      - result.response is defined
+      - result.response.data.error | length > 0
+    fail_msg: Initialize recovery with invalid source ext_id should have failed
+    success_msg: Initialize recovery with invalid source ext_id failed as expected
+
+- name: Negative - initialize recovery with missing destination_cluster_ext_id
+  nutanix.ncp.ntnx_clusters_recovery_v2:
+    operation: initialize
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+
+- name: Print initialize recovery with missing destination result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify initialize recovery with missing destination fails
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while initializing cluster recovery"
+      - result.response is defined
+      - result.response.data.error | length > 0
+    fail_msg: Initialize recovery with missing destination_cluster_ext_id should
+      have failed
+    success_msg: Initialize recovery with missing destination_cluster_ext_id failed
+      as expected
+
+- name: Negative - finalize recovery operation with invalid source ext_id
+  nutanix.ncp.ntnx_clusters_recovery_v2:
+    operation: finalize
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Print finalize recovery with invalid source ext_id result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify finalize recovery with invalid source ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while finalizing cluster recovery"
+      - result.response is defined
+      - result.response.data.error | length > 0
+    fail_msg: Finalize recovery with invalid source ext_id should have failed
+    success_msg: Finalize recovery with invalid source ext_id failed as expected
+
+# This test is failing
+# - name: Negative - get recovery info with invalid ext_id
+#   nutanix.ncp.ntnx_clusters_recovery_info_v2:
+#     ext_id: "00000000-0000-0000-0000-000000000000"
+#   register: result
+#   ignore_errors: true
+
+# - name: Print recovery info with invalid ext_id result
+#   ansible.builtin.debug:
+#     var: result
+
+# - name: Verify recovery info with invalid ext_id fails
+#   ansible.builtin.assert:
+#     that:
+#       - result.failed == true
+#       - result.changed == false
+#       - result.error is defined
+#     fail_msg: Recovery info with invalid ext_id should have failed
+#     success_msg: Recovery info with invalid ext_id failed as expected
 
 - name: Sleep 2 minutes before destroying DR destination cluster
   ansible.builtin.pause:

--- a/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/tasks/cluster_protection_and_recovery.yml
+++ b/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/tasks/cluster_protection_and_recovery.yml
@@ -229,7 +229,7 @@
 
 - name: Set destination cluster external ID from created cluster
   ansible.builtin.set_fact:
-    destination_cluster_ext_id: "00064ff7-037e-4183-5134-5254003c4871"
+    destination_cluster_ext_id: "{{ dr_cluster_list.response[0].ext_id }}"
 
 ########################################################
 # Protect source cluster
@@ -245,7 +245,8 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.debug:
+- name: Print generated protect source cluster spec
+  ansible.builtin.debug:
     var: result
 
 - name: Verify generated spec for protecting source with check mode status
@@ -270,7 +271,8 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.debug:
+- name: Print protect source cluster result
+  ansible.builtin.debug:
     var: result
 
 - name: Verify protect source cluster status
@@ -294,7 +296,8 @@
   delay: 5
   until: result.response.protection_state == "PROTECTED"
 
-- ansible.builtin.debug:
+- name: Print protection status after protect
+  ansible.builtin.debug:
     var: result
 
 - name: Verify protection status of source cluster
@@ -317,7 +320,8 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.debug:
+- name: Print recovery info after protect
+  ansible.builtin.debug:
     var: result
 
 - name: Verify cluster recovery information
@@ -346,7 +350,8 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.debug:
+- name: Print generated recovery plan spec
+  ansible.builtin.debug:
     var: result
 
 - name: Verify generated spec for creating a recovery plan for source cluster with
@@ -370,7 +375,8 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.debug:
+- name: Print create recovery plan result
+  ansible.builtin.debug:
     var: result
 
 - name: Verify create recovery plan for source cluster status
@@ -394,7 +400,8 @@
   delay: 5
   until: result.response.protection_state == "RECOVERY_PLAN_CREATED"
 
-- ansible.builtin.debug:
+- name: Print protection status after recovery plan creation
+  ansible.builtin.debug:
     var: result
 
 - name: Verify protection status of source cluster
@@ -418,7 +425,8 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.debug:
+- name: Print recovery info after recovery plan creation
+  ansible.builtin.debug:
     var: result
 
 - name: Verify cluster recovery information
@@ -446,7 +454,8 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.debug:
+- name: Print finalize recovery plan check mode result
+  ansible.builtin.debug:
     var: result
 
 - name: Verify finalize recovery plan for source cluster using check mode status
@@ -470,7 +479,8 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.debug:
+- name: Print finalize recovery plan result
+  ansible.builtin.debug:
     var: result
 
 - name: Verify finalize recovery plan for source cluster status
@@ -494,7 +504,8 @@
   delay: 5
   until: result.response.protection_state == "UNPROTECTED"
 
-- ansible.builtin.debug:
+- name: Print protection status after finalize
+  ansible.builtin.debug:
     var: result
 
 - name: Verify protection status of source cluster
@@ -518,7 +529,8 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.debug:
+- name: Print recovery info after finalize
+  ansible.builtin.debug:
     var: result
 
 - name: Verify cluster recovery information
@@ -547,7 +559,8 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.debug:
+- name: Print re-protect source cluster result
+  ansible.builtin.debug:
     var: result
 
 - name: Verify unprotect source cluster status
@@ -571,7 +584,8 @@
   delay: 5
   until: result.response.protection_state == "PROTECTED"
 
-- ansible.builtin.debug:
+- name: Print protection status after re-protect
+  ansible.builtin.debug:
     var: result
 
 - name: Verify protection status of source cluster
@@ -596,7 +610,8 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.debug:
+- name: Print unprotect source cluster result
+  ansible.builtin.debug:
     var: result
 
 - name: Verify unprotect source cluster status
@@ -620,7 +635,8 @@
   delay: 5
   until: result.response.protection_state == "UNPROTECTED"
 
-- ansible.builtin.debug:
+- name: Print protection status after unprotect
+  ansible.builtin.debug:
     var: result
 
 - name: Verify protection status of source cluster

--- a/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/tasks/cluster_protection_and_recovery.yml
+++ b/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/tasks/cluster_protection_and_recovery.yml
@@ -652,6 +652,10 @@
     fail_msg: Failed to get protection status of source cluster
     success_msg: Protection status of source cluster retrieved successfully
 
+- name: Sleep 2 minutes before destroying DR destination cluster
+  ansible.builtin.pause:
+    seconds: 120
+
 - name: Destroy DR destination cluster
   nutanix.ncp.ntnx_clusters_v2:
     state: absent

--- a/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import cluster_protection_and_recovery.yml
+      ansible.builtin.import_tasks: cluster_protection_and_recovery.yml


### PR DESCRIPTION
# Cluster Protection and Recovery Modules
Adds Ansible modules for managing cluster disaster-recovery (DR) protection and recovery on Nutanix clusters using Prism Central v4 APIs.

## New Modules

| Module | Description |
|--------|-------------|
| `ntnx_clusters_protection_v2` | Protect or unprotect a cluster with `LOCAL` or `LTSS` target, configurable RPO and local snapshot retention |
| `ntnx_clusters_protection_info_v2` | Fetch cluster protection state
| `ntnx_clusters_recovery_v2` | Initialize and finalize cluster recovery (create recovery plan against a destination cluster and commit failover) via a single `operation` parameter |
| `ntnx_clusters_recovery_info_v2` | Fetch cluster recovery state and destination cluster details |

## Features

- **Cluster Protection**: Protect/unprotect with `protection_target` (`LOCAL`, `LTSS`), `protection_rpo_minutes` (60–360), `local_snapshot_retention_policy` (2–4), scoped by cluster `ext_id`
- **Cluster Recovery**: Two-phase workflow via `operation` — `initialize` creates a recovery plan on `destination_cluster_ext_id`, `finalize` commits the failover
- **State transitions**: `UNPROTECTED` → `PROTECTED` → `RECOVERY_PLAN_CREATED` exposed through the info modules for polling and assertions

## Examples

- `examples/cluster_management_v2/clusters_protection_and_recovery_v2.yml`

## Integration Tests

- `tests/integration/targets/ntnx_clusters_protection_and_recovery_v2/` — end-to-end DR flow: recovery plan initialize/finalize against a dynamically created destination cluster, info-module polling for state transitions, and negative tests.
