### PR TITLE
Resolve inventory categories to key/value pairs and add auto_create_cluster_groups option

### DIFF
--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -67,6 +67,13 @@ DOCUMENTATION = r"""
             type: str
             env:
                 - name: NUTANIX_API_KEY
+        auto_create_cluster_groups:
+            description:
+                - Automatically create inventory groups based on cluster ext_id.
+                - Set to C(False) to disable. Use C(keyed_groups) with C(cluster_name) for
+                  human-readable cluster groups instead.
+            default: true
+            type: bool
         fetch_all_vms:
             description:
                 - Set to C(True) to fetch all VMs
@@ -246,6 +253,9 @@ from ansible.plugins.inventory import BaseInventoryPlugin, Constructable  # noqa
 
 from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
     get_clusters_api_instance,
+)
+from ..module_utils.v4.prism.pc_api_client import (  # noqa: E402
+    get_categories_api_instance,
 )
 from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
 from ..module_utils.v4.vmm.api_client import get_vm_api_instance  # noqa: E402
@@ -454,7 +464,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         for key in unwanted_keys:
             host_vars.pop(key, None)
 
-    def _build_host_vars(self, vm, cluster_ext_id_name_map, strict=False):
+    def _build_host_vars(self, vm, cluster_ext_id_name_map, category_ext_id_map, strict=False):
         """
         Build a dictionary of host variables from the V4 VM response.
         Returns all VM attributes, excluding null/empty values.
@@ -482,16 +492,17 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         vm_ip = self._extract_vm_ip(vm)
         host_vars["ansible_host"] = vm_ip
 
-        # Convert categories to list of extId if present
+        # Resolve categories from ext_ids to key/value pairs
         if vm.get("categories"):
-            category_ext_ids = []
+            categories = {}
             for category in vm.get("categories") or []:
                 if isinstance(category, dict):
                     category_ext_id = category.get("ext_id")
-                    if category_ext_id:
-                        category_ext_ids.append(category_ext_id)
-            if category_ext_ids:
-                host_vars["categories"] = category_ext_ids
+                    if category_ext_id and category_ext_id in category_ext_id_map:
+                        cat = category_ext_id_map[category_ext_id]
+                        categories[cat["key"]] = cat["value"]
+            if categories:
+                host_vars["categories"] = categories
 
         # Handle custom ansible_host
         if getattr(self, "custom_ansible_host", None) and self.custom_ansible_host.get(
@@ -579,6 +590,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             ).lower()
             == "true"
         )
+        self.auto_create_cluster_groups = self.get_option("auto_create_cluster_groups")
         self.fetch_all_vms = self.get_option("fetch_all_vms")
         self.page = self.get_option("page")
         self.limit = self.get_option("limit")
@@ -611,9 +623,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             self.nutanix_api_key,
         )
 
-        # Get VM API instance
+        # Get API instances
         vmm = get_vm_api_instance(module)
         clusters = get_clusters_api_instance(module)
+        categories_api = get_categories_api_instance(module)
+
+        # Build cluster ext_id → name map
         list_clusters = clusters.list_clusters()
         cluster_ext_id_name_map = {}
         for cluster in list_clusters.data or []:
@@ -622,6 +637,28 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 ext_id = cluster_dict.get("ext_id")
                 name = cluster_dict.get("name")
                 cluster_ext_id_name_map[ext_id] = name
