### PR TITLE
code-gen(cluster_management/AddSnmpTransport): ansible v2

### DIFF
--- a/example_logs_snmp_transport.txt
+++ b/example_logs_snmp_transport.txt
@@ -1,0 +1,253 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [SNMP Transport CRUD playbook] ********************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"cluster_ext_id": "0006507e-9fb0-cb29-1221-5254000db428"}, "changed": false}
+
+TASK [Add SNMP transport with check mode] **************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"port": 162, "protocol": "UDP"}, "task_ext_id": null}
+
+TASK [Check mode result for add SNMP transport] ********************************
+ok: [localhost] => {
+    "result": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": null,
+        "response": {
+            "port": 162,
+            "protocol": "UDP"
+        },
+        "skipped": false,
+        "task_ext_id": null
+    }
+}
+
+TASK [Verify check mode add result] ********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Check mode add SNMP transport passed"
+}
+
+TASK [Add SNMP transport] ******************************************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": "ZXJnb24=:9010cf85-0e39-4e23-48de-b8b0432ffccc"}, "task_ext_id": "ZXJnb24=:9010cf85-0e39-4e23-48de-b8b0432ffccc"}
+
+TASK [Add SNMP transport result] ***********************************************
+ok: [localhost] => {
+    "result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": null,
+        "response": {
+            "ext_id": "ZXJnb24=:9010cf85-0e39-4e23-48de-b8b0432ffccc"
+        },
+        "skipped": false,
+        "task_ext_id": "ZXJnb24=:9010cf85-0e39-4e23-48de-b8b0432ffccc"
+    }
+}
+
+TASK [Verify add SNMP transport] ***********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Add SNMP transport passed"
+}
+
+TASK [Add same SNMP transport again (idempotency)] *****************************
+skipping: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport already exists on cluster.", "response": null, "task_ext_id": null}
+
+TASK [Idempotency result] ******************************************************
+ok: [localhost] => {
+    "result": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": "SNMP transport already exists on cluster.",
+        "response": null,
+        "skipped": true,
+        "task_ext_id": null
+    }
+}
+
+TASK [Verify idempotency] ******************************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Idempotency check passed"
+}
+
+TASK [Fetch all SNMP transports] ***********************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": [{"port": 162, "protocol": "UDP"}]}
+
+TASK [Fetch all SNMP transports result] ****************************************
+ok: [localhost] => {
+    "result": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "response": [
+            {
+                "port": 162,
+                "protocol": "UDP"
+            }
+        ]
+    }
+}
+
+TASK [Verify fetch all SNMP transports] ****************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Fetch all SNMP transports passed"
+}
+
+TASK [Fetch specific SNMP transport] *******************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": {"port": 162, "protocol": "UDP"}}
+
+TASK [Fetch specific SNMP transport result] ************************************
+ok: [localhost] => {
+    "result": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "response": {
+            "port": 162,
+            "protocol": "UDP"
+        }
+    }
+}
+
+TASK [Verify fetch specific SNMP transport] ************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Fetch specific SNMP transport passed"
+}
+
+TASK [Update SNMP transport (change port from 162 to 163, protocol from UDP to TCP)] ***
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": "ZXJnb24=:c78b9495-e928-4f1c-4a1f-ee18742f646b"}, "task_ext_id": "ZXJnb24=:c78b9495-e928-4f1c-4a1f-ee18742f646b"}
+
+TASK [Update SNMP transport result] ********************************************
+ok: [localhost] => {
+    "result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": null,
+        "response": {
+            "ext_id": "ZXJnb24=:c78b9495-e928-4f1c-4a1f-ee18742f646b"
+        },
+        "skipped": false,
+        "task_ext_id": "ZXJnb24=:c78b9495-e928-4f1c-4a1f-ee18742f646b"
+    }
+}
+
+TASK [Verify update SNMP transport] ********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Update SNMP transport passed"
+}
+
+TASK [Fetch updated SNMP transport] ********************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": {"port": 163, "protocol": "TCP"}}
+
+TASK [Fetch updated transport result] ******************************************
+ok: [localhost] => {
+    "result": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "response": {
+            "port": 163,
+            "protocol": "TCP"
+        }
+    }
+}
+
+TASK [Verify fetch updated SNMP transport] *************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Fetch updated SNMP transport passed"
+}
+
+TASK [Remove SNMP transport with check mode] ***********************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport with port 163 and protocol TCP will be removed.", "response": null, "task_ext_id": null}
+
+TASK [Check mode result for remove SNMP transport] *****************************
+ok: [localhost] => {
+    "result": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": "SNMP transport with port 163 and protocol TCP will be removed.",
+        "response": null,
+        "skipped": false,
+        "task_ext_id": null
+    }
+}
+
+TASK [Verify check mode remove result] *****************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Check mode remove SNMP transport passed"
+}
+
+TASK [Remove SNMP transport] ***************************************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": "ZXJnb24=:5328c578-d9d3-4880-5d24-202d8d99d07a"}, "task_ext_id": "ZXJnb24=:5328c578-d9d3-4880-5d24-202d8d99d07a"}
+
+TASK [Remove SNMP transport result] ********************************************
+ok: [localhost] => {
+    "result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": null,
+        "response": {
+            "ext_id": "ZXJnb24=:5328c578-d9d3-4880-5d24-202d8d99d07a"
+        },
+        "skipped": false,
+        "task_ext_id": "ZXJnb24=:5328c578-d9d3-4880-5d24-202d8d99d07a"
+    }
+}
+
+TASK [Verify remove SNMP transport] ********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Remove SNMP transport passed"
+}
+
+TASK [Remove same SNMP transport again (idempotency)] **************************
+skipping: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport with port 163 and protocol TCP not found. Nothing to delete.", "response": null, "task_ext_id": null}
+
+TASK [Idempotency remove result] ***********************************************
+ok: [localhost] => {
+    "result": {
+        "changed": false,
+        "error": null,
+        "ext_id": "0006507e-9fb0-cb29-1221-5254000db428",
+        "failed": false,
+        "msg": "SNMP transport with port 163 and protocol TCP not found. Nothing to delete.",
+        "response": null,
+        "skipped": true,
+        "task_ext_id": null
+    }
+}
+
+TASK [Verify remove idempotency] ***********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Idempotency remove check passed"
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=29   changed=3    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   
+

