### PR TITLE
code-gen(cluster_management/AddSnmpTransport): ansible v2

### DIFF
--- a/examples/cluster_management_v2/snmp_transport_v2.yml
+++ b/examples/cluster_management_v2/snmp_transport_v2.yml
@@ -1,0 +1,176 @@
+---
+# Summary:
+# This playbook demonstrates SNMP transport management operations:
+# 1. Fetch existing SNMP transports for the cluster
+# 2. Add an SNMP transport (UDP on port 162)
+# 3. Verify the transport was added by fetching transports info
+# 4. Update the SNMP transport (change from UDP/162 to TCP/163)
+# 5. Verify the transport was updated
+# 6. Remove the SNMP transport (TCP/163)
+# 7. Verify the transport was removed
+# 8. Idempotency check - add same transport again
+
+- name: SNMP Transport CRUD playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "10.101.64.103"
+      nutanix_username: "admin"
+      nutanix_password: "Nutanix.123"
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        cluster_ext_id: "{{ cluster_uuid }}"
+      vars:
+        cluster_uuid: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+
+    - name: Get cluster ext_id from list
+      nutanix.ncp.ntnx_clusters_info_v2:
+        limit: 1
+      register: clusters_result
+
+    - name: Set cluster ext_id from first cluster found
+      ansible.builtin.set_fact:
+        cluster_ext_id: "{{ clusters_result.response[0].ext_id }}"
+      when: clusters_result.response | length > 0
+
+    - name: Display cluster ext_id
+      ansible.builtin.debug:
+        msg: "Using cluster ext_id: {{ cluster_ext_id }}"
+
+    # Step 1: Fetch existing SNMP transports
+    - name: Fetch existing SNMP transports for the cluster
+      nutanix.ncp.ntnx_snmp_transports_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+      register: initial_transports
+      ignore_errors: true
+
+    - name: Display initial SNMP transports
+      ansible.builtin.debug:
+        var: initial_transports
+
+    # Step 2: Add SNMP transport (UDP port 162)
+    - name: Add SNMP transport - UDP port 162
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        protocol: "UDP"
+        port: 162
+        state: present
+      register: add_result
+
+    - name: Display add result
+      ansible.builtin.debug:
+        var: add_result
+
+    - name: Verify transport was added
+      ansible.builtin.assert:
+        that:
+          - add_result.changed or add_result.skipped is defined
+        fail_msg: "SNMP transport add operation failed"
+
+    # Step 3: Fetch transports to verify addition
+    - name: Fetch SNMP transports after addition
+      nutanix.ncp.ntnx_snmp_transports_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+      register: after_add_transports
+
+    - name: Display transports after addition
+      ansible.builtin.debug:
+        var: after_add_transports
+
+    # Step 4: Idempotency - Try adding same transport again
+    - name: Idempotency check - Add same SNMP transport again
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        protocol: "UDP"
+        port: 162
+        state: present
+      register: idempotent_result
+
+    - name: Display idempotency result
+      ansible.builtin.debug:
+        var: idempotent_result
+
+    - name: Verify idempotency - should be skipped
+      ansible.builtin.assert:
+        that:
+          - idempotent_result.skipped is defined and idempotent_result.skipped
+        fail_msg: "Idempotency check failed - transport should have been skipped"
+
+    # Step 5: Update SNMP transport (from UDP/162 to TCP/163)
+    - name: Update SNMP transport - change from UDP/162 to TCP/163
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        protocol: "TCP"
+        port: 163
+        old_transport:
+          protocol: "UDP"
+          port: 162
+        state: present
+      register: update_result
+
+    - name: Display update result
+      ansible.builtin.debug:
+        var: update_result
+
+    - name: Verify transport was updated
+      ansible.builtin.assert:
+        that:
+          - update_result.changed
+        fail_msg: "SNMP transport update operation failed"
+
+    # Step 6: Fetch transports to verify update
+    - name: Fetch SNMP transports after update
+      nutanix.ncp.ntnx_snmp_transports_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+      register: after_update_transports
+
+    - name: Display transports after update
+      ansible.builtin.debug:
+        var: after_update_transports
+
+    # Step 7: Remove SNMP transport (TCP/163)
+    - name: Remove SNMP transport - TCP port 163
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        protocol: "TCP"
+        port: 163
+        state: absent
+      register: delete_result
+
+    - name: Display delete result
+      ansible.builtin.debug:
+        var: delete_result
+
+    - name: Verify transport was removed
+      ansible.builtin.assert:
+        that:
+          - delete_result.changed
+        fail_msg: "SNMP transport delete operation failed"
+
+    # Step 8: Fetch transports to verify removal
+    - name: Fetch SNMP transports after removal
+      nutanix.ncp.ntnx_snmp_transports_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+      register: after_delete_transports
+
+    - name: Display transports after removal
+      ansible.builtin.debug:
+        var: after_delete_transports
+
+    # Step 9: Idempotency - Try removing non-existent transport
+    - name: Idempotency check - Remove non-existent transport
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        protocol: "TCP"
+        port: 163
+        state: absent
+      register: idempotent_delete_result
+
+    - name: Verify idempotent delete - should be skipped
+      ansible.builtin.assert:
+        that:
+          - idempotent_delete_result.skipped is defined and idempotent_delete_result.skipped
+        fail_msg: "Idempotent delete check failed - should have been skipped"

