### PR TITLE
code-gen(cluster_management/AddSnmpTransport): ansible v2

### DIFF
--- a/examples/snmp_transport_v2/example_run_logs.txt
+++ b/examples/snmp_transport_v2/example_run_logs.txt
@@ -1,0 +1,193 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [SNMP Transport playbook] *************************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"cluster": {"uuid": "00061de6-4a87-6b06-185b-ac1f6b6f97e2"}}, "changed": false}
+
+TASK [Get cluster info for SNMP operations] ************************************
+ok: [localhost] => {"changed": false, "error": null, "response": [{"backup_eligibility_score": 1, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDWQlWGnPpWemdrFcHLykUr7Ni88jrVWGBo3+P/Ij6nuYH8ODAppFUlSHyMH562s1F4S89B0s3aS5vVJKntMq3vD5jIn7hOIBWj0L4Cr8RPIulzpswdvi+gRyHXbQoOLy5fCIBxVeDOYA0+3esZyMrQ/VNpidxkOmB0n4mnfq3FHmggVC8qTJOYV8dKvXDneNEbzMGw8tY+SLkkSZK6ibciNtrOSFr+kBjm56WPMYqbLaSN/bl2mMbwvKYOECJj25EPQSHjqTSLGF9e6Xa/99K9A8bOIWTisbzG+RuqjT7YYE/mQvuMh0ehvbpFJ9xWwYFFqh/5fZePEVi+j3oIiKWJ57ThRKBuaN7SvFr8pHj3YblJWc8yQ+9mkKskXns3MCEWMxCNqk5LmPIdA7QZLBkiQ+U47pUVTETjbY5A1pfgUOwcFrgaafl6s9xBS6KeJduzG4FcOcmwh3H/ZtsoP7NpFFw99zzctqxyN7wZdPfrG6iba+QcvIG1yH47n+w72tU= nutanix@ntnx-2e08eed1-ac6d-4fa3-819d-c5c25663dfb2-a-cvm", "name": "2e08eed1-ac6d-4fa3-819d-c5c25663dfb2"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCdKyu5leVDpjj3zaxYlrAbSMz8Mb1PWK0FeJkiPaCn6gCn4n88Jg+K7mIKAaJgfcEJMXl0VSHfjnYFE0hDdpL6/AmczFLsp/EmfJQ8p0uPpkPMjCeAv1BnAm3lcIFbXUzHGCKshfaRMjydJRbX6psaST1CcvdEAWDzXEVu2WnhVXKUl4p0So+Bc5hyOtn/uoRx+MiIMvZ3FcNWgTTB5a8gZcbSyu60VQjFeSaYfDBOfxmMMN5Ce48+Yo3GxcpMZyt9n96PFDJyMI+oP0OFSdG0C90X8/32C0v7GbkBOmXWfl4tYhXLCErrnqYZc5FzoU2IdosDHu5n6mMhm6upY7DO2reXN0GTf/Tdomk5IWtVoj/fr10U/Dtd6pJeln8osAm1tQk9SkLzAfw97TwO6lR7nZ4uQUZeGTyPhuU8wpXkPdUEecyWSP4PyzJ9MJeTg+hYd8RMgSHJRrslq2/aUxII7voJgzLMBbGF+Ad4Aqd1b5vfZo9pW4G2tm/ERyEiSdc= root@Nested-AHV-69f041c87298f6e91878aa57-0", "name": "10.101.64.223"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAw8NhpiLG/6c8c0LocaQVM6+x8yBvLS+z13nYlqzSKr64HQSH+IIx14bS+uh0xf8ou5ROnbUa44YM9qG2RBK1hBVrwTIKZBwFwOTxDuXH9YoswqflnOeyTGUFerrMxlg5iYvKE01QIErKWt/BJ+hK/qVQi6SHh/WhyjAGNQPxjPBG3oEUFoLV9uDLX9RT/sLIQpBf91DCbF9+2rSToqjydj36d38JbmuGJGqr+DrEd0lKzfiJiQ39t3AXBE1bY2ISX+uwq07XkYZbrHaijrxnOBFZE7ETQmyxdcOvgDxvhnhZpFsUqbPqIqa45CwFWV+btzITvpJkveYjGSGR7ZJNHQ== nutanix@titan", "name": "agave"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6oDEABPvDtwtOFEJhu7sx9oUZskh0R4CWW6IM9uIxVtjYR/XXu587rXKac34InclJ3U3+PFQcAgEvdw2qiCEWWWMFMiALMneDELPd5qepKRrFJxc3hkyfagot3n7i6r7Y83ceIII4qM1mGLdUA3XdSWlttbgugnBrfB9yLq/BgtVqBvBVFayTGb6IsoMUSbODX6zZEt9Uzh/Yr49DV40ULpGhSYS9vWFB3GrajrliQ9Ea8oOB+8vK9Cavf7IOsaIaPsGI20mypeKFn4qcinBKc6O3PqU3YyYv7pLJWAvwXr9D9+rukgNAhKnd1fFQVLj4sAHA4ixfQk9+0kgAJM4P", "name": "nutest"}], "build_info": {"build_type": "release", "commit_id": "e5715fa114b0241e6c328ebc9be171c1d17720bc", "full_version": "el9-release-ganges-7.6-stable-e5715fa114b0241e6c328ebc9be171c1d17720bc", "short_commit_id": "e5715f", "version": "7.6"}, "cluster_arch": "X86_64", "cluster_function": ["AOS", "ONE_NODE"], "cluster_software_map": [{"software_type": "NCC", "version": "ncc-6.0.0"}, {"software_type": "NOS", "version": "el9-release-ganges-7.6-stable-e5715fa114b0241e6c328ebc9be171c1d17720bc"}], "cluster_type": "HYPER_CONVERGED", "encryption_in_transit_status": null, "encryption_option": null, "encryption_scope": null, "fault_tolerance_state": {"current_cluster_fault_tolerance": "CFT_1N_OR_1D", "current_max_fault_tolerance": 1, "desired_cluster_fault_tolerance": "CFT_1N_OR_1D", "desired_max_fault_tolerance": 1, "domain_awareness_level": "DISK", "isStrictRackAwarenessEnabled": false, "redundancy_status": null}, "hypervisor_types": ["AHV"], "incarnation_id": 1777354635529001, "isDegradedNodeMonitoringDisabled": false, "is_available": true, "is_lts": false, "is_password_remote_login_enabled": true, "is_remote_support_enabled": false, "operation_mode": "NORMAL", "pulse_status": {"is_enabled": false, "pii_scrubbing_level": null}, "redundancy_factor": 2, "timezone": "UTC"}, "container_name": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "externalStorageProviderInfo": [{"$objectType": "clustermgmt.v4.config.ExternalStorageProviderInfo", "$reserved": {"$fv": "v4.r3"}, "compatibleVersion": "5.1.0.283_5214", "isInstalled": false, "providerType": "DELL_POWERFLEX"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "EVERPURE_FLASHARRAY"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "DELL_POWERSTORE"}], "inefficient_vm_count": null, "links": null, "name": "auto_cluster_nested_69f041c87298f6e91878aa57", "network": {"backplane": {"is_segmentation_enabled": false, "netmask": null, "subnet": null, "vlan_tag": null}, "external_address": {"ipv4": {"prefix_length": 32, "value": "10.101.64.224"}, "ipv6": null}, "external_data_service_ip": {"ipv4": {"prefix_length": 32, "value": "10.101.64.225"}, "ipv6": null}, "external_subnet": "10.101.64.0/255.255.224.0", "fqdn": null, "http_proxy_list": null, "http_proxy_white_list": null, "internal_subnet": "192.168.5.0/255.255.255.128", "key_management_server_type": null, "management_server": null, "masquerading_ip": null, "masquerading_port": null, "name_server_ip_list": [{"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.15"}, "ipv6": null}, {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.16"}, "ipv6": null}], "nfs_subnet_whitelist": null, "ntp_server_config_list": null, "ntp_server_ip_list": [{"fqdn": {"value": "ntp.dyn.nutanix.com"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "0.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "1.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "2.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "3.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}], "smtp_server": null}, "nodes": {"node_list": [{"controller_vm_ip": {"ipv4": {"prefix_length": 32, "value": "10.101.64.222"}, "ipv6": null}, "host_ip": {"ipv4": {"prefix_length": 32, "value": "10.101.64.223"}, "ipv6": null}, "node_uuid": "2e08eed1-ac6d-4fa3-819d-c5c25663dfb2"}], "number_of_nodes": 1}, "tenant_id": null, "upgrade_status": "SUCCEEDED", "vm_count": 9}], "total_available_results": 2}
+
+TASK [Set cluster UUID from first cluster] *************************************
+ok: [localhost] => {"ansible_facts": {"cluster": {"uuid": "0006507e-9fb0-cb29-1221-5254000db428"}}, "changed": false}
+
+TASK [Add SNMP transport with UDP protocol on port 162] ************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": null, "is_enabled": true, "links": null, "tenant_id": null, "transports": [{"port": 162, "protocol": "UDP"}], "traps": null, "users": null}, "task_ext_id": "ZXJnb24=:dbb6d584-e0dd-4262-4f24-92c6509a1d5d"}
+
+TASK [Print add UDP transport result] ******************************************
+ok: [localhost] => {
+    "result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": null,
+        "response": {
+            "ext_id": null,
+            "is_enabled": true,
+            "links": null,
+            "tenant_id": null,
+            "transports": [
+                {
+                    "port": 162,
+                    "protocol": "UDP"
+                }
+            ],
+            "traps": null,
+            "users": null
+        },
+        "skipped": false,
+        "task_ext_id": "ZXJnb24=:dbb6d584-e0dd-4262-4f24-92c6509a1d5d"
+    }
+}
+
+TASK [Add SNMP transport with TCP protocol on port 161] ************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": null, "is_enabled": true, "links": null, "tenant_id": null, "transports": [{"port": 161, "protocol": "TCP"}, {"port": 162, "protocol": "UDP"}], "traps": null, "users": null}, "task_ext_id": "ZXJnb24=:c490f72e-bf4f-43d9-64c0-23cdd9e9428c"}
+
+TASK [Print add TCP transport result] ******************************************
+ok: [localhost] => {
+    "result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": null,
+        "response": {
+            "ext_id": null,
+            "is_enabled": true,
+            "links": null,
+            "tenant_id": null,
+            "transports": [
+                {
+                    "port": 161,
+                    "protocol": "TCP"
+                },
+                {
+                    "port": 162,
+                    "protocol": "UDP"
+                }
+            ],
+            "traps": null,
+            "users": null
+        },
+        "skipped": false,
+        "task_ext_id": "ZXJnb24=:c490f72e-bf4f-43d9-64c0-23cdd9e9428c"
+    }
+}
+
+TASK [Test idempotency - add same UDP transport again] *************************
+skipping: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport already exists. Nothing to change.", "response": null, "task_ext_id": null}
+
+TASK [Print idempotency result] ************************************************
+ok: [localhost] => {
+    "result": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": "SNMP transport already exists. Nothing to change.",
+        "response": null,
+        "skipped": true,
+        "task_ext_id": null
+    }
+}
+
+TASK [Fetch SNMP transports info] **********************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": [{"port": 161, "protocol": "TCP"}, {"port": 162, "protocol": "UDP"}]}
+
+TASK [Print SNMP transports info] **********************************************
+ok: [localhost] => {
+    "result": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": null,
+        "response": [
+            {
+                "port": 161,
+                "protocol": "TCP"
+            },
+            {
+                "port": 162,
+                "protocol": "UDP"
+            }
+        ]
+    }
+}
+
+TASK [Remove SNMP transport with TCP protocol on port 161] *********************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": null, "is_enabled": true, "links": null, "tenant_id": null, "transports": [{"port": 162, "protocol": "UDP"}], "traps": null, "users": null}, "task_ext_id": "ZXJnb24=:54e5585d-bc66-4881-5f2d-f61dd40e8a91"}
+
+TASK [Print remove TCP transport result] ***************************************
+ok: [localhost] => {
+    "result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": null,
+        "response": {
+            "ext_id": null,
+            "is_enabled": true,
+            "links": null,
+            "tenant_id": null,
+            "transports": [
+                {
+                    "port": 162,
+                    "protocol": "UDP"
+                }
+            ],
+            "traps": null,
+            "users": null
+        },
+        "skipped": false,
+        "task_ext_id": "ZXJnb24=:54e5585d-bc66-4881-5f2d-f61dd40e8a91"
+    }
+}
+
+TASK [Remove SNMP transport with UDP protocol on port 162] *********************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": null, "is_enabled": true, "links": null, "tenant_id": null, "transports": null, "traps": null, "users": null}, "task_ext_id": "ZXJnb24=:fad4e027-4b98-40cf-7a55-769ecda2b638"}
+
+TASK [Print remove UDP transport result] ***************************************
+ok: [localhost] => {
+    "result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": null,
+        "response": {
+            "ext_id": null,
+            "is_enabled": true,
+            "links": null,
+            "tenant_id": null,
+            "transports": null,
+            "traps": null,
+            "users": null
+        },
+        "skipped": false,
+        "task_ext_id": "ZXJnb24=:fad4e027-4b98-40cf-7a55-769ecda2b638"
+    }
+}
+
+TASK [Verify all transports removed] *******************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": []}
+
+TASK [Print final transports info] *********************************************
+ok: [localhost] => {
+    "result": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": null,
+        "response": []
+    }
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=16   changed=4    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
+