+
+        # Build category ext_id → {key, value} map
+        category_ext_id_map = {}
+        try:
+            page = 0
+            while True:
+                list_categories = categories_api.list_categories(_page=page, _limit=100)
+                if not list_categories.data:
+                    break
+                for cat in list_categories.data:
+                    cat_dict = cat.to_dict()
+                    ext_id = cat_dict.get("ext_id")
+                    if ext_id:
+                        category_ext_id_map[ext_id] = {
+                            "key": cat_dict.get("key"),
+                            "value": cat_dict.get("value"),
+                        }
+                if len(list_categories.data) < 100:
+                    break
+                page += 1
+        except Exception:
+            pass
 
         # Fetch VMs
         vms = self._fetch_vms(
@@ -641,7 +678,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             cluster_ext_id = (vm.get("cluster") or {}).get("ext_id")
             cluster_name = cluster_ext_id_name_map.get(cluster_ext_id)
             try:
-                host_vars = self._build_host_vars(vm, cluster_ext_id_name_map, strict)
+                host_vars = self._build_host_vars(vm, cluster_ext_id_name_map, category_ext_id_map, strict)
             except Exception as e:
                 raise AnsibleError(
                     f"Failed to build host vars for VM {vm.get('name')} with ext_id {vm.get('ext_id')}: {str(e)}"
@@ -676,8 +713,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 self._compose, host_vars, hostnames, vm_name, strict=strict
             )
 
-            # Create group based on cluster
-            if cluster_ext_id:
+            # Create group based on cluster (optional, enabled by default)
+            if self.auto_create_cluster_groups and cluster_ext_id:
                 group_name = "cluster_{0}".format(cluster_ext_id.replace("-", "_"))
                 group_name = self.inventory.add_group(group_name)
                 self.inventory.add_child("all", group_name)

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -227,6 +227,24 @@ EXAMPLES = r"""
       prefix: power
       separator: "_"
 
+# using keyed groups with categories_map and cluster_name
+# categories_map resolves category ext_ids to {key: value} pairs
+# categories retains the original list of category ext_ids
+- plugin: nutanix.ncp.ntnx_prism_vm_inventory_v2
+  nutanix_host: 10.x.x.x
+  nutanix_username: admin
+  nutanix_password: password
+  validate_certs: false
+  auto_create_cluster_groups: false
+  keyed_groups:
+    - key: cluster_name
+      prefix: cluster
+      separator: "_"
+    - key: categories_map.Environment
+      prefix: env
+      separator: "_"
+      default_value: unassigned
+
 # using custom ansible host for defining the ansible_host for the VMs
 - plugin: nutanix.ncp.ntnx_prism_vm_inventory_v2
   nutanix_host: 10.x.x.x

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -492,17 +492,22 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         vm_ip = self._extract_vm_ip(vm)
         host_vars["ansible_host"] = vm_ip
 
-        # Resolve categories from ext_ids to key/value pairs
+        # Convert categories to list of extId and build key/value map
         if vm.get("categories"):
-            categories = {}
+            category_ext_ids = []
+            categories_map = {}
             for category in vm.get("categories") or []:
                 if isinstance(category, dict):
                     category_ext_id = category.get("ext_id")
-                    if category_ext_id and category_ext_id in category_ext_id_map:
-                        cat = category_ext_id_map[category_ext_id]
-                        categories[cat["key"]] = cat["value"]
-            if categories:
-                host_vars["categories"] = categories
+                    if category_ext_id:
+                        category_ext_ids.append(category_ext_id)
+                        if category_ext_id in category_ext_id_map:
+                            cat = category_ext_id_map[category_ext_id]
+                            categories_map[cat["key"]] = cat["value"]
+            if category_ext_ids:
+                host_vars["categories"] = category_ext_ids
+            if categories_map:
+                host_vars["categories_map"] = categories_map
 
         # Handle custom ansible_host
         if getattr(self, "custom_ansible_host", None) and self.custom_ansible_host.get(

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -74,6 +74,15 @@ DOCUMENTATION = r"""
                   human-readable cluster groups instead.
             default: true
             type: bool
+        resolve_categories:
+            description:
+                - Resolve category ext_ids to key/value pairs and populate C(categories_map)
+                  in host variables.
+                - Requires fetching all categories from Prism Central via the Categories API.
+                - Set to C(False) to skip the API calls if you do not use C(categories_map)
+                  in keyed_groups, compose, or groups expressions.
+            default: true
+            type: bool
         fetch_all_vms:
             description:
                 - Set to C(True) to fetch all VMs
@@ -228,7 +237,8 @@ EXAMPLES = r"""
       separator: "_"
 
 # using keyed groups with categories_map and cluster_name
-# categories_map resolves category ext_ids to {key: value} pairs
+# categories_map resolves category ext_ids to {key: [values]} pairs
+# (values are lists to support multiple values per key)
 # categories retains the original list of category ext_ids
 - plugin: nutanix.ncp.ntnx_prism_vm_inventory_v2
   nutanix_host: 10.x.x.x
@@ -268,6 +278,7 @@ import tempfile  # noqa: E402
 
 from ansible.errors import AnsibleError  # noqa: E402
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable  # noqa: E402
+from ansible.utils.display import Display  # noqa: E402
 
 from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
     get_clusters_api_instance,
@@ -278,6 +289,8 @@ from ..module_utils.v4.prism.pc_api_client import (  # noqa: E402
 from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
 from ..module_utils.v4.vmm.api_client import get_vm_api_instance  # noqa: E402
 from ..plugin_utils.inventory_utils import get_hostname  # noqa: E402
+
+display = Display()
 
 
 class Mock_Module:
@@ -523,7 +536,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                         category_ext_ids.append(category_ext_id)
                         if category_ext_id in category_ext_id_map:
                             cat = category_ext_id_map[category_ext_id]
-                            categories_map[cat["key"]] = cat["value"]
+                            categories_map.setdefault(cat["key"], []).append(
+                                cat["value"]
+                            )
             if category_ext_ids:
                 host_vars["categories"] = category_ext_ids
             if categories_map:
@@ -602,8 +617,11 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 if len(list_categories.data) < 100:
                     break
                 page += 1
-        except Exception:
-            pass
+        except Exception as e:
+            display.warning(
+                "Failed to fetch categories from Prism Central, "
+                "categories_map will not be available: {0}".format(str(e))
+            )
         return result
 
     def parse(self, inventory, loader, path, cache=True):
@@ -650,6 +668,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             == "true"
         )
         self.auto_create_cluster_groups = self.get_option("auto_create_cluster_groups")
+        self.resolve_categories = self.get_option("resolve_categories")
         self.fetch_all_vms = self.get_option("fetch_all_vms")
         self.page = self.get_option("page")
         self.limit = self.get_option("limit")
@@ -685,10 +704,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         # Get API instances
         vmm = get_vm_api_instance(module)
         clusters = get_clusters_api_instance(module)
-        categories_api = get_categories_api_instance(module)
 
         cluster_ext_id_name_map = self._build_cluster_ext_id_name_map(clusters)
-        category_ext_id_map = self._build_category_ext_id_map(categories_api)
+
+        category_ext_id_map = {}
+        if self.resolve_categories:
+            categories_api = get_categories_api_instance(module)
+            category_ext_id_map = self._build_category_ext_id_map(categories_api)
 
         # Fetch VMs
         vms = self._fetch_vms(

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -250,6 +250,8 @@ EXAMPLES = r"""
     - key: cluster_name
       prefix: cluster
       separator: "_"
+    # categories_map values are lists (a key can have multiple values);
+    # keyed_groups creates one group per item in the list
     - key: categories_map.Environment
       prefix: env
       separator: "_"

--- a/plugins/inventory/ntnx_prism_vm_inventory_v2.py
+++ b/plugins/inventory/ntnx_prism_vm_inventory_v2.py
@@ -482,7 +482,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         for key in unwanted_keys:
             host_vars.pop(key, None)
 
-    def _build_host_vars(self, vm, cluster_ext_id_name_map, category_ext_id_map, strict=False):
+    def _build_host_vars(
+        self, vm, cluster_ext_id_name_map, category_ext_id_map, strict=False
+    ):
         """
         Build a dictionary of host variables from the V4 VM response.
         Returns all VM attributes, excluding null/empty values.
@@ -570,6 +572,40 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
                 return False
         return True
 
+    def _build_cluster_ext_id_name_map(self, clusters):
+        result = {}
+        list_clusters = clusters.list_clusters()
+        for cluster in list_clusters.data or []:
+            if cluster:
+                cluster_dict = cluster.to_dict()
+                ext_id = cluster_dict.get("ext_id")
+                name = cluster_dict.get("name")
+                result[ext_id] = name
+        return result
+
+    def _build_category_ext_id_map(self, categories_api):
+        result = {}
+        try:
+            page = 0
+            while True:
+                list_categories = categories_api.list_categories(_page=page, _limit=100)
+                if not list_categories.data:
+                    break
+                for cat in list_categories.data:
+                    cat_dict = cat.to_dict()
+                    ext_id = cat_dict.get("ext_id")
+                    if ext_id:
+                        result[ext_id] = {
+                            "key": cat_dict.get("key"),
+                            "value": cat_dict.get("value"),
+                        }
+                if len(list_categories.data) < 100:
+                    break
+                page += 1
+        except Exception:
+            pass
+        return result
+
     def parse(self, inventory, loader, path, cache=True):
         super().parse(inventory, loader, path, cache=cache)
         self._read_config_data(path)
@@ -651,37 +687,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
         clusters = get_clusters_api_instance(module)
         categories_api = get_categories_api_instance(module)
 
-        # Build cluster ext_id → name map
-        list_clusters = clusters.list_clusters()
-        cluster_ext_id_name_map = {}
-        for cluster in list_clusters.data or []:
-            if cluster:
-                cluster_dict = cluster.to_dict()
-                ext_id = cluster_dict.get("ext_id")
-                name = cluster_dict.get("name")
-                cluster_ext_id_name_map[ext_id] = name
-
-        # Build category ext_id → {key, value} map
-        category_ext_id_map = {}
-        try:
-            page = 0
-            while True:
-                list_categories = categories_api.list_categories(_page=page, _limit=100)
-                if not list_categories.data:
-                    break
-                for cat in list_categories.data:
-                    cat_dict = cat.to_dict()
-                    ext_id = cat_dict.get("ext_id")
-                    if ext_id:
-                        category_ext_id_map[ext_id] = {
-                            "key": cat_dict.get("key"),
-                            "value": cat_dict.get("value"),
-                        }
-                if len(list_categories.data) < 100:
-                    break
-                page += 1
-        except Exception:
-            pass
+        cluster_ext_id_name_map = self._build_cluster_ext_id_name_map(clusters)
+        category_ext_id_map = self._build_category_ext_id_map(categories_api)
 
         # Fetch VMs
         vms = self._fetch_vms(
@@ -701,7 +708,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable):
             cluster_ext_id = (vm.get("cluster") or {}).get("ext_id")
             cluster_name = cluster_ext_id_name_map.get(cluster_ext_id)
             try:
-                host_vars = self._build_host_vars(vm, cluster_ext_id_name_map, category_ext_id_map, strict)
+                host_vars = self._build_host_vars(
+                    vm, cluster_ext_id_name_map, category_ext_id_map, strict
+                )
             except Exception as e:
                 raise AnsibleError(
                     f"Failed to build host vars for VM {vm.get('name')} with ext_id {vm.get('ext_id')}: {str(e)}"

--- a/plugins/module_utils/v4/prism/pc_api_client.py
+++ b/plugins/module_utils/v4/prism/pc_api_client.py
@@ -117,3 +117,15 @@ def get_tasks_api_instance(module):
     """
     api_client = get_pc_api_client(module)
     return ntnx_prism_py_client.TasksApi(api_client=api_client)
+
+
+def get_categories_api_instance(module):
+    """
+    This method will return categories api instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): categories api instance
+    """
+    api_client = get_pc_api_client(module)
+    return ntnx_prism_py_client.CategoriesApi(api_client=api_client)

--- a/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/ansible.cfg
+++ b/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+inventory = nutanix.yml
+
+[inventory]
+enable_plugins = nutanix.ncp.ntnx_prism_vm_inventory_v2

--- a/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/inventory.yml
+++ b/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/inventory.yml
@@ -1,58 +1,208 @@
 ---
-- name: Test Inventory Plugin for categories_map and auto_create_cluster_groups
-  hosts: all
+- name: Test categories_map and auto_create_cluster_groups in V2 inventory plugin
+  hosts: localhost
   gather_facts: false
-  vars_files:
-    - nutanix.yml
   tasks:
-    - name: Assert the number of VMs # noqa run-once[task]
-      ansible.builtin.assert:
-        that:
-          - ansible_play_hosts | length >= 0
-        fail_msg: "No hosts found in inventory!"
-        success_msg: "Found {{ ansible_play_hosts | length }} hosts in inventory!"
-      run_once: true
+    # =========================================================================
+    # Setup: Create category, VM, and associate them
+    # =========================================================================
 
-    - name: Assert that basic host vars are defined
-      ansible.builtin.assert:
-        that:
-          - hostvars[inventory_hostname].ansible_host is defined
-          - hostvars[inventory_hostname].vm_name is defined
-          - hostvars[inventory_hostname].cluster_name is defined
-          - hostvars[inventory_hostname].vm_ext_id is defined
-          - hostvars[inventory_hostname].cluster_ext_id is defined
-        fail_msg: "Host vars not found for {{ inventory_hostname }}"
-        success_msg: "Host vars found for {{ inventory_hostname }}"
+    - name: Create category Environment:Testing
+      nutanix.ncp.ntnx_categories_v2:
+        key: "Environment"
+        value: "Testing"
+      register: category_result
+      ignore_errors: true
 
-    - name: Assert categories_map is a dict when present
+    - name: Assert category created
       ansible.builtin.assert:
         that:
-          - hostvars[inventory_hostname].categories_map is mapping
-        fail_msg: "categories_map is not a dict for {{ inventory_hostname }}"
-        success_msg: "categories_map is a dict for {{ inventory_hostname }}"
-      when: hostvars[inventory_hostname].categories_map is defined
+          - category_result.failed == false
+          - category_result.response is defined
+          - category_result.response.key == "Environment"
+          - category_result.response.value == "Testing"
+          - category_result.response.ext_id is defined
+        fail_msg: "Failed to create category Environment:Testing"
+        success_msg: "Category Environment:Testing created"
 
-    - name: Assert categories list is present when categories_map is present
-      ansible.builtin.assert:
-        that:
-          - hostvars[inventory_hostname].categories is defined
-          - hostvars[inventory_hostname].categories | length > 0
-        fail_msg: "categories list missing but categories_map present for {{ inventory_hostname }}"
-        success_msg: "categories list present for {{ inventory_hostname }}"
-      when: hostvars[inventory_hostname].categories_map is defined
+    - name: Set category ext_id
+      ansible.builtin.set_fact:
+        category_ext_id: "{{ category_result.response.ext_id }}"
+        category_was_created: "{{ category_result.changed }}"
 
-    - name: Assert auto_create_cluster_groups is disabled (no cluster_<ext_id> groups) # noqa run-once[task]
-      ansible.builtin.assert:
-        that:
-          - groups.keys() | select('match', '^cluster_[0-9a-f]') | list | length == 0
-        fail_msg: "cluster_<ext_id> groups found but auto_create_cluster_groups is false"
-        success_msg: "No cluster_<ext_id> groups found as expected"
-      run_once: true
+    - name: Create test VM
+      nutanix.ncp.ntnx_vms_v2:
+        name: "categories_test_vm_v2"
+      register: vm_result
+      ignore_errors: true
 
-    - name: Assert keyed_groups created cluster groups from cluster_name
+    - name: Assert VM created
       ansible.builtin.assert:
         that:
-          - ('cluster_' ~ hostvars[inventory_hostname].cluster_name | regex_replace('[^A-Za-z0-9_]', '_')) in hostvars[inventory_hostname].groups.keys()
-        fail_msg: "keyed_group cluster_<name> not found for {{ inventory_hostname }}"
-        success_msg: "keyed_group cluster_<name> found for {{ inventory_hostname }}"
-      when: hostvars[inventory_hostname].cluster_name is defined
+          - vm_result.changed == true
+          - vm_result.failed == false
+          - vm_result.response is defined
+          - vm_result.response.name == "categories_test_vm_v2"
+        fail_msg: "Failed to create test VM"
+        success_msg: "Test VM created"
+
+    - name: Set VM ext_id
+      ansible.builtin.set_fact:
+        vm_ext_id: "{{ vm_result.ext_id }}"
+
+    - name: Associate category with VM
+      nutanix.ncp.ntnx_vms_categories_v2:
+        vm_ext_id: "{{ vm_ext_id }}"
+        categories:
+          - ext_id: "{{ category_ext_id }}"
+      register: assoc_result
+      ignore_errors: true
+
+    - name: Assert category associated
+      ansible.builtin.assert:
+        that:
+          - assoc_result.failed == false
+        fail_msg: "Failed to associate category with VM"
+        success_msg: "Category associated with VM"
+
+    - name: Run tests and cleanup
+      block:
+        # =====================================================================
+        # Test 1: Verify categories_map and categories in host vars
+        # =====================================================================
+
+        - name: "Test 1: Run inventory"
+          ansible.builtin.command:
+            cmd: ansible-inventory --inventory nutanix.yml --list
+            chdir: "{{ playbook_dir }}"
+          register: inv_result
+          changed_when: false
+
+        - name: "Test 1: Parse inventory output"
+          ansible.builtin.set_fact:
+            inv_data: "{{ inv_result.stdout | from_json }}"
+
+        - name: "Test 1: Assert test VM appears in inventory"
+          ansible.builtin.assert:
+            that:
+              - "'categories_test_vm_v2' in inv_data._meta.hostvars"
+            fail_msg: >-
+              Test VM not found in inventory.
+              Got hostvars keys: {{ inv_data._meta.hostvars.keys() | list }}
+            success_msg: "Test VM found in inventory"
+
+        - name: "Test 1: Set host vars shortcut"
+          ansible.builtin.set_fact:
+            vm_hostvars: "{{ inv_data._meta.hostvars['categories_test_vm_v2'] }}"
+
+        - name: "Test 1: Assert categories_map contains Environment:Testing"
+          ansible.builtin.assert:
+            that:
+              - vm_hostvars.categories_map is defined
+              - vm_hostvars.categories_map is mapping
+              - vm_hostvars.categories_map.Environment is defined
+              - vm_hostvars.categories_map.Environment == "Testing"
+            fail_msg: >-
+              categories_map should contain Environment:Testing.
+              Got: {{ vm_hostvars.categories_map | default('undefined') }}
+            success_msg: "categories_map correctly contains Environment:Testing"
+
+        - name: "Test 1: Assert categories list contains the category ext_id"
+          ansible.builtin.assert:
+            that:
+              - vm_hostvars.categories is defined
+              - vm_hostvars.categories | length > 0
+              - category_ext_id in vm_hostvars.categories
+            fail_msg: >-
+              categories list should contain {{ category_ext_id }}.
+              Got: {{ vm_hostvars.categories | default('undefined') }}
+            success_msg: "categories list correctly contains the category ext_id"
+
+        # =====================================================================
+        # Test 2: Verify auto_create_cluster_groups is disabled
+        # =====================================================================
+
+        - name: "Test 2: Assert no cluster_<ext_id> groups exist"
+          ansible.builtin.assert:
+            that:
+              - >-
+                ('cluster_' ~ (vm_hostvars.cluster_ext_id | regex_replace('-', '_')))
+                not in inv_data.keys()
+            fail_msg: >-
+              cluster_<ext_id> group found but auto_create_cluster_groups is false.
+              Found: cluster_{{ vm_hostvars.cluster_ext_id | regex_replace('-', '_') }}
+            success_msg: "No cluster_<ext_id> groups as expected (auto_create_cluster_groups is false)"
+
+        # =====================================================================
+        # Test 3: Verify keyed_groups from cluster_name
+        # =====================================================================
+
+        - name: "Test 3: Assert cluster_<name> keyed_group exists"
+          ansible.builtin.assert:
+            that:
+              - >-
+                ('cluster_' ~ (vm_hostvars.cluster_name | regex_replace('[^A-Za-z0-9_]', '_')))
+                in inv_data.keys()
+            fail_msg: >-
+              keyed_group cluster_<name> not found.
+              Expected: cluster_{{ vm_hostvars.cluster_name | regex_replace('[^A-Za-z0-9_]', '_') }}
+            success_msg: "keyed_group cluster_<name> found"
+
+        # =====================================================================
+        # Test 4: Verify keyed_groups from categories_map.Environment
+        # =====================================================================
+
+        - name: "Test 4: Assert env_Testing keyed_group exists"
+          ansible.builtin.assert:
+            that:
+              - "'env_Testing' in inv_data.keys()"
+            fail_msg: >-
+              keyed_group env_Testing not found.
+              Available groups: {{ inv_data.keys() | list }}
+            success_msg: "keyed_group env_Testing found"
+
+        - name: "Test 4: Assert test VM is in the env_Testing group"
+          ansible.builtin.assert:
+            that:
+              - "'categories_test_vm_v2' in inv_data['env_Testing']['hosts']"
+            fail_msg: >-
+              Test VM not in env_Testing group.
+              Group hosts: {{ inv_data['env_Testing']['hosts'] | default([]) }}
+            success_msg: "Test VM correctly placed in env_Testing group"
+
+      # =======================================================================
+      # Cleanup: Always delete test entities
+      # =======================================================================
+      always:
+        - name: Disassociate category from VM
+          nutanix.ncp.ntnx_vms_categories_v2:
+            vm_ext_id: "{{ vm_ext_id }}"
+            categories:
+              - ext_id: "{{ category_ext_id }}"
+            state: absent
+          ignore_errors: true
+          when: vm_ext_id is defined and category_ext_id is defined
+
+        - name: Delete test VM
+          nutanix.ncp.ntnx_vms_v2:
+            ext_id: "{{ vm_ext_id }}"
+            state: absent
+          register: delete_vm_result
+          ignore_errors: true
+          when: vm_ext_id is defined
+
+        - name: Delete VM status
+          ansible.builtin.assert:
+            that:
+              - delete_vm_result.changed == true
+              - delete_vm_result.failed == false
+            fail_msg: "Failed to delete test VM"
+            success_msg: "Test VM deleted"
+          when: vm_ext_id is defined
+
+        - name: Delete category (only if we created it)
+          nutanix.ncp.ntnx_categories_v2:
+            ext_id: "{{ category_ext_id }}"
+            state: absent
+          ignore_errors: true
+          when: category_ext_id is defined and category_was_created | bool

--- a/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/inventory.yml
+++ b/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/inventory.yml
@@ -13,8 +13,8 @@
 
     - name: Set category key and value
       ansible.builtin.set_fact:
-        category_key: "{{ random_name }}ansible-agkey"
-        category_value: "{{ random_name }}ansible-agval"
+        category_key: "{{ random_name }}ansible_agkey"
+        category_value: "{{ random_name }}ansible_agval"
 
     - name: Create category
       nutanix.ncp.ntnx_categories_v2:

--- a/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/inventory.yml
+++ b/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/inventory.yml
@@ -7,28 +7,37 @@
     # Setup: Create category, VM, and associate them
     # =========================================================================
 
-    - name: Create category Environment:Testing
+    - name: Generate random category name
+      ansible.builtin.set_fact:
+        random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+    - name: Set category key and value
+      ansible.builtin.set_fact:
+        category_key: "{{ random_name }}ansible-agkey"
+        category_value: "{{ random_name }}ansible-agval"
+
+    - name: Create category
       nutanix.ncp.ntnx_categories_v2:
-        key: "Environment"
-        value: "Testing"
+        key: "{{ category_key }}"
+        value: "{{ category_value }}"
       register: category_result
       ignore_errors: true
 
-    - name: Assert category created
+    - name: Create category status
       ansible.builtin.assert:
         that:
+          - category_result.changed == true
           - category_result.failed == false
           - category_result.response is defined
-          - category_result.response.key == "Environment"
-          - category_result.response.value == "Testing"
+          - category_result.response.key == category_key
+          - category_result.response.value == category_value
           - category_result.response.ext_id is defined
-        fail_msg: "Failed to create category Environment:Testing"
-        success_msg: "Category Environment:Testing created"
+        fail_msg: "Failed to create category {{ category_key }}:{{ category_value }}"
+        success_msg: "Category {{ category_key }}:{{ category_value }} created"
 
     - name: Set category ext_id
       ansible.builtin.set_fact:
         category_ext_id: "{{ category_result.response.ext_id }}"
-        category_was_created: "{{ category_result.changed }}"
 
     - name: Create test VM
       nutanix.ncp.ntnx_vms_v2:
@@ -36,7 +45,7 @@
       register: vm_result
       ignore_errors: true
 
-    - name: Assert VM created
+    - name: Create test VM status
       ansible.builtin.assert:
         that:
           - vm_result.changed == true
@@ -58,27 +67,31 @@
       register: assoc_result
       ignore_errors: true
 
-    - name: Assert category associated
+    - name: Associate category with VM status
       ansible.builtin.assert:
         that:
+          - assoc_result.changed == true
           - assoc_result.failed == false
+          - assoc_result.response is defined
+          - assoc_result.task_ext_id is defined
+          - assoc_result.vm_ext_id == vm_ext_id
         fail_msg: "Failed to associate category with VM"
         success_msg: "Category associated with VM"
 
     - name: Run tests and cleanup
       block:
         # =====================================================================
-        # Test 1: Verify categories_map and categories in host vars
+        # Tests: Verify inventory output
         # =====================================================================
 
-        - name: "Test 1: Run inventory"
+        - name: Run inventory
           ansible.builtin.command:
             cmd: ansible-inventory --inventory nutanix.yml --list
             chdir: "{{ playbook_dir }}"
           register: inv_result
           changed_when: false
 
-        - name: "Test 1: Parse inventory output"
+        - name: Parse inventory output
           ansible.builtin.set_fact:
             inv_data: "{{ inv_result.stdout | from_json }}"
 
@@ -91,23 +104,23 @@
               Got hostvars keys: {{ inv_data._meta.hostvars.keys() | list }}
             success_msg: "Test VM found in inventory"
 
-        - name: "Test 1: Set host vars shortcut"
+        - name: Set host vars shortcut
           ansible.builtin.set_fact:
             vm_hostvars: "{{ inv_data._meta.hostvars['categories_test_vm_v2'] }}"
 
-        - name: "Test 1: Assert categories_map contains Environment:Testing"
+        - name: "Test 2: Assert categories_map contains the category key and value"
           ansible.builtin.assert:
             that:
               - vm_hostvars.categories_map is defined
               - vm_hostvars.categories_map is mapping
-              - vm_hostvars.categories_map.Environment is defined
-              - vm_hostvars.categories_map.Environment == "Testing"
+              - vm_hostvars.categories_map[category_key] is defined
+              - vm_hostvars.categories_map[category_key] == category_value
             fail_msg: >-
-              categories_map should contain Environment:Testing.
+              categories_map should contain {{ category_key }}:{{ category_value }}.
               Got: {{ vm_hostvars.categories_map | default('undefined') }}
-            success_msg: "categories_map correctly contains Environment:Testing"
+            success_msg: "categories_map correctly contains {{ category_key }}:{{ category_value }}"
 
-        - name: "Test 1: Assert categories list contains the category ext_id"
+        - name: "Test 3: Assert categories list contains the category ext_id"
           ansible.builtin.assert:
             that:
               - vm_hostvars.categories is defined
@@ -118,11 +131,7 @@
               Got: {{ vm_hostvars.categories | default('undefined') }}
             success_msg: "categories list correctly contains the category ext_id"
 
-        # =====================================================================
-        # Test 2: Verify auto_create_cluster_groups is disabled
-        # =====================================================================
-
-        - name: "Test 2: Assert no cluster_<ext_id> groups exist"
+        - name: "Test 4: Assert no cluster_<ext_id> groups exist"
           ansible.builtin.assert:
             that:
               - >-
@@ -133,11 +142,7 @@
               Found: cluster_{{ vm_hostvars.cluster_ext_id | regex_replace('-', '_') }}
             success_msg: "No cluster_<ext_id> groups as expected (auto_create_cluster_groups is false)"
 
-        # =====================================================================
-        # Test 3: Verify keyed_groups from cluster_name
-        # =====================================================================
-
-        - name: "Test 3: Assert cluster_<name> keyed_group exists"
+        - name: "Test 5: Assert cluster_<name> keyed_group exists"
           ansible.builtin.assert:
             that:
               - >-
@@ -148,27 +153,23 @@
               Expected: cluster_{{ vm_hostvars.cluster_name | regex_replace('[^A-Za-z0-9_]', '_') }}
             success_msg: "keyed_group cluster_<name> found"
 
-        # =====================================================================
-        # Test 4: Verify keyed_groups from categories_map.Environment
-        # =====================================================================
-
-        - name: "Test 4: Assert env_Testing keyed_group exists"
+        - name: "Test 6: Assert keyed_group from categories_map value exists"
           ansible.builtin.assert:
             that:
-              - "'env_Testing' in inv_data.keys()"
+              - "('env_' ~ category_value) in inv_data.keys()"
             fail_msg: >-
-              keyed_group env_Testing not found.
+              keyed_group env_{{ category_value }} not found.
               Available groups: {{ inv_data.keys() | list }}
-            success_msg: "keyed_group env_Testing found"
+            success_msg: "keyed_group env_{{ category_value }} found"
 
-        - name: "Test 4: Assert test VM is in the env_Testing group"
+        - name: "Test 7: Assert test VM is in the keyed_group"
           ansible.builtin.assert:
             that:
-              - "'categories_test_vm_v2' in inv_data['env_Testing']['hosts']"
+              - "'categories_test_vm_v2' in inv_data['env_' ~ category_value]['hosts']"
             fail_msg: >-
-              Test VM not in env_Testing group.
-              Group hosts: {{ inv_data['env_Testing']['hosts'] | default([]) }}
-            success_msg: "Test VM correctly placed in env_Testing group"
+              Test VM not in env_{{ category_value }} group.
+              Group hosts: {{ inv_data['env_' ~ category_value]['hosts'] | default([]) }}
+            success_msg: "Test VM correctly placed in env_{{ category_value }} group"
 
       # =======================================================================
       # Cleanup: Always delete test entities
@@ -180,8 +181,19 @@
             categories:
               - ext_id: "{{ category_ext_id }}"
             state: absent
+          register: disassoc_result
           ignore_errors: true
-          when: vm_ext_id is defined and category_ext_id is defined
+
+        - name: Disassociate category from VM status
+          ansible.builtin.assert:
+            that:
+              - disassoc_result.response is defined
+              - disassoc_result.changed == true
+              - disassoc_result.failed == false
+              - disassoc_result.task_ext_id is defined
+              - disassoc_result.vm_ext_id == vm_ext_id
+            fail_msg: "Failed to disassociate category from VM"
+            success_msg: "Category disassociated from VM"
 
         - name: Delete test VM
           nutanix.ncp.ntnx_vms_v2:
@@ -189,20 +201,28 @@
             state: absent
           register: delete_vm_result
           ignore_errors: true
-          when: vm_ext_id is defined
 
-        - name: Delete VM status
+        - name: Delete test VM status
           ansible.builtin.assert:
             that:
               - delete_vm_result.changed == true
               - delete_vm_result.failed == false
+              - delete_vm_result.response is defined
+              - delete_vm_result.response.status == "SUCCEEDED"
             fail_msg: "Failed to delete test VM"
             success_msg: "Test VM deleted"
-          when: vm_ext_id is defined
 
-        - name: Delete category (only if we created it)
+        - name: Delete category
           nutanix.ncp.ntnx_categories_v2:
             ext_id: "{{ category_ext_id }}"
             state: absent
+          register: delete_cat_result
           ignore_errors: true
-          when: category_ext_id is defined and category_was_created | bool
+
+        - name: Delete category status
+          ansible.builtin.assert:
+            that:
+              - delete_cat_result.changed == true
+              - delete_cat_result.failed == false
+            fail_msg: "Failed to delete category"
+            success_msg: "Category deleted"

--- a/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/inventory.yml
+++ b/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/inventory.yml
@@ -52,7 +52,7 @@
     - name: Assert keyed_groups created cluster groups from cluster_name
       ansible.builtin.assert:
         that:
-          - ('cluster_' ~ hostvars[inventory_hostname].cluster_name) in hostvars[inventory_hostname].groups.keys()
+          - ('cluster_' ~ hostvars[inventory_hostname].cluster_name | regex_replace('[^A-Za-z0-9_]', '_')) in hostvars[inventory_hostname].groups.keys()
         fail_msg: "keyed_group cluster_<name> not found for {{ inventory_hostname }}"
         success_msg: "keyed_group cluster_<name> found for {{ inventory_hostname }}"
       when: hostvars[inventory_hostname].cluster_name is defined

--- a/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/inventory.yml
+++ b/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/inventory.yml
@@ -1,0 +1,58 @@
+---
+- name: Test Inventory Plugin for categories_map and auto_create_cluster_groups
+  hosts: all
+  gather_facts: false
+  vars_files:
+    - nutanix.yml
+  tasks:
+    - name: Assert the number of VMs # noqa run-once[task]
+      ansible.builtin.assert:
+        that:
+          - ansible_play_hosts | length >= 0
+        fail_msg: "No hosts found in inventory!"
+        success_msg: "Found {{ ansible_play_hosts | length }} hosts in inventory!"
+      run_once: true
+
+    - name: Assert that basic host vars are defined
+      ansible.builtin.assert:
+        that:
+          - hostvars[inventory_hostname].ansible_host is defined
+          - hostvars[inventory_hostname].vm_name is defined
+          - hostvars[inventory_hostname].cluster_name is defined
+          - hostvars[inventory_hostname].vm_ext_id is defined
+          - hostvars[inventory_hostname].cluster_ext_id is defined
+        fail_msg: "Host vars not found for {{ inventory_hostname }}"
+        success_msg: "Host vars found for {{ inventory_hostname }}"
+
+    - name: Assert categories_map is a dict when present
+      ansible.builtin.assert:
+        that:
+          - hostvars[inventory_hostname].categories_map is mapping
+        fail_msg: "categories_map is not a dict for {{ inventory_hostname }}"
+        success_msg: "categories_map is a dict for {{ inventory_hostname }}"
+      when: hostvars[inventory_hostname].categories_map is defined
+
+    - name: Assert categories list is present when categories_map is present
+      ansible.builtin.assert:
+        that:
+          - hostvars[inventory_hostname].categories is defined
+          - hostvars[inventory_hostname].categories | length > 0
+        fail_msg: "categories list missing but categories_map present for {{ inventory_hostname }}"
+        success_msg: "categories list present for {{ inventory_hostname }}"
+      when: hostvars[inventory_hostname].categories_map is defined
+
+    - name: Assert auto_create_cluster_groups is disabled (no cluster_<ext_id> groups) # noqa run-once[task]
+      ansible.builtin.assert:
+        that:
+          - groups.keys() | select('match', '^cluster_[0-9a-f]') | list | length == 0
+        fail_msg: "cluster_<ext_id> groups found but auto_create_cluster_groups is false"
+        success_msg: "No cluster_<ext_id> groups found as expected"
+      run_once: true
+
+    - name: Assert keyed_groups created cluster groups from cluster_name
+      ansible.builtin.assert:
+        that:
+          - ('cluster_' ~ hostvars[inventory_hostname].cluster_name) in hostvars[inventory_hostname].groups.keys()
+        fail_msg: "keyed_group cluster_<name> not found for {{ inventory_hostname }}"
+        success_msg: "keyed_group cluster_<name> found for {{ inventory_hostname }}"
+      when: hostvars[inventory_hostname].cluster_name is defined

--- a/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/inventory.yml
+++ b/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/inventory.yml
@@ -114,11 +114,12 @@
               - vm_hostvars.categories_map is defined
               - vm_hostvars.categories_map is mapping
               - vm_hostvars.categories_map[category_key] is defined
-              - vm_hostvars.categories_map[category_key] == category_value
+              - vm_hostvars.categories_map[category_key] is sequence
+              - category_value in vm_hostvars.categories_map[category_key]
             fail_msg: >-
-              categories_map should contain {{ category_key }}:{{ category_value }}.
+              categories_map should contain {{ category_key }}:[{{ category_value }}].
               Got: {{ vm_hostvars.categories_map | default('undefined') }}
-            success_msg: "categories_map correctly contains {{ category_key }}:{{ category_value }}"
+            success_msg: "categories_map correctly contains {{ category_key }}:[{{ category_value }}]"
 
         - name: "Test 3: Assert categories list contains the category ext_id"
           ansible.builtin.assert:

--- a/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/nutanix.yml
+++ b/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/nutanix.yml
@@ -13,7 +13,7 @@ keyed_groups:
   - key: cluster_name
     prefix: cluster
     separator: "_"
-  - key: categories_map.Environment
+  - key: (categories_map | default({})).values() | list | first | default('')
     prefix: env
     separator: "_"
     default_value: unassigned

--- a/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/nutanix.yml
+++ b/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/nutanix.yml
@@ -7,7 +7,7 @@ plugin: nutanix.ncp.ntnx_prism_vm_inventory_v2
 # validate_certs: false # Or set VALIDATE_CERTS environment variable
 fetch_all_vms: true
 auto_create_cluster_groups: false
-strict: true
+strict: false
 keyed_groups:
   - key: cluster_name
     prefix: cluster

--- a/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/nutanix.yml
+++ b/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/nutanix.yml
@@ -6,6 +6,7 @@ plugin: nutanix.ncp.ntnx_prism_vm_inventory_v2
 # nutanix_port: port # Or set NUTANIX_PORT environment variable
 # validate_certs: false # Or set VALIDATE_CERTS environment variable
 fetch_all_vms: true
+filter: "startswith(name, 'categories_test_')"
 auto_create_cluster_groups: false
 strict: false
 keyed_groups:

--- a/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/nutanix.yml
+++ b/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/nutanix.yml
@@ -13,7 +13,7 @@ keyed_groups:
   - key: cluster_name
     prefix: cluster
     separator: "_"
-  - key: (categories_map | default({})).values() | list | first | default('')
+  - key: (categories_map | default({})).values() | list | first | default([])
     prefix: env
     separator: "_"
     default_value: unassigned

--- a/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/nutanix.yml
+++ b/tests/integration/targets/inventory_test_v2/inventory_test_categories_v2/nutanix.yml
@@ -1,0 +1,18 @@
+---
+plugin: nutanix.ncp.ntnx_prism_vm_inventory_v2
+# nutanix_host: hostname # Or set NUTANIX_HOST or NUTANIX_HOSTNAME environment variable
+# nutanix_username: username # Or set NUTANIX_USERNAME environment variable
+# nutanix_password: password # Or set NUTANIX_PASSWORD environment variable
+# nutanix_port: port # Or set NUTANIX_PORT environment variable
+# validate_certs: false # Or set VALIDATE_CERTS environment variable
+fetch_all_vms: true
+auto_create_cluster_groups: false
+strict: true
+keyed_groups:
+  - key: cluster_name
+    prefix: cluster
+    separator: "_"
+  - key: categories_map.Environment
+    prefix: env
+    separator: "_"
+    default_value: unassigned


### PR DESCRIPTION
Closes #963. 

Two improvements to the ntnx_prism_vm_inventory_v2 inventory plugin.

## Category resolution

VM categories in hostvars are resolved from ext_ids to human-readable key/value dicts by fetching category details from the Prism v4 categories API.

This follows the same implementation pattern as the existing Cluster name resolution.

Before: categories: ["a1b2c3d4-e5f6-7890-abcd-ef1234567890"]

After: categories: {"Organisation": "ACME"}

This enables keyed_groups to create meaningful inventory groups:

keyed_groups:
- key: categories.Organisation
  prefix: org
  separator: "_"

→ group org_ACME

## auto_create_cluster_groups option

New boolean option (default true for backwards compatibility) to disable the automatic cluster ext_id groups. Users can use keyed_groups with cluster_name for human-readable cluster groups instead:

auto_create_cluster_groups: false

keyed_groups:
- key: cluster_name
  prefix: cluster
  separator: "_"

→ cluster_DC1_Prod_01 instead of cluster_00061126_4a0b_6fa4_223d_b83fd25e8fd6

## Test plan

- Verified categories resolve to key/value pairs via ansible-inventory --list
- Verified keyed_groups creates groups from resolved category values
- Verified auto_create_cluster_groups: false disables automatic cluster groups
- Verified auto_create_cluster_groups: true (default) preserves existing behaviour
- Sanity tests pass