--- a/examples_run_log.txt
+++ b/examples_run_log.txt
@@ -1,0 +1,324 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [SNMP Transport CRUD playbook] ********************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"cluster_ext_id": "00061de6-4a87-6b06-185b-ac1f6b6f97e2"}, "changed": false}
+
+TASK [Get cluster ext_id from list] ********************************************
+ok: [localhost] => {"changed": false, "error": null, "response": [{"backup_eligibility_score": 1, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDWQlWGnPpWemdrFcHLykUr7Ni88jrVWGBo3+P/Ij6nuYH8ODAppFUlSHyMH562s1F4S89B0s3aS5vVJKntMq3vD5jIn7hOIBWj0L4Cr8RPIulzpswdvi+gRyHXbQoOLy5fCIBxVeDOYA0+3esZyMrQ/VNpidxkOmB0n4mnfq3FHmggVC8qTJOYV8dKvXDneNEbzMGw8tY+SLkkSZK6ibciNtrOSFr+kBjm56WPMYqbLaSN/bl2mMbwvKYOECJj25EPQSHjqTSLGF9e6Xa/99K9A8bOIWTisbzG+RuqjT7YYE/mQvuMh0ehvbpFJ9xWwYFFqh/5fZePEVi+j3oIiKWJ57ThRKBuaN7SvFr8pHj3YblJWc8yQ+9mkKskXns3MCEWMxCNqk5LmPIdA7QZLBkiQ+U47pUVTETjbY5A1pfgUOwcFrgaafl6s9xBS6KeJduzG4FcOcmwh3H/ZtsoP7NpFFw99zzctqxyN7wZdPfrG6iba+QcvIG1yH47n+w72tU= nutanix@ntnx-2e08eed1-ac6d-4fa3-819d-c5c25663dfb2-a-cvm", "name": "2e08eed1-ac6d-4fa3-819d-c5c25663dfb2"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCdKyu5leVDpjj3zaxYlrAbSMz8Mb1PWK0FeJkiPaCn6gCn4n88Jg+K7mIKAaJgfcEJMXl0VSHfjnYFE0hDdpL6/AmczFLsp/EmfJQ8p0uPpkPMjCeAv1BnAm3lcIFbXUzHGCKshfaRMjydJRbX6psaST1CcvdEAWDzXEVu2WnhVXKUl4p0So+Bc5hyOtn/uoRx+MiIMvZ3FcNWgTTB5a8gZcbSyu60VQjFeSaYfDBOfxmMMN5Ce48+Yo3GxcpMZyt9n96PFDJyMI+oP0OFSdG0C90X8/32C0v7GbkBOmXWfl4tYhXLCErrnqYZc5FzoU2IdosDHu5n6mMhm6upY7DO2reXN0GTf/Tdomk5IWtVoj/fr10U/Dtd6pJeln8osAm1tQk9SkLzAfw97TwO6lR7nZ4uQUZeGTyPhuU8wpXkPdUEecyWSP4PyzJ9MJeTg+hYd8RMgSHJRrslq2/aUxII7voJgzLMBbGF+Ad4Aqd1b5vfZo9pW4G2tm/ERyEiSdc= root@Nested-AHV-69f041c87298f6e91878aa57-0", "name": "10.101.64.223"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAw8NhpiLG/6c8c0LocaQVM6+x8yBvLS+z13nYlqzSKr64HQSH+IIx14bS+uh0xf8ou5ROnbUa44YM9qG2RBK1hBVrwTIKZBwFwOTxDuXH9YoswqflnOeyTGUFerrMxlg5iYvKE01QIErKWt/BJ+hK/qVQi6SHh/WhyjAGNQPxjPBG3oEUFoLV9uDLX9RT/sLIQpBf91DCbF9+2rSToqjydj36d38JbmuGJGqr+DrEd0lKzfiJiQ39t3AXBE1bY2ISX+uwq07XkYZbrHaijrxnOBFZE7ETQmyxdcOvgDxvhnhZpFsUqbPqIqa45CwFWV+btzITvpJkveYjGSGR7ZJNHQ== nutanix@titan", "name": "agave"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6oDEABPvDtwtOFEJhu7sx9oUZskh0R4CWW6IM9uIxVtjYR/XXu587rXKac34InclJ3U3+PFQcAgEvdw2qiCEWWWMFMiALMneDELPd5qepKRrFJxc3hkyfagot3n7i6r7Y83ceIII4qM1mGLdUA3XdSWlttbgugnBrfB9yLq/BgtVqBvBVFayTGb6IsoMUSbODX6zZEt9Uzh/Yr49DV40ULpGhSYS9vWFB3GrajrliQ9Ea8oOB+8vK9Cavf7IOsaIaPsGI20mypeKFn4qcinBKc6O3PqU3YyYv7pLJWAvwXr9D9+rukgNAhKnd1fFQVLj4sAHA4ixfQk9+0kgAJM4P", "name": "nutest"}], "build_info": {"build_type": "release", "commit_id": "e5715fa114b0241e6c328ebc9be171c1d17720bc", "full_version": "el9-release-ganges-7.6-stable-e5715fa114b0241e6c328ebc9be171c1d17720bc", "short_commit_id": "e5715f", "version": "7.6"}, "cluster_arch": "X86_64", "cluster_function": ["AOS", "ONE_NODE"], "cluster_software_map": [{"software_type": "NCC", "version": "ncc-6.0.0"}, {"software_type": "NOS", "version": "el9-release-ganges-7.6-stable-e5715fa114b0241e6c328ebc9be171c1d17720bc"}], "cluster_type": "HYPER_CONVERGED", "encryption_in_transit_status": null, "encryption_option": null, "encryption_scope": null, "fault_tolerance_state": {"current_cluster_fault_tolerance": "CFT_1N_OR_1D", "current_max_fault_tolerance": 1, "desired_cluster_fault_tolerance": "CFT_1N_OR_1D", "desired_max_fault_tolerance": 1, "domain_awareness_level": "DISK", "isStrictRackAwarenessEnabled": false, "redundancy_status": null}, "hypervisor_types": ["AHV"], "incarnation_id": 1777354635529001, "isDegradedNodeMonitoringDisabled": false, "is_available": true, "is_lts": false, "is_password_remote_login_enabled": true, "is_remote_support_enabled": false, "operation_mode": "NORMAL", "pulse_status": {"is_enabled": false, "pii_scrubbing_level": null}, "redundancy_factor": 2, "timezone": "UTC"}, "container_name": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "externalStorageProviderInfo": [{"$objectType": "clustermgmt.v4.config.ExternalStorageProviderInfo", "$reserved": {"$fv": "v4.r3"}, "compatibleVersion": "5.1.0.283_5214", "isInstalled": false, "providerType": "DELL_POWERFLEX"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "EVERPURE_FLASHARRAY"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "DELL_POWERSTORE"}], "inefficient_vm_count": null, "links": null, "name": "auto_cluster_nested_69f041c87298f6e91878aa57", "network": {"backplane": {"is_segmentation_enabled": false, "netmask": null, "subnet": null, "vlan_tag": null}, "external_address": {"ipv4": {"prefix_length": 32, "value": "10.101.64.224"}, "ipv6": null}, "external_data_service_ip": {"ipv4": {"prefix_length": 32, "value": "10.101.64.225"}, "ipv6": null}, "external_subnet": "10.101.64.0/255.255.224.0", "fqdn": null, "http_proxy_list": null, "http_proxy_white_list": null, "internal_subnet": "192.168.5.0/255.255.255.128", "key_management_server_type": null, "management_server": null, "masquerading_ip": null, "masquerading_port": null, "name_server_ip_list": [{"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.15"}, "ipv6": null}, {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.16"}, "ipv6": null}], "nfs_subnet_whitelist": null, "ntp_server_config_list": null, "ntp_server_ip_list": [{"fqdn": {"value": "ntp.dyn.nutanix.com"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "0.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "1.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "2.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "3.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}], "smtp_server": null}, "nodes": {"node_list": [{"controller_vm_ip": {"ipv4": {"prefix_length": 32, "value": "10.101.64.222"}, "ipv6": null}, "host_ip": {"ipv4": {"prefix_length": 32, "value": "10.101.64.223"}, "ipv6": null}, "node_uuid": "2e08eed1-ac6d-4fa3-819d-c5c25663dfb2"}], "number_of_nodes": 1}, "tenant_id": null, "upgrade_status": "SUCCEEDED", "vm_count": 9}], "total_available_results": 2}
+
+TASK [Set cluster ext_id from first cluster found] *****************************
+ok: [localhost] => {"ansible_facts": {"cluster_ext_id": "0006507e-9fb0-cb29-1221-5254000db428"}, "changed": false}
+
+TASK [Display cluster ext_id] **************************************************
+ok: [localhost] => {
+    "msg": "Using cluster ext_id: 0006507e-9fb0-cb29-1221-5254000db428"
+}
+
+TASK [Fetch existing SNMP transports for the cluster] **************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": []}
+
+TASK [Display initial SNMP transports] *****************************************
+ok: [localhost] => {
+    "initial_transports": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "response": []
+    }
+}
+
+TASK [Add SNMP transport - UDP port 162] ***************************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-05-04T06:37:35.121484+00:00", "completion_details": null, "created_time": "2026-05-04T06:37:34.840500+00:00", "entities_affected": [{"ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "name": null, "rel": "clustermgmt:config:cluster"}], "error_messages": null, "ext_id": "ZXJnb24=:972c8f33-991b-4c57-4d02-9fb5e1b8520f", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-05-04T06:37:35.121483+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "Add Snmp Transports", "operation_description": "Add snmp transports", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-05-04T06:37:34.856316+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:2c8ae8cf-276a-4e3b-6f0e-41f651ab42f3", "href": "https://10.101.64.103:9440/api/prism/v4.3/config/tasks/ZXJnb24=:2c8ae8cf-276a-4e3b-6f0e-41f651ab42f3", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:972c8f33-991b-4c57-4d02-9fb5e1b8520f"}
+
+TASK [Display add result] ******************************************************
+ok: [localhost] => {
+    "add_result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "response": {
+            "app_name": null,
+            "batch_summary": null,
+            "cluster_ext_ids": null,
+            "completed_time": "2026-05-04T06:37:35.121484+00:00",
+            "completion_details": null,
+            "created_time": "2026-05-04T06:37:34.840500+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+                    "name": null,
+                    "rel": "clustermgmt:config:cluster"
+                }
+            ],
+            "error_messages": null,
+            "ext_id": "ZXJnb24=:972c8f33-991b-4c57-4d02-9fb5e1b8520f",
+            "is_background_task": false,
+            "is_cancelable": false,
+            "last_updated_time": "2026-05-04T06:37:35.121483+00:00",
+            "legacy_error_message": null,
+            "number_of_entities_affected": 1,
+            "number_of_subtasks": 1,
+            "operation": "Add Snmp Transports",
+            "operation_description": "Add snmp transports",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "projectExtId": "00000000-0000-0000-0000-000000000000",
+            "resource_links": null,
+            "root_task": null,
+            "started_time": "2026-05-04T06:37:34.856316+00:00",
+            "status": "SUCCEEDED",
+            "sub_steps": null,
+            "sub_tasks": [
+                {
+                    "ext_id": "ZXJnb24=:2c8ae8cf-276a-4e3b-6f0e-41f651ab42f3",
+                    "href": "https://10.101.64.103:9440/api/prism/v4.3/config/tasks/ZXJnb24=:2c8ae8cf-276a-4e3b-6f0e-41f651ab42f3",
+                    "rel": "subtask"
+                }
+            ],
+            "warnings": null
+        },
+        "task_ext_id": "ZXJnb24=:972c8f33-991b-4c57-4d02-9fb5e1b8520f"
+    }
+}
+
+TASK [Verify transport was added] **********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "All assertions passed"
+}
+
+TASK [Fetch SNMP transports after addition] ************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": [{"port": 161, "protocol": "TCP"}, {"port": 162, "protocol": "UDP"}]}
+
+TASK [Display transports after addition] ***************************************
+ok: [localhost] => {
+    "after_add_transports": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "response": [
+            {
+                "port": 161,
+                "protocol": "TCP"
+            },
+            {
+                "port": 162,
+                "protocol": "UDP"
+            }
+        ]
+    }
+}
+
+TASK [Idempotency check - Add same SNMP transport again] ***********************
+skipping: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport with protocol 'UDP' and port '162' already exists.", "response": null, "task_ext_id": null}
+
+TASK [Display idempotency result] **********************************************
+ok: [localhost] => {
+    "idempotent_result": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": "SNMP transport with protocol 'UDP' and port '162' already exists.",
+        "response": null,
+        "skipped": true,
+        "task_ext_id": null
+    }
+}
+
+TASK [Verify idempotency - should be skipped] **********************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "All assertions passed"
+}
+
+TASK [Update SNMP transport - change from UDP/162 to TCP/163] ******************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006507e-9fb0-cb29-1221-5254000db428"], "completed_time": "2026-05-04T06:37:44.430957+00:00", "completion_details": null, "created_time": "2026-05-04T06:37:43.937544+00:00", "entities_affected": [{"ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "name": null, "rel": "clustermgmt:config:cluster"}], "error_messages": null, "ext_id": "ZXJnb24=:b748b5fc-b580-4db7-7eae-344a8638c26f", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-05-04T06:37:44.430956+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "Add Snmp Transports", "operation_description": "Add snmp transports", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-05-04T06:37:43.962923+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:ce07fd61-f800-46d0-40bf-59f6b96af09e", "href": "https://10.101.64.103:9440/api/prism/v4.3/config/tasks/ZXJnb24=:ce07fd61-f800-46d0-40bf-59f6b96af09e", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:b748b5fc-b580-4db7-7eae-344a8638c26f"}
+
+TASK [Display update result] ***************************************************
+ok: [localhost] => {
+    "update_result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "response": {
+            "app_name": null,
+            "batch_summary": null,
+            "cluster_ext_ids": [
+                "0006507e-9fb0-cb29-1221-5254000db428"
+            ],
+            "completed_time": "2026-05-04T06:37:44.430957+00:00",
+            "completion_details": null,
+            "created_time": "2026-05-04T06:37:43.937544+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+                    "name": null,
+                    "rel": "clustermgmt:config:cluster"
+                }
+            ],
+            "error_messages": null,
+            "ext_id": "ZXJnb24=:b748b5fc-b580-4db7-7eae-344a8638c26f",
+            "is_background_task": false,
+            "is_cancelable": false,
+            "last_updated_time": "2026-05-04T06:37:44.430956+00:00",
+            "legacy_error_message": null,
+            "number_of_entities_affected": 1,
+            "number_of_subtasks": 1,
+            "operation": "Add Snmp Transports",
+            "operation_description": "Add snmp transports",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "projectExtId": "00000000-0000-0000-0000-000000000000",
+            "resource_links": null,
+            "root_task": null,
+            "started_time": "2026-05-04T06:37:43.962923+00:00",
+            "status": "SUCCEEDED",
+            "sub_steps": null,
+            "sub_tasks": [
+                {
+                    "ext_id": "ZXJnb24=:ce07fd61-f800-46d0-40bf-59f6b96af09e",
+                    "href": "https://10.101.64.103:9440/api/prism/v4.3/config/tasks/ZXJnb24=:ce07fd61-f800-46d0-40bf-59f6b96af09e",
+                    "rel": "subtask"
+                }
+            ],
+            "warnings": null
+        },
+        "task_ext_id": "ZXJnb24=:b748b5fc-b580-4db7-7eae-344a8638c26f"
+    }
+}
+
+TASK [Verify transport was updated] ********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "All assertions passed"
+}
+
+TASK [Fetch SNMP transports after update] **************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": [{"port": 163, "protocol": "TCP"}]}
+
+TASK [Display transports after update] *****************************************
+ok: [localhost] => {
+    "after_update_transports": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "response": [
+            {
+                "port": 163,
+                "protocol": "TCP"
+            }
+        ]
+    }
+}
+
+TASK [Remove SNMP transport - TCP port 163] ************************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006507e-9fb0-cb29-1221-5254000db428"], "completed_time": "2026-05-04T06:37:50.152136+00:00", "completion_details": null, "created_time": "2026-05-04T06:37:49.870664+00:00", "entities_affected": [{"ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "name": null, "rel": "clustermgmt:config:cluster"}], "error_messages": null, "ext_id": "ZXJnb24=:2b05f893-a912-4c05-69d8-b3b2ce8bc044", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-05-04T06:37:50.152134+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "Remove Snmp Transports", "operation_description": "Remove snmp transports", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-05-04T06:37:49.888509+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:f48134c8-d9a0-4278-7f06-7a348e16ea2e", "href": "https://10.101.64.103:9440/api/prism/v4.3/config/tasks/ZXJnb24=:f48134c8-d9a0-4278-7f06-7a348e16ea2e", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:2b05f893-a912-4c05-69d8-b3b2ce8bc044"}
+
+TASK [Display delete result] ***************************************************
+ok: [localhost] => {
+    "delete_result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "response": {
+            "app_name": null,
+            "batch_summary": null,
+            "cluster_ext_ids": [
+                "0006507e-9fb0-cb29-1221-5254000db428"
+            ],
+            "completed_time": "2026-05-04T06:37:50.152136+00:00",
+            "completion_details": null,
+            "created_time": "2026-05-04T06:37:49.870664+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+                    "name": null,
+                    "rel": "clustermgmt:config:cluster"
+                }
+            ],
+            "error_messages": null,
+            "ext_id": "ZXJnb24=:2b05f893-a912-4c05-69d8-b3b2ce8bc044",
+            "is_background_task": false,
+            "is_cancelable": false,
+            "last_updated_time": "2026-05-04T06:37:50.152134+00:00",
+            "legacy_error_message": null,
+            "number_of_entities_affected": 1,
+            "number_of_subtasks": 1,
+            "operation": "Remove Snmp Transports",
+            "operation_description": "Remove snmp transports",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "projectExtId": "00000000-0000-0000-0000-000000000000",
+            "resource_links": null,
+            "root_task": null,
+            "started_time": "2026-05-04T06:37:49.888509+00:00",
+            "status": "SUCCEEDED",
+            "sub_steps": null,
+            "sub_tasks": [
+                {
+                    "ext_id": "ZXJnb24=:f48134c8-d9a0-4278-7f06-7a348e16ea2e",
+                    "href": "https://10.101.64.103:9440/api/prism/v4.3/config/tasks/ZXJnb24=:f48134c8-d9a0-4278-7f06-7a348e16ea2e",
+                    "rel": "subtask"
+                }
+            ],
+            "warnings": null
+        },
+        "task_ext_id": "ZXJnb24=:2b05f893-a912-4c05-69d8-b3b2ce8bc044"
+    }
+}
+
+TASK [Verify transport was removed] ********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "All assertions passed"
+}
+
+TASK [Fetch SNMP transports after removal] *************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": []}
+
+TASK [Display transports after removal] ****************************************
+ok: [localhost] => {
+    "after_delete_transports": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "response": []
+    }
+}
+
+TASK [Idempotency check - Remove non-existent transport] ***********************
+skipping: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport with protocol 'TCP' and port '163' not found.", "response": null, "task_ext_id": null}
+
+TASK [Verify idempotent delete - should be skipped] ****************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "All assertions passed"
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=24   changed=3    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_snmp_transport_v2
+    - ntnx_snmp_transports_info_v2