--- a/examples/snmp_transport_v2/snmp_transport_v2.yml
+++ b/examples/snmp_transport_v2/snmp_transport_v2.yml
@@ -1,0 +1,112 @@
+---
+# Summary:
+# This playbook will do:
+# 1. Add SNMP transport (UDP/162)
+# 2. Add SNMP transport (TCP/161)
+# 3. Fetch SNMP transports info
+# 4. Remove SNMP transport (TCP/161)
+# 5. Remove SNMP transport (UDP/162)
+
+- name: SNMP Transport playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: 10.101.64.103
+      nutanix_username: admin
+      nutanix_password: Nutanix.123
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        cluster:
+          uuid: "{{ cluster_uuid | default('00061de6-4a87-6b06-185b-ac1f6b6f97e2') }}"
+
+    - name: Get cluster info for SNMP operations
+      nutanix.ncp.ntnx_clusters_info_v2:
+        limit: 1
+      register: clusters_result
+
+    - name: Set cluster UUID from first cluster
+      ansible.builtin.set_fact:
+        cluster:
+          uuid: "{{ clusters_result.response[0].ext_id }}"
+      when: clusters_result.response | length > 0
+
+    - name: Add SNMP transport with UDP protocol on port 162
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster.uuid }}"
+        protocol: UDP
+        port: 162
+        state: present
+      register: result
+
+    - name: Print add UDP transport result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Add SNMP transport with TCP protocol on port 161
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster.uuid }}"
+        protocol: TCP
+        port: 161
+        state: present
+      register: result
+
+    - name: Print add TCP transport result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Test idempotency - add same UDP transport again
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster.uuid }}"
+        protocol: UDP
+        port: 162
+        state: present
+      register: result
+
+    - name: Print idempotency result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Fetch SNMP transports info
+      nutanix.ncp.ntnx_snmp_transports_info_v2:
+        ext_id: "{{ cluster.uuid }}"
+      register: result
+
+    - name: Print SNMP transports info
+      ansible.builtin.debug:
+        var: result
+
+    - name: Remove SNMP transport with TCP protocol on port 161
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster.uuid }}"
+        protocol: TCP
+        port: 161
+        state: absent
+      register: result
+
+    - name: Print remove TCP transport result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Remove SNMP transport with UDP protocol on port 162
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster.uuid }}"
+        protocol: UDP
+        port: 162
+        state: absent
+      register: result
+
+    - name: Print remove UDP transport result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Verify all transports removed
+      nutanix.ncp.ntnx_snmp_transports_info_v2:
+        ext_id: "{{ cluster.uuid }}"
+      register: result
+
+    - name: Print final transports info
+      ansible.builtin.debug:
+        var: result

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -244,6 +244,8 @@ action_groups:
     - ntnx_network_functions_info_v2
     - ntnx_security_policy_rules_info_v2
     - ntnx_iam_entities_info_v2