--- a/examples/cluster_management_v2/snmp_transport_v2.yml
+++ b/examples/cluster_management_v2/snmp_transport_v2.yml
@@ -1,0 +1,259 @@
+---
+# Summary:
+# This playbook will do:
+# 1. Add SNMP transport to a cluster using check mode
+# 2. Add SNMP transport to a cluster
+# 3. Verify idempotency on add (same transport)
+# 4. Fetch all SNMP transports info
+# 5. Fetch specific SNMP transport info by port and protocol
+# 6. Update SNMP transport (change port/protocol)
+# 7. Fetch updated transport info
+# 8. Remove SNMP transport using check mode
+# 9. Remove SNMP transport
+# 10. Verify idempotency on remove (transport already removed)
+
+- name: SNMP Transport CRUD playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "10.101.64.103"
+      nutanix_username: "admin"
+      nutanix_password: "Nutanix.123"
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        cluster_ext_id: "0006507e-9fb0-cb29-1221-5254000db428"
+
+    ################################################################
+    # Add SNMP transport with check mode
+    ################################################################
+    - name: Add SNMP transport with check mode
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        port: 162
+        protocol: "UDP"
+      check_mode: true
+      register: result
+
+    - name: Check mode result for add SNMP transport
+      ansible.builtin.debug:
+        var: result
+
+    - name: Verify check mode add result
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed == false
+          - result.response.port == 162
+          - result.response.protocol == "UDP"
+        fail_msg: "Check mode add SNMP transport failed"
+        success_msg: "Check mode add SNMP transport passed"
+
+    ################################################################
+    # Add SNMP transport
+    ################################################################
+    - name: Add SNMP transport
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        port: 162
+        protocol: "UDP"
+      register: result
+
+    - name: Add SNMP transport result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Verify add SNMP transport
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+          - result.failed == false
+        fail_msg: "Add SNMP transport failed"
+        success_msg: "Add SNMP transport passed"
+
+    ################################################################
+    # Idempotency - add same transport again
+    ################################################################
+    - name: Add same SNMP transport again (idempotency)
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        port: 162
+        protocol: "UDP"
+      register: result
+
+    - name: Idempotency result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Verify idempotency
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed == false
+          - result.skipped == true
+        fail_msg: "Idempotency check failed"
+        success_msg: "Idempotency check passed"
+
+    ################################################################
+    # Fetch all SNMP transports
+    ################################################################
+    - name: Fetch all SNMP transports
+      nutanix.ncp.ntnx_snmp_transports_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+      register: result
+
+    - name: Fetch all SNMP transports result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Verify fetch all SNMP transports
+      ansible.builtin.assert:
+        that:
+          - result.failed == false
+          - result.response | length >= 1
+        fail_msg: "Fetch all SNMP transports failed"
+        success_msg: "Fetch all SNMP transports passed"
+
+    ################################################################
+    # Fetch specific SNMP transport
+    ################################################################
+    - name: Fetch specific SNMP transport
+      nutanix.ncp.ntnx_snmp_transports_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        port: 162
+        protocol: "UDP"
+      register: result
+
+    - name: Fetch specific SNMP transport result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Verify fetch specific SNMP transport
+      ansible.builtin.assert:
+        that:
+          - result.failed == false
+          - result.response.port == 162
+          - result.response.protocol == "UDP"
+        fail_msg: "Fetch specific SNMP transport failed"
+        success_msg: "Fetch specific SNMP transport passed"
+
+    ################################################################
+    # Update SNMP transport
+    ################################################################
+    - name: Update SNMP transport (change port from 162 to 163, protocol from UDP to TCP)
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        port: 163
+        protocol: "TCP"
+        old_port: 162
+        old_protocol: "UDP"
+      register: result
+
+    - name: Update SNMP transport result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Verify update SNMP transport
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+          - result.failed == false
+        fail_msg: "Update SNMP transport failed"
+        success_msg: "Update SNMP transport passed"
+
+    ################################################################
+    # Fetch updated transport
+    ################################################################
+    - name: Fetch updated SNMP transport
+      nutanix.ncp.ntnx_snmp_transports_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        port: 163
+        protocol: "TCP"
+      register: result
+
+    - name: Fetch updated transport result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Verify fetch updated SNMP transport
+      ansible.builtin.assert:
+        that:
+          - result.failed == false
+          - result.response.port == 163
+          - result.response.protocol == "TCP"
+        fail_msg: "Fetch updated SNMP transport failed"
+        success_msg: "Fetch updated SNMP transport passed"
+
+    ################################################################
+    # Remove SNMP transport with check mode
+    ################################################################
+    - name: Remove SNMP transport with check mode
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        port: 163
+        protocol: "TCP"
+        state: absent
+      check_mode: true
+      register: result
+
+    - name: Check mode result for remove SNMP transport
+      ansible.builtin.debug:
+        var: result
+
+    - name: Verify check mode remove result
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed == false
+          - result.msg is defined
+        fail_msg: "Check mode remove SNMP transport failed"
+        success_msg: "Check mode remove SNMP transport passed"
+
+    ################################################################
+    # Remove SNMP transport
+    ################################################################
+    - name: Remove SNMP transport
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        port: 163
+        protocol: "TCP"
+        state: absent
+      register: result
+
+    - name: Remove SNMP transport result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Verify remove SNMP transport
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+          - result.failed == false
+        fail_msg: "Remove SNMP transport failed"
+        success_msg: "Remove SNMP transport passed"
+
+    ################################################################
+    # Idempotency - remove same transport again
+    ################################################################
+    - name: Remove same SNMP transport again (idempotency)
+      nutanix.ncp.ntnx_snmp_transport_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        port: 163
+        protocol: "TCP"
+        state: absent
+      register: result
+
+    - name: Idempotency remove result
+      ansible.builtin.debug:
+        var: result
+
+    - name: Verify remove idempotency
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed == false
+          - result.skipped == true
+        fail_msg: "Idempotency remove check failed"
+        success_msg: "Idempotency remove check passed"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_snmp_transport_v2
+    - ntnx_snmp_transports_info_v2