--- a/plugins/module_utils/v4/clusters_mgmt/helpers.py
+++ b/plugins/module_utils/v4/clusters_mgmt/helpers.py
@@ -109,3 +109,25 @@ def get_cluster_profile(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching cluster profile info using ext_id",
         )
+
+
+def get_snmp_config(module, api_instance, cluster_ext_id):
+    """
+    This method will return SNMP config for a cluster using cluster external ID.
+    Args:
+        module: Ansible module
+        api_instance: ClustersApi instance from sdk
+        cluster_ext_id (str): cluster external ID
+    return:
+        snmp_config (object): SNMP config object for the cluster
+    """
+    try:
+        return api_instance.get_snmp_config_by_cluster_id(
+            clusterExtId=cluster_ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching SNMP config for cluster",
+        )

--- a/plugins/modules/ntnx_snmp_transport_v2.py
+++ b/plugins/modules/ntnx_snmp_transport_v2.py
@@ -1,0 +1,477 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_snmp_transport_v2
+short_description: Manage SNMP transport configuration for Nutanix clusters
+description:
+  - This module allows you to add, update, and remove SNMP transport ports and protocol details for a Nutanix cluster.
+  - Add (create) an SNMP transport by specifying the cluster, protocol, and port.
+  - Update an SNMP transport by providing existing transport details alongside new transport details.
+  - Remove (delete) an SNMP transport by specifying the cluster, protocol, and port to remove.
+  - This module uses PC v4 APIs based SDKs
+version_added: "2.6.0"
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Add SNMP transport) -
+      Operation Name: Add SNMP Transport -
+      Required Roles: Cluster Admin, Prism Admin, Super Admin
+    - >-
+      B(Remove SNMP transport) -
+      Operation Name: Remove SNMP Transport -
+      Required Roles: Cluster Admin, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  state:
+    description:
+      - Specify state.
+      - If C(state) is set to C(present) then the SNMP transport will be added to the cluster.
+      - >-
+        If C(state) is set to C(present) and C(old_transport) is given, the old transport
+        will be removed and the new transport will be added (update operation).
+      - If C(state) is set to C(absent) then the SNMP transport will be removed from the cluster.
+    choices:
+      - present
+      - absent
+    type: str
+    default: present
+  cluster_ext_id:
+    description:
+      - The external ID of the cluster.
+    type: str
+    required: true
+  protocol:
+    description:
+      - SNMP protocol type for the transport.
+    type: str
+    required: true
+    choices:
+      - UDP
+      - UDP6
+      - TCP
+      - TCP6
+  port:
+    description:
+      - SNMP port number for the transport.
+    type: int
+    required: true
+  old_transport:
+    description:
+      - The existing SNMP transport details to remove during an update operation.
+      - Required only for update operations where both old and new transport details differ.
+    type: dict
+    suboptions:
+      protocol:
+        description:
+          - SNMP protocol type of the existing transport to remove.
+        type: str
+        required: true
+        choices:
+          - UDP
+          - UDP6
+          - TCP
+          - TCP6
+      port:
+        description:
+          - SNMP port number of the existing transport to remove.
+        type: int
+        required: true
+  wait:
+    description:
+      - Whether to wait for the operation to complete.
+    type: bool
+    default: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Add SNMP transport to a cluster
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+    protocol: "UDP"
+    port: 162
+    state: present
+
+- name: Update SNMP transport (remove old and add new)
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+    protocol: "TCP"
+    port: 163
+    old_transport:
+      protocol: "UDP"
+      port: 162
+    state: present
+
+- name: Remove SNMP transport from a cluster
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+    protocol: "UDP"
+    port: 162
+    state: absent
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for the SNMP transport operation.
+        - Task details of the operation.
+    type: dict
+    returned: always
+    sample:
+        {
+            "ext_id": "ZXJnb24=:100a5778-9824-49c7-9444-222aa97f5874"
+        }
+ext_id:
+    description:
+        - The external ID of the cluster.
+    type: str
+    returned: always
+    sample: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+task_ext_id:
+    description:
+        - The task external ID.
+    type: str
+    returned: always
+    sample: "ZXJnb24=:100a5778-9824-49c7-9444-222aa97f5874"
+changed:
+    description:
+        - Indicates if any changes were made during the operation.
+    type: bool
+    returned: always
+    sample: true
+skipped:
+    description:
+        - Indicates if the operation was skipped due to idempotency.
+    type: bool
+    returned: when the operation was skipped
+    sample: true
+msg:
+    description:
+        - A message describing the result of the operation.
+    type: str
+    returned: always
+error:
+    description:
+        - The error message if an error occurs.
+    type: str
+    returned: when an error occurs
+failed:
+    description:
+        - Whether the operation failed.
+    type: bool
+    returned: when an error occurs
+    sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_clusters_api_instance,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import get_snmp_config  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_clustermgmt_py_client as clusters_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as clusters_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    old_transport_spec = dict(
+        protocol=dict(
+            type="str",
+            required=True,
+            choices=["UDP", "UDP6", "TCP", "TCP6"],
+        ),
+        port=dict(type="int", required=True),
+    )
+
+    module_args = dict(
+        cluster_ext_id=dict(type="str", required=True),
+        protocol=dict(
+            type="str",
+            required=True,
+            choices=["UDP", "UDP6", "TCP", "TCP6"],
+        ),
+        port=dict(type="int", required=True),
+        old_transport=dict(
+            type="dict",
+            options=old_transport_spec,
+        ),
+    )
+    return module_args
+
+
+def _build_snmp_transport_spec(protocol, port):
+    """Build an SnmpTransport SDK object from protocol and port values."""
+    snmp_protocol = getattr(clusters_sdk.SnmpProtocol, protocol)
+    return clusters_sdk.SnmpTransport(protocol=snmp_protocol, port=port)
+
+
+def _transport_exists(transports, protocol, port):
+    """Check if a given transport already exists in the list of transports."""
+    if not transports:
+        return False
+    for t in transports:
+        if t.protocol == protocol and t.port == port:
+            return True
+    return False
+
+
+def create_snmp_transport(module, api_instance, result):
+    """Add an SNMP transport to the cluster."""
+    cluster_ext_id = module.params["cluster_ext_id"]
+    protocol = module.params["protocol"]
+    port = module.params["port"]
+
+    result["ext_id"] = cluster_ext_id
+
+    snmp_config = get_snmp_config(module, api_instance, cluster_ext_id)
+    existing_transports = snmp_config.transports if snmp_config else []
+
+    if _transport_exists(existing_transports, protocol, port):
+        result["skipped"] = True
+        module.exit_json(
+            msg="SNMP transport with protocol '{0}' and port '{1}' already exists.".format(
+                protocol, port
+            ),
+            **result,
+        )
+
+    spec = _build_snmp_transport_spec(protocol, port)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.add_snmp_transport(clusterExtId=cluster_ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while adding SNMP transport",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        resp = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+def update_snmp_transport(module, api_instance, result):
+    """Update an SNMP transport by removing the old one and adding the new one."""
+    cluster_ext_id = module.params["cluster_ext_id"]
+    protocol = module.params["protocol"]
+    port = module.params["port"]
+    old_transport = module.params["old_transport"]
+    old_protocol = old_transport["protocol"]
+    old_port = old_transport["port"]
+
+    result["ext_id"] = cluster_ext_id
+
+    snmp_config = get_snmp_config(module, api_instance, cluster_ext_id)
+    existing_transports = snmp_config.transports if snmp_config else []
+
+    if (
+        old_protocol == protocol
+        and old_port == port
+        and _transport_exists(existing_transports, protocol, port)
+    ):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    if _transport_exists(existing_transports, protocol, port) and not _transport_exists(
+        existing_transports, old_protocol, old_port
+    ):
+        result["skipped"] = True
+        module.exit_json(
+            msg="New transport already exists and old transport not found. Nothing to change.",
+            **result,
+        )
+
+    new_spec = _build_snmp_transport_spec(protocol, port)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(new_spec.to_dict())
+        return
+
+    if _transport_exists(existing_transports, old_protocol, old_port):
+        old_spec = _build_snmp_transport_spec(old_protocol, old_port)
+        try:
+            resp = api_instance.remove_snmp_transport(
+                clusterExtId=cluster_ext_id, body=old_spec
+            )
+        except Exception as e:
+            raise_api_exception(
+                module=module,
+                exception=e,
+                msg="Api Exception raised while removing old SNMP transport during update",
+            )
+        task_ext_id = resp.data.ext_id
+        if task_ext_id and module.params.get("wait"):
+            wait_for_completion(module, task_ext_id)
+
+    resp = None
+    try:
+        resp = api_instance.add_snmp_transport(
+            clusterExtId=cluster_ext_id, body=new_spec
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while adding new SNMP transport during update",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        resp = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+def delete_snmp_transport(module, api_instance, result):
+    """Remove an SNMP transport from the cluster."""
+    cluster_ext_id = module.params["cluster_ext_id"]
+    protocol = module.params["protocol"]
+    port = module.params["port"]
+
+    result["ext_id"] = cluster_ext_id
+
+    snmp_config = get_snmp_config(module, api_instance, cluster_ext_id)
+    existing_transports = snmp_config.transports if snmp_config else []
+
+    if not _transport_exists(existing_transports, protocol, port):
+        result["skipped"] = True
+        module.exit_json(
+            msg="SNMP transport with protocol '{0}' and port '{1}' not found.".format(
+                protocol, port
+            ),
+            **result,
+        )
+
+    spec = _build_snmp_transport_spec(protocol, port)
+
+    if module.check_mode:
+        result["msg"] = (
+            "SNMP transport with protocol '{0}' and port '{1}' will be removed.".format(
+                protocol, port
+            )
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.remove_snmp_transport(
+            clusterExtId=cluster_ext_id, body=spec
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while removing SNMP transport",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        resp = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+
+    api_instance = get_clusters_api_instance(module)
+    state = module.params["state"]
+
+    if state == "present":
+        if module.params.get("old_transport"):
+            update_snmp_transport(module, api_instance, result)
+        else:
+            create_snmp_transport(module, api_instance, result)
+    else:
+        delete_snmp_transport(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_snmp_transports_info_v2.py
+++ b/plugins/modules/ntnx_snmp_transports_info_v2.py
@@ -1,0 +1,186 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_snmp_transports_info_v2
+short_description: Retrieve SNMP transport configuration info for Nutanix clusters
+description:
+    - This module retrieves SNMP transport configuration details for a Nutanix cluster.
+    - Fetch all SNMP transports configured on a cluster by providing the cluster external ID.
+    - This module uses PC v4 APIs based SDKs
+version_added: "2.6.0"
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get SNMP config) -
+      Operation Name: View SNMP Config -
+      Required Roles: Cluster Admin, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  cluster_ext_id:
+    description:
+      - The external ID of the cluster to fetch SNMP transport details for.
+    type: str
+    required: true
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch all SNMP transports for a cluster
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+  register: result
+"""
+
+RETURN = r"""
+response:
+    description:
+        - List of SNMP transport details for the cluster.
+    type: list
+    returned: always
+    sample:
+        [
+            {
+                "protocol": "UDP",
+                "port": 161
+            },
+            {
+                "protocol": "UDP",
+                "port": 162
+            }
+        ]
+ext_id:
+    description:
+        - The external ID of the cluster.
+    type: str
+    returned: always
+    sample: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+changed:
+    description:
+        - Indicates if any changes were made during the operation.
+        - Always false for info modules.
+    type: bool
+    returned: always
+    sample: false
+msg:
+    description:
+        - A message describing the result of the operation.
+    type: str
+    returned: when an error occurs
+error:
+    description:
+        - The error message if an error occurs.
+    type: str
+    returned: when an error occurs
+failed:
+    description:
+        - Whether the operation failed.
+    type: bool
+    returned: when an error occurs
+    sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_clusters_api_instance,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import get_snmp_config  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_clustermgmt_py_client  # noqa: E402, F401
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402, F401
+        mock_sdk as ntnx_clustermgmt_py_client,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        cluster_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_snmp_transports(module, api_instance, result):
+    """Fetch SNMP transports for a cluster."""
+    cluster_ext_id = module.params["cluster_ext_id"]
+    result["ext_id"] = cluster_ext_id
+
+    snmp_config = get_snmp_config(module, api_instance, cluster_ext_id)
+
+    transports = snmp_config.transports if snmp_config else []
+    if transports:
+        transports_list = [strip_internal_attributes(t.to_dict()) for t in transports]
+        result["response"] = transports_list
+    else:
+        result["response"] = []
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+    }
+
+    api_instance = get_clusters_api_instance(module)
+    get_snmp_transports(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/ntnx_snmp_transport_v2/aliases
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_snmp_transport_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_snmp_transport_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import SNMP transport CRUD tests
+      ansible.builtin.import_tasks: snmp_transport_crud.yml

--- a/tests/integration/targets/ntnx_snmp_transport_v2/tasks/snmp_transport_crud.yml
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/tasks/snmp_transport_crud.yml
@@ -1,0 +1,288 @@
+---
+# Test scenarios:
+#   1. Fetch cluster ext_id for testing
+#   2. Create - check_mode test for adding SNMP transport
+#   3. Create - Add SNMP transport (UDP/162)
+#   4. Verify transport was added using info module
+#   5. Create - Idempotency check (add same transport again, should be skipped)
+#   6. Update - check_mode test for updating SNMP transport
+#   7. Update - Change transport from UDP/162 to TCP/163
+#   8. Verify transport was updated using info module
+#   9. Delete - check_mode test for removing SNMP transport
+#   10. Delete - Remove SNMP transport (TCP/163)
+#   11. Verify transport was removed using info module
+#   12. Delete - Idempotency check (remove non-existent transport, should be skipped)
+#   13. Negative - Add transport with invalid protocol
+#   14. Negative - Add transport with missing required params
+
+- name: Start SNMP transport CRUD tests
+  ansible.builtin.debug:
+    msg: "Starting SNMP transport CRUD tests"
+
+####################################### Setup #######################################
+
+- name: List all clusters to get a cluster external ID
+  nutanix.ncp.ntnx_clusters_info_v2:
+    filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+    limit: 1
+  register: cluster_list_result
+  ignore_errors: true
+
+- name: Set cluster ext_id for testing
+  ansible.builtin.set_fact:
+    test_cluster_ext_id: "{{ cluster_list_result.response[0].ext_id }}"
+  when:
+    - cluster_list_result.response is defined
+    - cluster_list_result.response | length > 0
+
+- name: Skip tests if no cluster found
+  ansible.builtin.meta: end_play
+  when: test_cluster_ext_id is not defined
+
+- name: Display test cluster ext_id
+  ansible.builtin.debug:
+    msg: "Using cluster ext_id: {{ test_cluster_ext_id }}"
+
+############################### Create - check_mode #################################
+
+- name: Create SNMP transport - check_mode
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ test_cluster_ext_id }}"
+    protocol: "UDP"
+    port: 162
+    state: present
+  check_mode: true
+  register: check_mode_create_result
+
+- name: Verify check_mode create result
+  ansible.builtin.assert:
+    that:
+      - check_mode_create_result.changed == false
+      - check_mode_create_result.response is defined
+    fail_msg: "check_mode create test failed"
+    success_msg: "check_mode create test passed"
+
+################################# Create - Add SNMP transport #################################
+
+- name: Add SNMP transport - UDP port 162
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ test_cluster_ext_id }}"
+    protocol: "UDP"
+    port: 162
+    state: present
+  register: create_result
+
+- name: Verify create result
+  ansible.builtin.assert:
+    that:
+      - create_result.changed == true
+      - create_result.failed == false
+      - create_result.ext_id == test_cluster_ext_id
+    fail_msg: "SNMP transport create failed"
+    success_msg: "SNMP transport create passed"
+
+############################ Verify transport was added ##############################
+
+- name: Fetch SNMP transports after create
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    cluster_ext_id: "{{ test_cluster_ext_id }}"
+  register: info_after_create
+
+- name: Verify transport exists in list
+  ansible.builtin.assert:
+    that:
+      - info_after_create.failed == false
+      - info_after_create.response is defined
+      - info_after_create.response | length > 0
+    fail_msg: "Transport not found after creation"
+    success_msg: "Transport verified after creation"
+
+############################ Create - Idempotency check ##############################
+
+- name: Add same SNMP transport again - idempotency check
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ test_cluster_ext_id }}"
+    protocol: "UDP"
+    port: 162
+    state: present
+  register: idempotent_create_result
+
+- name: Verify idempotency - should be skipped
+  ansible.builtin.assert:
+    that:
+      - idempotent_create_result.changed == false
+      - idempotent_create_result.failed == false
+      - idempotent_create_result.skipped is defined
+      - idempotent_create_result.skipped == true
+    fail_msg: "Idempotency check for create failed"
+    success_msg: "Idempotency check for create passed"
+
+############################### Update - check_mode #################################
+
+- name: Update SNMP transport - check_mode
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ test_cluster_ext_id }}"
+    protocol: "TCP"
+    port: 163
+    old_transport:
+      protocol: "UDP"
+      port: 162
+    state: present
+  check_mode: true
+  register: check_mode_update_result
+
+- name: Verify check_mode update result
+  ansible.builtin.assert:
+    that:
+      - check_mode_update_result.changed == false
+      - check_mode_update_result.response is defined
+    fail_msg: "check_mode update test failed"
+    success_msg: "check_mode update test passed"
+
+############################## Update - Change transport ##############################
+
+- name: Update SNMP transport - change from UDP/162 to TCP/163
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ test_cluster_ext_id }}"
+    protocol: "TCP"
+    port: 163
+    old_transport:
+      protocol: "UDP"
+      port: 162
+    state: present
+  register: update_result
+
+- name: Verify update result
+  ansible.builtin.assert:
+    that:
+      - update_result.changed == true
+      - update_result.failed == false
+      - update_result.ext_id == test_cluster_ext_id
+    fail_msg: "SNMP transport update failed"
+    success_msg: "SNMP transport update passed"
+
+############################ Verify transport was updated ############################
+
+- name: Fetch SNMP transports after update
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    cluster_ext_id: "{{ test_cluster_ext_id }}"
+  register: info_after_update
+
+- name: Verify updated transport exists
+  ansible.builtin.assert:
+    that:
+      - info_after_update.failed == false
+      - info_after_update.response is defined
+    fail_msg: "Transport verification after update failed"
+    success_msg: "Transport verification after update passed"
+
+############################### Delete - check_mode #################################
+
+- name: Delete SNMP transport - check_mode
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ test_cluster_ext_id }}"
+    protocol: "TCP"
+    port: 163
+    state: absent
+  check_mode: true
+  register: check_mode_delete_result
+
+- name: Verify check_mode delete result
+  ansible.builtin.assert:
+    that:
+      - check_mode_delete_result.changed == false
+      - check_mode_delete_result.msg is defined
+    fail_msg: "check_mode delete test failed"
+    success_msg: "check_mode delete test passed"
+
+############################## Delete - Remove transport ##############################
+
+- name: Remove SNMP transport - TCP port 163
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ test_cluster_ext_id }}"
+    protocol: "TCP"
+    port: 163
+    state: absent
+  register: delete_result
+
+- name: Verify delete result
+  ansible.builtin.assert:
+    that:
+      - delete_result.changed == true
+      - delete_result.failed == false
+      - delete_result.ext_id == test_cluster_ext_id
+    fail_msg: "SNMP transport delete failed"
+    success_msg: "SNMP transport delete passed"
+
+############################ Verify transport was removed ############################
+
+- name: Fetch SNMP transports after delete
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    cluster_ext_id: "{{ test_cluster_ext_id }}"
+  register: info_after_delete
+
+- name: Verify transport info fetch succeeded after delete
+  ansible.builtin.assert:
+    that:
+      - info_after_delete.failed == false
+    fail_msg: "Transport info fetch after delete failed"
+    success_msg: "Transport info fetch after delete passed"
+
+######################## Delete - Idempotency check ##################################
+
+- name: Remove non-existent SNMP transport - idempotency check
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ test_cluster_ext_id }}"
+    protocol: "TCP"
+    port: 163
+    state: absent
+  register: idempotent_delete_result
+
+- name: Verify idempotent delete - should be skipped
+  ansible.builtin.assert:
+    that:
+      - idempotent_delete_result.changed == false
+      - idempotent_delete_result.failed == false
+      - idempotent_delete_result.skipped is defined
+      - idempotent_delete_result.skipped == true
+    fail_msg: "Idempotency check for delete failed"
+    success_msg: "Idempotency check for delete passed"
+
+######################### Negative - Invalid protocol ################################
+
+- name: Add transport with invalid protocol - should fail
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ test_cluster_ext_id }}"
+    protocol: "INVALID"
+    port: 162
+    state: present
+  register: invalid_protocol_result
+  ignore_errors: true
+
+- name: Verify invalid protocol fails
+  ansible.builtin.assert:
+    that:
+      - invalid_protocol_result.failed == true
+    fail_msg: "Invalid protocol test failed - should have errored"
+    success_msg: "Invalid protocol test passed - correctly rejected"
+
+######################### Negative - Missing cluster_ext_id ##########################
+
+- name: Add transport without cluster_ext_id - should fail
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    protocol: "UDP"
+    port: 162
+    state: present
+  register: missing_cluster_result
+  ignore_errors: true
+
+- name: Verify missing cluster_ext_id fails
+  ansible.builtin.assert:
+    that:
+      - missing_cluster_result.failed == true
+    fail_msg: "Missing cluster_ext_id test failed - should have errored"
+    success_msg: "Missing cluster_ext_id test passed - correctly rejected"
+
+- name: End SNMP transport CRUD tests
+  ansible.builtin.debug:
+    msg: "All SNMP transport CRUD tests completed successfully"