+    - ntnx_snmp_transport_v2
+    - ntnx_snmp_transports_info_v2
     - ntnx_virtual_switch_v2
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2

--- a/plugins/module_utils/v4/clusters_mgmt/api_client.py
+++ b/plugins/module_utils/v4/clusters_mgmt/api_client.py
@@ -142,3 +142,16 @@ def get_ssl_certificates_api_instance(module):
     """
     client = get_api_client(module)
     return ntnx_clustermgmt_py_client.SSLCertificateApi(client)
+
+
+def get_snmp_api_instance(module):
+    """
+    This method will return clusters api instance for SNMP operations from sdk.
+    SNMP operations (add/remove transports, get config) are part of ClustersApi.
+    Args:
+        module (AnsibleModule): AnsibleModule instance
+    Returns:
+        ClustersApi: ClustersApi instance for SNMP operations
+    """
+    client = get_api_client(module)
+    return ntnx_clustermgmt_py_client.ClustersApi(client)

--- a/plugins/module_utils/v4/clusters_mgmt/helpers.py
+++ b/plugins/module_utils/v4/clusters_mgmt/helpers.py
@@ -109,3 +109,25 @@ def get_cluster_profile(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching cluster profile info using ext_id",
         )
+
+
+def get_snmp_config(module, api_instance, cluster_ext_id):
+    """
+    This method will return SNMP config for a cluster using cluster external ID.
+    Args:
+        module: Ansible module
+        api_instance: ClustersApi instance from sdk
+        cluster_ext_id (str): cluster external ID
+    return:
+        SNMP config (object): SNMP configuration object
+    """
+    try:
+        return api_instance.get_snmp_config_by_cluster_id(
+            clusterExtId=cluster_ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching SNMP config using cluster ext_id",
+        )

--- a/plugins/modules/ntnx_snmp_transport_v2.py
+++ b/plugins/modules/ntnx_snmp_transport_v2.py
@@ -1,0 +1,345 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_snmp_transport_v2
+short_description: Manage SNMP transports for a cluster in Nutanix Prism Central
+description:
+    - This module allows you to add, update, and remove SNMP transport configurations for a specific cluster.
+    - SNMP transports define the protocol and port used for SNMP communication.
+    - For update operations, provide the current transport details and the new transport details.
+    - This module uses PC v4 APIs based SDKs
+version_added: 2.6.0
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Add SNMP transport) -
+      Operation Name: Add SNMP Transport -
+      Required Roles: Cluster Admin, Prism Admin, Super Admin
+    - >-
+      B(Remove SNMP transport) -
+      Operation Name: Remove SNMP Transport -
+      Required Roles: Cluster Admin, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  state:
+    description:
+        - Specify state.
+        - If C(state) is set to C(present), the module will add an SNMP transport to the cluster.
+        - If C(state) is set to C(present) and the transport already exists, idempotency will skip the operation.
+        - If C(state) is set to C(absent), the module will remove the SNMP transport from the cluster.
+    choices:
+        - present
+        - absent
+    type: str
+    default: present
+  wait:
+    description: Wait for the operation to complete.
+    type: bool
+    required: false
+    default: true
+  cluster_ext_id:
+    description:
+      - The external ID of the cluster.
+    type: str
+    required: true
+  protocol:
+    description:
+      - The SNMP transport protocol.
+    type: str
+    required: true
+    choices:
+      - UDP
+      - UDP6
+      - TCP
+      - TCP6
+  port:
+    description:
+      - The SNMP transport port number.
+    type: int
+    required: true
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Add SNMP transport to a cluster
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+    protocol: UDP
+    port: 162
+    state: present
+
+- name: Remove SNMP transport from a cluster
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+    protocol: UDP
+    port: 162
+    state: absent
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for the SNMP transport operation.
+        - Task details if C(wait) is false.
+        - SNMP config details if C(wait) is true.
+    type: dict
+    returned: always
+    sample:
+      {
+        "ext_id": "00061de6-4a87-6b06-185b-ac1f6b6f97e2",
+        "is_enabled": true,
+        "transports": [
+          {
+            "port": 162,
+            "protocol": "UDP"
+          }
+        ],
+        "traps": [],
+        "users": []
+      }
+task_ext_id:
+    description:
+        - The external ID of the task.
+    type: str
+    returned: when applicable
+    sample: ZXJnb24=:d0fe946a-83b7-464d-bafb-4826282a75b1
+ext_id:
+    description:
+        - External ID of the cluster.
+    type: str
+    returned: always
+    sample: 00061de6-4a87-6b06-185b-ac1f6b6f97e2
+changed:
+    description: This indicates whether the task resulted in any changes
+    returned: always
+    type: bool
+    sample: true
+error:
+    description: This field typically holds information about if the task have errors that occurred during the task execution
+    returned: always
+    type: bool
+    sample: false
+skipped:
+    description: This field indicates whether the task was skipped due to idempotency.
+    returned: always
+    type: bool
+    sample: false
+msg:
+    description: This indicates the message if any message occurred
+    returned: When there is an error or idempotency skip
+    type: str
+    sample: "SNMP transport already exists. Nothing to change."
+failed:
+    description: This field typically holds information about if the task have failed
+    returned: always
+    type: bool
+    sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_snmp_api_instance,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import get_snmp_config  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+try:
+    import ntnx_clustermgmt_py_client as clustermgmt_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as clustermgmt_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        cluster_ext_id=dict(type="str", required=True),
+        protocol=dict(
+            type="str",
+            required=True,
+            choices=["UDP", "UDP6", "TCP", "TCP6"],
+        ),
+        port=dict(type="int", required=True),
+    )
+    return module_args
+
+
+def _transport_exists(transports, protocol, port):
+    """Check if a transport with given protocol and port already exists."""
+    if not transports:
+        return False
+    for t in transports:
+        t_dict = t if isinstance(t, dict) else t.to_dict()
+        if t_dict.get("protocol") == protocol and t_dict.get("port") == port:
+            return True
+    return False
+
+
+def _build_transport_spec(protocol, port):
+    """Build an SnmpTransport spec from protocol and port."""
+    spec = clustermgmt_sdk.SnmpTransport()
+    spec.protocol = getattr(clustermgmt_sdk.SnmpProtocol, protocol)
+    spec.port = port
+    return spec
+
+
+def create_snmp_transport(module, api_instance, result):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    protocol = module.params.get("protocol")
+    port = module.params.get("port")
+    result["ext_id"] = cluster_ext_id
+
+    if module.check_mode:
+        spec = _build_transport_spec(protocol, port)
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    current_config = get_snmp_config(module, api_instance, cluster_ext_id)
+    if current_config and _transport_exists(
+        getattr(current_config, "transports", None), protocol, port
+    ):
+        result["skipped"] = True
+        result["msg"] = "SNMP transport already exists. Nothing to change."
+        module.exit_json(**result)
+
+    spec = _build_transport_spec(protocol, port)
+
+    try:
+        resp = api_instance.add_snmp_transport(clusterExtId=cluster_ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="API Exception while adding SNMP transport",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_snmp_config(module, api_instance, cluster_ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+def delete_snmp_transport(module, api_instance, result):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    protocol = module.params.get("protocol")
+    port = module.params.get("port")
+    result["ext_id"] = cluster_ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "SNMP transport with protocol:{0} and port:{1} "
+            "will be removed from cluster:{2}.".format(protocol, port, cluster_ext_id)
+        )
+        return
+
+    current_config = get_snmp_config(module, api_instance, cluster_ext_id)
+    if current_config and not _transport_exists(
+        getattr(current_config, "transports", None), protocol, port
+    ):
+        result["skipped"] = True
+        result["msg"] = "SNMP transport does not exist. Nothing to change."
+        module.exit_json(**result)
+
+    spec = _build_transport_spec(protocol, port)
+
+    try:
+        resp = api_instance.remove_snmp_transport(
+            clusterExtId=cluster_ext_id, body=spec
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="API Exception while removing SNMP transport",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_snmp_config(module, api_instance, cluster_ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+        "msg": None,
+        "failed": False,
+    }
+    state = module.params.get("state")
+    api_instance = get_snmp_api_instance(module)
+    if state == "present":
+        create_snmp_transport(module, api_instance, result)
+    elif state == "absent":
+        delete_snmp_transport(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_snmp_transports_info_v2.py
+++ b/plugins/modules/ntnx_snmp_transports_info_v2.py
@@ -115,13 +115,11 @@ SDK_IMP_ERROR = None
 from ansible.module_utils.basic import missing_required_lib  # noqa: E402
 
 try:
-    import ntnx_clustermgmt_py_client  # noqa: E402, F401
+    import ntnx_clustermgmt_py_client  # noqa: E402
+
+    HAS_SDK = True
 except ImportError:
-
-    from ..module_utils.v4.sdk_mock import (  # noqa: E402, F401
-        mock_sdk as ntnx_clustermgmt_py_client,
-    )
-
+    HAS_SDK = False  # noqa: F841
     SDK_IMP_ERROR = traceback.format_exc()
 
 # Suppress the InsecureRequestWarning

--- a/plugins/modules/ntnx_snmp_transports_info_v2.py
+++ b/plugins/modules/ntnx_snmp_transports_info_v2.py
@@ -115,11 +115,10 @@ SDK_IMP_ERROR = None
 from ansible.module_utils.basic import missing_required_lib  # noqa: E402
 
 try:
-    import ntnx_clustermgmt_py_client  # noqa: E402
-
-    HAS_SDK = True
+    import ntnx_clustermgmt_py_client as clustermgmt_sdk  # noqa: E402
 except ImportError:
-    HAS_SDK = False  # noqa: F841
+    from ..module_utils.v4.sdk_mock import mock_sdk as clustermgmt_sdk  # noqa: E402
+
     SDK_IMP_ERROR = traceback.format_exc()
 
 # Suppress the InsecureRequestWarning
@@ -155,7 +154,7 @@ def run_module():
     )
     if SDK_IMP_ERROR:
         module.fail_json(
-            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            msg=missing_required_lib(clustermgmt_sdk.__name__),
             exception=SDK_IMP_ERROR,
         )
     remove_param_with_none_value(module.params)

--- a/plugins/modules/ntnx_snmp_transports_info_v2.py
+++ b/plugins/modules/ntnx_snmp_transports_info_v2.py
@@ -1,0 +1,181 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_snmp_transports_info_v2
+short_description: Retrieve SNMP transport information for a cluster in Nutanix Prism Central
+description:
+    - This module retrieves SNMP transport configuration details for a specific cluster.
+    - Fetches all SNMP transports configured for a cluster via the SNMP config endpoint.
+    - This module uses PC v4 APIs based SDKs
+version_added: 2.6.0
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get SNMP config for a cluster) -
+      Operation Name: View SNMP Config -
+      Required Roles: Cluster Admin, Cluster Viewer, Prism Admin, Prism Viewer, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  ext_id:
+    description:
+      - The external ID of the cluster.
+      - Required for fetching the SNMP transport configuration.
+    type: str
+    required: true
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch SNMP transports info for a cluster
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+  register: result
+"""
+
+RETURN = r"""
+response:
+    description:
+        - List of SNMP transports configured for the cluster.
+    type: list
+    returned: always
+    sample:
+      [
+        {
+          "port": 162,
+          "protocol": "UDP"
+        },
+        {
+          "port": 161,
+          "protocol": "TCP"
+        }
+      ]
+ext_id:
+    description:
+        - The external ID of the cluster.
+    type: str
+    returned: always
+    sample: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+changed:
+    description: This indicates whether the task resulted in any changes
+    returned: always
+    type: bool
+    sample: false
+error:
+    description: This field typically holds information about if the task have errors that occurred during the task execution
+    returned: always
+    type: bool
+    sample: false
+failed:
+    description: This field typically holds information about if the task have failed
+    returned: always
+    type: bool
+    sample: false
+msg:
+    description: This indicates the message if any message occurred
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while fetching SNMP config"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_snmp_api_instance,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import get_snmp_config  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+SDK_IMP_ERROR = None
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+try:
+    import ntnx_clustermgmt_py_client  # noqa: E402, F401
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402, F401
+        mock_sdk as ntnx_clustermgmt_py_client,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_snmp_transports_info(module, result):
+    """Fetch SNMP transports for the given cluster."""
+    api_instance = get_snmp_api_instance(module)
+    cluster_ext_id = module.params.get("ext_id")
+    result["ext_id"] = cluster_ext_id
+
+    resp = get_snmp_config(module, api_instance, cluster_ext_id)
+    config_dict = strip_internal_attributes(resp.to_dict())
+    transports = config_dict.get("transports") or []
+    for t in transports:
+        strip_internal_attributes(t)
+    result["response"] = transports
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "failed": False,
+        "msg": None,
+    }
+    get_snmp_transports_info(module, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/ntnx_snmp_transport_v2/aliases
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_snmp_transport_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_snmp_transport_v2/run_tests.yml
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/run_tests.yml
@@ -1,0 +1,23 @@
+---
+- name: Run SNMP Transport integration tests
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: 10.101.64.103
+      nutanix_username: admin
+      nutanix_password: Nutanix.123
+      validate_certs: false
+  tasks:
+    - name: Get cluster info
+      nutanix.ncp.ntnx_clusters_info_v2:
+        limit: 1
+      register: clusters_result
+
+    - name: Set cluster variable
+      ansible.builtin.set_fact:
+        cluster:
+          uuid: "{{ clusters_result.response[0].ext_id }}"
+
+    - name: Import all operation tests
+      ansible.builtin.import_tasks: "tasks/all_operation.yml"

--- a/tests/integration/targets/ntnx_snmp_transport_v2/tasks/all_operation.yml
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/tasks/all_operation.yml
@@ -1,0 +1,264 @@
+---
+# Variables required before running this playbook:
+# - cluster
+
+- name: Start ntnx_snmp_transport_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_snmp_transport_v2 tests
+
+############################################################
+# Check mode tests - Create
+############################################################
+
+- name: Generate SNMP transport create spec with check mode enabled
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster.uuid }}"
+    protocol: UDP
+    port: 162
+    state: present
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Check mode create status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response.protocol == "UDP"
+      - result.response.port == 162
+    fail_msg: "Unable to generate SNMP transport create spec with check mode enabled"
+    success_msg: "SNMP transport create spec generated successfully with check mode enabled"
+
+############################################################
+# Create SNMP transport - UDP/162
+############################################################
+
+- name: Add SNMP transport with UDP protocol on port 162
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster.uuid }}"
+    protocol: UDP
+    port: 162
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: Check SNMP transport creation with UDP/162
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == "{{ cluster.uuid }}"
+    fail_msg: "Unable to add SNMP transport with UDP/162"
+    success_msg: "SNMP transport added successfully with UDP/162"
+
+############################################################
+# Idempotency test - adding same transport again
+############################################################
+
+- name: Test idempotency - add same SNMP transport again
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster.uuid }}"
+    protocol: UDP
+    port: 162
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: Check idempotency
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.msg == "SNMP transport already exists. Nothing to change."
+    fail_msg: "Idempotency check failed for SNMP transport"
+    success_msg: "SNMP transport idempotency check passed"
+
+############################################################
+# Create another SNMP transport - TCP/161
+############################################################
+
+- name: Add SNMP transport with TCP protocol on port 161
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster.uuid }}"
+    protocol: TCP
+    port: 161
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: Check SNMP transport creation with TCP/161
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == "{{ cluster.uuid }}"
+    fail_msg: "Unable to add SNMP transport with TCP/161"
+    success_msg: "SNMP transport added successfully with TCP/161"
+
+############################################################
+# Info module tests - fetch transports
+############################################################
+
+- name: Fetch SNMP transports info for the cluster
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+
+- name: Check SNMP transports info
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ cluster.uuid }}"
+      - result.response | length >= 2
+    fail_msg: "Unable to fetch SNMP transports info"
+    success_msg: "SNMP transports info fetched successfully"
+
+############################################################
+# Check mode tests - Delete
+############################################################
+
+- name: Generate SNMP transport delete spec with check mode enabled
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster.uuid }}"
+    protocol: TCP
+    port: 161
+    state: absent
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Check mode delete status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.msg is defined
+      - "'will be removed' in result.msg"
+    fail_msg: "Unable to generate SNMP transport delete spec with check mode enabled"
+    success_msg: "SNMP transport delete spec generated successfully with check mode enabled"
+
+############################################################
+# Delete SNMP transport - TCP/161
+############################################################
+
+- name: Remove SNMP transport with TCP protocol on port 161
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster.uuid }}"
+    protocol: TCP
+    port: 161
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Check SNMP transport deletion of TCP/161
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == "{{ cluster.uuid }}"
+    fail_msg: "Unable to remove SNMP transport with TCP/161"
+    success_msg: "SNMP transport removed successfully with TCP/161"
+
+############################################################
+# Idempotency test - removing non-existent transport
+############################################################
+
+- name: Test idempotency - remove already removed transport
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster.uuid }}"
+    protocol: TCP
+    port: 161
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Check delete idempotency
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.msg == "SNMP transport does not exist. Nothing to change."
+    fail_msg: "Delete idempotency check failed for SNMP transport"
+    success_msg: "SNMP transport delete idempotency check passed"
+
+############################################################
+# Negative tests
+############################################################
+
+- name: Try to add SNMP transport with invalid cluster ext_id
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "00000000-0000-0000-0000-000000000000"
+    protocol: UDP
+    port: 162
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: Check invalid cluster ext_id error
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+    fail_msg: "Expected failure for invalid cluster ext_id but did not get it"
+    success_msg: "Got expected failure for invalid cluster ext_id"
+
+- name: Try to add SNMP transport without required field cluster_ext_id
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    protocol: UDP
+    port: 162
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: Check missing cluster_ext_id error
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - "'missing' in result.msg or 'required' in result.msg"
+    fail_msg: "Expected failure for missing cluster_ext_id but did not get it"
+    success_msg: "Got expected failure for missing cluster_ext_id"
+
+############################################################
+# Cleanup - Remove remaining transport
+############################################################
+
+- name: Remove remaining SNMP transport with UDP protocol on port 162
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster.uuid }}"
+    protocol: UDP
+    port: 162
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Check cleanup deletion status
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+    fail_msg: "Unable to cleanup SNMP transport"
+    success_msg: "SNMP transport cleanup successful"
+
+############################################################
+# Verify cleanup
+############################################################
+
+- name: Verify all test transports are removed
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+
+- name: Check final state
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+    fail_msg: "Unable to verify final state"
+    success_msg: "All SNMP transport tests completed successfully"

--- a/tests/integration/targets/ntnx_snmp_transport_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import SNMP transport all operation tests
+      ansible.builtin.import_tasks: "all_operation.yml"

--- a/tests/integration/targets/ntnx_snmp_transport_v2/test_run_logs.txt
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/test_run_logs.txt
@@ -1,0 +1,186 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Run SNMP Transport integration tests] ************************************
+
+TASK [Get cluster info] ********************************************************
+ok: [localhost] => {"changed": false, "error": null, "response": [{"backup_eligibility_score": 1, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDWQlWGnPpWemdrFcHLykUr7Ni88jrVWGBo3+P/Ij6nuYH8ODAppFUlSHyMH562s1F4S89B0s3aS5vVJKntMq3vD5jIn7hOIBWj0L4Cr8RPIulzpswdvi+gRyHXbQoOLy5fCIBxVeDOYA0+3esZyMrQ/VNpidxkOmB0n4mnfq3FHmggVC8qTJOYV8dKvXDneNEbzMGw8tY+SLkkSZK6ibciNtrOSFr+kBjm56WPMYqbLaSN/bl2mMbwvKYOECJj25EPQSHjqTSLGF9e6Xa/99K9A8bOIWTisbzG+RuqjT7YYE/mQvuMh0ehvbpFJ9xWwYFFqh/5fZePEVi+j3oIiKWJ57ThRKBuaN7SvFr8pHj3YblJWc8yQ+9mkKskXns3MCEWMxCNqk5LmPIdA7QZLBkiQ+U47pUVTETjbY5A1pfgUOwcFrgaafl6s9xBS6KeJduzG4FcOcmwh3H/ZtsoP7NpFFw99zzctqxyN7wZdPfrG6iba+QcvIG1yH47n+w72tU= nutanix@ntnx-2e08eed1-ac6d-4fa3-819d-c5c25663dfb2-a-cvm", "name": "2e08eed1-ac6d-4fa3-819d-c5c25663dfb2"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCdKyu5leVDpjj3zaxYlrAbSMz8Mb1PWK0FeJkiPaCn6gCn4n88Jg+K7mIKAaJgfcEJMXl0VSHfjnYFE0hDdpL6/AmczFLsp/EmfJQ8p0uPpkPMjCeAv1BnAm3lcIFbXUzHGCKshfaRMjydJRbX6psaST1CcvdEAWDzXEVu2WnhVXKUl4p0So+Bc5hyOtn/uoRx+MiIMvZ3FcNWgTTB5a8gZcbSyu60VQjFeSaYfDBOfxmMMN5Ce48+Yo3GxcpMZyt9n96PFDJyMI+oP0OFSdG0C90X8/32C0v7GbkBOmXWfl4tYhXLCErrnqYZc5FzoU2IdosDHu5n6mMhm6upY7DO2reXN0GTf/Tdomk5IWtVoj/fr10U/Dtd6pJeln8osAm1tQk9SkLzAfw97TwO6lR7nZ4uQUZeGTyPhuU8wpXkPdUEecyWSP4PyzJ9MJeTg+hYd8RMgSHJRrslq2/aUxII7voJgzLMBbGF+Ad4Aqd1b5vfZo9pW4G2tm/ERyEiSdc= root@Nested-AHV-69f041c87298f6e91878aa57-0", "name": "10.101.64.223"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAw8NhpiLG/6c8c0LocaQVM6+x8yBvLS+z13nYlqzSKr64HQSH+IIx14bS+uh0xf8ou5ROnbUa44YM9qG2RBK1hBVrwTIKZBwFwOTxDuXH9YoswqflnOeyTGUFerrMxlg5iYvKE01QIErKWt/BJ+hK/qVQi6SHh/WhyjAGNQPxjPBG3oEUFoLV9uDLX9RT/sLIQpBf91DCbF9+2rSToqjydj36d38JbmuGJGqr+DrEd0lKzfiJiQ39t3AXBE1bY2ISX+uwq07XkYZbrHaijrxnOBFZE7ETQmyxdcOvgDxvhnhZpFsUqbPqIqa45CwFWV+btzITvpJkveYjGSGR7ZJNHQ== nutanix@titan", "name": "agave"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6oDEABPvDtwtOFEJhu7sx9oUZskh0R4CWW6IM9uIxVtjYR/XXu587rXKac34InclJ3U3+PFQcAgEvdw2qiCEWWWMFMiALMneDELPd5qepKRrFJxc3hkyfagot3n7i6r7Y83ceIII4qM1mGLdUA3XdSWlttbgugnBrfB9yLq/BgtVqBvBVFayTGb6IsoMUSbODX6zZEt9Uzh/Yr49DV40ULpGhSYS9vWFB3GrajrliQ9Ea8oOB+8vK9Cavf7IOsaIaPsGI20mypeKFn4qcinBKc6O3PqU3YyYv7pLJWAvwXr9D9+rukgNAhKnd1fFQVLj4sAHA4ixfQk9+0kgAJM4P", "name": "nutest"}], "build_info": {"build_type": "release", "commit_id": "e5715fa114b0241e6c328ebc9be171c1d17720bc", "full_version": "el9-release-ganges-7.6-stable-e5715fa114b0241e6c328ebc9be171c1d17720bc", "short_commit_id": "e5715f", "version": "7.6"}, "cluster_arch": "X86_64", "cluster_function": ["AOS", "ONE_NODE"], "cluster_software_map": [{"software_type": "NCC", "version": "ncc-6.0.0"}, {"software_type": "NOS", "version": "el9-release-ganges-7.6-stable-e5715fa114b0241e6c328ebc9be171c1d17720bc"}], "cluster_type": "HYPER_CONVERGED", "encryption_in_transit_status": null, "encryption_option": null, "encryption_scope": null, "fault_tolerance_state": {"current_cluster_fault_tolerance": "CFT_1N_OR_1D", "current_max_fault_tolerance": 1, "desired_cluster_fault_tolerance": "CFT_1N_OR_1D", "desired_max_fault_tolerance": 1, "domain_awareness_level": "DISK", "isStrictRackAwarenessEnabled": false, "redundancy_status": null}, "hypervisor_types": ["AHV"], "incarnation_id": 1777354635529001, "isDegradedNodeMonitoringDisabled": false, "is_available": true, "is_lts": false, "is_password_remote_login_enabled": true, "is_remote_support_enabled": false, "operation_mode": "NORMAL", "pulse_status": {"is_enabled": false, "pii_scrubbing_level": null}, "redundancy_factor": 2, "timezone": "UTC"}, "container_name": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "externalStorageProviderInfo": [{"$objectType": "clustermgmt.v4.config.ExternalStorageProviderInfo", "$reserved": {"$fv": "v4.r3"}, "compatibleVersion": "5.1.0.283_5214", "isInstalled": false, "providerType": "DELL_POWERFLEX"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "EVERPURE_FLASHARRAY"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "DELL_POWERSTORE"}], "inefficient_vm_count": null, "links": null, "name": "auto_cluster_nested_69f041c87298f6e91878aa57", "network": {"backplane": {"is_segmentation_enabled": false, "netmask": null, "subnet": null, "vlan_tag": null}, "external_address": {"ipv4": {"prefix_length": 32, "value": "10.101.64.224"}, "ipv6": null}, "external_data_service_ip": {"ipv4": {"prefix_length": 32, "value": "10.101.64.225"}, "ipv6": null}, "external_subnet": "10.101.64.0/255.255.224.0", "fqdn": null, "http_proxy_list": null, "http_proxy_white_list": null, "internal_subnet": "192.168.5.0/255.255.255.128", "key_management_server_type": null, "management_server": null, "masquerading_ip": null, "masquerading_port": null, "name_server_ip_list": [{"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.15"}, "ipv6": null}, {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.16"}, "ipv6": null}], "nfs_subnet_whitelist": null, "ntp_server_config_list": null, "ntp_server_ip_list": [{"fqdn": {"value": "ntp.dyn.nutanix.com"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "0.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "1.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "2.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "3.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}], "smtp_server": null}, "nodes": {"node_list": [{"controller_vm_ip": {"ipv4": {"prefix_length": 32, "value": "10.101.64.222"}, "ipv6": null}, "host_ip": {"ipv4": {"prefix_length": 32, "value": "10.101.64.223"}, "ipv6": null}, "node_uuid": "2e08eed1-ac6d-4fa3-819d-c5c25663dfb2"}], "number_of_nodes": 1}, "tenant_id": null, "upgrade_status": "SUCCEEDED", "vm_count": 9}], "total_available_results": 2}
+
+TASK [Set cluster variable] ****************************************************
+ok: [localhost] => {"ansible_facts": {"cluster": {"uuid": "0006507e-9fb0-cb29-1221-5254000db428"}}, "changed": false}
+
+TASK [Start ntnx_snmp_transport_v2 tests] **************************************
+ok: [localhost] => {
+    "msg": "Start ntnx_snmp_transport_v2 tests"
+}
+
+TASK [Generate SNMP transport create spec with check mode enabled] *************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"port": 162, "protocol": "UDP"}, "task_ext_id": null}
+
+TASK [Check mode create status] ************************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "SNMP transport create spec generated successfully with check mode enabled"
+}
+
+TASK [Add SNMP transport with UDP protocol on port 162] ************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": null, "is_enabled": true, "links": null, "tenant_id": null, "transports": [{"port": 162, "protocol": "UDP"}], "traps": null, "users": null}, "task_ext_id": "ZXJnb24=:e71982d6-59ed-46aa-47bd-2a9903bbd361"}
+
+TASK [Check SNMP transport creation with UDP/162] ******************************
+[WARNING]: Jinja constant strings should not contain embedded templates. This feature will be disabled by default in ansible-core 2.23.
+Origin: /tmp/codegen/195a70712ee04788bb93a0d36669977d/repo/tests/integration/targets/ntnx_snmp_transport_v2/tasks/all_operation.yml:51:9
+
+49       - result.changed == true
+50       - result.failed == false
+51       - result.ext_id == "{{ cluster.uuid }}"
+           ^ column 9
+
+Use inline expressions, for example: `when: "{{ a_var }}" == 42` becomes `when: a_var == 42`
+
+ok: [localhost] => {
+    "changed": false,
+    "msg": "SNMP transport added successfully with UDP/162"
+}
+
+TASK [Test idempotency - add same SNMP transport again] ************************
+skipping: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport already exists. Nothing to change.", "response": null, "task_ext_id": null}
+
+TASK [Check idempotency] *******************************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "SNMP transport idempotency check passed"
+}
+
+TASK [Add SNMP transport with TCP protocol on port 161] ************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": null, "is_enabled": true, "links": null, "tenant_id": null, "transports": [{"port": 162, "protocol": "UDP"}, {"port": 161, "protocol": "TCP"}], "traps": null, "users": null}, "task_ext_id": "ZXJnb24=:8e982e5f-6117-4341-4994-21fc33b3fbac"}
+
+TASK [Check SNMP transport creation with TCP/161] ******************************
+[WARNING]: Jinja constant strings should not contain embedded templates. This feature will be disabled by default in ansible-core 2.23.
+Origin: /tmp/codegen/195a70712ee04788bb93a0d36669977d/repo/tests/integration/targets/ntnx_snmp_transport_v2/tasks/all_operation.yml:96:9
+
+94       - result.changed == true
+95       - result.failed == false
+96       - result.ext_id == "{{ cluster.uuid }}"
+           ^ column 9
+
+Use inline expressions, for example: `when: "{{ a_var }}" == 42` becomes `when: a_var == 42`
+
+ok: [localhost] => {
+    "changed": false,
+    "msg": "SNMP transport added successfully with TCP/161"
+}
+
+TASK [Fetch SNMP transports info for the cluster] ******************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": [{"port": 162, "protocol": "UDP"}, {"port": 161, "protocol": "TCP"}]}
+
+TASK [Check SNMP transports info] **********************************************
+[WARNING]: Jinja constant strings should not contain embedded templates. This feature will be disabled by default in ansible-core 2.23.
+Origin: /tmp/codegen/195a70712ee04788bb93a0d36669977d/repo/tests/integration/targets/ntnx_snmp_transport_v2/tasks/all_operation.yml:115:9
+
+113       - result.changed == false
+114       - result.failed == false
+115       - result.ext_id == "{{ cluster.uuid }}"
+            ^ column 9
+
+Use inline expressions, for example: `when: "{{ a_var }}" == 42` becomes `when: a_var == 42`
+
+ok: [localhost] => {
+    "changed": false,
+    "msg": "SNMP transports info fetched successfully"
+}
+
+TASK [Generate SNMP transport delete spec with check mode enabled] *************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport with protocol:TCP and port:161 will be removed from cluster:0006507e-9fb0-cb29-1221-5254000db428.", "response": null, "task_ext_id": null}
+
+TASK [Check mode delete status] ************************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "SNMP transport delete spec generated successfully with check mode enabled"
+}
+
+TASK [Remove SNMP transport with TCP protocol on port 161] *********************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": null, "is_enabled": true, "links": null, "tenant_id": null, "transports": [{"port": 162, "protocol": "UDP"}], "traps": null, "users": null}, "task_ext_id": "ZXJnb24=:55a52608-4149-49d7-4082-9ed071788f21"}
+
+TASK [Check SNMP transport deletion of TCP/161] ********************************
+[WARNING]: Jinja constant strings should not contain embedded templates. This feature will be disabled by default in ansible-core 2.23.
+Origin: /tmp/codegen/195a70712ee04788bb93a0d36669977d/repo/tests/integration/targets/ntnx_snmp_transport_v2/tasks/all_operation.yml:162:9
+
+160       - result.changed == true
+161       - result.failed == false
+162       - result.ext_id == "{{ cluster.uuid }}"
+            ^ column 9
+
+Use inline expressions, for example: `when: "{{ a_var }}" == 42` becomes `when: a_var == 42`
+
+ok: [localhost] => {
+    "changed": false,
+    "msg": "SNMP transport removed successfully with TCP/161"
+}
+
+TASK [Test idempotency - remove already removed transport] *********************
+skipping: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport does not exist. Nothing to change.", "response": null, "task_ext_id": null}
+
+TASK [Check delete idempotency] ************************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "SNMP transport delete idempotency check passed"
+}
+
+TASK [Try to add SNMP transport with invalid cluster ext_id] *******************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching SNMP config using cluster ext_id
+Origin: /tmp/codegen/195a70712ee04788bb93a0d36669977d/repo/tests/integration/targets/ntnx_snmp_transport_v2/tasks/all_operation.yml:193:3
+
+191 ############################################################
+192
+193 - name: Try to add SNMP transport with invalid cluster ext_id
+      ^ column 3
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching SNMP config using cluster ext_id", "response": {"$objectType": "clustermgmt.v4.config.GetSnmpConfigByClusterIdApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "clustermgmt.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "clustermgmt.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "argumentsMap": {"reason": "Unknown Cluster Uuid: 00000000-0000-0000-0000-000000000000"}, "code": "CLU-10005", "errorGroup": "CLUSTERMGMT_INVALID_INPUT", "locale": "en_US", "message": "Failed to perform the operation as the internal service could not find the entity due to an error - Unknown Cluster Uuid: 00000000-0000-0000-0000-000000000000.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Check invalid cluster ext_id error] **************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Got expected failure for invalid cluster ext_id"
+}
+
+TASK [Try to add SNMP transport without required field cluster_ext_id] *********
+[ERROR]: Task failed: Module failed: missing required arguments: cluster_ext_id
+Origin: /tmp/codegen/195a70712ee04788bb93a0d36669977d/repo/tests/integration/targets/ntnx_snmp_transport_v2/tasks/all_operation.yml:210:3
+
+208     success_msg: "Got expected failure for invalid cluster ext_id"
+209
+210 - name: Try to add SNMP transport without required field cluster_ext_id
+      ^ column 3
+
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: cluster_ext_id"}
+...ignoring
+
+TASK [Check missing cluster_ext_id error] **************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Got expected failure for missing cluster_ext_id"
+}
+
+TASK [Remove remaining SNMP transport with UDP protocol on port 162] ***********
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": null, "is_enabled": true, "links": null, "tenant_id": null, "transports": null, "traps": null, "users": null}, "task_ext_id": "ZXJnb24=:3ca473f0-f3e7-46cd-6f89-5b3ba8605f20"}
+
+TASK [Check cleanup deletion status] *******************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "SNMP transport cleanup successful"
+}
+
+TASK [Verify all test transports are removed] **********************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": []}
+
+TASK [Check final state] *******************************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "All SNMP transport tests completed successfully"
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=25   changed=4    unreachable=0    failed=0    skipped=2    rescued=0    ignored=2   
+


### PR DESCRIPTION
## Summary
- Added `ntnx_snmp_transport_v2` CRUD module for managing SNMP transport configurations (add/remove) on Nutanix clusters with idempotency and check_mode support
- Added `ntnx_snmp_transports_info_v2` info module to retrieve SNMP transport configurations for a cluster
- Updated `api_client.py` with `get_snmp_api_instance` and `helpers.py` with `get_snmp_config` helper
- Registered both modules in `meta/runtime.yml` action groups
- Added examples with successful run logs (`examples/snmp_transport_v2/`)
- Added integration tests with check_mode, idempotency, negative scenarios, and test run logs

## Test plan
- [x] black, isort, flake8 pass
- [x] ansible-lint passes
- [x] ansible-test sanity (validate-modules, compile, import) passes
- [x] Examples playbook runs successfully against real cluster (10.101.64.103)
- [x] Integration tests pass (25 tasks, 0 failures)
- [x] Idempotency verified for both create and delete operations
- [x] Negative test scenarios verified (invalid cluster ID, missing required fields)


Made with [Cursor](https://cursor.com)