--- a/plugins/module_utils/v4/clusters_mgmt/helpers.py
+++ b/plugins/module_utils/v4/clusters_mgmt/helpers.py
@@ -1,4 +1,4 @@
-# Copyright: (c) 2024, Nutanix
+# Copyright: (c) 2026, Nutanix
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -108,4 +108,26 @@ def get_cluster_profile(module, api_instance, ext_id):
             module=module,
             exception=e,
             msg="Api Exception raised while fetching cluster profile info using ext_id",
+        )
+
+
+def get_snmp_config(module, api_instance, cluster_ext_id):
+    """
+    This method will return SNMP config for a cluster using cluster external ID.
+    Args:
+        module: Ansible module
+        api_instance: ClustersApi instance from sdk
+        cluster_ext_id (str): cluster external ID
+    Returns:
+        SnmpConfig: SNMP config object for the cluster
+    """
+    try:
+        return api_instance.get_snmp_config_by_cluster_id(
+            clusterExtId=cluster_ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching SNMP config for cluster",
         )

--- a/plugins/modules/ntnx_snmp_transport_v2.py
+++ b/plugins/modules/ntnx_snmp_transport_v2.py
@@ -1,0 +1,429 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_snmp_transport_v2
+short_description: Manage SNMP transports in Nutanix Prism Central
+description:
+    - This module allows you to add, update, and remove SNMP transport ports and protocol details on a Nutanix cluster.
+    - This module uses PC v4 APIs based SDKs
+version_added: 2.6.0
+notes:
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  state:
+    description:
+        - Specify state
+        - If C(state) is set to C(present) then module will add SNMP transport.
+        - >-
+          If C(state) is set to C(present) and C(old_port) or C(old_protocol) is given,
+          then module will update SNMP transport by removing old and adding new.
+        - If C(state) is set to C(absent), then module will remove SNMP transport.
+    choices:
+        - present
+        - absent
+    type: str
+    default: present
+  cluster_ext_id:
+    description:
+        - The external ID of the cluster.
+    type: str
+    required: true
+  port:
+    description:
+        - The port number for SNMP transport.
+    type: int
+    required: true
+  protocol:
+    description:
+        - The protocol for SNMP transport.
+    type: str
+    required: true
+    choices: ['UDP', 'UDP6', 'TCP', 'TCP6']
+  old_port:
+    description:
+        - The old port number to be replaced during update operation.
+        - Required when updating an existing SNMP transport.
+    type: int
+    required: false
+  old_protocol:
+    description:
+        - The old protocol to be replaced during update operation.
+        - Required when updating an existing SNMP transport.
+    type: str
+    required: false
+    choices: ['UDP', 'UDP6', 'TCP', 'TCP6']
+extends_documentation_fragment:
+      - nutanix.ncp.ntnx_credentials
+      - nutanix.ncp.ntnx_operations_v2
+      - nutanix.ncp.ntnx_logger
+      - nutanix.ncp.ntnx_proxy_v2
+author:
+ - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Add SNMP transport to a cluster
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+    port: 162
+    protocol: "UDP"
+
+- name: Update SNMP transport on a cluster
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+    port: 163
+    protocol: "TCP"
+    old_port: 162
+    old_protocol: "UDP"
+
+- name: Remove SNMP transport from a cluster
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+    port: 162
+    protocol: "UDP"
+    state: absent
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for the SNMP transport operation.
+        - Task details if operation triggers a task.
+    type: dict
+    returned: always
+    sample:
+      {
+        "ext_id": "ZXJnb24=:d0fe946a-83b7-464d-bafb-4826282a75b1"
+      }
+task_ext_id:
+    description:
+        - Task external ID.
+    type: str
+    returned: when applicable
+    sample: ZXJnb24=:d0fe946a-83b7-464d-bafb-4826282a75b1
+ext_id:
+    description:
+        - Cluster external ID.
+    type: str
+    returned: always
+    sample: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+msg:
+    description: This indicates the message if any message occurred
+    returned: When there is an error, module is idempotent or check mode
+    type: str
+    sample: "SNMP transport already exists on cluster"
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  returned: always
+  type: bool
+  sample: false
+skipped:
+    description: This field indicates whether the task was skipped. For example during idempotency checks.
+    returned: always
+    type: bool
+    sample: true
+failed:
+    description: This field indicates whether the task failed.
+    returned: always
+    type: bool
+    sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_clusters_api_instance,
+    get_etag,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import get_snmp_config  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+try:
+    import ntnx_clustermgmt_py_client as clustermgmt_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as clustermgmt_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        cluster_ext_id=dict(type="str", required=True),
+        port=dict(type="int", required=True),
+        protocol=dict(
+            type="str", required=True, choices=["UDP", "UDP6", "TCP", "TCP6"]
+        ),
+        old_port=dict(type="int", required=False),
+        old_protocol=dict(
+            type="str", required=False, choices=["UDP", "UDP6", "TCP", "TCP6"]
+        ),
+    )
+    return module_args
+
+
+def _transport_exists(transports, port, protocol):
+    """Check if a transport with given port and protocol exists in the list."""
+    if not transports:
+        return False
+    for t in transports:
+        if t.port == port and t.protocol == protocol:
+            return True
+    return False
+
+
+def create_snmp_transport(module, clusters_api, result):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    port = module.params.get("port")
+    protocol = module.params.get("protocol")
+    result["ext_id"] = cluster_ext_id
+
+    snmp_config = get_snmp_config(module, clusters_api, cluster_ext_id)
+    if _transport_exists(snmp_config.transports, port, protocol):
+        result["skipped"] = True
+        result["msg"] = "SNMP transport already exists on cluster."
+        module.exit_json(**result)
+
+    transport = clustermgmt_sdk.SnmpTransport()
+    transport.port = port
+    transport.protocol = protocol
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(transport.to_dict())
+        return
+
+    try:
+        resp = clusters_api.add_snmp_transport(
+            clusterExtId=cluster_ext_id, body=transport
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="API Exception while adding SNMP transport",
+        )
+
+    task_ext_id = None
+    if hasattr(resp, "data") and resp.data and hasattr(resp.data, "ext_id"):
+        task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    result["changed"] = True
+
+
+def update_snmp_transport(module, clusters_api, result):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    port = module.params.get("port")
+    protocol = module.params.get("protocol")
+    old_port = module.params.get("old_port")
+    old_protocol = module.params.get("old_protocol")
+    result["ext_id"] = cluster_ext_id
+
+    if old_port == port and old_protocol == protocol:
+        result["skipped"] = True
+        result["msg"] = "Nothing to change."
+        module.exit_json(**result)
+
+    snmp_config = get_snmp_config(module, clusters_api, cluster_ext_id)
+    etag = get_etag(data=snmp_config)
+
+    if not _transport_exists(snmp_config.transports, old_port, old_protocol):
+        result["msg"] = (
+            "SNMP transport with port {0} and protocol {1} not found on cluster.".format(
+                old_port, old_protocol
+            )
+        )
+        module.fail_json(**result)
+
+    if _transport_exists(snmp_config.transports, port, protocol):
+        result["skipped"] = True
+        result["msg"] = (
+            "SNMP transport with port {0} and protocol {1} already exists.".format(
+                port, protocol
+            )
+        )
+        module.exit_json(**result)
+
+    if module.check_mode:
+        new_transport = clustermgmt_sdk.SnmpTransport()
+        new_transport.port = port
+        new_transport.protocol = protocol
+        result["response"] = strip_internal_attributes(new_transport.to_dict())
+        return
+
+    old_transport = clustermgmt_sdk.SnmpTransport()
+    old_transport.port = old_port
+    old_transport.protocol = old_protocol
+
+    kwargs = {}
+    if etag:
+        kwargs["if_match"] = etag
+
+    try:
+        clusters_api.remove_snmp_transport(
+            clusterExtId=cluster_ext_id, body=old_transport, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="API Exception while removing old SNMP transport during update",
+        )
+
+    new_transport = clustermgmt_sdk.SnmpTransport()
+    new_transport.port = port
+    new_transport.protocol = protocol
+
+    try:
+        resp = clusters_api.add_snmp_transport(
+            clusterExtId=cluster_ext_id, body=new_transport
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="API Exception while adding new SNMP transport during update",
+        )
+
+    task_ext_id = None
+    if hasattr(resp, "data") and resp.data and hasattr(resp.data, "ext_id"):
+        task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    result["changed"] = True
+
+
+def delete_snmp_transport(module, clusters_api, result):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    port = module.params.get("port")
+    protocol = module.params.get("protocol")
+    result["ext_id"] = cluster_ext_id
+
+    snmp_config = get_snmp_config(module, clusters_api, cluster_ext_id)
+
+    if not _transport_exists(snmp_config.transports, port, protocol):
+        result["skipped"] = True
+        result["msg"] = (
+            "SNMP transport with port {0} and protocol {1} not found. Nothing to delete.".format(
+                port, protocol
+            )
+        )
+        module.exit_json(**result)
+
+    if module.check_mode:
+        result["msg"] = (
+            "SNMP transport with port {0} and protocol {1} will be removed.".format(
+                port, protocol
+            )
+        )
+        return
+
+    transport = clustermgmt_sdk.SnmpTransport()
+    transport.port = port
+    transport.protocol = protocol
+
+    etag = get_etag(data=snmp_config)
+    kwargs = {}
+    if etag:
+        kwargs["if_match"] = etag
+
+    try:
+        resp = clusters_api.remove_snmp_transport(
+            clusterExtId=cluster_ext_id, body=transport, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="API Exception while removing SNMP transport",
+        )
+
+    task_ext_id = None
+    if hasattr(resp, "data") and resp.data and hasattr(resp.data, "ext_id"):
+        task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("cluster_ext_id", "port", "protocol")),
+            ("state", "present", ("cluster_ext_id", "port", "protocol")),
+        ],
+        required_together=[
+            ("old_port", "old_protocol"),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+        "msg": None,
+        "failed": False,
+    }
+    state = module.params.get("state")
+    clusters_api = get_clusters_api_instance(module)
+    if state == "present":
+        if module.params.get("old_port") or module.params.get("old_protocol"):
+            update_snmp_transport(module, clusters_api, result)
+        else:
+            create_snmp_transport(module, clusters_api, result)
+    elif state == "absent":
+        delete_snmp_transport(module, clusters_api, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_snmp_transports_info_v2.py
+++ b/plugins/modules/ntnx_snmp_transports_info_v2.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_snmp_transports_info_v2
+short_description: Retrieve SNMP transport information from a Nutanix cluster
+description:
+    - This module retrieves SNMP transport information from a Nutanix cluster.
+    - Fetch a specific SNMP transport by port and protocol.
+    - Fetch all SNMP transports configured on a cluster.
+    - This module uses PC v4 APIs based SDKs
+version_added: 2.6.0
+notes:
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  cluster_ext_id:
+    description:
+        - The external ID of the cluster.
+    type: str
+    required: true
+  port:
+    description:
+        - The port number of the SNMP transport to fetch.
+        - If provided along with C(protocol), returns specific transport info.
+    type: int
+    required: false
+  protocol:
+    description:
+        - The protocol of the SNMP transport to fetch.
+        - If provided along with C(port), returns specific transport info.
+    type: str
+    required: false
+    choices: ['UDP', 'UDP6', 'TCP', 'TCP6']
+  read_timeout:
+    description:
+        - Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+      - nutanix.ncp.ntnx_credentials
+      - nutanix.ncp.ntnx_logger
+      - nutanix.ncp.ntnx_proxy_v2
+author:
+ - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch all SNMP transports for a cluster
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+  register: result
+
+- name: Fetch specific SNMP transport by port and protocol
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+    port: 162
+    protocol: "UDP"
+  register: result
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for fetching SNMP transport info.
+        - Returns a single transport dict if port and protocol are specified.
+        - Returns a list of transports if only cluster_ext_id is given.
+    type: dict
+    returned: always
+    sample:
+      [
+        {
+          "port": 162,
+          "protocol": "UDP"
+        }
+      ]
+ext_id:
+    description:
+        - The external ID of the cluster.
+    type: str
+    returned: always
+    sample: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+changed:
+    description: This indicates whether the task resulted in any changes
+    returned: always
+    type: bool
+    sample: false
+msg:
+    description: This indicates the message if any message occurred
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while fetching SNMP config"
+error:
+    description: The error message if an error occurs.
+    type: str
+    returned: when an error occurs
+failed:
+    description: This field indicates whether the task failed.
+    returned: always
+    type: bool
+    sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_clusters_api_instance,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import get_snmp_config  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        cluster_ext_id=dict(type="str", required=True),
+        port=dict(type="int", required=False),
+        protocol=dict(
+            type="str", required=False, choices=["UDP", "UDP6", "TCP", "TCP6"]
+        ),
+    )
+    return module_args
+
+
+def get_snmp_transport_by_port_protocol(module, result):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    port = module.params.get("port")
+    protocol = module.params.get("protocol")
+    clusters_api = get_clusters_api_instance(module)
+    snmp_config = get_snmp_config(module, clusters_api, cluster_ext_id)
+
+    result["ext_id"] = cluster_ext_id
+    transports = snmp_config.transports or []
+    for t in transports:
+        if t.port == port and t.protocol == protocol:
+            result["response"] = strip_internal_attributes(t.to_dict())
+            return
+
+    result["msg"] = "SNMP transport with port {0} and protocol {1} not found.".format(
+        port, protocol
+    )
+    module.fail_json(**result)
+
+
+def get_snmp_transports(module, result):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    clusters_api = get_clusters_api_instance(module)
+    snmp_config = get_snmp_config(module, clusters_api, cluster_ext_id)
+
+    result["ext_id"] = cluster_ext_id
+    transports = snmp_config.transports or []
+
+    resp = []
+    for t in transports:
+        resp.append(strip_internal_attributes(t.to_dict()))
+
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+        required_together=[
+            ("port", "protocol"),
+        ],
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "error": None, "response": None}
+    if module.params.get("port") and module.params.get("protocol"):
+        get_snmp_transport_by_port_protocol(module, result)
+    else:
+        get_snmp_transports(module, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/test_logs_snmp_transport.txt
+++ b/test_logs_snmp_transport.txt
@@ -1,0 +1,176 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Run SNMP Transport integration tests] ************************************
+
+TASK [Start ntnx_snmp_transport_v2 and ntnx_snmp_transports_info_v2 tests] *****
+ok: [localhost] => {
+    "msg": "Start SNMP transport tests"
+}
+
+TASK [Set cluster ext ID for SNMP transport tests] *****************************
+ok: [localhost] => {"ansible_facts": {"cluster_ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "todelete": []}, "changed": false}
+
+TASK [Add SNMP transport with check mode enabled] ******************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"port": 162, "protocol": "UDP"}, "task_ext_id": null}
+
+TASK [Verify check mode create SNMP transport] *********************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Check mode add SNMP transport spec generated successfully"
+}
+
+TASK [Add SNMP transport with port 162 and protocol UDP] ***********************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": "ZXJnb24=:d5cf1f76-fc86-4b2d-7835-936002a7cf07"}, "task_ext_id": "ZXJnb24=:d5cf1f76-fc86-4b2d-7835-936002a7cf07"}
+
+TASK [Verify add SNMP transport] ***********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Add SNMP transport passed"
+}
+
+TASK [Add transport to cleanup list] *******************************************
+ok: [localhost] => {"ansible_facts": {"todelete": [{"port": 162, "protocol": "UDP"}]}, "changed": false}
+
+TASK [Add same SNMP transport again for idempotency] ***************************
+skipping: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport already exists on cluster.", "response": null, "task_ext_id": null}
+
+TASK [Verify idempotency on add] ***********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Idempotency check for add SNMP transport passed"
+}
+
+TASK [Fetch all SNMP transports from cluster] **********************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": [{"port": 162, "protocol": "UDP"}]}
+
+TASK [Verify fetch all SNMP transports] ****************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Fetch all SNMP transports passed"
+}
+
+TASK [Fetch specific SNMP transport by port and protocol] **********************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": {"port": 162, "protocol": "UDP"}}
+
+TASK [Verify fetch specific SNMP transport] ************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Fetch specific SNMP transport passed"
+}
+
+TASK [Update SNMP transport with check mode enabled] ***************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"port": 163, "protocol": "TCP"}, "task_ext_id": null}
+
+TASK [Verify check mode update SNMP transport] *********************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Check mode update SNMP transport passed"
+}
+
+TASK [Update SNMP transport from port 162/UDP to 163/TCP] **********************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": "ZXJnb24=:3ef68ce8-0ca1-41b1-5875-e085c67da8b9"}, "task_ext_id": "ZXJnb24=:3ef68ce8-0ca1-41b1-5875-e085c67da8b9"}
+
+TASK [Verify update SNMP transport] ********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Update SNMP transport passed"
+}
+
+TASK [Update cleanup list after update] ****************************************
+ok: [localhost] => {"ansible_facts": {"todelete": [{"port": 163, "protocol": "TCP"}]}, "changed": false}
+
+TASK [Fetch updated SNMP transport] ********************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": {"port": 163, "protocol": "TCP"}}
+
+TASK [Verify updated SNMP transport values] ************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Verify updated SNMP transport passed"
+}
+
+TASK [Update SNMP transport with same values (idempotency)] ********************
+skipping: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "Nothing to change.", "response": null, "task_ext_id": null}
+
+TASK [Verify idempotency on update] ********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Idempotency check for update SNMP transport passed"
+}
+
+TASK [Fetch non-existent SNMP transport] ***************************************
+[ERROR]: Task failed: Module failed: SNMP transport with port 9999 and protocol UDP6 not found.
+Origin: /tmp/codegen/93a09f09e44d45d9989a9ca3b3da339f/repo/tests/integration/targets/ntnx_snmp_transport_v2/tasks/all_operation.yml:206:3
+
+204 # NEGATIVE - Fetch non-existent transport
+205 ####################################################################
+206 - name: Fetch non-existent SNMP transport
+      ^ column 3
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport with port 9999 and protocol UDP6 not found.", "response": null}
+...ignoring
+
+TASK [Verify non-existent transport returns error] *****************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Negative test for non-existent transport passed"
+}
+
+TASK [Update non-existent SNMP transport] **************************************
+[ERROR]: Task failed: Module failed: SNMP transport with port 9999 and protocol UDP6 not found on cluster.
+Origin: /tmp/codegen/93a09f09e44d45d9989a9ca3b3da339f/repo/tests/integration/targets/ntnx_snmp_transport_v2/tasks/all_operation.yml:225:3
+
+223 # NEGATIVE - Update non-existent transport
+224 ####################################################################
+225 - name: Update non-existent SNMP transport
+      ^ column 3
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport with port 9999 and protocol UDP6 not found on cluster.", "response": null, "task_ext_id": null}
+...ignoring
+
+TASK [Verify update non-existent transport fails] ******************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Negative test for update non-existent transport passed"
+}
+
+TASK [Remove SNMP transport with check mode enabled] ***************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport with port 163 and protocol TCP will be removed.", "response": null, "task_ext_id": null}
+
+TASK [Verify check mode delete SNMP transport] *********************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Check mode delete SNMP transport passed"
+}
+
+TASK [Remove SNMP transport with port 163 and protocol TCP] ********************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": null, "response": {"ext_id": "ZXJnb24=:98e55c64-f19e-4021-5337-a4cd6dae3b9f"}, "task_ext_id": "ZXJnb24=:98e55c64-f19e-4021-5337-a4cd6dae3b9f"}
+
+TASK [Verify remove SNMP transport] ********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Remove SNMP transport passed"
+}
+
+TASK [Remove same SNMP transport again for idempotency] ************************
+skipping: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "msg": "SNMP transport with port 163 and protocol TCP not found. Nothing to delete.", "response": null, "task_ext_id": null}
+
+TASK [Verify idempotency on delete] ********************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "Idempotency check for delete SNMP transport passed"
+}
+
+TASK [Verify all transports are cleaned up] ************************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "0006507e-9fb0-cb29-1221-5254000db428", "response": []}
+
+TASK [Verify no test transports remain] ****************************************
+ok: [localhost] => {
+    "changed": false,
+    "msg": "All SNMP transport tests completed successfully"
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=31   changed=3    unreachable=0    failed=0    skipped=3    rescued=0    ignored=2   
+

--- a/tests/integration/targets/ntnx_snmp_transport_v2/aliases
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_snmp_transport_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_snmp_transport_v2/tasks/all_operation.yml
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/tasks/all_operation.yml
@@ -1,0 +1,318 @@
+---
+- name: Start ntnx_snmp_transport_v2 and ntnx_snmp_transports_info_v2 tests
+  ansible.builtin.debug:
+    msg: Start SNMP transport tests
+
+- name: Set cluster ext ID for SNMP transport tests
+  ansible.builtin.set_fact:
+    cluster_ext_id: "{{ cluster.uuid }}"
+    todelete: []
+
+####################################################################
+# CHECK MODE - Create SNMP transport
+####################################################################
+- name: Add SNMP transport with check mode enabled
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 162
+    protocol: "UDP"
+  check_mode: true
+  register: result
+
+- name: Verify check mode create SNMP transport
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response.port == 162
+      - result.response.protocol == "UDP"
+    fail_msg: "Check mode add SNMP transport spec generation failed"
+    success_msg: "Check mode add SNMP transport spec generated successfully"
+
+####################################################################
+# CREATE - Add SNMP transport
+####################################################################
+- name: Add SNMP transport with port 162 and protocol UDP
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 162
+    protocol: "UDP"
+  register: result
+
+- name: Verify add SNMP transport
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == cluster_ext_id
+    fail_msg: "Add SNMP transport failed"
+    success_msg: "Add SNMP transport passed"
+
+- name: Add transport to cleanup list
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [{'port': 162, 'protocol': 'UDP'}] }}"
+
+####################################################################
+# IDEMPOTENCY - Add same transport again
+####################################################################
+- name: Add same SNMP transport again for idempotency
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 162
+    protocol: "UDP"
+  register: result
+
+- name: Verify idempotency on add
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+    fail_msg: "Idempotency check for add SNMP transport failed"
+    success_msg: "Idempotency check for add SNMP transport passed"
+
+####################################################################
+# INFO - Fetch all SNMP transports
+####################################################################
+- name: Fetch all SNMP transports from cluster
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+  register: result
+
+- name: Verify fetch all SNMP transports
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response | length >= 1
+      - result.ext_id == cluster_ext_id
+    fail_msg: "Fetch all SNMP transports failed"
+    success_msg: "Fetch all SNMP transports passed"
+
+####################################################################
+# INFO - Fetch specific SNMP transport by port and protocol
+####################################################################
+- name: Fetch specific SNMP transport by port and protocol
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 162
+    protocol: "UDP"
+  register: result
+
+- name: Verify fetch specific SNMP transport
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response.port == 162
+      - result.response.protocol == "UDP"
+    fail_msg: "Fetch specific SNMP transport failed"
+    success_msg: "Fetch specific SNMP transport passed"
+
+####################################################################
+# CHECK MODE - Update SNMP transport
+####################################################################
+- name: Update SNMP transport with check mode enabled
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 163
+    protocol: "TCP"
+    old_port: 162
+    old_protocol: "UDP"
+  check_mode: true
+  register: result
+
+- name: Verify check mode update SNMP transport
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response.port == 163
+      - result.response.protocol == "TCP"
+    fail_msg: "Check mode update SNMP transport failed"
+    success_msg: "Check mode update SNMP transport passed"
+
+####################################################################
+# UPDATE - Change port and protocol
+####################################################################
+- name: Update SNMP transport from port 162/UDP to 163/TCP
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 163
+    protocol: "TCP"
+    old_port: 162
+    old_protocol: "UDP"
+  register: result
+
+- name: Verify update SNMP transport
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == cluster_ext_id
+    fail_msg: "Update SNMP transport failed"
+    success_msg: "Update SNMP transport passed"
+
+- name: Update cleanup list after update
+  ansible.builtin.set_fact:
+    todelete:
+      - port: 163
+        protocol: "TCP"
+
+####################################################################
+# VERIFY UPDATE - Fetch updated transport
+####################################################################
+- name: Fetch updated SNMP transport
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 163
+    protocol: "TCP"
+  register: result
+
+- name: Verify updated SNMP transport values
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response.port == 163
+      - result.response.protocol == "TCP"
+    fail_msg: "Verify updated SNMP transport failed"
+    success_msg: "Verify updated SNMP transport passed"
+
+####################################################################
+# IDEMPOTENCY - Update with same values (no old_port change needed)
+####################################################################
+- name: Update SNMP transport with same values (idempotency)
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 163
+    protocol: "TCP"
+    old_port: 163
+    old_protocol: "TCP"
+  register: result
+
+- name: Verify idempotency on update
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+    fail_msg: "Idempotency check for update SNMP transport failed"
+    success_msg: "Idempotency check for update SNMP transport passed"
+
+####################################################################
+# NEGATIVE - Fetch non-existent transport
+####################################################################
+- name: Fetch non-existent SNMP transport
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 9999
+    protocol: "UDP6"
+  register: result
+  ignore_errors: true
+
+- name: Verify non-existent transport returns error
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - "'not found' in result.msg"
+    fail_msg: "Negative test for non-existent transport failed"
+    success_msg: "Negative test for non-existent transport passed"
+
+####################################################################
+# NEGATIVE - Update non-existent transport
+####################################################################
+- name: Update non-existent SNMP transport
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 200
+    protocol: "TCP"
+    old_port: 9999
+    old_protocol: "UDP6"
+  register: result
+  ignore_errors: true
+
+- name: Verify update non-existent transport fails
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - "'not found' in result.msg"
+    fail_msg: "Negative test for update non-existent transport failed"
+    success_msg: "Negative test for update non-existent transport passed"
+
+####################################################################
+# CHECK MODE - Delete SNMP transport
+####################################################################
+- name: Remove SNMP transport with check mode enabled
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 163
+    protocol: "TCP"
+    state: absent
+  check_mode: true
+  register: result
+
+- name: Verify check mode delete SNMP transport
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.msg is defined
+    fail_msg: "Check mode delete SNMP transport failed"
+    success_msg: "Check mode delete SNMP transport passed"
+
+####################################################################
+# DELETE - Remove SNMP transport
+####################################################################
+- name: Remove SNMP transport with port 163 and protocol TCP
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 163
+    protocol: "TCP"
+    state: absent
+  register: result
+
+- name: Verify remove SNMP transport
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == cluster_ext_id
+    fail_msg: "Remove SNMP transport failed"
+    success_msg: "Remove SNMP transport passed"
+
+####################################################################
+# IDEMPOTENCY - Delete same transport again
+####################################################################
+- name: Remove same SNMP transport again for idempotency
+  nutanix.ncp.ntnx_snmp_transport_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    port: 163
+    protocol: "TCP"
+    state: absent
+  register: result
+
+- name: Verify idempotency on delete
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+    fail_msg: "Idempotency check for delete SNMP transport failed"
+    success_msg: "Idempotency check for delete SNMP transport passed"
+
+####################################################################
+# NEGATIVE - Delete non-existent transport (already verified above)
+####################################################################
+- name: Verify all transports are cleaned up
+  nutanix.ncp.ntnx_snmp_transports_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+  register: result
+
+- name: Verify no test transports remain
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+    fail_msg: "Cleanup verification failed"
+    success_msg: "All SNMP transport tests completed successfully"

--- a/tests/integration/targets/ntnx_snmp_transport_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_snmp_transport_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import SNMP transport all operation tests
+      ansible.builtin.import_tasks: "all_operation.yml"


### PR DESCRIPTION
## Summary
- Added `ntnx_snmp_transport_v2` CRUD module for managing SNMP transport ports and protocol details on Nutanix clusters (add, update, delete with idempotency and check_mode support)
- Added `ntnx_snmp_transports_info_v2` info module for fetching SNMP transports (all or specific by port/protocol)
- Added `get_snmp_config` helper in `clusters_mgmt/helpers.py`
- Registered both modules in `meta/runtime.yml` action groups
- Includes examples playbook, integration tests, and execution logs

## Test plan
- [x] Examples playbook runs successfully against PC (10.101.64.103)
- [x] Integration tests pass (all operations: CRUD, idempotency, check_mode, negative scenarios)
- [x] black, isort, flake8 pass
- [x] ansible-lint passes
- [x] ansible-test sanity passes


Made with [Cursor](https://cursor.com)