--- a/tests_run_log.txt
+++ b/tests_run_log.txt
@@ -1,0 +1,168 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Run SNMP transport integration tests] ************************************
+
+TASK [Start SNMP transport CRUD tests] *****************************************
+ok: [localhost] => {
+    "msg": "Starting SNMP transport CRUD tests"
+}
+
+TASK [List all clusters to get a cluster external ID] **************************
+ok: [localhost] => {"changed": false, "error": null, "response": [{"backup_eligibility_score": 1, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDWQlWGnPpWemdrFcHLykUr7Ni88jrVWGBo3+P/Ij6nuYH8ODAppFUlSHyMH562s1F4S89B0s3aS5vVJKntMq3vD5jIn7hOIBWj0L4Cr8RPIulzpswdvi+gRyHXbQoOLy5fCIBxVeDOYA0+3esZyMrQ/VNpidxkOmB0n4mnfq3FHmggVC8qTJOYV8dKvXDneNEbzMGw8tY+SLkkSZK6ibciNtrOSFr+kBjm56WPMYqbLaSN/bl2mMbwvKYOECJj25EPQSHjqTSLGF9e6Xa/99K9A8bOIWTisbzG+RuqjT7YYE/mQvuMh0ehvbpFJ9xWwYFFqh/5fZePEVi+j3oIiKWJ57ThRKBuaN7SvFr8pHj3YblJWc8yQ+9mkKskXns3MCEWMxCNqk5LmPIdA7QZLBkiQ+U47pUVTETjbY5A1pfgUOwcFrgaafl6s9xBS6KeJduzG4FcOcmwh3H/ZtsoP7NpFFw99zzctqxyN7wZdPfrG6iba+QcvIG1yH47n+w72tU= nutanix@ntnx-2e08eed1-ac6d-4fa3-819d-c5c25663dfb2-a-cvm", "name": "2e08eed1-ac6d-4fa3-819d-c5c25663dfb2"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCdKyu5leVDpjj3zaxYlrAbSMz8Mb1PWK0FeJkiPaCn6gCn4n88Jg+K7mIKAaJgfcEJMXl0VSHfjnYFE0hDdpL6/AmczFLsp/EmfJQ8p0uPpkPMjCeAv1BnAm3lcIFbXUzHGCKshfaRMjydJRbX6psaST1CcvdEAWDzXEVu2WnhVXKUl4p0So+Bc5hyOtn/uoRx+MiIMvZ3FcNWgTTB5a8gZcbSyu60VQjFeSaYfDBOfxmMMN5Ce48+Yo3GxcpMZyt9n96PFDJyMI+oP0OFSdG0C90X8/32C0v7GbkBOmXWfl4tYhXLCErrnqYZc5FzoU2IdosDHu5n6mMhm6upY7DO2reXN0GTf/Tdomk5IWtVoj/fr10U/Dtd6pJeln8osAm1tQk9SkLzAfw97TwO6lR7nZ4uQUZeGTyPhuU8wpXkPdUEecyWSP4PyzJ9MJeTg+hYd8RMgSHJRrslq2/aUxII7voJgzLMBbGF+Ad4Aqd1b5vfZo9pW4G2tm/ERyEiSdc= root@Nested-AHV-69f041c87298f6e91878aa57-0", "name": "10.101.64.223"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAw8NhpiLG/6c8c0LocaQVM6+x8yBvLS+z13nYlqzSKr64HQSH+IIx14bS+uh0xf8ou5ROnbUa44YM9qG2RBK1hBVrwTIKZBwFwOTxDuXH9YoswqflnOeyTGUFerrMxlg5iYvKE01QIErKWt/BJ+hK/qVQi6SHh/WhyjAGNQPxjPBG3oEUFoLV9uDLX9RT/sLIQpBf91DCbF9+2rSToqjydj36d38JbmuGJGqr+DrEd0lKzfiJiQ39t3AXBE1bY2ISX+uwq07XkYZbrHaijrxnOBFZE7ETQmyxdcOvgDxvhnhZpFsUqbPqIqa45CwFWV+btzITvpJkveYjGSGR7ZJNHQ== nutanix@titan", "name": "agave"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6oDEABPvDtwtOFEJhu7sx9oUZskh0R4CWW6IM9uIxVtjYR/XXu587rXKac34InclJ3U3+PFQcAgEvdw2qiCEWWWMFMiALMneDELPd5qepKRrFJxc3hkyfagot3n7i6r7Y83ceIII4qM1mGLdUA3XdSWlttbgugnBrfB9yLq/BgtVqBvBVFayTGb6IsoMUSbODX6zZEt9Uzh/Yr49DV40ULpGhSYS9vWFB3GrajrliQ9Ea8oOB+8vK9Cavf7IOsaIaPsGI20mypeKFn4qcinBKc6O3PqU3YyYv7pLJWAvwXr9D9+rukgNAhKnd1fFQVLj4sAHA4ixfQk9+0kgAJM4P", "name": "nutest"}], "build_info": {"build_type": "release", "commit_id": "e5715fa114b0241e6c328ebc9be171c1d17720bc", "full_version": "el9-release-ganges-7.6-stable-e5715fa114b0241e6c328ebc9be171c1d17720bc", "short_commit_id": "e5715f", "version": "7.6"}, "cluster_arch": "X86_64", "cluster_function": ["AOS", "ONE_NODE"], "cluster_software_map": [{"software_type": "NCC", "version": "ncc-6.0.0"}, {"software_type": "NOS", "version": "el9-release-ganges-7.6-stable-e5715fa114b0241e6c328ebc9be171c1d17720bc"}], "cluster_type": "HYPER_CONVERGED", "encryption_in_transit_status": null, "encryption_option": null, "encryption_scope": null, "fault_tolerance_state": {"current_cluster_fault_tolerance": "CFT_1N_OR_1D", "current_max_fault_tolerance": 1, "desired_cluster_fault_tolerance": "CFT_1N_OR_1D", "desired_max_fault_tolerance": 1, "domain_awareness_level": "DISK", "isStrictRackAwarenessEnabled": false, "redundancy_status": null}, "hypervisor_types": ["AHV"], "incarnation_id": 1777354635529001, "isDegradedNodeMonitoringDisabled": false, "is_available": true, "is_lts": false, "is_password_remote_login_enabled": true, "is_remote_support_enabled": false, "operation_mode": "NORMAL", "pulse_status": {"is_enabled": false, "pii_scrubbing_level": null}, "redundancy_factor": 2, "timezone": "UTC"}, "container_name": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "externalStorageProviderInfo": [{"$objectType": "clustermgmt.v4.config.ExternalStorageProviderInfo", "$reserved": {"$fv": "v4.r3"}, "compatibleVersion": "5.1.0.283_5214", "isInstalled": false, "providerType": "DELL_POWERFLEX"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "EVERPURE_FLASHARRAY"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "DELL_POWERSTORE"}], "inefficient_vm_count": null, "links": null, "name": "auto_cluster_nested_69f041c87298f6e91878aa57", "network": {"backplane": {"is_segmentation_enabled": false, "netmask": null, "subnet": null, "vlan_tag": null}, "external_address": {"ipv4": {"prefix_length": 32, "value": "10.101.64.224"}, "ipv6": null}, "external_data_service_ip": {"ipv4": {"prefix_length": 32, "value": "10.101.64.225"}, "ipv6": null}, "external_subnet": "10.101.64.0/255.255.224.0", "fqdn": null, "http_proxy_list": null, "http_proxy_white_list": null, "internal_subnet": "192.168.5.0/255.255.255.128", "key_management_server_type": null, "management_server": null, "masquerading_ip": null, "masquerading_port": null, "name_server_ip_list": [{"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.15"}, "ipv6": null}, {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.16"}, "ipv6": null}], "nfs_subnet_whitelist": null, "ntp_server_config_list": null, "ntp_server_ip_list": [{"fqdn": {"value": "ntp.dyn.nutanix.com"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "0.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "1.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "2.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "3.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}], "smtp_server": null}, "nodes": {"node_list": [{"controller_vm_ip": {"ipv4": {"prefix_length": 32, "value": "10.101.64.222"}, "ipv6": null}, "host_ip": {"ipv4": {"prefix_length": 32, "value": "10.101.64.223"}, "ipv6": null}, "node_uuid": "2e08eed1-ac6d-4fa3-819d-c5c25663dfb2"}], "number_of_nodes": 1}, "tenant_id": null, "upgrade_status": "SUCCEEDED", "vm_count": 9}], "total_available_results": 1}
+
+TASK [Set cluster ext_id for testing] ******************************************
+ok: [localhost] => {"ansible_facts": {"test_cluster_ext_id": "0006507e-9fb0-cb29-1221-5254000db428"}, "changed": false}
+
+TASK [Skip tests if no cluster found] ******************************************
+skipping: [localhost] => {"msg": "end_play", "skip_reason": "end_play conditional evaluated to False, continuing play"}
+
+TASK [Display test cluster ext_id] *********************************************
+ok: [localhost] => {
+    "msg": "Using cluster ext_id: 0006507e-9fb0-cb29-1221-5254000db428"
+}
+
+TASK [Create SNMP transport - check_mode] **************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": {"port": 162, "protocol": "UDP"}, "task_ext_id": null}
+
+TASK [Verify check_mode create result] *****************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "check_mode create test passed"
+}
+
+TASK [Add SNMP transport - UDP port 162] ***************************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006507e-9fb0-cb29-1221-5254000db428"], "completed_time": "2026-05-04T06:39:16.957464+00:00", "completion_details": null, "created_time": "2026-05-04T06:39:16.650546+00:00", "entities_affected": [{"ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "name": null, "rel": "clustermgmt:config:cluster"}], "error_messages": null, "ext_id": "ZXJnb24=:e9c41b6e-cedd-463b-5a5e-73fee02d1098", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-05-04T06:39:16.957463+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "Add Snmp Transports", "operation_description": "Add snmp transports", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-05-04T06:39:16.674247+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:ce2692bb-fabf-4f0a-5647-97351b75f49c", "href": "https://10.101.64.103:9440/api/prism/v4.3/config/tasks/ZXJnb24=:ce2692bb-fabf-4f0a-5647-97351b75f49c", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:e9c41b6e-cedd-463b-5a5e-73fee02d1098"}
+
+TASK [Verify create result] ****************************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "SNMP transport create passed"
+}
+
+TASK [Fetch SNMP transports after create] **************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": [{"port": 162, "protocol": "UDP"}]}
+
+TASK [Verify transport exists in list] *****************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Transport verified after creation"
+}
+
+TASK [Add same SNMP transport again - idempotency check] ***********************
+skipping: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport with protocol 'UDP' and port '162' already exists.", "response": null, "task_ext_id": null}
+
+TASK [Verify idempotency - should be skipped] **********************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Idempotency check for create passed"
+}
+
+TASK [Update SNMP transport - check_mode] **************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": {"port": 163, "protocol": "TCP"}, "task_ext_id": null}
+
+TASK [Verify check_mode update result] *****************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "check_mode update test passed"
+}
+
+TASK [Update SNMP transport - change from UDP/162 to TCP/163] ******************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006507e-9fb0-cb29-1221-5254000db428"], "completed_time": "2026-05-04T06:39:26.738547+00:00", "completion_details": null, "created_time": "2026-05-04T06:39:26.458004+00:00", "entities_affected": [{"ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "name": null, "rel": "clustermgmt:config:cluster"}], "error_messages": null, "ext_id": "ZXJnb24=:313d8a50-0325-4fb4-6de5-fcc588c79cb1", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-05-04T06:39:26.738546+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "Add Snmp Transports", "operation_description": "Add snmp transports", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-05-04T06:39:26.475070+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:eeaf8f63-e14b-481a-4d39-0f4277902d97", "href": "https://10.101.64.103:9440/api/prism/v4.3/config/tasks/ZXJnb24=:eeaf8f63-e14b-481a-4d39-0f4277902d97", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:313d8a50-0325-4fb4-6de5-fcc588c79cb1"}
+
+TASK [Verify update result] ****************************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "SNMP transport update passed"
+}
+
+TASK [Fetch SNMP transports after update] **************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": [{"port": 163, "protocol": "TCP"}]}
+
+TASK [Verify updated transport exists] *****************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Transport verification after update passed"
+}
+
+TASK [Delete SNMP transport - check_mode] **************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport with protocol 'TCP' and port '163' will be removed.", "response": null, "task_ext_id": null}
+
+TASK [Verify check_mode delete result] *****************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "check_mode delete test passed"
+}
+
+TASK [Remove SNMP transport - TCP port 163] ************************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006507e-9fb0-cb29-1221-5254000db428"], "completed_time": "2026-05-04T06:39:33.466325+00:00", "completion_details": null, "created_time": "2026-05-04T06:39:32.948039+00:00", "entities_affected": [{"ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "name": null, "rel": "clustermgmt:config:cluster"}], "error_messages": null, "ext_id": "ZXJnb24=:fd81106a-b3ff-4ea9-7448-0483d14b2fc4", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-05-04T06:39:33.466324+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "Remove Snmp Transports", "operation_description": "Remove snmp transports", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-05-04T06:39:32.965879+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:c521c880-59d8-4a08-70c1-32b524508922", "href": "https://10.101.64.103:9440/api/prism/v4.3/config/tasks/ZXJnb24=:c521c880-59d8-4a08-70c1-32b524508922", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:fd81106a-b3ff-4ea9-7448-0483d14b2fc4"}
+
+TASK [Verify delete result] ****************************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "SNMP transport delete passed"
+}
+
+TASK [Fetch SNMP transports after delete] **************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": []}
+
+TASK [Verify transport info fetch succeeded after delete] **********************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Transport info fetch after delete passed"
+}
+
+TASK [Remove non-existent SNMP transport - idempotency check] ******************
+skipping: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport with protocol 'TCP' and port '163' not found.", "response": null, "task_ext_id": null}
+
+TASK [Verify idempotent delete - should be skipped] ****************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Idempotency check for delete passed"
+}
+
+TASK [Add transport with invalid protocol - should fail] ***********************
+[ERROR]: Task failed: Module failed: value of protocol must be one of: UDP, UDP6, TCP, TCP6, got: INVALID
+Origin: /tmp/codegen/d30fad03583646e1bb8c87aed1edbb92/repo/tests/integration/targets/ntnx_snmp_transport_v2/tasks/snmp_transport_crud.yml:253:3
+
+251 ######################### Negative - Invalid protocol ################################
+252
+253 - name: Add transport with invalid protocol - should fail
+      ^ column 3
+
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of protocol must be one of: UDP, UDP6, TCP, TCP6, got: INVALID"}
+...ignoring
+
+TASK [Verify invalid protocol fails] *******************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Invalid protocol test passed - correctly rejected"
+}
+
+TASK [Add transport without cluster_ext_id - should fail] **********************
+[ERROR]: Task failed: Module failed: missing required arguments: cluster_ext_id
+Origin: /tmp/codegen/d30fad03583646e1bb8c87aed1edbb92/repo/tests/integration/targets/ntnx_snmp_transport_v2/tasks/snmp_transport_crud.yml:271:3
+
+269 ######################### Negative - Missing cluster_ext_id ##########################
+270
+271 - name: Add transport without cluster_ext_id - should fail
+      ^ column 3
+
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: cluster_ext_id"}
+...ignoring
+
+TASK [Verify missing cluster_ext_id fails] *************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Missing cluster_ext_id test passed - correctly rejected"
+}
+
+TASK [End SNMP transport CRUD tests] *******************************************
+ok: [localhost] => {
+    "msg": "All SNMP transport CRUD tests completed successfully"
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=29   changed=3    unreachable=0    failed=0    skipped=2    rescued=0    ignored=2   
+


### PR DESCRIPTION
## Summary
- Added `ntnx_snmp_transport_v2` CRUD module for managing SNMP transport ports and protocol details on Nutanix clusters (add, update, delete with idempotency and check_mode support)
- Added `ntnx_snmp_transports_info_v2` info module for retrieving SNMP transport configuration from a cluster
- Added `get_snmp_config` helper function in `plugins/module_utils/v4/clusters_mgmt/helpers.py`
- Registered both modules in `meta/runtime.yml` action groups
- Added example playbook in `examples/cluster_management_v2/snmp_transport_v2.yml`
- Added integration tests under `tests/integration/targets/ntnx_snmp_transport_v2/` covering CRUD, check_mode, idempotency, and negative scenarios
- All examples and tests executed successfully against PC at 10.101.64.103 with logs stored in `examples_run_log.txt` and `tests_run_log.txt`

## Test plan
- [x] Examples playbook ran successfully (all assertions passed)
- [x] Integration tests passed (create, update, delete, check_mode, idempotency, negative tests)
- [x] black, isort, flake8 formatting checks pass
- [x] ansible-lint passes
- [x] ansible-test sanity validate-modules passes


Made with [Cursor](https://cursor.com)