### PR TITLE
VM Guest Customization Profile Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/vmm_v2/vm_guest_customization_profiles_v2.yml
+++ b/examples/vmm_v2/vm_guest_customization_profiles_v2.yml
@@ -1,0 +1,144 @@
+---
+# Summary:
+# This playbook will:
+# 1. Create a VM Guest Customization Profile using sysprep parameters (Workgroup, DHCP).
+# 2. Create a VM Guest Customization Profile using a pre-built unattend XML answer file.
+# 3. Update an existing profile to use a domain join and a must-provide-during-deployment IP config.
+# 4. Fetch a single profile by external ID.
+# 5. List profiles using a filter and a limit.
+# 6. Delete the created profiles.
+
+- name: VM Guest Customization Profile playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Create VM Guest Customization Profile with sysprep params (Workgroup,DHCP)
+      nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+        state: present
+        name: "win-sysprep-profile-workgroup"
+        description: "Reusable Windows Sysprep profile - Workgroup, DHCP"
+        config:
+          sysprep:
+            customization:
+              sysprep_params:
+                general_settings:
+                  computer_name:
+                    use_vm_name: {}
+                  timezone: "Pacific Standard Time"
+                  administrator_password: "admin123"
+                  registered_owner: "admin"
+                  registered_organization: "admin"
+                locale_settings:
+                  user_locale: "en-US"
+                  system_locale: "en-US"
+                  ui_language: "en-US"
+                first_logon_commands:
+                  - "powershell -Command Enable-PSRemoting -Force"
+                workgroup_or_domain_info:
+                  workgroup:
+                    name: "workgroup"
+                network_settings:
+                  nic_config_list:
+                    - dns_config:
+                        preferred_dns_server_address: "10.0.0.10"
+                        alternate_dns_server_addresses:
+                          - "10.0.0.11"
+                      ipv4_config:
+                        use_dhcp: {}
+      register: result_workgroup
+      ignore_errors: true
+
+    - name: Save workgroup profile ext_id
+      ansible.builtin.set_fact:
+        workgroup_profile_ext_id: "{{ result_workgroup.response.ext_id }}"
+
+    - name: Create VM Guest Customization Profile using an unattend XML answer file
+      nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+        state: present
+        name: "win-sysprep-profile-answer-file"
+        description: "Sysprep using a pre-built unattend.xml"
+        config:
+          sysprep:
+            customization:
+              answer_file:
+                unattend_xml: "{{ lookup('file', 'unattend_xml_content.xml') | b64encode }}"
+      register: result_answer_file
+      ignore_errors: true
+
+    - name: Save answer-file profile ext_id
+      ansible.builtin.set_fact:
+        answer_file_profile_ext_id: "{{ result_answer_file.response.ext_id }}"
+
+    - name: Update profile to use domain settings
+      nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+        state: present
+        ext_id: "{{ workgroup_profile_ext_id }}"
+        name: "win-sysprep-profile-domain-settings"
+        description: "Updated profile - domain settings"
+        config:
+          sysprep:
+            customization:
+              sysprep_params:
+                general_settings:
+                  computer_name:
+                    must_provide_during_deployment: {}
+                  timezone: "UTC"
+                  administrator_password: "admin123"
+                workgroup_or_domain_info:
+                  domain_settings:
+                    credentials:
+                      domain_name: "domain.example.local"
+                      username: "admin"
+                      password: "admin123"
+                network_settings:
+                  nic_config_list:
+                    - dns_config:
+                        preferred_dns_server_address: "10.0.0.10"
+                        alternate_dns_server_addresses:
+                          - "10.0.0.11"
+                      ipv4_config:
+                        must_provide_during_deployment: {}
+      register: result_update
+      ignore_errors: true
+
+    - name: Fetch VM Guest Customization Profile by ext_id
+      nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+        ext_id: "{{ workgroup_profile_ext_id }}"
+      register: profile_info
+
+    - name: List all VM Guest Customization Profiles
+      nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+      register: profile_list_all
+      ignore_errors: true
+
+    - name: List VM Guest Customization Profiles using filter
+      nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+        filter: "name eq 'win-sysprep-profile-domain-settings'"
+      register: profile_list_filter
+      ignore_errors: true
+
+    - name: List VM Guest Customization Profiles with limit
+      nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+        limit: 1
+      register: profile_list_limit
+      ignore_errors: true
+
+    - name: Delete the workgroup/domain profile
+      nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+        state: absent
+        ext_id: "{{ workgroup_profile_ext_id }}"
+      register: result_delete_workgroup
+      ignore_errors: true
+
+    - name: Delete the answer_file profile
+      nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+        state: absent
+        ext_id: "{{ answer_file_profile_ext_id }}"
+      register: result_delete_answer_file
+      ignore_errors: true

--- a/examples/vmm_v2/vms_clone_v2.yml
+++ b/examples/vmm_v2/vms_clone_v2.yml
@@ -3,6 +3,9 @@
 # This playbook will do:
 # 1. Clone VM with same attributes values
 # 2. Clone VM with different attributes values
+# 3. Clone VM with a VM Guest Customization Profile reference and per-clone overrides
+#    (registered owner/organization, static IP). Requires NGT installed on the
+#    source VM; otherwise the clone API rejects the request.
 
 - name: VM clone playbook
   hosts: localhost
@@ -17,6 +20,7 @@
     - name: Setting Variables
       ansible.builtin.set_fact:
         vm_uuid: "a990cfaa-95a8-4861-bdf6-14060555442d"
+        gc_profile_ext_id: "b1c2d3e4-5f67-4890-a123-456789abcdef"
 
     - name: Clone VM with same attributes values
       nutanix.ncp.ntnx_vms_clone_v2:
@@ -32,5 +36,50 @@
         num_sockets: 2
         num_cores_per_socket: 2
         num_threads_per_core: 2
+      register: result
+      ignore_errors: true
+
+    # NGT must be installed on the source VM, otherwise the clone API rejects
+    # the request with an NGT-not-installed error.
+    # When the referenced profile marks fields with `must_provide_during_deployment`,
+    # the per-clone override MUST supply those fields (e.g. computer_name, ipv4_config)
+    # or the API rejects the request.
+    - name: Clone VM with Guest Customization Profile (registered owner/organization,
+        static IP)
+      nutanix.ncp.ntnx_vms_clone_v2:
+        ext_id: "{{ vm_uuid }}"
+        name: "integration_test_vm_clone_with_profile"
+        guest_customization_profile_config:
+          profile:
+            ext_id: "{{ gc_profile_ext_id }}"
+          config_override_spec:
+            customization:
+              sysprep_params:
+                general_settings:
+                  computer_name:
+                    name:
+                      value: "cloned-host"
+                  timezone:
+                    value:
+                      value: "Pacific Standard Time"
+                  registered_owner:
+                    value:
+                      value: "cloned-owner"
+                  registered_organization:
+                    value:
+                      value: "cloned-org"
+                network_settings:
+                  nic_config_list:
+                    - dns_config:
+                        preferred_dns_server_address: "10.1.0.100"
+                        alternate_dns_server_addresses:
+                          - "10.1.0.101"
+                      ipv4_config:
+                        static_config:
+                          ip_address:
+                            value: "10.1.0.50"
+                            prefix_length: 24
+                          default_gateways:
+                            - "10.1.0.1"
       register: result
       ignore_errors: true

--- a/examples/vmm_v2/vms_clone_v2.yml
+++ b/examples/vmm_v2/vms_clone_v2.yml
@@ -44,8 +44,7 @@
     # When the referenced profile marks fields with `must_provide_during_deployment`,
     # the per-clone override MUST supply those fields (e.g. computer_name, ipv4_config)
     # or the API rejects the request.
-    - name: Clone VM with Guest Customization Profile (registered owner/organization,
-        static IP)
+    - name: Clone VM with Guest Customization Profile
       nutanix.ncp.ntnx_vms_clone_v2:
         ext_id: "{{ vm_uuid }}"
         name: "integration_test_vm_clone_with_profile"

--- a/examples/vmm_v2/vms_templates_v2.yml
+++ b/examples/vmm_v2/vms_templates_v2.yml
@@ -71,7 +71,8 @@
       register: result
       ignore_errors: true
 
-    - name: Retrieve the Template Version details for the given Template Version identifier.
+    - name: Retrieve the Template Version details for the given Template Version
+        identifier.
       nutanix.ncp.ntnx_templates_versions_info_v2:
         ext_id: "{{ version_id }}"
         template_ext_id: "{{ template_ext_id }}"
@@ -100,9 +101,27 @@
       register: result
       ignore_errors: true
 
-    # NGT must be installed on the source VM the template was captured from,
-    # otherwise the deploy API rejects the request with an NGT-not-installed error.
-    - name: Deploy VM from template with Guest Customization Profile (workgroup join, DHCP)
+    - name: Initiate_guest_os_update
+      nutanix.ncp.ntnx_templates_guest_os_v2:
+        template_ext_id: "{{ template_ext_id }}"
+        version_id: "{{ version_id }}"
+        state: start
+      register: result
+      ignore_errors: true
+
+    - name: Finish guest_os_update
+      nutanix.ncp.ntnx_templates_guest_os_v2:
+        template_ext_id: "{{ template_ext_id }}"
+        version_id: "{{ version_id }}"
+        state: finish
+        version_name: "{{ version_name }}"
+        version_description: finish guest os update
+      register: result
+      ignore_errors: true
+      # NGT must be installed on the source VM the template was captured from,
+      # otherwise the deploy API rejects the request with an NGT-not-installed error.
+    - name: Deploy VM from template with Guest Customization Profile (workgroup join,
+        DHCP)
       nutanix.ncp.ntnx_templates_deploy_v2:
         ext_id: "{{ template_ext_id }}"
         version_id: "{{ version_id }}"
@@ -138,24 +157,6 @@
                               - "10.0.0.101"
                           ipv4_config:
                             use_dhcp: {}
-      register: result
-      ignore_errors: true
-
-    - name: Initiate_guest_os_update
-      nutanix.ncp.ntnx_templates_guest_os_v2:
-        template_ext_id: "{{ template_ext_id }}"
-        version_id: "{{ version_id }}"
-        state: start
-      register: result
-      ignore_errors: true
-
-    - name: Finish guest_os_update
-      nutanix.ncp.ntnx_templates_guest_os_v2:
-        template_ext_id: "{{ template_ext_id }}"
-        version_id: "{{ version_id }}"
-        state: finish
-        version_name: "{{ version_name }}"
-        version_description: finish guest os update
       register: result
       ignore_errors: true
 

--- a/examples/vmm_v2/vms_templates_v2.yml
+++ b/examples/vmm_v2/vms_templates_v2.yml
@@ -8,9 +8,13 @@
 # 5. Publish template version as active version
 # 6. Delete Template Version
 # 7. Deploy VM
-# 8. Initiate_guest_os_update
-# 9. Finish guest_os_update
-# 10. Delete Template
+# 8. Deploy VM from template with a VM Guest Customization Profile reference and
+#    per-VM overrides (workgroup join, DHCP). Requires NGT installed on the
+#    source VM the template was captured from; otherwise the deploy API rejects
+#    the request.
+# 9. Initiate_guest_os_update
+# 10. Finish guest_os_update
+# 11. Delete Template
 
 - name: VM templates playbook
   hosts: localhost
@@ -31,6 +35,7 @@
         version_id: "00000000-0000-0000-0000-000000000000"
         vm2_name: "ansible_template_vm"
         cluster_uuid: "00062899-4a29-0cf9-0000-000000028f57"
+        gc_profile_ext_id: "b1c2d3e4-5f67-4890-a123-456789abcdef"
 
     - name: Create new template from a vm
       nutanix.ncp.ntnx_templates_v2:
@@ -92,6 +97,47 @@
         ext_id: "{{ template_ext_id }}"
         version_id: "{{ version_id }}"
         cluster_reference: "{{ cluster_uuid }}"
+      register: result
+      ignore_errors: true
+
+    # NGT must be installed on the source VM the template was captured from,
+    # otherwise the deploy API rejects the request with an NGT-not-installed error.
+    - name: Deploy VM from template with Guest Customization Profile (workgroup join, DHCP)
+      nutanix.ncp.ntnx_templates_deploy_v2:
+        ext_id: "{{ template_ext_id }}"
+        version_id: "{{ version_id }}"
+        cluster_reference: "{{ cluster_uuid }}"
+        override_vms_config:
+          - name: vm_deployed_with_profile
+            num_sockets: 2
+            num_cores_per_socket: 2
+            guest_customization_profile_config:
+              profile:
+                ext_id: "{{ gc_profile_ext_id }}"
+              config_override_spec:
+                customization:
+                  sysprep_params:
+                    general_settings:
+                      computer_name:
+                        name:
+                          value: "deployed-host"
+                      timezone:
+                        value:
+                          value: "UTC"
+                      registered_owner:
+                        value:
+                          value: "deployed-owner"
+                    workgroup_or_domain_info:
+                      workgroup:
+                        name: "DEPLOYED-WG"
+                    network_settings:
+                      nic_config_list:
+                        - dns_config:
+                            preferred_dns_server_address: "10.0.0.100"
+                            alternate_dns_server_addresses:
+                              - "10.0.0.101"
+                          ipv4_config:
+                            use_dhcp: {}
       register: result
       ignore_errors: true
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vm_guest_customization_profile_v2
+    - ntnx_vm_guest_customization_profiles_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,9 +48,7 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
-        VM_GUEST_CUSTOMIZATION_PROFILE = (
-            "vmm:ahv:config:vm-guest-customization-profile"
-        )
+        VM_GUEST_CUSTOMIZATION_PROFILE = "vmm:ahv:config:vm-guest-customization-profile"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,9 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        VM_GUEST_CUSTOMIZATION_PROFILE = (
+            "vmm:ahv:config:vm-guest-customization-profile"
+        )
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/utils.py
+++ b/plugins/module_utils/v4/utils.py
@@ -306,3 +306,31 @@ def strip_read_only_fields(spec, fields=None):
         if hasattr(spec, field):
             delattr(spec, field)
     return spec
+
+
+def normalize_oneof_marker_values(params, marker_keys):
+    """Normalize one-of marker variants from ``null`` to ``{}``.
+
+    Some one-of (discriminated union) variants map to SDK classes with no
+    user-facing fields; the variant is selected purely by *which* key is
+    present. Users may write either ``some_marker: {}`` or simply
+    ``some_marker:`` (null) in their playbook. The latter form would otherwise
+    be stripped by ``remove_param_with_none_value`` before the spec generator
+    could dispatch it, so we promote ``null`` to ``{}`` for the given marker
+    keys here.
+
+    The structure is mutated in place.
+
+    Args:
+        params (dict | list): module params (or a nested fragment) to normalize.
+        marker_keys (Iterable[str]): keys whose ``null`` value should become ``{}``.
+    """
+    if isinstance(params, dict):
+        for key, value in params.items():
+            if key in marker_keys and value is None:
+                params[key] = {}
+            elif isinstance(value, dict):
+                normalize_oneof_marker_values(value, marker_keys)
+            elif isinstance(value, list):
+                for item in value:
+                    normalize_oneof_marker_values(item, marker_keys)

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,13 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_vm_guest_customization_profiles_api_instance(module):
+    """
+    This method will return VM Guest Customization Profiles API instance
+    Args:
+        api_instance (obj): v4 VM Guest Customization Profiles api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.VmGuestCustomizationProfilesApi(api_client=api_client)

--- a/plugins/module_utils/v4/vmm/helpers.py
+++ b/plugins/module_utils/v4/vmm/helpers.py
@@ -191,3 +191,23 @@ def get_ova(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching OVA info using ext_id",
         )
+
+
+def get_vm_guest_customization_profile(module, api_instance, ext_id):
+    """
+    Get VM Guest Customization Profile by ext_id
+    Args:
+        module: Ansible module
+        api_instance: VmGuestCustomizationProfilesApi instance from ntnx_vmm_py_client sdk
+        ext_id: ext_id of VM Guest Customization Profile
+    Returns:
+        profile (obj): VM Guest Customization Profile info object
+    """
+    try:
+        return api_instance.get_vm_guest_customization_profile_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VM Guest Customization Profile info using ext_id",
+        )

--- a/plugins/module_utils/v4/vmm/spec/vm_guest_customization_profiles.py
+++ b/plugins/module_utils/v4/vmm/spec/vm_guest_customization_profiles.py
@@ -17,8 +17,68 @@ except ImportError:
     SDK_IMP_ERROR = traceback.format_exc()
 
 
+def _empty_options():
+    """Options dict for SDK marker types that carry no fields."""
+    return dict()
+
+
+def _scalar_value_options():
+    """Options dict for SDK ``{value: str}`` wrapper types."""
+    return dict(value=dict(type="str"))
+
+
+def _scalar_secret_value_options():
+    """Same as ``_scalar_value_options`` but with ``no_log=True``."""
+    return dict(value=dict(type="str", no_log=True))
+
+
+def _ip_address_options():
+    """Options dict for the SDK ``IPv4Address`` type."""
+    return dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int"),
+    )
+
+
+def _logon_count_options():
+    """Options dict shared by ``VmGcProfileAutoLogonSettings`` and its override."""
+    return dict(logon_count=dict(type="int"))
+
+
+def _dns_config_options():
+    """Options dict shared by ``VmGcProfileDnsConfig`` and its override."""
+    return dict(
+        preferred_dns_server_address=dict(type="str"),
+        alternate_dns_server_addresses=dict(type="list", elements="str"),
+    )
+
+
+def _domain_credentials_options():
+    """Options dict shared by ``VmGcProfileDomainCredentials`` and its override."""
+    return dict(
+        domain_name=dict(type="str"),
+        username=dict(type="str"),
+        password=dict(type="str", no_log=True),
+    )
+
+
+def _workgroup_options():
+    """Options dict shared by ``VmGcProfileWorkgroup`` and its override."""
+    return dict(name=dict(type="str"))
+
+
+def _answer_file_options():
+    """Options dict shared by ``VmGcProfileAnswerFile`` and its override."""
+    return dict(unattend_xml=dict(type="str"))
+
+
 class VmGuestCustomizationProfileSpecs:
-    """Module specs related to VM Guest Customization Profiles."""
+    """Argument spec for the VM Guest Customization Profile resource.
+
+    Used by ``ntnx_vm_guest_customization_profile_v2`` for create/update.
+    Models the saved-profile shape: ``VmGuestCustomizationProfile`` and the
+    ``VmGcProfile*`` (non-override) SDK types.
+    """
 
     sysprep_customization_allowed_types = {
         "sysprep_params": vmm_sdk.VmGcProfileSysprepParams,
@@ -53,23 +113,17 @@ class VmGuestCustomizationProfileSpecs:
     @classmethod
     def get_module_spec(cls):
 
-        use_vm_name_spec = dict()
-        must_provide_during_deployment_spec = dict()
-        use_dhcp_spec = dict()
-
         computer_name_spec = dict(
             use_vm_name=dict(
-                type="dict", options=use_vm_name_spec, obj=vmm_sdk.VmGcProfileUseVmName
+                type="dict",
+                options=_empty_options(),
+                obj=vmm_sdk.VmGcProfileUseVmName,
             ),
             must_provide_during_deployment=dict(
                 type="dict",
-                options=must_provide_during_deployment_spec,
+                options=_empty_options(),
                 obj=vmm_sdk.VmGcProfileMustProvideDuringDeployment,
             ),
-        )
-
-        auto_logon_settings_spec = dict(
-            logon_count=dict(type="int"),
         )
 
         general_settings_spec = dict(
@@ -85,7 +139,7 @@ class VmGuestCustomizationProfileSpecs:
             administrator_password=dict(type="str", no_log=True),
             auto_logon_settings=dict(
                 type="dict",
-                options=auto_logon_settings_spec,
+                options=_logon_count_options(),
                 obj=vmm_sdk.VmGcProfileAutoLogonSettings,
             ),
             windows_product_key=dict(type="str", no_log=True),
@@ -99,28 +153,20 @@ class VmGuestCustomizationProfileSpecs:
             ui_language=dict(type="str"),
         )
 
-        domain_credentials_spec = dict(
-            domain_name=dict(type="str"),
-            username=dict(type="str"),
-            password=dict(type="str", no_log=True),
-        )
-
         domain_settings_spec = dict(
             credentials=dict(
                 type="dict",
-                options=domain_credentials_spec,
+                options=_domain_credentials_options(),
                 obj=vmm_sdk.VmGcProfileDomainCredentials,
                 no_log=False,
             ),
         )
 
-        workgroup_spec = dict(
-            name=dict(type="str"),
-        )
-
         workgroup_or_domain_info_spec = dict(
             workgroup=dict(
-                type="dict", options=workgroup_spec, obj=vmm_sdk.VmGcProfileWorkgroup
+                type="dict",
+                options=_workgroup_options(),
+                obj=vmm_sdk.VmGcProfileWorkgroup,
             ),
             domain_settings=dict(
                 type="dict",
@@ -129,25 +175,24 @@ class VmGuestCustomizationProfileSpecs:
             ),
         )
 
-        dns_config_spec = dict(
-            preferred_dns_server_address=dict(type="str"),
-            alternate_dns_server_addresses=dict(type="list", elements="str"),
-        )
-
         ipv4_config_spec = dict(
             use_dhcp=dict(
-                type="dict", options=use_dhcp_spec, obj=vmm_sdk.VmGcProfileUseDhcp
+                type="dict",
+                options=_empty_options(),
+                obj=vmm_sdk.VmGcProfileUseDhcp,
             ),
             must_provide_during_deployment=dict(
                 type="dict",
-                options=must_provide_during_deployment_spec,
+                options=_empty_options(),
                 obj=vmm_sdk.VmGcProfileMustProvideDuringDeployment,
             ),
         )
 
         nic_config_spec = dict(
             dns_config=dict(
-                type="dict", options=dns_config_spec, obj=vmm_sdk.VmGcProfileDnsConfig
+                type="dict",
+                options=_dns_config_options(),
+                obj=vmm_sdk.VmGcProfileDnsConfig,
             ),
             ipv4_config=dict(
                 type="dict",
@@ -197,10 +242,6 @@ class VmGuestCustomizationProfileSpecs:
             ),
         )
 
-        answer_file_spec = dict(
-            unattend_xml=dict(type="str"),
-        )
-
         sysprep_customization_spec = dict(
             sysprep_params=dict(
                 type="dict",
@@ -210,7 +251,7 @@ class VmGuestCustomizationProfileSpecs:
             ),
             answer_file=dict(
                 type="dict",
-                options=answer_file_spec,
+                options=_answer_file_options(),
                 obj=vmm_sdk.VmGcProfileAnswerFile,
             ),
         )
@@ -249,3 +290,341 @@ class VmGuestCustomizationProfileSpecs:
         )
 
         return module_args
+
+
+class VmGcProfileOverrideSpecs:
+    """Argument spec for per-request VM Guest Customization Profile overrides.
+
+    Used by:
+
+    * ``ntnx_vms_clone_v2`` to populate
+      ``CloneOverrideParams.guest_customization_profile_config``.
+    * ``ntnx_templates_deploy_v2`` to populate
+      ``VmConfigOverride.guest_customization_profile_config`` for each
+      ``override_vms_config`` entry.
+
+    Models the ``VmGcProfile*OverrideSpec`` SDK types. The override-spec
+    differs from the saved-profile shape in two ways:
+
+    * Most scalar fields are wrapped in a ``OneOf[<value-wrapper>, DiscardSettings]``
+      so the caller can either provide a new value per clone/deploy request or
+      explicitly discard the value coming from the referenced profile.
+    * ``computer_name`` additionally supports ``UseVmNameOverrideSpec`` and
+      ``ipv4_config`` supports ``UseDhcpOverrideSpec``.
+    """
+
+    computer_name_allowed_types = {
+        "name": vmm_sdk.VmGcProfileComputerName,
+        "use_vm_name": vmm_sdk.VmGcProfileUseVmNameOverrideSpec,
+        "discard": vmm_sdk.VmGcProfileDiscardSettings,
+    }
+
+    timezone_allowed_types = {
+        "value": vmm_sdk.VmGcProfileTimezone,
+        "discard": vmm_sdk.VmGcProfileDiscardSettings,
+    }
+
+    administrator_password_allowed_types = {
+        "value": vmm_sdk.VmGcProfileAdministratorPassword,
+        "discard": vmm_sdk.VmGcProfileDiscardSettings,
+    }
+
+    windows_product_key_allowed_types = {
+        "value": vmm_sdk.VmGcProfileWindowsProductKey,
+        "discard": vmm_sdk.VmGcProfileDiscardSettings,
+    }
+
+    registered_owner_allowed_types = {
+        "value": vmm_sdk.VmGcProfileRegisteredOwner,
+        "discard": vmm_sdk.VmGcProfileDiscardSettings,
+    }
+
+    registered_organization_allowed_types = {
+        "value": vmm_sdk.VmGcProfileRegisteredOrganization,
+        "discard": vmm_sdk.VmGcProfileDiscardSettings,
+    }
+
+    locale_setting_allowed_types = {
+        "value": vmm_sdk.VmGcProfileLocaleSettingOverride,
+        "discard": vmm_sdk.VmGcProfileDiscardSettings,
+    }
+
+    workgroup_or_domain_info_allowed_types = {
+        "workgroup": vmm_sdk.VmGcProfileWorkgroupOverrideSpec,
+        "domain_settings": vmm_sdk.VmGcProfileDomainSettingsOverrideSpec,
+        "discard": vmm_sdk.VmGcProfileDiscardSettings,
+    }
+
+    nic_ipv4_config_allowed_types = {
+        "use_dhcp": vmm_sdk.VmGcProfileUseDhcpOverrideSpec,
+        "static_config": vmm_sdk.VmGcProfileNicIpv4ConfigOverrideSpec,
+    }
+
+    sysprep_customization_allowed_types = {
+        "sysprep_params": vmm_sdk.VmGcProfileSysprepParamsOverrideSpec,
+        "answer_file": vmm_sdk.VmGcProfileAnswerFileOverrideSpec,
+    }
+
+    @staticmethod
+    def _value_or_discard_spec(value_obj, secret=False):
+        """Build a OneOf[value-wrapper, DiscardSettings] options dict."""
+        options = _scalar_secret_value_options() if secret else _scalar_value_options()
+        value_entry = dict(type="dict", options=options, obj=value_obj)
+        if secret:
+            value_entry["no_log"] = False
+        return dict(
+            value=value_entry,
+            discard=dict(
+                type="dict",
+                options=_empty_options(),
+                obj=vmm_sdk.VmGcProfileDiscardSettings,
+            ),
+        )
+
+    @classmethod
+    def get_module_spec(cls):
+
+        computer_name_spec = dict(
+            name=dict(
+                type="dict",
+                options=_scalar_value_options(),
+                obj=vmm_sdk.VmGcProfileComputerName,
+            ),
+            use_vm_name=dict(
+                type="dict",
+                options=_empty_options(),
+                obj=vmm_sdk.VmGcProfileUseVmNameOverrideSpec,
+            ),
+            discard=dict(
+                type="dict",
+                options=_empty_options(),
+                obj=vmm_sdk.VmGcProfileDiscardSettings,
+            ),
+        )
+
+        general_settings_spec = dict(
+            computer_name=dict(
+                type="dict",
+                options=computer_name_spec,
+                obj=cls.computer_name_allowed_types,
+                mutually_exclusive=[("name", "use_vm_name", "discard")],
+            ),
+            timezone=dict(
+                type="dict",
+                options=cls._value_or_discard_spec(vmm_sdk.VmGcProfileTimezone),
+                obj=cls.timezone_allowed_types,
+                mutually_exclusive=[("value", "discard")],
+            ),
+            administrator_password=dict(
+                type="dict",
+                options=cls._value_or_discard_spec(
+                    vmm_sdk.VmGcProfileAdministratorPassword, secret=True
+                ),
+                obj=cls.administrator_password_allowed_types,
+                no_log=False,
+                mutually_exclusive=[("value", "discard")],
+            ),
+            auto_logon_settings=dict(
+                type="dict",
+                options=_logon_count_options(),
+                obj=vmm_sdk.VmGcProfileAutoLogonSettingsOverrideSpec,
+            ),
+            windows_product_key=dict(
+                type="dict",
+                options=cls._value_or_discard_spec(
+                    vmm_sdk.VmGcProfileWindowsProductKey, secret=True
+                ),
+                obj=cls.windows_product_key_allowed_types,
+                no_log=False,
+                mutually_exclusive=[("value", "discard")],
+            ),
+            registered_owner=dict(
+                type="dict",
+                options=cls._value_or_discard_spec(vmm_sdk.VmGcProfileRegisteredOwner),
+                obj=cls.registered_owner_allowed_types,
+                mutually_exclusive=[("value", "discard")],
+            ),
+            registered_organization=dict(
+                type="dict",
+                options=cls._value_or_discard_spec(
+                    vmm_sdk.VmGcProfileRegisteredOrganization
+                ),
+                obj=cls.registered_organization_allowed_types,
+                mutually_exclusive=[("value", "discard")],
+            ),
+        )
+
+        locale_settings_spec = dict(
+            user_locale=dict(
+                type="dict",
+                options=cls._value_or_discard_spec(
+                    vmm_sdk.VmGcProfileLocaleSettingOverride
+                ),
+                obj=cls.locale_setting_allowed_types,
+                mutually_exclusive=[("value", "discard")],
+            ),
+            system_locale=dict(
+                type="dict",
+                options=cls._value_or_discard_spec(
+                    vmm_sdk.VmGcProfileLocaleSettingOverride
+                ),
+                obj=cls.locale_setting_allowed_types,
+                mutually_exclusive=[("value", "discard")],
+            ),
+            ui_language=dict(
+                type="dict",
+                options=cls._value_or_discard_spec(
+                    vmm_sdk.VmGcProfileLocaleSettingOverride
+                ),
+                obj=cls.locale_setting_allowed_types,
+                mutually_exclusive=[("value", "discard")],
+            ),
+        )
+
+        domain_settings_spec = dict(
+            credentials=dict(
+                type="dict",
+                options=_domain_credentials_options(),
+                obj=vmm_sdk.VmGcProfileDomainCredentialsOverrideSpec,
+                no_log=False,
+            ),
+        )
+
+        workgroup_or_domain_info_spec = dict(
+            workgroup=dict(
+                type="dict",
+                options=_workgroup_options(),
+                obj=vmm_sdk.VmGcProfileWorkgroupOverrideSpec,
+            ),
+            domain_settings=dict(
+                type="dict",
+                options=domain_settings_spec,
+                obj=vmm_sdk.VmGcProfileDomainSettingsOverrideSpec,
+                no_log=False,
+            ),
+            discard=dict(
+                type="dict",
+                options=_empty_options(),
+                obj=vmm_sdk.VmGcProfileDiscardSettings,
+            ),
+        )
+
+        nic_ipv4_static_config_spec = dict(
+            ip_address=dict(
+                type="dict",
+                options=_ip_address_options(),
+                obj=vmm_sdk.IPv4Address,
+            ),
+            default_gateways=dict(type="list", elements="str"),
+        )
+
+        ipv4_config_spec = dict(
+            use_dhcp=dict(
+                type="dict",
+                options=_empty_options(),
+                obj=vmm_sdk.VmGcProfileUseDhcpOverrideSpec,
+            ),
+            static_config=dict(
+                type="dict",
+                options=nic_ipv4_static_config_spec,
+                obj=vmm_sdk.VmGcProfileNicIpv4ConfigOverrideSpec,
+            ),
+        )
+
+        nic_config_spec = dict(
+            dns_config=dict(
+                type="dict",
+                options=_dns_config_options(),
+                obj=vmm_sdk.VmGcProfileDnsConfigOverrideSpec,
+            ),
+            ipv4_config=dict(
+                type="dict",
+                options=ipv4_config_spec,
+                obj=cls.nic_ipv4_config_allowed_types,
+                mutually_exclusive=[("use_dhcp", "static_config")],
+            ),
+        )
+
+        network_settings_spec = dict(
+            nic_config_list=dict(
+                type="list",
+                elements="dict",
+                options=nic_config_spec,
+                obj=vmm_sdk.VmGcProfileNicConfigOverrideSpec,
+            ),
+        )
+
+        sysprep_params_spec = dict(
+            general_settings=dict(
+                type="dict",
+                options=general_settings_spec,
+                obj=vmm_sdk.VmGcProfileGeneralSettingsOverrideSpec,
+                no_log=False,
+            ),
+            first_logon_commands=dict(type="list", elements="str"),
+            locale_settings=dict(
+                type="dict",
+                options=locale_settings_spec,
+                obj=vmm_sdk.VmGcProfileLocaleSettingsOverrideSpec,
+            ),
+            workgroup_or_domain_info=dict(
+                type="dict",
+                options=workgroup_or_domain_info_spec,
+                obj=cls.workgroup_or_domain_info_allowed_types,
+                no_log=False,
+                mutually_exclusive=[
+                    ("workgroup", "domain_settings", "discard"),
+                ],
+            ),
+            network_settings=dict(
+                type="dict",
+                options=network_settings_spec,
+                obj=vmm_sdk.VmGcProfileNetworkSettingsOverrideSpec,
+            ),
+        )
+
+        sysprep_customization_spec = dict(
+            sysprep_params=dict(
+                type="dict",
+                options=sysprep_params_spec,
+                obj=vmm_sdk.VmGcProfileSysprepParamsOverrideSpec,
+                no_log=False,
+            ),
+            answer_file=dict(
+                type="dict",
+                options=_answer_file_options(),
+                obj=vmm_sdk.VmGcProfileAnswerFileOverrideSpec,
+            ),
+        )
+
+        config_override_spec = dict(
+            customization=dict(
+                type="dict",
+                options=sysprep_customization_spec,
+                obj=cls.sysprep_customization_allowed_types,
+                no_log=False,
+                mutually_exclusive=[("sysprep_params", "answer_file")],
+            ),
+        )
+
+        profile_reference_spec = dict(
+            ext_id=dict(type="str", required=True),
+        )
+
+        return dict(
+            profile=dict(
+                type="dict",
+                options=profile_reference_spec,
+                obj=vmm_sdk.VmGcProfileReference,
+            ),
+            config_override_spec=dict(
+                type="dict",
+                options=config_override_spec,
+                obj=vmm_sdk.VmGcProfileSysprepConfigOverrideSpec,
+                no_log=False,
+            ),
+        )
+
+    @classmethod
+    def get_guest_customization_profile_config_spec(cls):
+        return cls.get_module_spec()

--- a/plugins/module_utils/v4/vmm/spec/vm_guest_customization_profiles.py
+++ b/plugins/module_utils/v4/vmm/spec/vm_guest_customization_profiles.py
@@ -1,0 +1,251 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_vmm_py_client as vmm_sdk  # noqa: E402
+except ImportError:
+
+    from ...sdk_mock import mock_sdk as vmm_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+class VmGuestCustomizationProfileSpecs:
+    """Module specs related to VM Guest Customization Profiles."""
+
+    sysprep_customization_allowed_types = {
+        "sysprep_params": vmm_sdk.VmGcProfileSysprepParams,
+        "answer_file": vmm_sdk.VmGcProfileAnswerFile,
+    }
+
+    computer_name_allowed_types = {
+        "use_vm_name": vmm_sdk.VmGcProfileUseVmName,
+        "must_provide_during_deployment": vmm_sdk.VmGcProfileMustProvideDuringDeployment,
+    }
+
+    workgroup_or_domain_info_allowed_types = {
+        "workgroup": vmm_sdk.VmGcProfileWorkgroup,
+        "domain_settings": vmm_sdk.VmGcProfileDomainSettings,
+    }
+
+    nic_ipv4_config_allowed_types = {
+        "use_dhcp": vmm_sdk.VmGcProfileUseDhcp,
+        "must_provide_during_deployment": vmm_sdk.VmGcProfileMustProvideDuringDeployment,
+    }
+
+    config_allowed_types = {
+        "sysprep": vmm_sdk.VmGcProfileSysprepConfig,
+    }
+
+    empty_marker_keys = (
+        "use_vm_name",
+        "must_provide_during_deployment",
+        "use_dhcp",
+    )
+
+    @classmethod
+    def get_module_spec(cls):
+
+        use_vm_name_spec = dict()
+        must_provide_during_deployment_spec = dict()
+        use_dhcp_spec = dict()
+
+        computer_name_spec = dict(
+            use_vm_name=dict(
+                type="dict", options=use_vm_name_spec, obj=vmm_sdk.VmGcProfileUseVmName
+            ),
+            must_provide_during_deployment=dict(
+                type="dict",
+                options=must_provide_during_deployment_spec,
+                obj=vmm_sdk.VmGcProfileMustProvideDuringDeployment,
+            ),
+        )
+
+        auto_logon_settings_spec = dict(
+            logon_count=dict(type="int"),
+        )
+
+        general_settings_spec = dict(
+            computer_name=dict(
+                type="dict",
+                options=computer_name_spec,
+                obj=cls.computer_name_allowed_types,
+                mutually_exclusive=[
+                    ("use_vm_name", "must_provide_during_deployment"),
+                ],
+            ),
+            timezone=dict(type="str"),
+            administrator_password=dict(type="str", no_log=True),
+            auto_logon_settings=dict(
+                type="dict",
+                options=auto_logon_settings_spec,
+                obj=vmm_sdk.VmGcProfileAutoLogonSettings,
+            ),
+            windows_product_key=dict(type="str", no_log=True),
+            registered_owner=dict(type="str"),
+            registered_organization=dict(type="str"),
+        )
+
+        locale_settings_spec = dict(
+            user_locale=dict(type="str"),
+            system_locale=dict(type="str"),
+            ui_language=dict(type="str"),
+        )
+
+        domain_credentials_spec = dict(
+            domain_name=dict(type="str"),
+            username=dict(type="str"),
+            password=dict(type="str", no_log=True),
+        )
+
+        domain_settings_spec = dict(
+            credentials=dict(
+                type="dict",
+                options=domain_credentials_spec,
+                obj=vmm_sdk.VmGcProfileDomainCredentials,
+                no_log=False,
+            ),
+        )
+
+        workgroup_spec = dict(
+            name=dict(type="str"),
+        )
+
+        workgroup_or_domain_info_spec = dict(
+            workgroup=dict(
+                type="dict", options=workgroup_spec, obj=vmm_sdk.VmGcProfileWorkgroup
+            ),
+            domain_settings=dict(
+                type="dict",
+                options=domain_settings_spec,
+                obj=vmm_sdk.VmGcProfileDomainSettings,
+            ),
+        )
+
+        dns_config_spec = dict(
+            preferred_dns_server_address=dict(type="str"),
+            alternate_dns_server_addresses=dict(type="list", elements="str"),
+        )
+
+        ipv4_config_spec = dict(
+            use_dhcp=dict(
+                type="dict", options=use_dhcp_spec, obj=vmm_sdk.VmGcProfileUseDhcp
+            ),
+            must_provide_during_deployment=dict(
+                type="dict",
+                options=must_provide_during_deployment_spec,
+                obj=vmm_sdk.VmGcProfileMustProvideDuringDeployment,
+            ),
+        )
+
+        nic_config_spec = dict(
+            dns_config=dict(
+                type="dict", options=dns_config_spec, obj=vmm_sdk.VmGcProfileDnsConfig
+            ),
+            ipv4_config=dict(
+                type="dict",
+                options=ipv4_config_spec,
+                obj=cls.nic_ipv4_config_allowed_types,
+                mutually_exclusive=[
+                    ("use_dhcp", "must_provide_during_deployment"),
+                ],
+            ),
+        )
+
+        network_settings_spec = dict(
+            nic_config_list=dict(
+                type="list",
+                elements="dict",
+                options=nic_config_spec,
+                obj=vmm_sdk.VmGcProfileNicConfig,
+            ),
+        )
+
+        sysprep_params_spec = dict(
+            general_settings=dict(
+                type="dict",
+                options=general_settings_spec,
+                obj=vmm_sdk.VmGcProfileGeneralSettings,
+                no_log=False,
+            ),
+            first_logon_commands=dict(type="list", elements="str"),
+            locale_settings=dict(
+                type="dict",
+                options=locale_settings_spec,
+                obj=vmm_sdk.VmGcProfileLocaleSettings,
+            ),
+            workgroup_or_domain_info=dict(
+                type="dict",
+                options=workgroup_or_domain_info_spec,
+                obj=cls.workgroup_or_domain_info_allowed_types,
+                no_log=False,
+                mutually_exclusive=[
+                    ("workgroup", "domain_settings"),
+                ],
+            ),
+            network_settings=dict(
+                type="dict",
+                options=network_settings_spec,
+                obj=vmm_sdk.VmGcProfileNetworkSettings,
+            ),
+        )
+
+        answer_file_spec = dict(
+            unattend_xml=dict(type="str"),
+        )
+
+        sysprep_customization_spec = dict(
+            sysprep_params=dict(
+                type="dict",
+                options=sysprep_params_spec,
+                obj=vmm_sdk.VmGcProfileSysprepParams,
+                no_log=False,
+            ),
+            answer_file=dict(
+                type="dict",
+                options=answer_file_spec,
+                obj=vmm_sdk.VmGcProfileAnswerFile,
+            ),
+        )
+
+        sysprep_config_spec = dict(
+            customization=dict(
+                type="dict",
+                options=sysprep_customization_spec,
+                obj=cls.sysprep_customization_allowed_types,
+                no_log=False,
+                mutually_exclusive=[
+                    ("sysprep_params", "answer_file"),
+                ],
+            ),
+        )
+
+        config_spec = dict(
+            sysprep=dict(
+                type="dict",
+                options=sysprep_config_spec,
+                obj=vmm_sdk.VmGcProfileSysprepConfig,
+                no_log=False,
+            ),
+        )
+
+        module_args = dict(
+            ext_id=dict(type="str"),
+            name=dict(type="str"),
+            description=dict(type="str"),
+            config=dict(
+                type="dict",
+                options=config_spec,
+                obj=cls.config_allowed_types,
+                no_log=False,
+            ),
+        )
+
+        return module_args

--- a/plugins/module_utils/v4/vmm/spec/vm_guest_customization_profiles.py
+++ b/plugins/module_utils/v4/vmm/spec/vm_guest_customization_profiles.py
@@ -45,31 +45,31 @@ def _logon_count_options():
     return dict(logon_count=dict(type="int"))
 
 
-def _dns_config_options():
+def _dns_config_options(required=False):
     """Options dict shared by ``VmGcProfileDnsConfig`` and its override."""
     return dict(
-        preferred_dns_server_address=dict(type="str"),
+        preferred_dns_server_address=dict(type="str", required=required),
         alternate_dns_server_addresses=dict(type="list", elements="str"),
     )
 
 
-def _domain_credentials_options():
+def _domain_credentials_options(required=False):
     """Options dict shared by ``VmGcProfileDomainCredentials`` and its override."""
     return dict(
-        domain_name=dict(type="str"),
-        username=dict(type="str"),
-        password=dict(type="str", no_log=True),
+        domain_name=dict(type="str", required=required),
+        username=dict(type="str", required=required),
+        password=dict(type="str", no_log=True, required=required),
     )
 
 
-def _workgroup_options():
+def _workgroup_options(required=False):
     """Options dict shared by ``VmGcProfileWorkgroup`` and its override."""
-    return dict(name=dict(type="str"))
+    return dict(name=dict(type="str", required=required))
 
 
-def _answer_file_options():
+def _answer_file_options(required=False):
     """Options dict shared by ``VmGcProfileAnswerFile`` and its override."""
-    return dict(unattend_xml=dict(type="str"))
+    return dict(unattend_xml=dict(type="str", required=required))
 
 
 class VmGuestCustomizationProfileSpecs:
@@ -156,16 +156,17 @@ class VmGuestCustomizationProfileSpecs:
         domain_settings_spec = dict(
             credentials=dict(
                 type="dict",
-                options=_domain_credentials_options(),
+                options=_domain_credentials_options(required=True),
                 obj=vmm_sdk.VmGcProfileDomainCredentials,
                 no_log=False,
+                required=True,
             ),
         )
 
         workgroup_or_domain_info_spec = dict(
             workgroup=dict(
                 type="dict",
-                options=_workgroup_options(),
+                options=_workgroup_options(required=True),
                 obj=vmm_sdk.VmGcProfileWorkgroup,
             ),
             domain_settings=dict(
@@ -191,13 +192,14 @@ class VmGuestCustomizationProfileSpecs:
         nic_config_spec = dict(
             dns_config=dict(
                 type="dict",
-                options=_dns_config_options(),
+                options=_dns_config_options(required=True),
                 obj=vmm_sdk.VmGcProfileDnsConfig,
             ),
             ipv4_config=dict(
                 type="dict",
                 options=ipv4_config_spec,
                 obj=cls.nic_ipv4_config_allowed_types,
+                required=True,
                 mutually_exclusive=[
                     ("use_dhcp", "must_provide_during_deployment"),
                 ],
@@ -251,7 +253,7 @@ class VmGuestCustomizationProfileSpecs:
             ),
             answer_file=dict(
                 type="dict",
-                options=_answer_file_options(),
+                options=_answer_file_options(required=True),
                 obj=vmm_sdk.VmGcProfileAnswerFile,
             ),
         )

--- a/plugins/modules/ntnx_project_v2.py
+++ b/plugins/modules/ntnx_project_v2.py
@@ -277,7 +277,9 @@ def create_project(module, projects, result):
         else:
             raise_api_exception(
                 module=module,
-                exception=Exception("Failed to get entity ext_id from task for Project"),
+                exception=Exception(
+                    "Failed to get entity ext_id from task for Project"
+                ),
                 msg="Failed to get entity ext_id from task for Project",
             )
 

--- a/plugins/modules/ntnx_resource_group_v2.py
+++ b/plugins/modules/ntnx_resource_group_v2.py
@@ -329,7 +329,9 @@ def create_resource_group(module, resource_groups, result):
         else:
             raise_api_exception(
                 module=module,
-                exception=Exception("Failed to get entity ext_id from task for Resource Group"),
+                exception=Exception(
+                    "Failed to get entity ext_id from task for Resource Group"
+                ),
                 msg="Failed to get entity ext_id from task for Resource Group",
             )
 

--- a/plugins/modules/ntnx_templates_deploy_v2.py
+++ b/plugins/modules/ntnx_templates_deploy_v2.py
@@ -463,6 +463,368 @@ options:
                                                                         value:
                                                                             description: The value associated with the key for this key-value pair
                                                                             type: raw
+                guest_customization_profile_config:
+                    description:
+                        - Reference to an existing VM Guest Customization Profile to apply when deploying this VM,
+                          with optional per-VM overrides.
+                        - Mutually exclusive with C(guest_customization) at the API level
+                          (use either an inline customization or a profile reference, not both).
+                        - Nutanix Guest Tools (NGT) must be installed on the source VM
+                          that backs the template; otherwise, the API rejects the
+                          template-deploy request with VMM-24120 ("Guest customization
+                          profile config is provided during Template deployment but
+                          NGT was not installed on the source VM.").
+                    required: false
+                    type: dict
+                    suboptions:
+                        profile:
+                            description:
+                                - Reference to a VM Guest Customization profile.
+                            type: dict
+                            suboptions:
+                                ext_id:
+                                    description: External ID of the VM Guest Customization Profile.
+                                    type: str
+                                    required: true
+                        config_override_spec:
+                            description:
+                                - Sysprep configuration override specification for Windows operating system customization.
+                            type: dict
+                            suboptions:
+                                customization:
+                                    description:
+                                        - Sysprep customization override.
+                                        - Either C(sysprep_params) or C(answer_file) is allowed, not both.
+                                    type: dict
+                                    suboptions:
+                                        answer_file:
+                                            description: Override the answer file (unattend.xml).
+                                            type: dict
+                                            suboptions:
+                                                unattend_xml:
+                                                    description:
+                                                        - The custom unattend.xml file content as a string.
+                                                        - This replaces the unattend.xml from the referenced VM Guest Customization Profile.
+                                                        - Note that double quotes in the XML file must be escaped to maintain correctness.
+                                                        - Should be base64 encoded.
+                                                        - You can either pass an already-encoded string, or pass the raw
+                                                          unattend.xml content and let Ansible encode it using the
+                                                          C(b64encode) filter, e.g.
+                                                          C("{{ unattend_xml_content | b64encode }}").
+                                                    type: str
+                                        sysprep_params:
+                                            description: Override individual Sysprep parameters.
+                                            type: dict
+                                            suboptions:
+                                                general_settings:
+                                                    description:
+                                                    - Override specification for general Windows unattended installation settings.
+                                                    - These settings override the corresponding general settings from the referenced profile.
+                                                    - To completely discard the setting from the referenced profile, specify an empty object as the value.
+                                                    type: dict
+                                                    suboptions:
+                                                        computer_name:
+                                                            description:
+                                                                - Override mechanism for computer name generation.
+                                                                - You can either use the VM name, provide a computer name,
+                                                                  or discard the setting from the referenced profile.
+                                                                - If using a VM name or computer name, meet the sysprep's computer name requirements;
+                                                                  otherwise, the request would fail.
+                                                            type: dict
+                                                            suboptions:
+                                                                name:
+                                                                    description: Set computer name to a specific value.
+                                                                    type: dict
+                                                                    suboptions:
+                                                                        value:
+                                                                            description: The computer name.
+                                                                            type: str
+                                                                use_vm_name:
+                                                                    description: Use the deployed VM's name as the computer name.
+                                                                    type: dict
+                                                                discard:
+                                                                    description: Discard the profile's computer-name value.
+                                                                    type: dict
+                                                        timezone:
+                                                            description:
+                                                                - Override for timezone setting. You can either provide a new timezone value or
+                                                                  discard the setting from the referenced profile.
+                                                                - For valid timezone values, refer to Windows sysprep documentation.
+                                                            type: dict
+                                                            suboptions:
+                                                                value:
+                                                                    description: Set timezone to a specific value.
+                                                                    type: dict
+                                                                    suboptions:
+                                                                        value:
+                                                                            description: Timezone value.
+                                                                            type: str
+                                                                discard:
+                                                                    description: Discard the profile's timezone.
+                                                                    type: dict
+                                                        administrator_password:
+                                                            description:
+                                                                - Override for administrator password.
+                                                                - You can either provide a new password or discard the setting from the referenced profile.
+                                                            type: dict
+                                                            suboptions:
+                                                                value:
+                                                                    description: Set administrator password to a specific value
+                                                                    type: dict
+                                                                    suboptions:
+                                                                        value:
+                                                                            description: The administrator password.
+                                                                            type: str
+                                                                discard:
+                                                                    description: Discard the profile's administrator password.
+                                                                    type: dict
+                                                        auto_logon_settings:
+                                                            description:
+                                                                - Override specification for autologon settings.
+                                                                - These settings override the corresponding autologon settings
+                                                                  from the referenced profile.
+                                                                - To completely discard the setting from the referenced profile,
+                                                                  specify an empty object as the value.
+                                                            type: dict
+                                                            suboptions:
+                                                                logon_count:
+                                                                    description:
+                                                                        - Override value for the number of automatic logons allowed.
+                                                                        - This overrides the logon count from the referenced profile.
+                                                                    type: int
+                                                        windows_product_key:
+                                                            description:
+                                                                - Override for Windows product key.
+                                                                - You can either provide a new product key or discard the setting from the referenced profile.
+                                                                - Note that entering an invalid product key causes Windows Setup to fail.
+                                                            type: dict
+                                                            suboptions:
+                                                                value:
+                                                                    description: Set Windows product key to a specific value.
+                                                                    type: dict
+                                                                    suboptions:
+                                                                        value:
+                                                                            description: The Windows product key.
+                                                                            type: str
+                                                                discard:
+                                                                    description: Discard the profile's Windows product key.
+                                                                    type: dict
+                                                        registered_owner:
+                                                            description:
+                                                                - Override for registered owner information.
+                                                                - You can either provide new owner details or discard the setting from the referenced profile.
+                                                            type: dict
+                                                            suboptions:
+                                                                value:
+                                                                    description: Set registered owner to a specific value.
+                                                                    type: dict
+                                                                    suboptions:
+                                                                        value:
+                                                                            description: The registered owner name.
+                                                                            type: str
+                                                                discard:
+                                                                    description: Discard the profile's registered owner.
+                                                                    type: dict
+                                                        registered_organization:
+                                                            description:
+                                                                - Override for registered organization information.
+                                                                - You can either provide new organization details or discard
+                                                                  the setting from the referenced profile.
+                                                            type: dict
+                                                            suboptions:
+                                                                value:
+                                                                    description: Set registered organization to a specific value.
+                                                                    type: dict
+                                                                    suboptions:
+                                                                        value:
+                                                                            description: The registered organization name.
+                                                                            type: str
+                                                                discard:
+                                                                    description: Discard the profile's registered organization.
+                                                                    type: dict
+                                                first_logon_commands:
+                                                    description:
+                                                        - Override for first logon commands.
+                                                        - This overrides the first logon commands from the referenced profile.
+                                                        - Commands are executed in the order specified.
+                                                        - To completely discard the setting from the referenced profile, specify an empty array as the value.
+                                                    type: list
+                                                    elements: str
+                                                locale_settings:
+                                                    description:
+                                                        - Override specification for language and input locale settings.
+                                                        - These settings override the corresponding locale settings from the referenced profile.
+                                                        - To completely discard the setting from the referenced profile, specify an empty object as the value.
+                                                    type: dict
+                                                    suboptions:
+                                                        user_locale:
+                                                            description:
+                                                                - Override for per-user locale settings used for formatting dates, times, currency, and numbers.
+                                                                - You can either provide a new locale value or discard the setting from the referenced profile.
+                                                                - Value must follow RFC 3066 language-tagging conventions, for example, en-US, fr-FR, es-ES.
+                                                            type: dict
+                                                            suboptions:
+                                                                value:
+                                                                    description: Set user locale to a specific value.
+                                                                    type: dict
+                                                                    suboptions:
+                                                                        value:
+                                                                            description: The new locale value.
+                                                                            type: str
+                                                                discard:
+                                                                    description: Discard the profile's user locale.
+                                                                    type: dict
+                                                        system_locale:
+                                                            description:
+                                                                - Override for the default language used for non-Unicode programs.
+                                                                - You can either provide a new locale value or discard the setting from the referenced profile.
+                                                                - Value must follow RFC 3066 language-tagging conventions, for example, en-US, fr-FR, es-ES.
+                                                            type: dict
+                                                            suboptions:
+                                                                value:
+                                                                    description: Set system locale to a specific value.
+                                                                    type: dict
+                                                                    suboptions:
+                                                                        value:
+                                                                            description: The new locale value.
+                                                                            type: str
+                                                                discard:
+                                                                    description: Discard the profile's system locale.
+                                                                    type: dict
+                                                        ui_language:
+                                                            description:
+                                                                - Override for the default system language used to display user interface items.
+                                                                - You can either provide a new language value or discard
+                                                                  the setting from the referenced profile.
+                                                                - Value must follow RFC 3066 language-tagging conventions,
+                                                                  for example, en-US, fr-FR, es-ES.
+                                                            type: dict
+                                                            suboptions:
+                                                                value:
+                                                                    description: Set UI language to a specific value.
+                                                                    type: dict
+                                                                    suboptions:
+                                                                        value:
+                                                                            description: The new language value.
+                                                                            type: str
+                                                                discard:
+                                                                    description: Discard the profile's UI language.
+                                                                    type: dict
+                                                workgroup_or_domain_info:
+                                                    description:
+                                                        - Override specification for workgroup or domain information.
+                                                        - You can either provide a new workgroup or domain settings or discard
+                                                          the settings from the referenced profile.
+                                                    type: dict
+                                                    suboptions:
+                                                        workgroup:
+                                                            description: Override workgroup settings.
+                                                            type: dict
+                                                            suboptions:
+                                                                name:
+                                                                    description:
+                                                                        - Override value for workgroup name.
+                                                                        - This overrides the workgroup name from the referenced profile.
+                                                                        - It must be a valid NetBIOS name.
+                                                                    type: str
+                                                        domain_settings:
+                                                            description: Override domain join settings.
+                                                            type: dict
+                                                            suboptions:
+                                                                credentials:
+                                                                    description:
+                                                                        - Override specification for domain credentials.
+                                                                        - This overrides the domain credentials from the referenced profile.
+                                                                    type: dict
+                                                                    suboptions:
+                                                                        domain_name:
+                                                                            description:
+                                                                                - Override value for domain name.
+                                                                                - This overrides the domain name from the referenced profile.
+                                                                                - Can be either the fully qualified DNS name or NetBIOS name of the domain.
+                                                                            type: str
+                                                                        username:
+                                                                            description:
+                                                                                - Override value for domain username.
+                                                                                - This overrides the domain username from the referenced profile.
+                                                                            type: str
+                                                                        password:
+                                                                            description:
+                                                                                - Override value for domain password.
+                                                                                - This overrides the domain password from the referenced profile.
+                                                                            type: str
+                                                        discard:
+                                                            description: Discard the profile's workgroup or domain settings.
+                                                            type: dict
+                                                network_settings:
+                                                    description:
+                                                       - Override specification for network settings.
+                                                       - These settings override the corresponding network settings from the referenced profile.
+                                                       - To completely discard the setting from the referenced profile, specify an empty object as the value.
+                                                    type: dict
+                                                    suboptions:
+                                                        nic_config_list:
+                                                            description:
+                                                               - Override specification for NIC configuration list.
+                                                               - This overrides the NIC configurations from the referenced profile.
+                                                               - Configurations are applied to NICs in serial order.
+                                                            type: list
+                                                            elements: dict
+                                                            suboptions:
+                                                                dns_config:
+                                                                    description:
+                                                                        - Override specification for DNS configuration.
+                                                                        - This overrides the DNS settings from the referenced profile.
+                                                                    type: dict
+                                                                    suboptions:
+                                                                        preferred_dns_server_address:
+                                                                            description:
+                                                                                - Override value for preferred DNS server address.
+                                                                                - This overrides the preferred DNS server from the referenced profile.
+                                                                            type: str
+                                                                        alternate_dns_server_addresses:
+                                                                            description:
+                                                                                - Override value for alternate DNS server addresses.
+                                                                                - This overrides the alternate DNS servers from the referenced profile.
+                                                                            type: list
+                                                                            elements: str
+                                                                ipv4_config:
+                                                                    description:
+                                                                        - Override mechanism for IPv4 configuration.
+                                                                        - You can either use DHCP, provide a custom IPv4 configuration,
+                                                                          or discard the setting from the referenced profile.
+                                                                        - If DHCP is specified, DhcpEnabled is set to True in the unattend.xml.
+                                                                    type: dict
+                                                                    suboptions:
+                                                                        use_dhcp:
+                                                                            description: Use DHCP for IPv4.
+                                                                            type: dict
+                                                                        static_config:
+                                                                            description: Static IPv4 configuration.
+                                                                            type: dict
+                                                                            suboptions:
+                                                                                ip_address:
+                                                                                    description:
+                                                                                        - An unique address that identifies a device on the internet
+                                                                                          or a local network in IPv4 format.
+                                                                                    type: dict
+                                                                                    suboptions:
+                                                                                        value:
+                                                                                            description: IPv4 address value.
+                                                                                            type: str
+                                                                                            required: true
+                                                                                        prefix_length:
+                                                                                            description:
+                                                                                                - Prefix length for the address.
+                                                                                                - Defaults to 32 if not provided.
+                                                                                            type: int
+                                                                                default_gateways:
+                                                                                    description:
+                                                                                        - Override value for default gateways.
+                                                                                        - This overrides the default gateway configuration
+                                                                                          from the referenced profile.
+                                                                                    type: list
+                                                                                    elements: str
     cluster_reference:
         description:
             - The identifier of the Cluster where the VM(s) will be created using a Template.
@@ -508,6 +870,48 @@ EXAMPLES = r"""
         num_cores_per_socket: 4
         num_threads_per_core: 2
         memory_size_bytes: 4294967296
+
+- name: Deploy VM from template with a Guest Customization Profile and per-VM overrides
+  nutanix.ncp.ntnx_templates_deploy_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "{{ template_ext_id }}"
+    version_id: "{{ version_ext_id }}"
+    cluster_reference: "{{ cluster.uuid }}"
+    number_of_vms: 1
+    override_vms_config:
+      - name: vm_template_with_profile
+        guest_customization_profile_config:
+          profile:
+            ext_id: "b1c2d3e4-5f67-4890-a123-456789abcdef"
+          config_override_spec:
+            customization:
+              sysprep_params:
+                general_settings:
+                  computer_name:
+                    name:
+                      value: "PC-DEPLOY-1"
+                  timezone:
+                    value:
+                      value: "UTC"
+                  administrator_password:
+                    value:
+                      value: "Password123"
+                network_settings:
+                  nic_config_list:
+                    - dns_config:
+                        preferred_dns_server_address: "10.0.0.10"
+                        alternate_dns_server_addresses:
+                          - "10.0.0.11"
+                      ipv4_config:
+                        static_config:
+                          ip_address:
+                            value: "10.0.0.50"
+                            prefix_length: 24
+                          default_gateways:
+                            - "10.0.0.1"
 """
 
 RETURN = r"""
@@ -607,6 +1011,9 @@ from ..module_utils.v4.vmm.api_client import (  # noqa: E402
     get_templates_api_instance,
 )
 from ..module_utils.v4.vmm.helpers import get_template  # noqa: E402
+from ..module_utils.v4.vmm.spec.vm_guest_customization_profiles import (  # noqa: E402
+    VmGcProfileOverrideSpecs,
+)
 from ..module_utils.v4.vmm.spec.vms import VmSpecs as vm_specs  # noqa: E402
 
 SDK_IMP_ERROR = None
@@ -640,6 +1047,12 @@ def get_override_vm_config_schema():
             options=vm_specs.get_gc_spec(),
             obj=vmm_sdk.GuestCustomizationParams,
         ),
+        guest_customization_profile_config=dict(
+            type="dict",
+            options=VmGcProfileOverrideSpecs.get_guest_customization_profile_config_spec(),
+            obj=vmm_sdk.VmGcProfileConfig,
+            no_log=False,
+        ),
     )
     return override_config_schema
 
@@ -651,7 +1064,12 @@ def get_module_spec():
         version_id=dict(type="str"),
         number_of_vms=dict(type="int"),
         override_vms_config=dict(
-            type="list", elements="dict", options=get_override_vm_config_schema()
+            type="list",
+            elements="dict",
+            options=get_override_vm_config_schema(),
+            mutually_exclusive=[
+                ("guest_customization", "guest_customization_profile_config"),
+            ],
         ),
         cluster_reference=dict(type="str"),
     )

--- a/plugins/modules/ntnx_templates_deploy_v2.py
+++ b/plugins/modules/ntnx_templates_deploy_v2.py
@@ -912,6 +912,48 @@ EXAMPLES = r"""
                             prefix_length: 24
                           default_gateways:
                             - "10.0.0.1"
+
+# NGT must be installed on the source VM that the template was captured from,
+# otherwise the deploy API rejects the request with an NGT-not-installed error.
+- name: Deploy VM from template with a Guest Customization Profile (workgroup join, DHCP)
+  nutanix.ncp.ntnx_templates_deploy_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b3b"
+    cluster_reference: "f005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b3b"
+    override_vms_config:
+      - name: vm_deployed_from_template
+        num_sockets: 2
+        num_cores_per_socket: 2
+        guest_customization_profile_config:
+          profile:
+            ext_id: "b1c2d3e4-5f67-4890-a123-456789abcdef"
+          config_override_spec:
+            customization:
+              sysprep_params:
+                general_settings:
+                  computer_name:
+                    name:
+                      value: "deployed-host"
+                  timezone:
+                    value:
+                      value: "UTC"
+                  registered_owner:
+                    value:
+                      value: "deployed-owner"
+                workgroup_or_domain_info:
+                  workgroup:
+                    name: "DEPLOYED-WG"
+                network_settings:
+                  nic_config_list:
+                    - dns_config:
+                        preferred_dns_server_address: "10.0.0.100"
+                        alternate_dns_server_addresses:
+                          - "10.0.0.101"
+                      ipv4_config:
+                        use_dhcp: {}
 """
 
 RETURN = r"""

--- a/plugins/modules/ntnx_vm_anti_affinity_policy_v2.py
+++ b/plugins/modules/ntnx_vm_anti_affinity_policy_v2.py
@@ -292,7 +292,9 @@ def create_policy(module, api_instance, result):
         else:
             raise_api_exception(
                 module=module,
-                exception=Exception("Failed to get entity ext_id from task for VM Anti-Affinity Policy"),
+                exception=Exception(
+                    "Failed to get entity ext_id from task for VM Anti-Affinity Policy"
+                ),
                 msg="Failed to get entity ext_id from task for VM Anti-Affinity Policy",
             )
 

--- a/plugins/modules/ntnx_vm_guest_customization_profile_v2.py
+++ b/plugins/modules/ntnx_vm_guest_customization_profile_v2.py
@@ -98,15 +98,12 @@ options:
                           use_vm_name:
                             description:
                               - Use the VM name as the computer name.
-                              - To enable this option, specify the key with no value (C(use_vm_name:))
-                                or with an empty dictionary (C(use_vm_name: {})).
+                              - Specify C(use_vm_name) with no value or with an empty dictionary to enable this option.
                             type: dict
                           must_provide_during_deployment:
                             description:
                               - Indicates that this value must be provided during deployment.
-                              - To enable this option, specify the key with no value
-                                (C(must_provide_during_deployment:)) or with an empty dictionary
-                                (C(must_provide_during_deployment: {})).
+                              - Specify C(must_provide_during_deployment) with no value or with an empty dictionary to enable this option.
                             type: dict
                       timezone:
                         description:
@@ -240,24 +237,22 @@ options:
                                 elements: str
                           ipv4_config:
                             description:
-                              - Mechanism to configure IPv4 settings of the NIC. Either UseDhcp or MustProvideDuringDeployment should be specified as a value. If UseDhcp is specified,
-                                DhcpEnabled is set to True for the interface in the unattend XML.
-                              - If MustProvideDuringDeployment is specified, the user must provide the IPv4 address with the prefix length and gateway details during the deployment.
+                              - Mechanism to configure IPv4 settings of the NIC.
+                              - Either UseDhcp or MustProvideDuringDeployment should be specified as a value.
+                              - If UseDhcp is specified, DhcpEnabled is set to True for the interface in the unattend XML.
+                              - If MustProvideDuringDeployment is specified, the IPv4 address, prefix length, and gateway must be supplied during deployment.
                               - C(use_dhcp) and C(must_provide_during_deployment) are mutually exclusive.
                             type: dict
                             suboptions:
                               use_dhcp:
                                 description:
                                   - The NIC will obtain its IPv4 address via DHCP.
-                                  - To enable this option, specify the key with no value (C(use_dhcp:))
-                                    or with an empty dictionary (C(use_dhcp: {})).
+                                  - Specify C(use_dhcp) with no value or with an empty dictionary to enable this option.
                                 type: dict
                               must_provide_during_deployment:
                                 description:
                                   - The IPv4 configuration must be provided at deployment-time.
-                                  - To enable this option, specify the key with no value
-                                    (C(must_provide_during_deployment:)) or with an empty dictionary
-                                    (C(must_provide_during_deployment: {})).
+                                  - Specify C(must_provide_during_deployment) with no value or with an empty dictionary to enable this option.
                                 type: dict
               answer_file:
                 description:

--- a/plugins/modules/ntnx_vm_guest_customization_profile_v2.py
+++ b/plugins/modules/ntnx_vm_guest_customization_profile_v2.py
@@ -32,6 +32,14 @@ notes:
     - >-
       B(Delete the specified VM Guest Customization Profile.) -
       Required Roles: Prism Admin, Super Admin, Virtual Machine Admin
+    - >-
+      Profiles created by this module are consumed by
+      M(nutanix.ncp.ntnx_vms_clone_v2) and M(nutanix.ncp.ntnx_templates_deploy_v2)
+      via their C(guest_customization_profile_config) option. For the profile to
+      be applied successfully at clone or deploy time, Nutanix Guest Tools (NGT)
+      must be installed on the source VM (or the source VM that backs the
+      template); otherwise, the corresponding clone or deploy request will be
+      rejected by the API.
     - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
 options:
   state:
@@ -379,49 +387,55 @@ response:
   sample:
     {
       "config": {
-        "sysprep": {
           "customization": {
-            "sysprep_params": {
-              "first_logon_commands": ["powershell -Command Enable-PSRemoting -Force"],
+              "first_logon_commands": [
+                  "powershell -Command Enable-PSRemoting -Force"
+              ],
               "general_settings": {
-                "administrator_password": null,
-                "auto_logon_settings": null,
-                "computer_name": {"use_vm_name": {}},
-                "registered_organization": "Nutanix",
-                "registered_owner": "Nutanix",
-                "timezone": "Pacific Standard Time",
-                "windows_product_key": null
+                  "administrator_password": "MASKED_FIELD",
+                  "auto_logon_settings": null,
+                  "computer_name": {},
+                  "registered_organization": "admin",
+                  "registered_owner": "admin",
+                  "timezone": "Pacific Standard Time",
+                  "windows_product_key": null
               },
               "locale_settings": {
-                "system_locale": "en-US",
-                "ui_language": "en-US",
-                "user_locale": "en-US"
+                  "system_locale": "en-US",
+                  "ui_language": "en-US",
+                  "user_locale": "en-US"
               },
               "network_settings": {
-                "nic_config_list": [
-                  {
-                    "dns_config": {
-                      "alternate_dns_server_addresses": ["10.0.0.11"],
-                      "preferred_dns_server_address": "10.0.0.10"
-                    },
-                    "ipv4_config": {"use_dhcp": {}}
-                  }
-                ]
+                  "nic_config_list": [
+                      {
+                          "dns_config": {
+                              "alternate_dns_server_addresses": [
+                                  "10.0.0.11"
+                              ],
+                              "preferred_dns_server_address": "10.0.0.10"
+                          },
+                          "ipv4_config": {}
+                      }
+                  ]
               },
-              "workgroup_or_domain_info": {"workgroup": {"name": "WORKGROUP"}}
-            }
+              "workgroup_or_domain_info": {
+                  "name": "workgroup"
+              }
           }
-        }
       },
-      "created_by": null,
-      "create_time": "2026-05-03T11:25:36.123456+00:00",
-      "description": "Reusable Windows Sysprep profile for QA Workgroup VMs",
-      "ext_id": "a0dea088-5cd2-4d18-8d20-addba20c937c",
+      "create_time": "2026-05-05T11:26:57.496782+00:00",
+      "created_by": {
+          "ext_id": "00000000-0000-0000-0000-000000000000"
+      },
+      "description": "Sysprep profile created by integration tests",
+      "ext_id": "08bed846-7bf2-48b5-5c92-741500be3a3f",
       "links": null,
-      "name": "win2019-sysprep-profile",
+      "name": "vm_gc_profile_ansible_test_sysprep_WQOHNIIZdzzT",
       "tenant_id": null,
-      "update_time": "2026-05-03T11:25:36.123456+00:00",
-      "updated_by": null
+      "update_time": "2026-05-05T11:26:57.496782+00:00",
+      "updated_by": {
+          "ext_id": "00000000-0000-0000-0000-000000000000"
+      }
     }
 ext_id:
   description:
@@ -449,7 +463,7 @@ changed:
   sample: true
 failed:
   description: Indicates if the module failed
-  returned: when failed
+  returned: always
   type: bool
   sample: false
 """
@@ -472,6 +486,7 @@ from ..module_utils.v4.utils import (  # noqa: E402
     raise_api_exception,
     remove_fields_from_spec,
     strip_internal_attributes,
+    validate_required_params,
 )
 from ..module_utils.v4.vmm.api_client import (  # noqa: E402
     get_etag,
@@ -523,6 +538,7 @@ def normalize_oneof_marker_values(params):
 
 
 def create_profile(module, result, profiles):
+    validate_required_params(module, ["config"])
     sg = SpecGenerator(module)
     default_spec = vmm_sdk.VmGuestCustomizationProfile()
     spec, err = sg.generate_spec(obj=default_spec)

--- a/plugins/modules/ntnx_vm_guest_customization_profile_v2.py
+++ b/plugins/modules/ntnx_vm_guest_customization_profile_v2.py
@@ -1,0 +1,726 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_guest_customization_profile_v2
+short_description: Create, update and delete VM Guest Customization Profiles in Nutanix Prism Central
+version_added: 2.6.0
+description:
+  - Create, update and delete VM Guest Customization Profiles.
+  - A VM Guest Customization Profile is a reusable template that describes how to customize
+    a guest operating system at deployment-time (currently Windows Sysprep, either by
+    specifying parameters individually or by providing an unattend XML file).
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Create a VM Guest Customization Profile.) -
+      Required Roles: Prism Admin, Super Admin, Virtual Machine Admin
+    - >-
+      B(Update the specified VM Guest Customization Profile.) -
+      Required Roles: Prism Admin, Super Admin, Virtual Machine Admin
+    - >-
+      B(Delete the specified VM Guest Customization Profile.) -
+      Required Roles: Prism Admin, Super Admin, Virtual Machine Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  state:
+    description:
+      - If C(state) is present, it will create or update the VM guest customization profile.
+      - If C(state) is set to C(present) and C(ext_id) is not provided, the operation will create the profile.
+      - If C(state) is set to C(present) and C(ext_id) is provided, the operation will update the profile.
+      - If C(state) is set to C(absent) and C(ext_id) is provided, the operation will delete the profile.
+    type: str
+    choices: ["present", "absent"]
+  ext_id:
+    description:
+      - VM Guest Customization Profile external ID.
+      - Required for updating or deleting the profile.
+    type: str
+  name:
+    description:
+      - Name of the VM Guest Customization Profile.
+      - Required for creating a profile.
+    type: str
+  description:
+    description:
+      - A description of the VM Guest Customization Profile.
+    type: str
+  config:
+    description:
+      - The customization configuration that will be applied to the guest OS.
+      - Currently only Windows Sysprep customization is supported.
+    type: dict
+    suboptions:
+      sysprep:
+        description:
+          - Configuration of the VM Guest Customization Profile for customization of a Windows guest operating system.
+        type: dict
+        suboptions:
+          customization:
+            description:
+              - Either specify the values for the parameters (sysprep_params) or an unattend XML file (answer_file).
+              - C(sysprep_params) and C(answer_file) are mutually exclusive.
+            type: dict
+            suboptions:
+              sysprep_params:
+                description:
+                  - A set of various unattended settings supported by Windows Sysprep.
+                  - The Windows unattend XML file is generated based on the values provided for these elements.
+                type: dict
+                suboptions:
+                  general_settings:
+                    description:
+                      - Generic Windows installation settings such as computer name, timezone, product key,
+                        registered owner/organization and the administrator password.
+                    type: dict
+                    suboptions:
+                      computer_name:
+                        description:
+                          - Mechanism to use to generate the computer name of the VM.
+                          - Either UseVmName or MustProvideDuringDeployment should be provided.
+                          - If MustProvideDuringDeployment is specified, then the user must provide the value for the computer name during the VM deployment;
+                            otherwise, the deployment request fails.
+                          - If the UseVmName is specified, then during VM deployment, the name of the VM needs to meet the sysprep's computer name
+                            requirements; otherwise, the request fails.
+                        type: dict
+                        suboptions:
+                          use_vm_name:
+                            description:
+                              - Use the VM name as the computer name.
+                              - To enable this option, specify the key with no value (C(use_vm_name:))
+                                or with an empty dictionary (C(use_vm_name: {})).
+                            type: dict
+                          must_provide_during_deployment:
+                            description:
+                              - Indicates that this value must be provided during deployment.
+                              - To enable this option, specify the key with no value
+                                (C(must_provide_during_deployment:)) or with an empty dictionary
+                                (C(must_provide_during_deployment: {})).
+                            type: dict
+                      timezone:
+                        description:
+                          - The computer's time zone in string format.
+                          - For different timezone values, refer to the Windows unattend installation documentation.
+                        type: str
+                      administrator_password:
+                        description:
+                          - Password to be configured for built-in Administrator account.
+                        type: str
+                      auto_logon_settings:
+                        description:
+                          - Autologon settings that need to be specified to enable autologon.
+                            Currently, it is for only the Administrator account, and the value for the Administrator Password should be provided in the
+                            General Settings section when configuring this setting.
+                        type: dict
+                        suboptions:
+                          logon_count:
+                            description:
+                              - The number of automatic logons allowed for the computer using the specified local account.
+                              - The C(logon_count) must be specified if the C(auto_logon_settings) is used.
+                            type: int
+                      windows_product_key:
+                        description:
+                          - The product key to use to install and activate Windows.
+                          - Note that entering an invalid product key causes Windows Setup to fail.
+                        type: str
+                      registered_owner:
+                        description:
+                          - Full name of the end user. Note that this is the full name in the format, not only the username.
+                        type: str
+                      registered_organization:
+                        description:
+                          - Name of the organization of the end user.
+                        type: str
+                  first_logon_commands:
+                    description:
+                      - List of commands to be executed automatically when a user logs in for the first time after Windows setup.
+                      - This is an ordered list. The first command in the list is given the order as 1, and so on,
+                        in FirstLogonCommands in the generated unattend XML.
+                      - For more information, refer to Windows unattend installation documentation.
+                    type: list
+                    elements: str
+                  locale_settings:
+                    description:
+                      - Language and locale settings for the system and the user.
+                    type: dict
+                    suboptions:
+                      user_locale:
+                        description:
+                          - Per-user settings to be used for formatting dates, times, currency, and numbers.
+                          - Its value is based on the language-tagging conventions of RFC 3066.
+                          - The pattern language-region is used, where language is a language code and region is a country or region identifier.
+                        type: str
+                      system_locale:
+                        description:
+                          - Default language to use for non-Unicode programs.
+                          - Its value is based on the language-tagging conventions of RFC 3066.
+                          - The pattern language-region is used, where language is a language code and region is a country or region identifier.
+                        type: str
+                      ui_language:
+                        description:
+                          - Default system language to use to display user interface (UI) items.
+                          - Its value is based on the language-tagging conventions of RFC 3066.
+                          - The pattern language-region is used, where language is a language code and region is a country or region identifier.
+                        type: str
+                  workgroup_or_domain_info:
+                    description:
+                      - Either join a workgroup or join an Active Directory domain.
+                      - C(workgroup) and C(domain_settings) are mutually exclusive.
+                    type: dict
+                    suboptions:
+                      workgroup:
+                        description:
+                          - Workgroup configuration of the computer.
+                        type: dict
+                        suboptions:
+                          name:
+                            description:
+                              - Name of workgroup to be applied to the computer when joining the workgroup. It must be a valid NetBIOS name.
+                            type: str
+                      domain_settings:
+                        description:
+                          - Domain Settings Configuration.
+                        type: dict
+                        suboptions:
+                          credentials:
+                            description:
+                              - Credentials of the domain account to use to join the domain.
+                            type: dict
+                            suboptions:
+                              domain_name:
+                                description:
+                                  - The name of the domain to use for authentication of the account before the computer
+                                    can be joined to a domain. A domain name can be the fully qualified DNS name or the NetBIOS name of the domain.
+                                type: str
+                              username:
+                                description:
+                                  - Name of the domain user account with permission to add the computer to a domain.
+                                type: str
+                              password:
+                                description:
+                                  - The password of the domain user account to use for authenticating an account to the domain before
+                                    the computer can be joined to a domain.
+                                type: str
+                  network_settings:
+                    description:
+                      - Network settings to apply to the NICs attached to the VM.
+                    type: dict
+                    suboptions:
+                      nic_config_list:
+                        description:
+                          - List of NIC configurations to be applied to the NICs attached to the VM in serial order.
+                          - The first configuration provided in the list is applied to the first NIC attached to the VM, and so on for other NICs.
+                        type: list
+                        elements: dict
+                        suboptions:
+                          dns_config:
+                            description:
+                              - DNS configuration to be applied to the NIC.
+                            type: dict
+                            suboptions:
+                              preferred_dns_server_address:
+                                description:
+                                  - An IPv4 address is preferred to search first when searching for the DNS server on the network.
+                                type: str
+                              alternate_dns_server_addresses:
+                                description:
+                                  - List of IPv4 addresses to look for after preferred DNS server when searching for the DNS server on the network.
+                                type: list
+                                elements: str
+                          ipv4_config:
+                            description:
+                              - Mechanism to configure IPv4 settings of the NIC. Either UseDhcp or MustProvideDuringDeployment should be specified as a value. If UseDhcp is specified,
+                                DhcpEnabled is set to True for the interface in the unattend XML.
+                              - If MustProvideDuringDeployment is specified, the user must provide the IPv4 address with the prefix length and gateway details during the deployment.
+                              - C(use_dhcp) and C(must_provide_during_deployment) are mutually exclusive.
+                            type: dict
+                            suboptions:
+                              use_dhcp:
+                                description:
+                                  - The NIC will obtain its IPv4 address via DHCP.
+                                  - To enable this option, specify the key with no value (C(use_dhcp:))
+                                    or with an empty dictionary (C(use_dhcp: {})).
+                                type: dict
+                              must_provide_during_deployment:
+                                description:
+                                  - The IPv4 configuration must be provided at deployment-time.
+                                  - To enable this option, specify the key with no value
+                                    (C(must_provide_during_deployment:)) or with an empty dictionary
+                                    (C(must_provide_during_deployment: {})).
+                                type: dict
+              answer_file:
+                description:
+                  - A pre-built Windows unattend XML file used as the customization input.
+                type: dict
+                suboptions:
+                  unattend_xml:
+                    description:
+                      - The unattend XML file as a string value.
+                      - Note that double quotes in the XML file need to be escaped to maintain correctness.
+                      - The XML file needs to be Base64 encoded (e.g. using the Ansible C(b64encode) filter).
+                    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create VM Guest Customization Profile with sysprep params (Workgroup join, DHCP)
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    name: "win-sysprep-profile"
+    description: "Windows Sysprep profile description"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name:
+              timezone: "Pacific Standard Time"
+              administrator_password: "admin123"
+              registered_owner: "admin"
+              registered_organization: "admin"
+            locale_settings:
+              user_locale: "en-US"
+              system_locale: "en-US"
+              ui_language: "en-US"
+            first_logon_commands:
+              - "powershell -Command Enable-PSRemoting -Force"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "workgroup"
+            network_settings:
+              nic_config_list:
+                - dns_config:
+                    preferred_dns_server_address: "8.8.8.8"
+                    alternate_dns_server_addresses:
+                      - "8.8.4.4"
+                  ipv4_config:
+                    use_dhcp:
+
+- name: Create VM Guest Customization Profile with an unattend XML answer file
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    name: "answer-file-profile"
+    description: "Answer file profile description"
+    config:
+      sysprep:
+        customization:
+          answer_file:
+            unattend_xml: "{{ lookup('file', 'unattend.xml') | b64encode }}"
+
+- name: Update VM Guest Customization Profile (switch to domain join, must-provide IP)
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "a3265671-de53-41be-af9b-f06241b95356"
+    name: "sysprep-profile-domain-updated"
+    description: "Updated profile description"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                must_provide_during_deployment: {}
+              timezone: "UTC"
+              administrator_password: "admin123"
+            workgroup_or_domain_info:
+              domain_settings:
+                credentials:
+                  domain_name: "domain.com"
+                  username: "admin"
+                  password: "admin123"
+            network_settings:
+              nic_config_list:
+                - ipv4_config:
+                    must_provide_during_deployment: {}
+
+- name: Delete VM Guest Customization Profile
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: absent
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "a3265671-de53-41be-af9b-f06241b95356"
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating or deleting the VM Guest Customization Profile.
+    - VM Guest Customization Profile details if C(wait) is true and the operation is create or update.
+    - Task details if C(wait) is false or the operation is delete.
+  type: dict
+  returned: always
+  sample:
+    {
+      "config": {
+        "sysprep": {
+          "customization": {
+            "sysprep_params": {
+              "first_logon_commands": ["powershell -Command Enable-PSRemoting -Force"],
+              "general_settings": {
+                "administrator_password": null,
+                "auto_logon_settings": null,
+                "computer_name": {"use_vm_name": {}},
+                "registered_organization": "Nutanix",
+                "registered_owner": "Nutanix",
+                "timezone": "Pacific Standard Time",
+                "windows_product_key": null
+              },
+              "locale_settings": {
+                "system_locale": "en-US",
+                "ui_language": "en-US",
+                "user_locale": "en-US"
+              },
+              "network_settings": {
+                "nic_config_list": [
+                  {
+                    "dns_config": {
+                      "alternate_dns_server_addresses": ["10.0.0.11"],
+                      "preferred_dns_server_address": "10.0.0.10"
+                    },
+                    "ipv4_config": {"use_dhcp": {}}
+                  }
+                ]
+              },
+              "workgroup_or_domain_info": {"workgroup": {"name": "WORKGROUP"}}
+            }
+          }
+        }
+      },
+      "created_by": null,
+      "create_time": "2026-05-03T11:25:36.123456+00:00",
+      "description": "Reusable Windows Sysprep profile for QA Workgroup VMs",
+      "ext_id": "a0dea088-5cd2-4d18-8d20-addba20c937c",
+      "links": null,
+      "name": "win2019-sysprep-profile",
+      "tenant_id": null,
+      "update_time": "2026-05-03T11:25:36.123456+00:00",
+      "updated_by": null
+    }
+ext_id:
+  description:
+    - External ID of the VM Guest Customization Profile.
+  type: str
+  returned: always
+task_ext_id:
+  description: Task External ID
+  returned: always
+  type: str
+  sample: "ZXJnb24=:350f0fd5-097d-4ece-8f44-6e5bfbe2dc08"
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating VM Guest Customization Profile"
+error:
+  description: Error message if any
+  returned: always
+  type: str
+changed:
+  description: Indicates if the module made any changes
+  returned: always
+  type: bool
+  sample: true
+failed:
+  description: Indicates if the module failed
+  returned: when failed
+  type: bool
+  sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    remove_fields_from_spec,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_etag,
+    get_vm_guest_customization_profiles_api_instance,
+)
+from ..module_utils.v4.vmm.helpers import (  # noqa: E402
+    get_vm_guest_customization_profile,
+)
+from ..module_utils.v4.vmm.spec.vm_guest_customization_profiles import (  # noqa: E402
+    VmGuestCustomizationProfileSpecs as profile_specs,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_vmm_py_client as vmm_sdk  # noqa: E402
+except ImportError:
+    from ..module_utils.v4.sdk_mock import mock_sdk as vmm_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    return profile_specs.get_module_spec()
+
+
+def normalize_oneof_marker_values(params):
+    """Normalize one-of marker variants from ``null`` to ``{}``.
+
+    The empty-marker variants (``use_vm_name``, ``must_provide_during_deployment``,
+    ``use_dhcp``) map to SDK classes with no user-facing fields; the variant is
+    selected purely by *which* key is present. Users may write either
+    ``use_vm_name: {}`` or simply ``use_vm_name:`` (null) in their playbook.
+    The latter form would otherwise be stripped by ``remove_param_with_none_value``
+    before the spec generator could dispatch it, so we promote ``null`` to ``{}``
+    for known marker keys here.
+    """
+    marker_keys = profile_specs.empty_marker_keys
+    if isinstance(params, dict):
+        for key, value in params.items():
+            if key in marker_keys and value is None:
+                params[key] = {}
+            elif isinstance(value, dict):
+                normalize_oneof_marker_values(value)
+            elif isinstance(value, list):
+                for item in value:
+                    normalize_oneof_marker_values(item)
+
+
+def create_profile(module, result, profiles):
+    sg = SpecGenerator(module)
+    default_spec = vmm_sdk.VmGuestCustomizationProfile()
+    spec, err = sg.generate_spec(obj=default_spec)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating create VM Guest Customization Profile spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = profiles.create_vm_guest_customization_profile(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating VM Guest Customization Profile",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task,
+            rel=TASK_CONSTANTS.RelEntityType.VM_GUEST_CUSTOMIZATION_PROFILE,
+        )
+        if ext_id:
+            resp = get_vm_guest_customization_profile(module, profiles, ext_id)
+            result["ext_id"] = ext_id
+            result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+SECRET_FIELDS = {"administrator_password", "windows_product_key", "password"}
+
+
+def check_idempotency(current_spec, update_spec):
+    current_dict = (
+        current_spec.to_dict() if hasattr(current_spec, "to_dict") else current_spec
+    )
+    update_dict = (
+        update_spec.to_dict() if hasattr(update_spec, "to_dict") else update_spec
+    )
+    strip_internal_attributes(current_dict)
+    strip_internal_attributes(update_dict)
+    remove_fields_from_spec(current_dict, SECRET_FIELDS, deep=True)
+    remove_fields_from_spec(update_dict, SECRET_FIELDS, deep=True)
+    return current_dict == update_dict
+
+
+def update_profile(module, result, profiles):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    current_spec = get_vm_guest_customization_profile(module, profiles, ext_id=ext_id)
+    etag = get_etag(data=current_spec)
+    if not etag:
+        return module.fail_json(
+            "Unable to fetch etag for updating VM Guest Customization Profile",
+            **result,
+        )
+
+    kwargs = {"if_match": etag}
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(current_spec))
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating VM Guest Customization Profile update spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    result["current_spec"] = strip_internal_attributes(current_spec.to_dict())
+    result["update_spec"] = strip_internal_attributes(update_spec.to_dict())
+
+    if check_idempotency(current_spec, update_spec):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    resp = None
+    try:
+        resp = profiles.update_vm_guest_customization_profile_by_id(
+            extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating VM Guest Customization Profile",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_vm_guest_customization_profile(module, profiles, ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+def delete_profile(module, result, profiles):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "VM Guest Customization Profile with ext_id:{0} will be deleted.".format(
+                ext_id
+            )
+        )
+        return
+
+    current_spec = get_vm_guest_customization_profile(module, profiles, ext_id=ext_id)
+    etag = get_etag(data=current_spec)
+    kwargs = {"if_match": etag} if etag else {}
+
+    try:
+        resp = profiles.delete_vm_guest_customization_profile_by_id(
+            extId=ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting VM Guest Customization Profile",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "present", ("name", "ext_id"), True),
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    normalize_oneof_marker_values(module.params)
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    profiles = get_vm_guest_customization_profiles_api_instance(module)
+    state = module.params["state"]
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_profile(module, result, profiles)
+        else:
+            create_profile(module, result, profiles)
+    else:
+        delete_profile(module, result, profiles)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_vm_guest_customization_profile_v2.py
+++ b/plugins/modules/ntnx_vm_guest_customization_profile_v2.py
@@ -170,7 +170,8 @@ options:
                         description:
                           - Default language to use for non-Unicode programs.
                           - Its value is based on the language-tagging conventions of RFC 3066.
-                          - The pattern language-region is used, where language is a language code and region is a country or region identifier.
+                          - The pattern language-region is used, where language is a language code and region is a country or region identifier
+                            (for example, en-US, fr-FR, or es-ES).
                         type: str
                       ui_language:
                         description:
@@ -193,6 +194,7 @@ options:
                             description:
                               - Name of workgroup to be applied to the computer when joining the workgroup. It must be a valid NetBIOS name.
                             type: str
+                            required: true
                       domain_settings:
                         description:
                           - Domain Settings Configuration.
@@ -202,21 +204,25 @@ options:
                             description:
                               - Credentials of the domain account to use to join the domain.
                             type: dict
+                            required: true
                             suboptions:
                               domain_name:
                                 description:
                                   - The name of the domain to use for authentication of the account before the computer
                                     can be joined to a domain. A domain name can be the fully qualified DNS name or the NetBIOS name of the domain.
                                 type: str
+                                required: true
                               username:
                                 description:
                                   - Name of the domain user account with permission to add the computer to a domain.
                                 type: str
+                                required: true
                               password:
                                 description:
                                   - The password of the domain user account to use for authenticating an account to the domain before
                                     the computer can be joined to a domain.
                                 type: str
+                                required: true
                   network_settings:
                     description:
                       - Network settings to apply to the NICs attached to the VM.
@@ -238,6 +244,7 @@ options:
                                 description:
                                   - An IPv4 address is preferred to search first when searching for the DNS server on the network.
                                 type: str
+                                required: true
                               alternate_dns_server_addresses:
                                 description:
                                   - List of IPv4 addresses to look for after preferred DNS server when searching for the DNS server on the network.
@@ -246,11 +253,12 @@ options:
                           ipv4_config:
                             description:
                               - Mechanism to configure IPv4 settings of the NIC.
-                              - Either UseDhcp or MustProvideDuringDeployment should be specified as a value.
+                              - Either specify C(use_dhcp) or C(must_provide_during_deployment) as a value.
                               - If UseDhcp is specified, DhcpEnabled is set to True for the interface in the unattend XML.
                               - If MustProvideDuringDeployment is specified, the IPv4 address, prefix length, and gateway must be supplied during deployment.
                               - C(use_dhcp) and C(must_provide_during_deployment) are mutually exclusive.
                             type: dict
+                            required: true
                             suboptions:
                               use_dhcp:
                                 description:
@@ -273,6 +281,7 @@ options:
                       - Note that double quotes in the XML file need to be escaped to maintain correctness.
                       - The XML file needs to be Base64 encoded (e.g. using the Ansible C(b64encode) filter).
                     type: str
+                    required: true
 extends_documentation_fragment:
   - nutanix.ncp.ntnx_credentials
   - nutanix.ncp.ntnx_operations_v2
@@ -442,6 +451,7 @@ ext_id:
     - External ID of the VM Guest Customization Profile.
   type: str
   returned: always
+  sample: "08bed846-7bf2-48b5-5c92-741500be3a3f"
 task_ext_id:
   description: Task External ID
   returned: always
@@ -483,6 +493,7 @@ from ..module_utils.v4.prism.tasks import (  # noqa: E402
 )
 from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402
+    normalize_oneof_marker_values,
     raise_api_exception,
     remove_fields_from_spec,
     strip_internal_attributes,
@@ -509,32 +520,11 @@ except ImportError:
 
 warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
 
+SECRET_FIELDS = {"administrator_password", "windows_product_key", "password"}
+
 
 def get_module_spec():
     return profile_specs.get_module_spec()
-
-
-def normalize_oneof_marker_values(params):
-    """Normalize one-of marker variants from ``null`` to ``{}``.
-
-    The empty-marker variants (``use_vm_name``, ``must_provide_during_deployment``,
-    ``use_dhcp``) map to SDK classes with no user-facing fields; the variant is
-    selected purely by *which* key is present. Users may write either
-    ``use_vm_name: {}`` or simply ``use_vm_name:`` (null) in their playbook.
-    The latter form would otherwise be stripped by ``remove_param_with_none_value``
-    before the spec generator could dispatch it, so we promote ``null`` to ``{}``
-    for known marker keys here.
-    """
-    marker_keys = profile_specs.empty_marker_keys
-    if isinstance(params, dict):
-        for key, value in params.items():
-            if key in marker_keys and value is None:
-                params[key] = {}
-            elif isinstance(value, dict):
-                normalize_oneof_marker_values(value)
-            elif isinstance(value, list):
-                for item in value:
-                    normalize_oneof_marker_values(item)
 
 
 def create_profile(module, result, profiles):
@@ -579,9 +569,6 @@ def create_profile(module, result, profiles):
             result["response"] = strip_internal_attributes(resp.to_dict())
 
     result["changed"] = True
-
-
-SECRET_FIELDS = {"administrator_password", "windows_product_key", "password"}
 
 
 def check_idempotency(current_spec, update_spec):
@@ -708,11 +695,11 @@ def run_module():
             exception=SDK_IMP_ERROR,
         )
 
-    normalize_oneof_marker_values(module.params)
+    normalize_oneof_marker_values(module.params, profile_specs.empty_marker_keys)
     remove_param_with_none_value(module.params)
     result = {
         "changed": False,
-        "error": None,
+        "failed": False,
         "response": None,
         "ext_id": None,
         "task_ext_id": None,

--- a/plugins/modules/ntnx_vm_guest_customization_profile_v2.py
+++ b/plugins/modules/ntnx_vm_guest_customization_profile_v2.py
@@ -67,7 +67,6 @@ options:
   config:
     description:
       - The customization configuration that will be applied to the guest OS.
-      - Currently only Windows Sysprep customization is supported.
     type: dict
     suboptions:
       sysprep:
@@ -164,7 +163,8 @@ options:
                         description:
                           - Per-user settings to be used for formatting dates, times, currency, and numbers.
                           - Its value is based on the language-tagging conventions of RFC 3066.
-                          - The pattern language-region is used, where language is a language code and region is a country or region identifier.
+                          - The pattern language-region is used, where language is a language code and region is a country or region identifier
+                            (for example, en-US, fr-FR, or es-ES).
                         type: str
                       system_locale:
                         description:
@@ -177,7 +177,8 @@ options:
                         description:
                           - Default system language to use to display user interface (UI) items.
                           - Its value is based on the language-tagging conventions of RFC 3066.
-                          - The pattern language-region is used, where language is a language code and region is a country or region identifier.
+                          - The pattern language-region is used, where language is a language code and region is a country or region identifier
+                            (for example, en-US, fr-FR, or es-ES).
                         type: str
                   workgroup_or_domain_info:
                     description:
@@ -254,8 +255,8 @@ options:
                             description:
                               - Mechanism to configure IPv4 settings of the NIC.
                               - Either specify C(use_dhcp) or C(must_provide_during_deployment) as a value.
-                              - If UseDhcp is specified, DhcpEnabled is set to True for the interface in the unattend XML.
-                              - If MustProvideDuringDeployment is specified, the IPv4 address, prefix length, and gateway must be supplied during deployment.
+                              - If C(use_dhcp) is specified, DhcpEnabled is set to True for the interface in the unattend XML.
+                              - If C(must_provide_during_deployment) is specified, the IPv4 address, prefix length, and gateway must be supplied during deployment.
                               - C(use_dhcp) and C(must_provide_during_deployment) are mutually exclusive.
                             type: dict
                             required: true
@@ -329,6 +330,7 @@ EXAMPLES = r"""
                       - "8.8.4.4"
                   ipv4_config:
                     use_dhcp:
+  register: result
 
 - name: Create VM Guest Customization Profile with an unattend XML answer file
   nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
@@ -344,6 +346,7 @@ EXAMPLES = r"""
         customization:
           answer_file:
             unattend_xml: "{{ lookup('file', 'unattend.xml') | b64encode }}"
+  register: result
 
 - name: Update VM Guest Customization Profile (switch to domain join, must-provide IP)
   nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
@@ -374,7 +377,7 @@ EXAMPLES = r"""
               nic_config_list:
                 - ipv4_config:
                     must_provide_during_deployment: {}
-
+  register: result
 - name: Delete VM Guest Customization Profile
   nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
     state: absent
@@ -383,6 +386,7 @@ EXAMPLES = r"""
     nutanix_password: "{{ password }}"
     validate_certs: false
     ext_id: "a3265671-de53-41be-af9b-f06241b95356"
+  register: result
 """
 
 RETURN = r"""
@@ -567,6 +571,12 @@ def create_profile(module, result, profiles):
             resp = get_vm_guest_customization_profile(module, profiles, ext_id)
             result["ext_id"] = ext_id
             result["response"] = strip_internal_attributes(resp.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception("Failed to get entity ext_id from task for VM Guest Customization Profile"),
+                msg="Failed to get entity ext_id from task for VM Guest Customization Profile",
+            )
 
     result["changed"] = True
 

--- a/plugins/modules/ntnx_vm_guest_customization_profile_v2.py
+++ b/plugins/modules/ntnx_vm_guest_customization_profile_v2.py
@@ -256,7 +256,8 @@ options:
                               - Mechanism to configure IPv4 settings of the NIC.
                               - Either specify C(use_dhcp) or C(must_provide_during_deployment) as a value.
                               - If C(use_dhcp) is specified, DhcpEnabled is set to True for the interface in the unattend XML.
-                              - If C(must_provide_during_deployment) is specified, the IPv4 address, prefix length, and gateway must be supplied during deployment.
+                              - If C(must_provide_during_deployment) is specified, the IPv4 address, prefix length,
+                                and gateway must be supplied during deployment.
                               - C(use_dhcp) and C(must_provide_during_deployment) are mutually exclusive.
                             type: dict
                             required: true
@@ -574,7 +575,9 @@ def create_profile(module, result, profiles):
         else:
             raise_api_exception(
                 module=module,
-                exception=Exception("Failed to get entity ext_id from task for VM Guest Customization Profile"),
+                exception=Exception(
+                    "Failed to get entity ext_id from task for VM Guest Customization Profile"
+                ),
                 msg="Failed to get entity ext_id from task for VM Guest Customization Profile",
             )
 

--- a/plugins/modules/ntnx_vm_guest_customization_profiles_info_v2.py
+++ b/plugins/modules/ntnx_vm_guest_customization_profiles_info_v2.py
@@ -1,0 +1,231 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+module: ntnx_vm_guest_customization_profiles_info_v2
+short_description: Fetch information about VM Guest Customization Profile(s)
+description:
+  - This module fetches information about Nutanix VM Guest Customization Profile(s).
+  - Fetch a specific VM Guest Customization Profile using external ID.
+  - Fetch the list of VM Guest Customization Profiles if external ID is not provided with optional filter.
+  - This module uses PC v4 APIs based SDKs.
+version_added: "2.6.0"
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get the VM Guest Customization Profile for this extId) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin, Virtual Machine Admin, Virtual Machine Viewer
+    - >-
+      B(Get the list of existing VM Guest Customization Profiles.) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin, Virtual Machine Admin, Virtual Machine Viewer
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  ext_id:
+    description:
+      - The external ID of the VM Guest Customization Profile.
+    type: str
+    required: false
+author:
+  - George Ghawali (@george-ghawali)
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+"""
+
+EXAMPLES = r"""
+- name: List all VM Guest Customization Profiles
+  nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+  register: result
+
+- name: List VM Guest Customization Profiles with filter
+  nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    filter: "name eq 'win-sysprep-profile'"
+  register: result
+
+- name: List VM Guest Customization Profiles with limit
+  nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    limit: 1
+  register: result
+
+- name: Get details of a specific VM Guest Customization Profile
+  nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "a3265671-de53-41be-af9b-f06241b95356"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response for fetching VM Guest Customization Profile(s).
+    - Single profile if external ID is provided.
+    - List of profiles if external ID is not provided.
+  type: dict
+  returned: always
+  sample:
+    {
+      "config": {
+        "sysprep": {
+          "customization": {
+            "sysprep_params": {
+              "first_logon_commands": null,
+              "general_settings": {
+                "administrator_password": null,
+                "auto_logon_settings": null,
+                "computer_name": {"use_vm_name": {}},
+                "registered_organization": "Nutanix",
+                "registered_owner": "Nutanix",
+                "timezone": "Pacific Standard Time",
+                "windows_product_key": null
+              },
+              "locale_settings": {
+                "system_locale": "en-US",
+                "ui_language": "en-US",
+                "user_locale": "en-US"
+              },
+              "network_settings": null,
+              "workgroup_or_domain_info": {"workgroup": {"name": "WORKGROUP"}}
+            }
+          }
+        }
+      },
+      "create_time": "2026-05-03T11:25:36.123456+00:00",
+      "created_by": null,
+      "description": "Reusable Windows Sysprep profile for QA Workgroup VMs",
+      "ext_id": "a0dea088-5cd2-4d18-8d20-addba20c937c",
+      "links": null,
+      "name": "win2019-sysprep-profile",
+      "tenant_id": null,
+      "update_time": "2026-05-03T11:25:36.123456+00:00",
+      "updated_by": null
+    }
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching VM Guest Customization Profiles info"
+error:
+  description: Error message if something goes wrong.
+  type: str
+  returned: always
+ext_id:
+  description: The external ID of the VM Guest Customization Profile that was fetched.
+  type: str
+  returned: when fetching a specific profile
+  sample: "a3265671-de53-41be-af9b-f06241b95356"
+total_available_results:
+  description: The total number of available VM Guest Customization Profiles in PC.
+  type: int
+  returned: when listing all profiles
+  sample: 10
+"""
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_guest_customization_profiles_api_instance,
+)
+from ..module_utils.v4.vmm.helpers import (  # noqa: E402
+    get_vm_guest_customization_profile,
+)
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def get_profile_using_ext_id(module, profiles, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_vm_guest_customization_profile(
+        module=module,
+        api_instance=profiles,
+        ext_id=ext_id,
+    )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_profiles(module, profiles, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating VM Guest Customization Profiles info Spec", **result
+        )
+
+    try:
+        resp = profiles.list_vm_guest_customization_profiles(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VM Guest Customization Profiles info",
+        )
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "error": None, "response": None}
+    profiles = get_vm_guest_customization_profiles_api_instance(module)
+    if module.params.get("ext_id"):
+        get_profile_using_ext_id(module, profiles, result)
+    else:
+        get_profiles(module, profiles, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_vm_guest_customization_profiles_info_v2.py
+++ b/plugins/modules/ntnx_vm_guest_customization_profiles_info_v2.py
@@ -84,53 +84,80 @@ response:
   description:
     - The response for fetching VM Guest Customization Profile(s).
     - Single profile if external ID is provided.
-    - List of profiles if external ID is not provided.
+    - List of multiple VM Guest Customization Profiles if external ID is not provided.
   type: dict
   returned: always
   sample:
     {
       "config": {
-        "sysprep": {
           "customization": {
-            "sysprep_params": {
-              "first_logon_commands": null,
+              "first_logon_commands": [
+                  "powershell -Command Enable-PSRemoting -Force",
+                  "powershell -Command Set-ExecutionPolicy RemoteSigned -Force"
+              ],
               "general_settings": {
-                "administrator_password": null,
-                "auto_logon_settings": null,
-                "computer_name": {"use_vm_name": {}},
-                "registered_organization": "Nutanix",
-                "registered_owner": "Nutanix",
-                "timezone": "Pacific Standard Time",
-                "windows_product_key": null
+                  "administrator_password": "MASKED_FIELD",
+                  "auto_logon_settings": null,
+                  "computer_name": {},
+                  "registered_organization": "admin Updated",
+                  "registered_owner": "admin Updated",
+                  "timezone": "Eastern Standard Time",
+                  "windows_product_key": null
               },
               "locale_settings": {
-                "system_locale": "en-US",
-                "ui_language": "en-US",
-                "user_locale": "en-US"
+                  "system_locale": "en-GB",
+                  "ui_language": "en-GB",
+                  "user_locale": "en-GB"
               },
-              "network_settings": null,
-              "workgroup_or_domain_info": {"workgroup": {"name": "WORKGROUP"}}
-            }
+              "network_settings": {
+                  "nic_config_list": [
+                      {
+                          "dns_config": {
+                              "alternate_dns_server_addresses": [
+                                  "10.0.0.51"
+                              ],
+                              "preferred_dns_server_address": "10.0.0.50"
+                          },
+                          "ipv4_config": {}
+                      }
+                  ]
+              },
+              "workgroup_or_domain_info": {
+                  "name": "QA"
+              }
           }
-        }
       },
-      "create_time": "2026-05-03T11:25:36.123456+00:00",
-      "created_by": null,
-      "description": "Reusable Windows Sysprep profile for QA Workgroup VMs",
-      "ext_id": "a0dea088-5cd2-4d18-8d20-addba20c937c",
+      "create_time": "2026-05-05T11:26:57.496782+00:00",
+      "created_by": {
+          "ext_id": "00000000-0000-0000-0000-000000000000"
+      },
+      "description": "Updated sysprep profile description",
+      "ext_id": "08bed846-7bf2-48b5-5c92-741500be3a3f",
       "links": null,
-      "name": "win2019-sysprep-profile",
+      "name": "vm_gc_profile_ansible_test_sysprep_WQOHNIIZdzzT_updated",
       "tenant_id": null,
-      "update_time": "2026-05-03T11:25:36.123456+00:00",
-      "updated_by": null
+      "update_time": "2026-05-05T11:27:21.493223+00:00",
+      "updated_by": {
+          "ext_id": "00000000-0000-0000-0000-000000000000"
+      }
     }
+changed:
+  description: Indicates if the module made any changes.
+  returned: always
+  type: bool
+  sample: true
+failed:
+  description: Indicates if the module failed.
+  returned: always
+  type: bool
+  sample: false
 msg:
   description: This indicates the message if any message occurred.
   returned: When there is an error
   type: str
   sample: "Api Exception raised while fetching VM Guest Customization Profiles info"
 error:
-  description: Error message if something goes wrong.
+  description: Error message if any error occurs.
   type: str
   returned: always
 ext_id:
@@ -139,7 +166,7 @@ ext_id:
   returned: when fetching a specific profile
   sample: "a3265671-de53-41be-af9b-f06241b95356"
 total_available_results:
-  description: The total number of available VM Guest Customization Profiles in PC.
+  description: The total number of available VM Guest Customization Profiles in the PC.
   type: int
   returned: when listing all profiles
   sample: 10

--- a/plugins/modules/ntnx_vm_host_affinity_policy_v2.py
+++ b/plugins/modules/ntnx_vm_host_affinity_policy_v2.py
@@ -304,7 +304,9 @@ def create_policy(module, api_instance, result):
         else:
             raise_api_exception(
                 module=module,
-                exception=Exception("Failed to get entity ext_id from task for VM Host Affinity Policy"),
+                exception=Exception(
+                    "Failed to get entity ext_id from task for VM Host Affinity Policy"
+                ),
                 msg="Failed to get entity ext_id from task for VM Host Affinity Policy",
             )
 

--- a/plugins/modules/ntnx_vms_clone_v2.py
+++ b/plugins/modules/ntnx_vms_clone_v2.py
@@ -639,6 +639,358 @@ options:
                                                         description: Key Value
                                                         type: raw
                                                         required: false
+    guest_customization_profile_config:
+        description:
+            - Reference to an existing VM Guest Customization Profile to apply at clone time,
+              with optional per-clone overrides.
+            - Mutually exclusive with C(guest_customization) at the API level
+              (use either an inline customization or a profile reference, not both).
+            - Nutanix Guest Tools (NGT) must be installed on the source VM for this
+              field to be accepted; otherwise, the API rejects the clone request.
+        required: false
+        type: dict
+        suboptions:
+            profile:
+                description:
+                    - Reference to a VM Guest Customization profile.
+                type: dict
+                suboptions:
+                    ext_id:
+                        description: External ID of the VM Guest Customization Profile.
+                        type: str
+                        required: true
+            config_override_spec:
+                description:
+                    - Sysprep configuration override specification for Windows operating system customization.
+                type: dict
+                suboptions:
+                    customization:
+                        description:
+                            - Sysprep customization override.
+                            - Either C(sysprep_params) or C(answer_file) is allowed, not both.
+                        type: dict
+                        suboptions:
+                            answer_file:
+                                description: Override the answer file (unattend.xml).
+                                type: dict
+                                suboptions:
+                                    unattend_xml:
+                                        description:
+                                            - The custom unattend.xml file content as a string.
+                                            - This replaces the unattend.xml from the referenced VM Guest Customization Profile.
+                                            - Note that double quotes in the XML file must be escaped to maintain correctness.
+                                            - Should be base64 encoded.
+                                            - You can either pass an already-encoded string, or pass the raw
+                                              unattend.xml content and let Ansible encode it using the
+                                              C(b64encode) filter, e.g.
+                                              C("{{ unattend_xml_content | b64encode }}").
+                                        type: str
+                            sysprep_params:
+                                description: Override individual Sysprep parameters.
+                                type: dict
+                                suboptions:
+                                    general_settings:
+                                        description:
+                                        - Override specification for general Windows unattended installation settings.
+                                        - These settings override the corresponding general settings from the referenced profile.
+                                        - To completely discard the setting from the referenced profile, specify an empty object as the value.
+                                        type: dict
+                                        suboptions:
+                                            computer_name:
+                                                description:
+                                                    - Override mechanism for computer name generation.
+                                                    - You can either use the VM name, provide a computer name,
+                                                      or discard the setting from the referenced profile.
+                                                    - If using a VM name or computer name, meet the sysprep's computer name requirements;
+                                                      otherwise, the request would fail.
+                                                type: dict
+                                                suboptions:
+                                                    name:
+                                                        description: Set computer name to a specific value.
+                                                        type: dict
+                                                        suboptions:
+                                                            value:
+                                                                description: The computer name.
+                                                                type: str
+                                                    use_vm_name:
+                                                        description: Use the cloned VM's name as the computer name.
+                                                        type: dict
+                                                    discard:
+                                                        description: Discard the profile's computer-name value.
+                                                        type: dict
+                                            timezone:
+                                                description:
+                                                    - Override for timezone setting. You can either provide a new timezone value or
+                                                      discard the setting from the referenced profile.
+                                                    - For valid timezone values, refer to Windows sysprep documentation.
+                                                type: dict
+                                                suboptions:
+                                                    value:
+                                                        description: Set timezone to a specific value.
+                                                        type: dict
+                                                        suboptions:
+                                                            value:
+                                                                description: Timezone value.
+                                                                type: str
+                                                    discard:
+                                                        description: Discard the profile's timezone.
+                                                        type: dict
+                                            administrator_password:
+                                                description:
+                                                    - Override for administrator password.
+                                                    - You can either provide a new password or discard the setting from the referenced profile.
+                                                type: dict
+                                                suboptions:
+                                                    value:
+                                                        description: Set administrator password to a specific value
+                                                        type: dict
+                                                        suboptions:
+                                                            value:
+                                                                description: The administrator password.
+                                                                type: str
+                                                    discard:
+                                                        description: Discard the profile's administrator password.
+                                                        type: dict
+                                            auto_logon_settings:
+                                                description:
+                                                    - Override specification for autologon settings.
+                                                    - These settings override the corresponding autologon settings from the referenced profile.
+                                                    - To completely discard the setting from the referenced profile, specify an empty object as the value.
+                                                type: dict
+                                                suboptions:
+                                                    logon_count:
+                                                        description:
+                                                            - Override value for the number of automatic logons allowed.
+                                                            - This overrides the logon count from the referenced profile.
+                                                        type: int
+                                            windows_product_key:
+                                                description:
+                                                    - Override for Windows product key.
+                                                    - You can either provide a new product key or discard the setting from the referenced profile.
+                                                    - Note that entering an invalid product key causes Windows Setup to fail.
+                                                type: dict
+                                                suboptions:
+                                                    value:
+                                                        description: Set Windows product key to a specific value.
+                                                        type: dict
+                                                        suboptions:
+                                                            value:
+                                                                description: The Windows product key.
+                                                                type: str
+                                                    discard:
+                                                        description: Discard the profile's Windows product key.
+                                                        type: dict
+                                            registered_owner:
+                                                description:
+                                                    - Override for registered owner information.
+                                                    - You can either provide new owner details or discard the setting from the referenced profile.
+                                                type: dict
+                                                suboptions:
+                                                    value:
+                                                        description: Set registered owner to a specific value.
+                                                        type: dict
+                                                        suboptions:
+                                                            value:
+                                                                description: The registered owner name.
+                                                                type: str
+                                                    discard:
+                                                        description: Discard the profile's registered owner.
+                                                        type: dict
+                                            registered_organization:
+                                                description:
+                                                    - Override for registered organization information.
+                                                    - You can either provide new organization details or discard the setting from the referenced profile.
+                                                type: dict
+                                                suboptions:
+                                                    value:
+                                                        description: Set registered organization to a specific value.
+                                                        type: dict
+                                                        suboptions:
+                                                            value:
+                                                                description: The registered organization name.
+                                                                type: str
+                                                    discard:
+                                                        description: Discard the profile's registered organization.
+                                                        type: dict
+                                    first_logon_commands:
+                                        description:
+                                            - Override for first logon commands.
+                                            - This overrides the first logon commands from the referenced profile.
+                                            - Commands are executed in the order specified.
+                                            - To completely discard the setting from the referenced profile, specify an empty array as the value.
+                                        type: list
+                                        elements: str
+                                    locale_settings:
+                                        description:
+                                            - Override specification for language and input locale settings.
+                                            - These settings override the corresponding locale settings from the referenced profile.
+                                            - To completely discard the setting from the referenced profile, specify an empty object as the value.
+                                        type: dict
+                                        suboptions:
+                                            user_locale:
+                                                description:
+                                                    - Override for per-user locale settings used for formatting dates, times, currency, and numbers.
+                                                    - You can either provide a new locale value or discard the setting from the referenced profile.
+                                                    - Value must follow RFC 3066 language-tagging conventions, for example, en-US, fr-FR, es-ES.
+                                                type: dict
+                                                suboptions:
+                                                    value:
+                                                        description: Set user locale to a specific value.
+                                                        type: dict
+                                                        suboptions:
+                                                            value:
+                                                                description: The new locale value.
+                                                                type: str
+                                                    discard:
+                                                        description: Discard the profile's user locale.
+                                                        type: dict
+                                            system_locale:
+                                                description:
+                                                    - Override for the default language used for non-Unicode programs.
+                                                    - You can either provide a new locale value or discard the setting from the referenced profile.
+                                                    - Value must follow RFC 3066 language-tagging conventions, for example, en-US, fr-FR, es-ES.
+                                                type: dict
+                                                suboptions:
+                                                    value:
+                                                        description: Set system locale to a specific value.
+                                                        type: dict
+                                                        suboptions:
+                                                            value:
+                                                                description: The new locale value.
+                                                                type: str
+                                                    discard:
+                                                        description: Discard the profile's system locale.
+                                                        type: dict
+                                            ui_language:
+                                                description:
+                                                    - Override for the default system language used to display user interface items.
+                                                    - You can either provide a new language value or discard the setting from the referenced profile.
+                                                    - Value must follow RFC 3066 language-tagging conventions, for example, en-US, fr-FR, es-ES.
+                                                type: dict
+                                                suboptions:
+                                                    value:
+                                                        description: Set UI language to a specific value.
+                                                        type: dict
+                                                        suboptions:
+                                                            value:
+                                                                description: The new language value.
+                                                                type: str
+                                                    discard:
+                                                        description: Discard the profile's UI language.
+                                                        type: dict
+                                    workgroup_or_domain_info:
+                                        description:
+                                            - Override specification for workgroup or domain information.
+                                            - You can either provide a new workgroup or domain settings or discard the settings from the referenced profile.
+                                        type: dict
+                                        suboptions:
+                                            workgroup:
+                                                description: Override workgroup settings.
+                                                type: dict
+                                                suboptions:
+                                                    name:
+                                                        description:
+                                                            - Override value for workgroup name.
+                                                            - This overrides the workgroup name from the referenced profile.
+                                                            - It must be a valid NetBIOS name.
+                                                        type: str
+                                            domain_settings:
+                                                description: Override domain join settings.
+                                                type: dict
+                                                suboptions:
+                                                    credentials:
+                                                        description:
+                                                            - Override specification for domain credentials.
+                                                            - This overrides the domain credentials from the referenced profile.
+                                                        type: dict
+                                                        suboptions:
+                                                            domain_name:
+                                                                description:
+                                                                    - Override value for domain name.
+                                                                    - This overrides the domain name from the referenced profile.
+                                                                    - Can be either the fully qualified DNS name or NetBIOS name of the domain.
+                                                                type: str
+                                                            username:
+                                                                description:
+                                                                    - Override value for domain username.
+                                                                    - This overrides the domain username from the referenced profile.
+                                                                type: str
+                                                            password:
+                                                                description:
+                                                                    - Override value for domain password.
+                                                                    - This overrides the domain password from the referenced profile.
+                                                                type: str
+                                            discard:
+                                                description: Discard the profile's workgroup or domain settings.
+                                                type: dict
+                                    network_settings:
+                                        description:
+                                           - Override specification for network settings.
+                                           - These settings override the corresponding network settings from the referenced profile.
+                                           - To completely discard the setting from the referenced profile, specify an empty object as the value.
+                                        type: dict
+                                        suboptions:
+                                            nic_config_list:
+                                                description:
+                                                   - Override specification for NIC configuration list.
+                                                   - This overrides the NIC configurations from the referenced profile.
+                                                   - Configurations are applied to NICs in serial order.
+                                                type: list
+                                                elements: dict
+                                                suboptions:
+                                                    dns_config:
+                                                        description:
+                                                            - Override specification for DNS configuration.
+                                                            - This overrides the DNS settings from the referenced profile.
+                                                        type: dict
+                                                        suboptions:
+                                                            preferred_dns_server_address:
+                                                                description:
+                                                                    - Override value for preferred DNS server address.
+                                                                    - This overrides the preferred DNS server from the referenced profile.
+                                                                type: str
+                                                            alternate_dns_server_addresses:
+                                                                description:
+                                                                    - Override value for alternate DNS server addresses.
+                                                                    - This overrides the alternate DNS servers from the referenced profile.
+                                                                type: list
+                                                                elements: str
+                                                    ipv4_config:
+                                                        description:
+                                                            - Override mechanism for IPv4 configuration.
+                                                            - You can either use DHCP, provide a custom IPv4 configuration,
+                                                              or discard the setting from the referenced profile.
+                                                            - If DHCP is specified, DhcpEnabled is set to True in the unattend.xml.
+                                                        type: dict
+                                                        suboptions:
+                                                            use_dhcp:
+                                                                description: Use DHCP for IPv4.
+                                                                type: dict
+                                                            static_config:
+                                                                description: Static IPv4 configuration.
+                                                                type: dict
+                                                                suboptions:
+                                                                    ip_address:
+                                                                        description:
+                                                                            - An unique address that identifies a device on the internet
+                                                                              or a local network in IPv4 format.
+                                                                        type: dict
+                                                                        suboptions:
+                                                                            value:
+                                                                                description: IPv4 address value.
+                                                                                type: str
+                                                                                required: true
+                                                                            prefix_length:
+                                                                                description:
+                                                                                    - Prefix length for the address.
+                                                                                    - Defaults to 32 if not provided.
+                                                                                type: int
+                                                                    default_gateways:
+                                                                        description:
+                                                                            - Override value for default gateways.
+                                                                            - This overrides the default gateway configuration from the referenced profile.
+                                                                        type: list
+                                                                        elements: str
     wait:
         description:
             - Whether to wait for the clone operation to complete.
@@ -692,6 +1044,44 @@ EXAMPLES = r"""
           cloud_init_script:
             user_data:
               value: "{{ vm_cloud_init_user_data | b64encode }}"
+
+- name: Clone VM with a VM Guest Customization Profile reference and per-clone overrides
+  nutanix.ncp.ntnx_vms_clone_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "de84a538-32bf-4a42-913b-340540af18fd"
+    name: "cloned_VM_with_profile"
+    guest_customization_profile_config:
+      profile:
+        ext_id: "b1c2d3e4-5f67-4890-a123-456789abcdef"
+      config_override_spec:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                name:
+                  value: "PC-CLONE-1"
+              timezone:
+                value:
+                  value: "UTC"
+              administrator_password:
+                value:
+                  value: "Password123"
+            network_settings:
+              nic_config_list:
+                - dns_config:
+                    preferred_dns_server_address: "10.0.0.10"
+                    alternate_dns_server_addresses:
+                      - "10.0.0.11"
+                  ipv4_config:
+                    static_config:
+                      ip_address:
+                        value: "10.0.0.50"
+                        prefix_length: 24
+                      default_gateways:
+                        - "10.0.0.1"
 """
 
 RETURN = r"""
@@ -823,6 +1213,9 @@ from ..module_utils.v4.utils import (  # noqa: E402
 )
 from ..module_utils.v4.vmm.api_client import get_etag, get_vm_api_instance  # noqa: E402
 from ..module_utils.v4.vmm.helpers import get_vm  # noqa: E402
+from ..module_utils.v4.vmm.spec.vm_guest_customization_profiles import (  # noqa: E402
+    VmGcProfileOverrideSpecs,
+)
 from ..module_utils.v4.vmm.spec.vms import VmSpecs as vm_specs  # noqa: E402
 
 SDK_IMP_ERROR = None
@@ -863,6 +1256,11 @@ def get_module_spec():
             type="dict",
             options=vm_specs.get_gc_spec(),
             obj=vmm_sdk.GuestCustomizationParams,
+        ),
+        guest_customization_profile_config=dict(
+            type="dict",
+            options=VmGcProfileOverrideSpecs.get_guest_customization_profile_config_spec(),
+            obj=vmm_sdk.VmGcProfileConfig,
         ),
     )
 
@@ -930,6 +1328,9 @@ def run_module():
     module = BaseModuleV4(
         argument_spec=get_module_spec(),
         supports_check_mode=True,
+        mutually_exclusive=[
+            ("guest_customization", "guest_customization_profile_config"),
+        ],
     )
     if SDK_IMP_ERROR:
         module.fail_json(

--- a/plugins/modules/ntnx_vms_clone_v2.py
+++ b/plugins/modules/ntnx_vms_clone_v2.py
@@ -1082,6 +1082,52 @@ EXAMPLES = r"""
                         prefix_length: 24
                       default_gateways:
                         - "10.0.0.1"
+
+# NGT must be installed on the source VM, otherwise the clone API rejects the
+# request with an NGT-not-installed error.
+# When the referenced profile marks fields with C(must_provide_during_deployment),
+# the per-clone override MUST supply those fields (e.g. computer_name, ipv4_config)
+# or the API rejects the request.
+- name: Clone VM with a Guest Customization Profile
+  nutanix.ncp.ntnx_vms_clone_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "de84a538-32bf-4a42-913b-340540af18fd"
+    name: "cloned_VM_with_profile"
+    guest_customization_profile_config:
+      profile:
+        ext_id: "b1c2d3e4-5f67-4890-a123-456789abcdef"
+      config_override_spec:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                name:
+                  value: "cloned-host"
+              timezone:
+                value:
+                  value: "Pacific Standard Time"
+              registered_owner:
+                value:
+                  value: "cloned-owner"
+              registered_organization:
+                value:
+                  value: "cloned-org"
+            network_settings:
+              nic_config_list:
+                - dns_config:
+                    preferred_dns_server_address: "10.1.0.100"
+                    alternate_dns_server_addresses:
+                      - "10.1.0.101"
+                  ipv4_config:
+                    static_config:
+                      ip_address:
+                        value: "10.1.0.50"
+                        prefix_length: 24
+                      default_gateways:
+                        - "10.1.0.1"
 """
 
 RETURN = r"""

--- a/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import vm_guest_customization_profiles.yml
+      ansible.builtin.import_tasks: vm_guest_customization_profiles.yml

--- a/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/vm_guest_customization_profiles.yml
+++ b/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/vm_guest_customization_profiles.yml
@@ -26,7 +26,7 @@
 # Pre-create an NGT-capable base VM and a (no-NGT) template used for the negative
 # deploy test. NGT is intentionally NOT installed yet on the base VM so that the
 # template1 captures a non-NGT source-VM state. We later install NGT and create a
-# second template (template2) from the same VM for the positive deploy test.
+# second template (template2) from the same VM for the deploy test.
 ########################################################################################
 - name: Set base VM / template / clone / deploy names
   ansible.builtin.set_fact:
@@ -849,7 +849,7 @@
     success_msg: "NGT confirmed as installed on base VM"
 
 ########################################################################################
-# Create a new template (template2) from the NGT-installed base VM. The positive
+# Create a new template (template2) from the NGT-installed base VM.
 # deploy test below uses this template.
 ########################################################################################
 - name: Create template from base VM (NGT now installed)
@@ -1317,37 +1317,34 @@
   register: result
   ignore_errors: true
 
-- name: Print result of positive deploy (must_provide fields supplied)
+- name: Print result of deploy (must_provide fields supplied)
   ansible.builtin.debug:
     var: result
 
-- name: Verify positive deploy succeeds when must_provide fields are supplied
+- name: Verify deploy succeeds when must_provide fields are supplied
   ansible.builtin.assert:
     that:
       - result.changed == true
       - result.failed == false
       - result.response is defined
       - result.response.status == "SUCCEEDED"
-    fail_msg: "Positive must_provide deploy failed unexpectedly"
-    success_msg: "Positive must_provide deploy succeeded as expected"
+    fail_msg: "Deploy failed unexpectedly when must_provide fields were supplied"
+    success_msg: "Deploy succeeded when must_provide fields were supplied"
 
-- name: Find positive must_provide deployed VM by name
+- name: Find must_provide deployed VM by name
   nutanix.ncp.ntnx_vms_info_v2:
     filter: "name eq '{{ deployed_vm_name }}_must_provide'"
   register: must_provide_deploy_info
   ignore_errors: true
 
-- name: Delete positive must_provide deployed VM (cleanup inline)
+- name: Delete must_provide deployed VM (cleanup inline)
   nutanix.ncp.ntnx_vms_v2:
     state: absent
     ext_id: "{{ must_provide_deploy_info.response[0].ext_id }}"
-  when:
-    - must_provide_deploy_info.response is defined
-    - must_provide_deploy_info.response | length == 1
-  ignore_errors: true
+    ignore_errors: true
 
 ########################################################################################
-# Positive CRUD test: Clone with must_provide profile and complete override
+# Clone with must_provide profile and complete override
 ########################################################################################
 - name: Clone with must_provide profile and complete override
   nutanix.ncp.ntnx_vms_clone_v2:
@@ -1382,11 +1379,11 @@
   register: result
   ignore_errors: true
 
-- name: Print result of positive clone (must_provide fields supplied)
+- name: Print result of clone (must_provide fields supplied)
   ansible.builtin.debug:
     var: result
 
-- name: Verify positive clone succeeds when must_provide fields are supplied
+- name: Verify clone succeeds when must_provide fields are supplied
   ansible.builtin.assert:
     that:
       - result.changed == true
@@ -1394,14 +1391,13 @@
       - result.response is defined
       - result.response.name == cloned_vm_name + "_must_provide"
       - result.response.ext_id is defined
-    fail_msg: "Positive must_provide clone failed unexpectedly"
-    success_msg: "Positive must_provide clone succeeded as expected"
+    fail_msg: "Clone failed unexpectedly when must_provide fields were supplied"
+    success_msg: "Clone succeeded when must_provide fields were supplied"
 
-- name: Delete positive must_provide cloned VM (cleanup inline)
+- name: Delete must_provide cloned VM (cleanup inline)
   nutanix.ncp.ntnx_vms_v2:
     state: absent
     ext_id: "{{ result.response.ext_id }}"
-  when: result.response is defined and result.response.ext_id is defined
   ignore_errors: true
 
 ########################################################################################

--- a/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/vm_guest_customization_profiles.yml
+++ b/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/vm_guest_customization_profiles.yml
@@ -1,0 +1,728 @@
+---
+- name: Start VM Guest Customization Profile tests
+  ansible.builtin.debug:
+    msg: Start VM Guest Customization Profile tests
+
+- name: Generate random suffix
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false,
+      special=false, length=12)[0] }}"
+    suffix_name: "ansible_test"
+    todelete: []
+
+- name: Set profile names
+  ansible.builtin.set_fact:
+    profile_sysprep_name: "vm_gc_profile_{{ suffix_name }}_sysprep_{{ random_name }}"
+    profile_answer_file_name: "vm_gc_profile_{{ suffix_name }}_answer_{{ random_name }}"
+    profile_domain_name: "vm_gc_profile_{{ suffix_name }}_domain_{{ random_name }}"
+    profile_sysprep_name_updated: "vm_gc_profile_{{ suffix_name }}_sysprep_{{ random_name }}_updated"
+
+- name: Load sample unattend XML for answer-file profile from file (base64 encoded)
+  ansible.builtin.set_fact:
+    sample_unattend_xml: "{{ lookup('file', role_path ~
+      '/vars/unattend_xml_content.xml') | b64encode }}"
+
+########################################################################################
+# Check-mode: generate spec for creating a workgroup/sysprep profile
+########################################################################################
+- name: Generate spec for creating VM Guest Customization Profile (sysprep
+    params)using check mode
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    name: "{{ profile_sysprep_name }}"
+    description: "Windows Sysprep profile description"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name: {}
+              timezone: "Pacific Standard Time"
+              administrator_password: "admin123"
+              auto_logon_settings:
+                logon_count: 1
+              windows_product_key: "XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
+              registered_owner: "admin"
+              registered_organization: "admin"
+            first_logon_commands:
+              - "powershell -Command Enable-PSRemoting -Force"
+            locale_settings:
+              user_locale: "en-US"
+              system_locale: "en-US"
+              ui_language: "en-US"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "workgroup"
+            network_settings:
+              nic_config_list:
+                - dns_config:
+                    preferred_dns_server_address: "8.8.8.8"
+                    alternate_dns_server_addresses:
+                      - "8.8.4.4"
+                  ipv4_config:
+                    use_dhcp: {}
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Print result of generated check-mode spec for sysprep params
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify generated spec for creating VM Guest Customization Profile (sysprep
+    params, Workgroup) using check mode
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == profile_sysprep_name
+      - result.response.description == "Windows Sysprep profile description"
+      - result.response.config.customization is defined
+      - result.response.config.customization.general_settings.timezone ==
+        "Pacific Standard Time"
+      - result.response.config.customization.general_settings.registered_owner
+        == "admin"
+      - result.response.config.customization.general_settings.auto_logon_settings.logon_count
+        == 1
+      - result.response.config.customization.first_logon_commands | length == 1
+      - result.response.config.customization.locale_settings.user_locale ==
+        "en-US"
+      - result.response.config.customization.locale_settings.system_locale ==
+        "en-US"
+      - result.response.config.customization.locale_settings.ui_language ==
+        "en-US"
+      - result.response.config.customization.workgroup_or_domain_info.name ==
+        "workgroup"
+      - result.response.config.customization.network_settings.nic_config_list |
+        length == 1
+      - result.response.config.customization.network_settings.nic_config_list[0].dns_config.preferred_dns_server_address
+        == "8.8.8.8"
+      - result.response.config.customization.network_settings.nic_config_list[0].dns_config.alternate_dns_server_addresses
+        == ["8.8.4.4"]
+    fail_msg: "Failed to generate sysprep params profile spec in check mode"
+    success_msg: "Sysprep params profile spec generated successfully in check mode"
+
+########################################################################################
+# Create VM Guest Customization Profile
+########################################################################################
+- name: Create VM Guest Customization Profile (sysprep params, Workgroup)
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    name: "{{ profile_sysprep_name }}"
+    description: "Sysprep profile created by integration tests"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name:
+              timezone: "Pacific Standard Time"
+              administrator_password: "admin123"
+              registered_owner: "admin"
+              registered_organization: "admin"
+            first_logon_commands:
+              - "powershell -Command Enable-PSRemoting -Force"
+            locale_settings:
+              user_locale: "en-US"
+              system_locale: "en-US"
+              ui_language: "en-US"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "workgroup"
+            network_settings:
+              nic_config_list:
+                - dns_config:
+                    preferred_dns_server_address: "10.0.0.10"
+                    alternate_dns_server_addresses:
+                      - "10.0.0.11"
+                  ipv4_config:
+                    use_dhcp:
+  register: result
+  ignore_errors: true
+
+- name: Print result of create VM Guest Customization Profile (sysprep params,
+    Sysprep params)
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify create VM Guest Customization Profile (sysprep params, Workgroup,
+    Sysprep params)
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response.name == profile_sysprep_name
+      - result.response.description == "Sysprep profile created by integration
+        tests"
+      - result.response.config.customization is defined
+      - result.response.config.customization.general_settings.timezone ==
+        "Pacific Standard Time"
+      - result.response.config.customization.general_settings.registered_owner
+        == "admin"
+      - result.response.config.customization.general_settings.registered_organization
+        == "admin"
+      - result.response.config.customization.first_logon_commands | length == 1
+      - result.response.config.customization.locale_settings.user_locale ==
+        "en-US"
+      - result.response.config.customization.locale_settings.system_locale ==
+        "en-US"
+      - result.response.config.customization.locale_settings.ui_language ==
+        "en-US"
+      - result.response.config.customization.workgroup_or_domain_info.name ==
+        "workgroup"
+      - result.response.config.customization.network_settings.nic_config_list |
+        length == 1
+      - result.response.config.customization.network_settings.nic_config_list[0].dns_config.preferred_dns_server_address
+        == "10.0.0.10"
+      - result.response.config.customization.network_settings.nic_config_list[0].dns_config.alternate_dns_server_addresses
+        == ["10.0.0.11"]
+    fail_msg: "Failed to create VM Guest Customization Profile (sysprep params,
+      Workgroup, DHCP)"
+    success_msg: "VM Guest Customization Profile (sysprep params, Workgroup, DHCP)
+      created successfully"
+
+- name: Save workgroup profile ext_id
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+########################################################################################
+# Create VM Guest Customization Profile (sysprep params, Domain join, must-provide IP)
+########################################################################################
+- name: Create VM Guest Customization Profile (sysprep params, Domain settings)
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    name: "{{ profile_domain_name }}"
+    description: "Domain settings sysprep profile created by integration tests"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                must_provide_during_deployment: {}
+              timezone: "UTC"
+              administrator_password: "admin123"
+              registered_owner: "admin"
+              registered_organization: "admin"
+            first_logon_commands:
+              - "net user admin /password:admin123"
+            locale_settings:
+              user_locale: "en-US"
+              system_locale: "en-US"
+              ui_language: "en-US"
+            workgroup_or_domain_info:
+              domain_settings:
+                credentials:
+                  domain_name: "domain.example.local"
+                  username: "admin"
+                  password: "admin123"
+            network_settings:
+              nic_config_list:
+                - dns_config:
+                    preferred_dns_server_address: "10.1.0.10"
+                    alternate_dns_server_addresses:
+                      - "10.1.0.11"
+                  ipv4_config:
+                    must_provide_during_deployment: {}
+  register: result
+  ignore_errors: true
+
+- name: Print result of create VM Guest Customization Profile (sysprep params,
+    Domain settings)
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify create VM Guest Customization Profile (sysprep params, Domain
+    settings) must-provide IP)
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response.name == profile_domain_name
+      - result.response.description == "Domain settings sysprep profile created
+        by integration tests"
+      - result.response.config.customization is defined
+      - result.response.config.customization.general_settings.timezone == "UTC"
+      - result.response.config.customization.general_settings.registered_owner
+        == "admin"
+      - result.response.config.customization.general_settings.registered_organization
+        == "admin"
+      - result.response.config.customization.workgroup_or_domain_info.credentials
+        is defined
+      - result.response.config.customization.workgroup_or_domain_info.credentials.domain_name
+        == "domain.example.local"
+      - result.response.config.customization.workgroup_or_domain_info.credentials.username
+        == "admin"
+      - result.response.config.customization.workgroup_or_domain_info.credentials.password
+        is defined
+      - result.response.config.customization.network_settings.nic_config_list |
+        length == 1
+      - result.response.config.customization.network_settings.nic_config_list[0].dns_config.preferred_dns_server_address
+        == "10.1.0.10"
+      - result.response.config.customization.network_settings.nic_config_list[0].dns_config.alternate_dns_server_addresses
+        == ["10.1.0.11"]
+    fail_msg: "Failed to create VM Guest Customization Profile (sysprep params,
+      Domain settings)"
+    success_msg: "VM Guest Customization Profile (sysprep params, Domain settings)
+      created successfully"
+
+- name: Save domain settings profile ext_id
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+########################################################################################
+# Create VM Guest Customization Profile (answer file)
+########################################################################################
+- name: Create VM Guest Customization Profile (answer file)
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    name: "{{ profile_answer_file_name }}"
+    description: "Answer file sysprep profile created by integration tests"
+    config:
+      sysprep:
+        customization:
+          answer_file:
+            unattend_xml: "{{ sample_unattend_xml }}"
+  register: result
+  ignore_errors: true
+
+- name: Print result of create answer-file profile
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify create answer-file profile
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response.name == profile_answer_file_name
+      - result.response.config.customization.unattend_xml is defined
+      - result.response.config.customization.unattend_xml == sample_unattend_xml
+    fail_msg: "Failed to create answer-file VM Guest Customization Profile"
+    success_msg: "Answer-file VM Guest Customization Profile created successfully"
+
+- name: Save answer-file profile ext_id
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+########################################################################################
+# Check-mode: generate update spec
+########################################################################################
+- name: Generate spec for updating sysprep profile using check mode
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    ext_id: "{{ todelete[0] }}"
+    name: "updated-sysprep-profile"
+    description: "Updated sysprep profile description"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name: {}
+              timezone: "Eastern Standard Time"
+              administrator_password: "admin12345"
+              registered_owner: "admin Updated"
+              registered_organization: "admin Updated"
+            first_logon_commands:
+              - "powershell -Command Enable-PSRemoting -Force"
+              - "powershell -Command Set-ExecutionPolicy RemoteSigned -Force"
+            locale_settings:
+              user_locale: "en-GB"
+              system_locale: "en-GB"
+              ui_language: "en-GB"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "QA"
+            network_settings:
+              nic_config_list:
+                - dns_config:
+                    preferred_dns_server_address: "10.0.0.50"
+                    alternate_dns_server_addresses:
+                      - "10.0.0.51"
+                  ipv4_config:
+                    use_dhcp: {}
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Print result of generated update spec for sysprep profile using check mode
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify generated update spec for sysprep profile using check mode
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "updated-sysprep-profile"
+      - result.response.description == "Updated sysprep profile description"
+      - result.response.config.customization is defined
+      - result.response.config.customization.general_settings.timezone ==
+        "Eastern Standard Time"
+      - result.response.config.customization.general_settings.registered_owner
+        == "admin Updated"
+      - result.response.config.customization.general_settings.registered_organization
+        == "admin Updated"
+      - result.response.config.customization.first_logon_commands | length == 2
+      - result.response.config.customization.locale_settings.user_locale ==
+        "en-GB"
+      - result.response.config.customization.workgroup_or_domain_info.name ==
+        "QA"
+      - result.response.config.customization.network_settings.nic_config_list |
+        length == 1
+      - result.response.config.customization.network_settings.nic_config_list[0].dns_config.preferred_dns_server_address
+        == "10.0.0.50"
+      - result.response.config.customization.network_settings.nic_config_list[0].dns_config.alternate_dns_server_addresses
+        == ["10.0.0.51"]
+    fail_msg: "Failed generating update spec in check mode"
+    success_msg: "Update spec generated successfully in check mode"
+
+########################################################################################
+# Update VM Guest Customization Profile
+########################################################################################
+- name: Update VM Guest Customization Profile
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    ext_id: "{{ todelete[0] }}"
+    name: "{{ profile_sysprep_name_updated }}"
+    description: "Updated sysprep profile description"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name: {}
+              timezone: "Eastern Standard Time"
+              administrator_password: "admin12345"
+              registered_owner: "admin Updated"
+              registered_organization: "admin Updated"
+            first_logon_commands:
+              - "powershell -Command Enable-PSRemoting -Force"
+              - "powershell -Command Set-ExecutionPolicy RemoteSigned -Force"
+            locale_settings:
+              user_locale: "en-GB"
+              system_locale: "en-GB"
+              ui_language: "en-GB"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "QA"
+            network_settings:
+              nic_config_list:
+                - dns_config:
+                    preferred_dns_server_address: "10.0.0.50"
+                    alternate_dns_server_addresses:
+                      - "10.0.0.51"
+                  ipv4_config:
+                    use_dhcp: {}
+  register: result
+  ignore_errors: true
+
+- name: Print result of update VM Guest Customization Profile
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify update VM Guest Customization Profile
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == profile_sysprep_name_updated
+      - result.response.description == "Updated sysprep profile description"
+      - result.response.config.customization is defined
+      - result.response.config.customization.general_settings.timezone ==
+        "Eastern Standard Time"
+      - result.response.config.customization.general_settings.registered_owner
+        == "admin Updated"
+      - result.response.config.customization.general_settings.registered_organization
+        == "admin Updated"
+      - result.response.config.customization.first_logon_commands | length == 2
+      - result.response.config.customization.locale_settings.user_locale ==
+        "en-GB"
+      - result.response.config.customization.workgroup_or_domain_info.name ==
+        "QA"
+      - result.response.config.customization.network_settings.nic_config_list |
+        length == 1
+      - result.response.config.customization.network_settings.nic_config_list[0].dns_config.preferred_dns_server_address
+        == "10.0.0.50"
+      - result.response.config.customization.network_settings.nic_config_list[0].dns_config.alternate_dns_server_addresses
+        == ["10.0.0.51"]
+    fail_msg: "Failed to update VM Guest Customization Profile"
+    success_msg: "VM Guest Customization Profile updated successfully"
+
+########################################################################################
+# Idempotency: re-apply the same update payload, expect no change
+########################################################################################
+- name: Re-apply same update payload (idempotency test)
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    ext_id: "{{ todelete[0] }}"
+    name: "{{ profile_sysprep_name_updated }}"
+    description: "Updated sysprep profile description"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name: {}
+              timezone: "Eastern Standard Time"
+              administrator_password: "admin12345"
+              registered_owner: "admin Updated"
+              registered_organization: "admin Updated"
+            first_logon_commands:
+              - "powershell -Command Enable-PSRemoting -Force"
+              - "powershell -Command Set-ExecutionPolicy RemoteSigned -Force"
+            locale_settings:
+              user_locale: "en-GB"
+              system_locale: "en-GB"
+              ui_language: "en-GB"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "QA"
+            network_settings:
+              nic_config_list:
+                - dns_config:
+                    preferred_dns_server_address: "10.0.0.50"
+                    alternate_dns_server_addresses:
+                      - "10.0.0.51"
+                  ipv4_config:
+                    use_dhcp: {}
+  register: result
+  ignore_errors: true
+
+- name: Print result of idempotency on update VM Guest Customization Profile
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify idempotency on update VM Guest Customization Profile
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == false
+      - result.skipped == true
+      - result.msg == "Nothing to change."
+    fail_msg: "Failed to verify idempotency on update VM Guest Customization Profile"
+    success_msg: "Idempotency on update VM Guest Customization Profile verified
+      successfully"
+
+########################################################################################
+# Fetch a VM Guest Customization Profile by ext_id
+########################################################################################
+- name: Fetch the sysprep profile by ext_id
+  nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+    ext_id: "{{ todelete[0] }}"
+  register: result
+  ignore_errors: true
+
+- name: Print result of fetch by ext_id
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify fetch by ext_id
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == todelete[0]
+      - result.response.ext_id == todelete[0]
+      - result.response.name == profile_sysprep_name_updated
+      - result.response.description == "Updated sysprep profile description"
+      - result.response.config.customization is defined
+      - result.response.config.customization.general_settings.timezone ==
+        "Eastern Standard Time"
+      - result.response.config.customization.general_settings.registered_owner
+        == "admin Updated"
+      - result.response.config.customization.general_settings.registered_organization
+        == "admin Updated"
+      - result.response.config.customization.first_logon_commands | length == 2
+      - result.response.config.customization.locale_settings.user_locale ==
+        "en-GB"
+      - result.response.config.customization.locale_settings.system_locale ==
+        "en-GB"
+      - result.response.config.customization.locale_settings.ui_language ==
+        "en-GB"
+      - result.response.config.customization.workgroup_or_domain_info.name ==
+        "QA"
+      - result.response.config.customization.network_settings.nic_config_list |
+        length == 1
+      - result.response.config.customization.network_settings.nic_config_list[0].dns_config.preferred_dns_server_address
+        == "10.0.0.50"
+      - result.response.config.customization.network_settings.nic_config_list[0].dns_config.alternate_dns_server_addresses
+        == ["10.0.0.51"]
+    fail_msg: "Failed to fetch VM Guest Customization Profile by ext_id"
+    success_msg: "Fetched VM Guest Customization Profile by ext_id successfully"
+
+#######################################################################################
+# List VM Guest Customization Profiles
+########################################################################################
+- name: List VM Guest Customization Profiles
+  nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: Print result of list VM Guest Customization Profiles
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify list VM Guest Customization Profiles
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 2
+      - result.total_available_results is defined
+      - result.total_available_results >= 2
+    fail_msg: "Failed to list VM Guest Customization Profiles"
+    success_msg: "VM Guest Customization Profiles listed successfully"
+
+########################################################################################
+# List with filter
+########################################################################################
+- name: List VM Guest Customization Profiles with filter
+  nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+    filter: "name eq '{{ profile_sysprep_name_updated }}'"
+  register: result
+  ignore_errors: true
+
+- name: Print result of list with filter
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify list with filter
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+      - result.response[0].ext_id == todelete[0]
+      - result.response[0].name == profile_sysprep_name_updated
+      - result.response[0].description == "Updated sysprep profile description"
+      - result.response[0].config.customization is defined
+      - result.response[0].config.customization.general_settings.timezone ==
+        "Eastern Standard Time"
+      - result.response[0].config.customization.general_settings.registered_owner
+        == "admin Updated"
+      - result.response[0].config.customization.general_settings.registered_organization
+        == "admin Updated"
+      - result.response[0].config.customization.first_logon_commands | length ==
+        2
+      - result.response[0].config.customization.locale_settings.user_locale ==
+        "en-GB"
+      - result.response[0].config.customization.locale_settings.system_locale ==
+        "en-GB"
+      - result.response[0].config.customization.locale_settings.ui_language ==
+        "en-GB"
+      - result.response[0].config.customization.workgroup_or_domain_info.name ==
+        "QA"
+      - result.response[0].config.customization.network_settings.nic_config_list
+        | length == 1
+      - result.response[0].config.customization.network_settings.nic_config_list[0].dns_config.preferred_dns_server_address
+        == "10.0.0.50"
+      - result.response[0].config.customization.network_settings.nic_config_list[0].dns_config.alternate_dns_server_addresses
+        == ["10.0.0.51"]
+      - result.total_available_results is defined
+      - result.total_available_results == 1
+    fail_msg: "Failed listing VM Guest Customization Profiles with filter"
+    success_msg: "VM Guest Customization Profiles listed with filter successfully"
+
+########################################################################################
+# List with limit
+########################################################################################
+- name: List VM Guest Customization Profiles with limit
+  nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: Print result of list with limit
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify list with limit
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+      - result.total_available_results is defined
+      - result.total_available_results >= 2
+    fail_msg: "Failed listing VM Guest Customization Profiles with limit"
+    success_msg: "VM Guest Customization Profiles listed with limit successfully"
+
+########################################################################################
+# Delete VM Guest Customization Profile
+########################################################################################
+- name: Delete VM Guest Customization Profile in check mode
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: absent
+    ext_id: "{{ todelete[0] }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Print result of delete VM Guest Customization Profile in check mode
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify delete VM Guest Customization Profile in check mode
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == false
+      - result.ext_id == todelete[0]
+      - result.msg == "VM Guest Customization Profile with ext_id:" ~
+        todelete[0] ~ " will be deleted."
+    fail_msg: "Failed to delete VM Guest Customization Profile in check mode"
+    success_msg: "Delete VM Guest Customization Profile in check mode passed"
+
+- name: Delete VM Guest Customization Profile
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  loop: "{{ todelete }}"
+  register: delete_results
+  ignore_errors: true
+
+- name: Print result of delete VM Guest Customization Profiles
+  ansible.builtin.debug:
+    var: delete_results
+
+- name: Verify all VM Guest Customization Profiles deleted
+  ansible.builtin.assert:
+    that:
+      - item.changed == true
+      - item.failed == false
+      - item.task_ext_id is defined
+      - item.ext_id in todelete
+      - delete_results.results | length == todelete | length
+      - delete_results.msg == "All items completed"
+    fail_msg: "Failed to delete one or more VM Guest Customization Profiles"
+    success_msg: "All VM Guest Customization Profiles deleted successfully"
+  loop: "{{ delete_results.results }}"
+  loop_control:
+    label: "{{ item.ext_id }}"
+
+- name: Reset todelete list
+  ansible.builtin.set_fact:
+    todelete: []

--- a/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/vm_guest_customization_profiles.yml
+++ b/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/vm_guest_customization_profiles.yml
@@ -84,8 +84,7 @@
       - result.response.cd_roms[0].disk_address.bus_type == "IDE"
       - result.response.disks[0].disk_address.bus_type == "SCSI"
       - result.response.nics[0].network_info.subnet.ext_id == network.dhcp.uuid
-    fail_msg: "Failed to create Windows base VM for guest-customization
-      profile tests"
+    fail_msg: "Failed to create Windows base VM for guest-customization profile tests"
     success_msg: "Windows base VM created successfully"
 
 - name: Add base VM ext_id to cleanup list
@@ -121,13 +120,14 @@
 
 - name: Set base VM IP fact
   ansible.builtin.set_fact:
-    base_vm_ip: "{{ result.response.nics[0].network_info.ipv4_info.learned_ip_addresses[0].value }}"
+    base_vm_ip: "{{
+      result.response.nics[0].network_info.ipv4_info.learned_ip_addresses[0].va\
+      lue }}"
 
 - name: Create template (no-NGT) from base VM - used for the negative deploy test
   nutanix.ncp.ntnx_templates_v2:
     template_name: "{{ template_name }}"
-    template_description: "Template (NGT not installed) for VM Guest
-      Customization Profile tests"
+    template_description: "Template (NGT not installed) for VM Guest Customization Profile tests"
     template_version_spec:
       version_source:
         template_vm_reference:
@@ -800,326 +800,6 @@
     success_msg: "VM Guest Customization Profiles listed with limit successfully"
 
 ########################################################################################
-# Negative CRUD test: Create profile without name nor ext_id (state=present)
-# Expected: module-level required_if rejects the call with
-# "one of the following is required: name, ext_id".
-########################################################################################
-- name: Negative - Create profile without name nor ext_id
-  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
-    state: present
-    description: "should fail - no name and no ext_id"
-    config:
-      sysprep:
-        customization:
-          sysprep_params:
-            general_settings:
-              computer_name:
-                use_vm_name: {}
-              timezone: "UTC"
-              administrator_password: "admin123"
-            workgroup_or_domain_info:
-              workgroup:
-                name: "workgroup"
-            network_settings:
-              nic_config_list:
-                - ipv4_config:
-                    use_dhcp: {}
-  register: result
-  ignore_errors: true
-
-- name: Verify create without name nor ext_id fails as expected
-  ansible.builtin.assert:
-    that:
-      - result.changed == false
-      - result.failed == true
-      - >-
-        result.msg ==
-        "state is present but any of the following are missing: name, ext_id"
-    fail_msg: "Create profile without name nor ext_id did not fail as expected"
-    success_msg: "Create profile without name nor ext_id failed as expected"
-
-########################################################################################
-# Negative CRUD test: Create profile with name but without required `config`
-# Expected: module-level validate_required_params rejects the call with
-# "Missing required parameter(s): config".
-########################################################################################
-- name: Negative - Create profile without required `config` field
-  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
-    state: present
-    name: "vm_gc_profile_{{ suffix_name }}_no_config_{{ random_name }}"
-    description: "should fail - no config provided"
-  register: result
-  ignore_errors: true
-
-- name: Verify create without `config` fails as expected
-  ansible.builtin.assert:
-    that:
-      - result.changed == false
-      - result.failed == true
-      - result.msg == "Missing required parameter(s): config"
-    fail_msg: "Create profile without `config` did not fail as expected"
-    success_msg: "Create profile without `config` failed as expected"
-
-########################################################################################
-# Negative CRUD test: Create profile with mutually-exclusive customization branches
-# (sysprep_params AND answer_file). Argspec mutual_exclusive constraint should reject.
-########################################################################################
-- name: Negative - Create profile with both sysprep_params and answer_file (mutually exclusive)
-  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
-    state: present
-    name: "vm_gc_profile_{{ suffix_name }}_mutex_{{ random_name }}"
-    description: "should fail - both sysprep_params and answer_file provided"
-    config:
-      sysprep:
-        customization:
-          sysprep_params:
-            general_settings:
-              computer_name:
-                use_vm_name: {}
-              timezone: "UTC"
-              administrator_password: "admin123"
-            workgroup_or_domain_info:
-              workgroup:
-                name: "workgroup"
-            network_settings:
-              nic_config_list:
-                - ipv4_config:
-                    use_dhcp: {}
-          answer_file:
-            unattend_xml: "{{ sample_unattend_xml }}"
-  register: result
-  ignore_errors: true
-
-- name: Verify create with both sysprep_params and answer_file fails as expected
-  ansible.builtin.assert:
-    that:
-      - result.changed == false
-      - result.failed == true
-      - result.msg is search("parameters are mutually exclusive")
-      - result.msg is search("sysprep_params")
-      - result.msg is search("answer_file")
-    fail_msg: "Create with both sysprep_params and answer_file did not fail
-      as expected"
-    success_msg: "Create with both sysprep_params and answer_file failed
-      as expected"
-
-########################################################################################
-# Negative CRUD test: Create profile with mutually-exclusive workgroup AND domain_settings.
-########################################################################################
-- name: Negative - Create profile with both workgroup and domain_settings (mutually exclusive)
-  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
-    state: present
-    name: "vm_gc_profile_{{ suffix_name }}_wg_dom_{{ random_name }}"
-    description: "should fail - both workgroup and domain_settings provided"
-    config:
-      sysprep:
-        customization:
-          sysprep_params:
-            general_settings:
-              computer_name:
-                use_vm_name: {}
-              timezone: "UTC"
-              administrator_password: "admin123"
-            workgroup_or_domain_info:
-              workgroup:
-                name: "workgroup"
-              domain_settings:
-                credentials:
-                  domain_name: "domain.example.local"
-                  username: "admin"
-                  password: "admin123"
-            network_settings:
-              nic_config_list:
-                - ipv4_config:
-                    use_dhcp: {}
-  register: result
-  ignore_errors: true
-
-- name: Verify create with both workgroup and domain_settings fails as expected
-  ansible.builtin.assert:
-    that:
-      - result.changed == false
-      - result.failed == true
-      - result.msg is search("parameters are mutually exclusive")
-      - result.msg is search("workgroup")
-      - result.msg is search("domain_settings")
-    fail_msg: "Create with both workgroup and domain_settings did not fail
-      as expected"
-    success_msg: "Create with both workgroup and domain_settings failed
-      as expected"
-
-########################################################################################
-# Negative CRUD test: Fetch profile using a non-existent External ID
-# Expected: API exception with "Api Exception raised while fetching VM Guest
-# Customization Profile info using ext_id".
-########################################################################################
-- name: Negative - Fetch profile using non-existent External ID
-  nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
-    ext_id: "00000000-0000-0000-0000-000000000000"
-  register: result
-  ignore_errors: true
-
-- name: Verify fetch with non-existent External ID fails as expected
-  ansible.builtin.assert:
-    that:
-      - result.changed == false
-      - result.failed == true
-      - result.msg == "Api Exception raised while fetching VM Guest Customization
-        Profile info using ext_id"
-      - result.response is defined
-      - result.response.data.error | length > 0
-    fail_msg: "Fetch profile with non-existent External ID did not fail as expected"
-    success_msg: "Fetch profile with non-existent External ID failed as expected"
-
-########################################################################################
-# Negative CRUD test: Update profile using a non-existent External ID
-# Expected: API exception (the module fetches current profile first to obtain etag).
-########################################################################################
-- name: Negative - Update profile using non-existent External ID
-  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
-    state: present
-    ext_id: "00000000-0000-0000-0000-000000000000"
-    name: "vm_gc_profile_{{ suffix_name }}_update_neg_{{ random_name }}"
-    description: "should fail - non-existent External ID"
-    config:
-      sysprep:
-        customization:
-          sysprep_params:
-            general_settings:
-              computer_name:
-                use_vm_name: {}
-              timezone: "UTC"
-              administrator_password: "admin123"
-            workgroup_or_domain_info:
-              workgroup:
-                name: "workgroup"
-            network_settings:
-              nic_config_list:
-                - ipv4_config:
-                    use_dhcp: {}
-  register: result
-  ignore_errors: true
-
-- name: Verify update with non-existent External ID fails as expected
-  ansible.builtin.assert:
-    that:
-      - result.changed == false
-      - result.failed == true
-      - result.msg == "Api Exception raised while fetching VM Guest Customization
-        Profile info using ext_id"
-      - result.response is defined
-      - result.response.data.error | length > 0
-    fail_msg: "Update profile with non-existent External ID did not fail as expected"
-    success_msg: "Update profile with non-existent External ID failed as expected"
-
-########################################################################################
-# Negative CRUD test: Delete profile using a non-existent External ID
-# Expected: API exception (delete also fetches current profile first to obtain etag).
-########################################################################################
-- name: Negative - Delete profile using non-existent External ID
-  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
-    state: absent
-    ext_id: "00000000-0000-0000-0000-000000000000"
-  register: result
-  ignore_errors: true
-
-- name: Verify delete with non-existent External ID fails as expected
-  ansible.builtin.assert:
-    that:
-      - result.changed == false
-      - result.failed == true
-      - result.msg == "Api Exception raised while fetching VM Guest Customization
-        Profile info using ext_id"
-      - result.response is defined
-      - result.response.data.error | length > 0
-    fail_msg: "Delete profile with non-existent External ID did not fail as expected"
-    success_msg: "Delete profile with non-existent External ID failed as expected"
-
-########################################################################################
-# NEGATIVE TEST: Deploy from template using guest_customization_profile_config when
-# NGT is NOT installed on the source VM. The API rejects the request.
-########################################################################################
-- name: "Negative test - deploy template + profile config when NGT not installed"
-  nutanix.ncp.ntnx_templates_deploy_v2:
-    ext_id: "{{ template_ext_id }}"
-    cluster_reference: "{{ cluster.uuid }}"
-    override_vms_config:
-      - name: "{{ deployed_vm_name }}_neg"
-        guest_customization_profile_config:
-          profile:
-            ext_id: "{{ todelete[0] }}"
-  register: result
-  ignore_errors: true
-
-- name: Print result of negative deploy
-  ansible.builtin.debug:
-    var: result
-
-- name: Verify negative deploy fails because NGT is not installed on the source VM
-  ansible.builtin.assert:
-    that:
-      - result.changed == false
-      - result.failed == true
-      - result.response is defined
-      - result.response.status == "FAILED"
-      - result.response.error_messages is defined
-      - result.response.error_messages | length > 0
-    fail_msg: "Negative deploy did not fail as expected (NGT-not-installed
-      precondition)"
-    success_msg: "Negative deploy correctly failed because NGT is not installed
-      on source VM"
-
-########################################################################################
-# NEGATIVE TEST: Clone the base VM with guest_customization_profile_config when NGT
-# is NOT installed on the source VM. The clone API enforces the same NGT
-# prerequisite as deploy and returns a FAILED task.
-########################################################################################
-- name: "Negative test - clone VM + profile config when NGT not installed"
-  nutanix.ncp.ntnx_vms_clone_v2:
-    ext_id: "{{ vms_to_delete[0] }}"
-    name: "{{ cloned_vm_name }}_neg"
-    guest_customization_profile_config:
-      profile:
-        ext_id: "{{ todelete[0] }}"
-  register: result
-  ignore_errors: true
-
-- name: Print result of negative clone
-  ansible.builtin.debug:
-    var: result
-
-- name: Verify negative clone fails because NGT is not installed on the source VM
-  ansible.builtin.assert:
-    that:
-      - result.changed == false
-      - result.failed == true
-      - result.response is defined
-      - result.response.status == "FAILED"
-      - result.response.error_messages is defined
-      - result.response.error_messages | length > 0
-    fail_msg: "Negative clone did not fail as expected (NGT-not-installed
-      precondition)"
-    success_msg: "Negative clone correctly failed because NGT is not installed
-      on source VM"
-
-- name: Delete the no-NGT template (used only for the negative deploy test)
-  nutanix.ncp.ntnx_templates_v2:
-    state: absent
-    ext_id: "{{ template_ext_id }}"
-  register: template_delete_result
-  ignore_errors: true
-
-- name: Verify the no-NGT template was deleted
-  ansible.builtin.assert:
-    that:
-      - template_delete_result.changed == true
-      - template_delete_result.failed == false
-      - template_delete_result.response is defined
-      - template_delete_result.response.status == "SUCCEEDED"
-    fail_msg: "Failed to delete the no-NGT template after negative test"
-    success_msg: "No-NGT template deleted successfully"
-
-########################################################################################
 # Install NGT on the base VM so guest_customization_profile_config can be applied.
 ########################################################################################
 - name: Install NGT on the base VM (reboot IMMEDIATE)
@@ -1175,8 +855,7 @@
 - name: Create template from base VM (NGT now installed)
   nutanix.ncp.ntnx_templates_v2:
     template_name: "{{ template2_name }}"
-    template_description: "Template (NGT installed) for VM Guest Customization
-      Profile tests"
+    template_description: "Template (NGT installed) for VM Guest Customization Profile tests"
     template_version_spec:
       version_source:
         template_vm_reference:
@@ -1201,10 +880,535 @@
     template2_ext_id: "{{ result.ext_id }}"
 
 ########################################################################################
-# POSITIVE TEST: Deploy from NGT-installed template with guest_customization_profile_config
-# + per-VM overrides (todelete[0] = updated workgroup-sysprep profile).
+# Negative CRUD test: Create profile without name nor ext_id (state=present)
+# Expected: module-level required_if rejects the call with
+# "one of the following is required: name, ext_id".
 ########################################################################################
-- name: Deploy VM from NGT template with guest customization profile and overrides
+- name: Negative - Create profile without name nor ext_id
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    description: "should fail - no name and no ext_id"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name: {}
+              timezone: "UTC"
+              administrator_password: "admin123"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "workgroup"
+            network_settings:
+              nic_config_list:
+                - ipv4_config:
+                    use_dhcp: {}
+  register: result
+  ignore_errors: true
+
+- name: Verify create without name nor ext_id fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - >-
+        result.msg == "state is present but any of the following are missing:
+        name, ext_id"
+    fail_msg: "Create profile without name nor ext_id did not fail as expected"
+    success_msg: "Create profile without name nor ext_id failed as expected"
+
+########################################################################################
+# Negative CRUD test: Create profile with name but without required `config`
+# Expected: module-level validate_required_params rejects the call with
+# "Missing required parameter(s): config".
+########################################################################################
+- name: Negative - Create profile without required `config` field
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    name: "vm_gc_profile_{{ suffix_name }}_no_config_{{ random_name }}"
+    description: "should fail - no config provided"
+  register: result
+  ignore_errors: true
+
+- name: Verify create without `config` fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): config"
+    fail_msg: "Create profile without `config` did not fail as expected"
+    success_msg: "Create profile without `config` failed as expected"
+
+########################################################################################
+# Negative CRUD test: Create profile with mutually-exclusive customization branches
+# (sysprep_params AND answer_file). Argspec mutual_exclusive constraint should reject.
+########################################################################################
+- name: Negative - Create profile with both sysprep_params and answer_file
+    (mutually exclusive)
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    name: "vm_gc_profile_{{ suffix_name }}_mutex_{{ random_name }}"
+    description: "should fail - both sysprep_params and answer_file provided"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name: {}
+              timezone: "UTC"
+              administrator_password: "admin123"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "workgroup"
+            network_settings:
+              nic_config_list:
+                - ipv4_config:
+                    use_dhcp: {}
+          answer_file:
+            unattend_xml: "{{ sample_unattend_xml }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify create with both sysprep_params and answer_file fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg is search("parameters are mutually exclusive")
+      - result.msg is search("sysprep_params")
+      - result.msg is search("answer_file")
+    fail_msg: "Create with both sysprep_params and answer_file did not fail as expected"
+    success_msg: "Create with both sysprep_params and answer_file failed as expected"
+
+########################################################################################
+# Negative CRUD test: Create profile with mutually-exclusive workgroup AND domain_settings.
+########################################################################################
+- name: Negative - Create profile with both workgroup and domain_settings
+    (mutually exclusive)
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    name: "vm_gc_profile_{{ suffix_name }}_wg_dom_{{ random_name }}"
+    description: "should fail - both workgroup and domain_settings provided"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name: {}
+              timezone: "UTC"
+              administrator_password: "admin123"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "workgroup"
+              domain_settings:
+                credentials:
+                  domain_name: "domain.example.local"
+                  username: "admin"
+                  password: "admin123"
+            network_settings:
+              nic_config_list:
+                - ipv4_config:
+                    use_dhcp: {}
+  register: result
+  ignore_errors: true
+
+- name: Verify create with both workgroup and domain_settings fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg is search("parameters are mutually exclusive")
+      - result.msg is search("workgroup")
+      - result.msg is search("domain_settings")
+    fail_msg: "Create with both workgroup and domain_settings did not fail as expected"
+    success_msg: "Create with both workgroup and domain_settings failed as expected"
+
+########################################################################################
+# Negative CRUD test: Fetch profile using a non-existent External ID
+# Expected: API exception with "Api Exception raised while fetching VM Guest
+# Customization Profile info using ext_id".
+########################################################################################
+- name: Negative - Fetch profile using non-existent External ID
+  nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Verify fetch with non-existent External ID fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching VM Guest
+        Customization Profile info using ext_id"
+      - result.response is defined
+      - result.response.data.error | length > 0
+    fail_msg: "Fetch profile with non-existent External ID did not fail as expected"
+    success_msg: "Fetch profile with non-existent External ID failed as expected"
+
+########################################################################################
+# Negative CRUD test: Update profile using a non-existent External ID
+# Expected: API exception (the module fetches current profile first to obtain etag).
+########################################################################################
+- name: Negative - Update profile using non-existent External ID
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    name: "vm_gc_profile_{{ suffix_name }}_update_neg_{{ random_name }}"
+    description: "should fail - non-existent External ID"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name: {}
+              timezone: "UTC"
+              administrator_password: "admin123"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "workgroup"
+            network_settings:
+              nic_config_list:
+                - ipv4_config:
+                    use_dhcp: {}
+  register: result
+  ignore_errors: true
+
+- name: Verify update with non-existent External ID fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching VM Guest
+        Customization Profile info using ext_id"
+      - result.response is defined
+      - result.response.data.error | length > 0
+    fail_msg: "Update profile with non-existent External ID did not fail as expected"
+    success_msg: "Update profile with non-existent External ID failed as expected"
+
+########################################################################################
+# Negative CRUD test: Delete profile using a non-existent External ID
+# Expected: API exception (delete also fetches current profile first to obtain etag).
+########################################################################################
+- name: Negative - Delete profile using non-existent External ID
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: absent
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Verify delete with non-existent External ID fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching VM Guest
+        Customization Profile info using ext_id"
+      - result.response is defined
+      - result.response.data.error | length > 0
+    fail_msg: "Delete profile with non-existent External ID did not fail as expected"
+    success_msg: "Delete profile with non-existent External ID failed as expected"
+
+########################################################################################
+# Negative CRUD test: Deploy from template using guest_customization_profile_config when
+# NGT is NOT installed on the source VM. The API rejects the request.
+########################################################################################
+- name: Negative - Deploy template + profile config when NGT not installed
+  nutanix.ncp.ntnx_templates_deploy_v2:
+    ext_id: "{{ template_ext_id }}"
+    cluster_reference: "{{ cluster.uuid }}"
+    override_vms_config:
+      - name: "{{ deployed_vm_name }}_neg"
+        guest_customization_profile_config:
+          profile:
+            ext_id: "{{ todelete[0] }}"
+  register: result
+  ignore_errors: true
+
+- name: Print result of negative deploy
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify negative deploy fails because NGT is not installed on the source VM
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.response is defined
+      - result.response.status == "FAILED"
+      - result.response.error_messages is defined
+      - result.response.error_messages | length > 0
+    fail_msg: "Negative deploy did not fail as expected (NGT-not-installed precondition)"
+    success_msg: "Negative deploy correctly failed because NGT is not installed on
+      source VM"
+
+########################################################################################
+# Negative CRUD test: Clone the base VM with guest_customization_profile_config when NGT
+# is NOT installed on the source VM. The clone API enforces the same NGT
+# prerequisite as deploy and returns a FAILED task.
+########################################################################################
+- name: Negative - Clone VM + profile config when NGT not installed
+  nutanix.ncp.ntnx_vms_clone_v2:
+    ext_id: "{{ vms_to_delete[0] }}"
+    name: "{{ cloned_vm_name }}_neg"
+    guest_customization_profile_config:
+      profile:
+        ext_id: "{{ todelete[0] }}"
+  register: result
+  ignore_errors: true
+
+- name: Print result of negative clone
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify negative clone fails because NGT is not installed on the source VM
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.response is defined
+      - result.response.status == "FAILED"
+      - result.response.error_messages is defined
+      - result.response.error_messages | length > 0
+    fail_msg: "Negative clone did not fail as expected (NGT-not-installed precondition)"
+    success_msg: "Negative clone correctly failed because NGT is not installed on source VM"
+
+- name: Delete the no-NGT template (used only for the negative deploy test)
+  nutanix.ncp.ntnx_templates_v2:
+    state: absent
+    ext_id: "{{ template_ext_id }}"
+  register: template_delete_result
+  ignore_errors: true
+
+- name: Verify the no-NGT template was deleted
+  ansible.builtin.assert:
+    that:
+      - template_delete_result.changed == true
+      - template_delete_result.failed == false
+      - template_delete_result.response is defined
+      - template_delete_result.response.status == "SUCCEEDED"
+    fail_msg: "Failed to delete the no-NGT template after negative test"
+    success_msg: "No-NGT template deleted successfully"
+
+########################################################################################
+# Negative CRUD test: Deploy with must_provide profile, override missing computer_name and ipv4_config
+########################################################################################
+- name: Negative - Deploy with must_provide profile, override missing
+    computer_name and ipv4_config
+  nutanix.ncp.ntnx_templates_deploy_v2:
+    ext_id: "{{ template2_ext_id }}"
+    cluster_reference: "{{ cluster.uuid }}"
+    override_vms_config:
+      - name: "{{ deployed_vm_name }}_neg_must_provide"
+        guest_customization_profile_config:
+          profile:
+            ext_id: "{{ todelete[1] }}"
+          config_override_spec:
+            customization:
+              sysprep_params:
+                general_settings:
+                  timezone:
+                    value:
+                      value: "UTC"
+                  registered_owner:
+                    value:
+                      value: "neg-owner"
+  register: result
+  ignore_errors: true
+
+- name: Print result of negative deploy (must_provide fields missing)
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify negative deploy fails because must_provide_during_deployment fields
+    are missing
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.response is defined
+      - result.response.status == "FAILED"
+      - result.response.error_messages is defined
+      - result.response.error_messages | length > 0
+    fail_msg: "Negative deploy did not fail as expected
+      (must_provide_during_deployment fields missing)"
+    success_msg: "Negative deploy correctly failed as expected because must_provide
+      fields were not supplied in the override"
+
+########################################################################################
+# Negative CRUD test: Clone with must_provide profile, override missing computer_name and ipv4_config
+########################################################################################
+
+- name: Negative - Clone with must_provide profile, override missing computer_name
+    and ipv4_config
+  nutanix.ncp.ntnx_vms_clone_v2:
+    ext_id: "{{ vms_to_delete[0] }}"
+    name: "{{ cloned_vm_name }}_neg_must_provide"
+    guest_customization_profile_config:
+      profile:
+        ext_id: "{{ todelete[1] }}"
+      config_override_spec:
+        customization:
+          sysprep_params:
+            general_settings:
+              timezone:
+                value:
+                  value: "UTC"
+              registered_owner:
+                value:
+                  value: "neg-owner"
+  register: result
+  ignore_errors: true
+
+- name: Print result of negative clone (must_provide fields missing)
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify negative clone fails because must_provide_during_deployment fields
+    are missing
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.response is defined
+      - result.response.status == "FAILED"
+      - result.response.error_messages is defined
+      - result.response.error_messages | length > 0
+    fail_msg: "Negative clone did not fail as expected
+      (must_provide_during_deployment fields missing)"
+    success_msg: "Negative clone correctly failed as expected because must_provide
+      fields were not supplied in the override"
+
+########################################################################################
+# Deploy with must_provide profile, override complete computer_name and ipv4_config
+########################################################################################
+- name: Deploy with must_provide profile, override computer_name and ipv4_config
+    ipv4_config
+  nutanix.ncp.ntnx_templates_deploy_v2:
+    ext_id: "{{ template2_ext_id }}"
+    cluster_reference: "{{ cluster.uuid }}"
+    override_vms_config:
+      - name: "{{ deployed_vm_name }}_must_provide"
+        guest_customization_profile_config:
+          profile:
+            ext_id: "{{ todelete[1] }}"
+          config_override_spec:
+            customization:
+              sysprep_params:
+                general_settings:
+                  computer_name:
+                    name:
+                      value: "deployed-mp"
+                  timezone:
+                    value:
+                      value: "UTC"
+                network_settings:
+                  nic_config_list:
+                    - dns_config:
+                        preferred_dns_server_address: "10.1.0.10"
+                        alternate_dns_server_addresses:
+                          - "10.1.0.11"
+                      ipv4_config:
+                        use_dhcp: {}
+  register: result
+  ignore_errors: true
+
+- name: Print result of positive deploy (must_provide fields supplied)
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify positive deploy succeeds when must_provide fields are supplied
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.status == "SUCCEEDED"
+    fail_msg: "Positive must_provide deploy failed unexpectedly"
+    success_msg: "Positive must_provide deploy succeeded as expected"
+
+- name: Find positive must_provide deployed VM by name
+  nutanix.ncp.ntnx_vms_info_v2:
+    filter: "name eq '{{ deployed_vm_name }}_must_provide'"
+  register: must_provide_deploy_info
+  ignore_errors: true
+
+- name: Delete positive must_provide deployed VM (cleanup inline)
+  nutanix.ncp.ntnx_vms_v2:
+    state: absent
+    ext_id: "{{ must_provide_deploy_info.response[0].ext_id }}"
+  when:
+    - must_provide_deploy_info.response is defined
+    - must_provide_deploy_info.response | length == 1
+  ignore_errors: true
+
+########################################################################################
+# Positive CRUD test: Clone with must_provide profile and complete override
+########################################################################################
+- name: Clone with must_provide profile and complete override
+  nutanix.ncp.ntnx_vms_clone_v2:
+    ext_id: "{{ vms_to_delete[0] }}"
+    name: "{{ cloned_vm_name }}_must_provide"
+    guest_customization_profile_config:
+      profile:
+        ext_id: "{{ todelete[1] }}"
+      config_override_spec:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                name:
+                  value: "cloned-mp"
+              timezone:
+                value:
+                  value: "UTC"
+            network_settings:
+              nic_config_list:
+                - dns_config:
+                    preferred_dns_server_address: "10.1.0.10"
+                    alternate_dns_server_addresses:
+                      - "10.1.0.11"
+                  ipv4_config:
+                    static_config:
+                      ip_address:
+                        value: "10.1.0.51"
+                        prefix_length: 24
+                      default_gateways:
+                        - "10.1.0.1"
+  register: result
+  ignore_errors: true
+
+- name: Print result of positive clone (must_provide fields supplied)
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify positive clone succeeds when must_provide fields are supplied
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == cloned_vm_name + "_must_provide"
+      - result.response.ext_id is defined
+    fail_msg: "Positive must_provide clone failed unexpectedly"
+    success_msg: "Positive must_provide clone succeeded as expected"
+
+- name: Delete positive must_provide cloned VM (cleanup inline)
+  nutanix.ncp.ntnx_vms_v2:
+    state: absent
+    ext_id: "{{ result.response.ext_id }}"
+  when: result.response is defined and result.response.ext_id is defined
+  ignore_errors: true
+
+########################################################################################
+# Deploy from NGT-installed template with guest_customization_profile_config
+# + per-VM overrides (todelete[0] = updated workgroup-sysprep profile)
+########################################################################################
+- name: Deploy from NGT template with guest customization profile and overrides
   nutanix.ncp.ntnx_templates_deploy_v2:
     ext_id: "{{ template2_ext_id }}"
     cluster_reference: "{{ cluster.uuid }}"
@@ -1305,10 +1509,11 @@
       - deployed_vm.response.nics | length == 1
       - deployed_vm.response.cd_roms | length == 1
     fail_msg: "Deployed VM did not have expected guest customization status or overrides"
-    success_msg: "Deployed VM is in PENDING guest customization state with overrides applied"
+    success_msg: "Deployed VM is in PENDING guest customization state with overrides
+      applied"
 
 ########################################################################################
-# POSITIVE TEST: Clone the base VM using todelete[1] (domain-settings profile) + per-clone
+# Clone the base VM using todelete[1] (domain-settings profile) + per-clone
 # overrides. computer_name and ipv4_config are marked must_provide_during_deployment in
 # the profile, so the override MUST supply both.
 ########################################################################################
@@ -1398,15 +1603,16 @@
       - cloned_vm.response.disks | length == 1
       - cloned_vm.response.nics | length == 1
       - cloned_vm.response.cd_roms | length == 1
-    fail_msg: "Cloned VM did not have expected guest customization status or inherited config"
+    fail_msg: "Cloned VM did not have expected guest customization status or
+      inherited config"
     success_msg: "Cloned VM is in PENDING guest customization state with inherited config"
 
 ########################################################################################
-# Power on the deployed and cloned VMs so guest customization actually executes,
-# then wait for NGT to become reachable and assert post-customization state.
+# Power on the deployed and cloned VMs so guest customization actually executes
+# then wait for NGT to become reachable and assert post-customization state
 # After the VM boots and customization runs, the API stops returning
 # vm_guest_customization_status (PENDING is the only meaningful enum value), and
-# guest_tools/NGT comes online with a learned IP on the NIC.
+# guest_tools/NGT comes online with a learned IP on the NIC
 ########################################################################################
 - name: Power on the deployed VM to trigger guest customization
   nutanix.ncp.ntnx_vms_power_actions_v2:
@@ -1455,8 +1661,10 @@
     - deployed_vm_post.response.guest_tools is defined
     - deployed_vm_post.response.guest_tools.is_reachable == true
     - deployed_vm_post.response.nics[0].network_info.ipv4_info is defined
-    - deployed_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses is defined
-    - deployed_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses | length > 0
+    - deployed_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses
+      is defined
+    - deployed_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses
+      | length > 0
 
 - name: Print deployed VM post-customization details
   ansible.builtin.debug:
@@ -1468,8 +1676,8 @@
       - deployed_vm_post.response is defined
       - deployed_vm_post.response.ext_id == vms_to_delete[1]
       - deployed_vm_post.response.power_state == "ON"
-      - deployed_vm_post.response.vm_guest_customization_status is not defined or
-        deployed_vm_post.response.vm_guest_customization_status == None
+      - deployed_vm_post.response.vm_guest_customization_status is not defined
+        or deployed_vm_post.response.vm_guest_customization_status == None
       - deployed_vm_post.response.host is defined
       - deployed_vm_post.response.host.ext_id is defined
       - deployed_vm_post.response.guest_tools.is_installed == true
@@ -1479,8 +1687,10 @@
       - deployed_vm_post.response.guest_tools.guest_os_version is defined
       - "'windows' in deployed_vm_post.response.guest_tools.guest_os_version"
       - deployed_vm_post.response.guest_tools.guest_info is defined
-      - deployed_vm_post.response.guest_tools.guest_info.guest_os_full_name is defined
-      - "'windows' in deployed_vm_post.response.guest_tools.guest_info.guest_os_full_name"
+      - deployed_vm_post.response.guest_tools.guest_info.guest_os_full_name is
+        defined
+      - "'windows' in
+        deployed_vm_post.response.guest_tools.guest_info.guest_os_full_name"
     fail_msg: "Deployed VM did not reach the expected post-customization state"
     success_msg: "Deployed VM completed guest customization"
 
@@ -1497,8 +1707,10 @@
     - cloned_vm_post.response.guest_tools is defined
     - cloned_vm_post.response.guest_tools.is_reachable == true
     - cloned_vm_post.response.nics[0].network_info.ipv4_info is defined
-    - cloned_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses is defined
-    - cloned_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses | length > 0
+    - cloned_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses
+      is defined
+    - cloned_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses
+      | length > 0
 
 - name: Print cloned VM post-customization details
   ansible.builtin.debug:
@@ -1521,8 +1733,10 @@
       - cloned_vm_post.response.guest_tools.guest_os_version is defined
       - "'windows' in cloned_vm_post.response.guest_tools.guest_os_version"
       - cloned_vm_post.response.guest_tools.guest_info is defined
-      - cloned_vm_post.response.guest_tools.guest_info.guest_os_full_name is defined
-      - "'windows' in cloned_vm_post.response.guest_tools.guest_info.guest_os_full_name"
+      - cloned_vm_post.response.guest_tools.guest_info.guest_os_full_name is
+        defined
+      - "'windows' in
+        cloned_vm_post.response.guest_tools.guest_info.guest_os_full_name"
     fail_msg: "Cloned VM did not reach the expected post-customization state"
     success_msg: "Cloned VM completed guest customization"
 

--- a/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/vm_guest_customization_profiles.yml
+++ b/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/vm_guest_customization_profiles.yml
@@ -1337,11 +1337,22 @@
   register: must_provide_deploy_info
   ignore_errors: true
 
-- name: Delete must_provide deployed VM (cleanup inline)
+- name: Delete deployed VM with must_provide fields
   nutanix.ncp.ntnx_vms_v2:
     state: absent
     ext_id: "{{ must_provide_deploy_info.response[0].ext_id }}"
-    ignore_errors: true
+  register: result
+  ignore_errors: true
+
+- name: Verify deployed VM with must_provide fields was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.status == "SUCCEEDED"
+    fail_msg: "Failed to delete deployed VM with must_provide fields"
+    success_msg: "Deployed VM with must_provide fields deleted successfully"
 
 ########################################################################################
 # Clone with must_provide profile and complete override
@@ -1394,11 +1405,22 @@
     fail_msg: "Clone failed unexpectedly when must_provide fields were supplied"
     success_msg: "Clone succeeded when must_provide fields were supplied"
 
-- name: Delete must_provide cloned VM (cleanup inline)
+- name: Delete cloned VM with must_provide fields
   nutanix.ncp.ntnx_vms_v2:
     state: absent
     ext_id: "{{ result.response.ext_id }}"
+  register: result
   ignore_errors: true
+
+- name: Verify cloned VM with must_provide fields was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.status == "SUCCEEDED"
+    fail_msg: "Failed to delete cloned VM with must_provide fields"
+    success_msg: "Cloned VM with must_provide fields deleted successfully"
 
 ########################################################################################
 # Deploy from NGT-installed template with guest_customization_profile_config

--- a/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/vm_guest_customization_profiles.yml
+++ b/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/vm_guest_customization_profiles.yml
@@ -23,6 +23,135 @@
       '/vars/unattend_xml_content.xml') | b64encode }}"
 
 ########################################################################################
+# Pre-create an NGT-capable base VM and a (no-NGT) template used for the negative
+# deploy test. NGT is intentionally NOT installed yet on the base VM so that the
+# template1 captures a non-NGT source-VM state. We later install NGT and create a
+# second template (template2) from the same VM for the positive deploy test.
+########################################################################################
+- name: Set base VM / template / clone / deploy names
+  ansible.builtin.set_fact:
+    base_vm_name: "vm_gc_profile_{{ suffix_name }}_base_{{ random_name }}"
+    template_name: "vm_gc_profile_{{ suffix_name }}_template_{{ random_name }}"
+    template2_name: "vm_gc_profile_{{ suffix_name }}_template2_{{ random_name }}"
+    deployed_vm_name: "vm_gc_profile_{{ suffix_name }}_deployed_{{ random_name }}"
+    cloned_vm_name: "vm_gc_profile_{{ suffix_name }}_clone_{{ random_name }}"
+    vms_to_delete: []
+
+- name: Create base VM (Windows UEFI image, CD-ROM, DHCP NIC) - NGT not yet installed
+  nutanix.ncp.ntnx_vms_v2:
+    state: present
+    name: "{{ base_vm_name }}"
+    cluster:
+      ext_id: "{{ cluster.uuid }}"
+    num_sockets: 2
+    num_cores_per_socket: 2
+    memory_size_bytes: 8589934592
+    boot_config:
+      uefi_boot: {}
+    disks:
+      - backing_info:
+          vm_disk:
+            disk_size_bytes: 42949672960
+            data_source:
+              reference:
+                image_reference:
+                  image_ext_id: "{{ windows_image_config.image_uuid }}"
+        disk_address:
+          bus_type: SCSI
+          index: 0
+    cd_roms:
+      - disk_address:
+          bus_type: IDE
+          index: 0
+    nics:
+      - network_info:
+          subnet:
+            ext_id: "{{ network.dhcp.uuid }}"
+          ipv4_config:
+            should_assign_ip: true
+  register: result
+  ignore_errors: true
+
+- name: Verify creation of base VM
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id is defined
+      - result.response.name == base_vm_name
+      - result.response.cluster.ext_id == cluster.uuid
+      - result.response.cd_roms[0].disk_address.bus_type == "IDE"
+      - result.response.disks[0].disk_address.bus_type == "SCSI"
+      - result.response.nics[0].network_info.subnet.ext_id == network.dhcp.uuid
+    fail_msg: "Failed to create Windows base VM for guest-customization
+      profile tests"
+    success_msg: "Windows base VM created successfully"
+
+- name: Add base VM ext_id to cleanup list
+  ansible.builtin.set_fact:
+    vms_to_delete: "{{ vms_to_delete + [result.ext_id] }}"
+
+- name: Power on the base VM (required to install NGT later)
+  nutanix.ncp.ntnx_vms_power_actions_v2:
+    state: power_on
+    ext_id: "{{ vms_to_delete[0] }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify base VM powered on
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response.status == "SUCCEEDED"
+    fail_msg: "Failed to power on base VM"
+    success_msg: "Base VM powered on successfully"
+
+- name: Wait for the base VM to receive an IP address via DHCP
+  nutanix.ncp.ntnx_vms_info_v2:
+    ext_id: "{{ vms_to_delete[0] }}"
+  register: result
+  ignore_errors: true
+  retries: 60
+  delay: 5
+  until: result.response.nics[0].network_info.ipv4_info.learned_ip_addresses[0].value
+    is defined
+
+- name: Set base VM IP fact
+  ansible.builtin.set_fact:
+    base_vm_ip: "{{ result.response.nics[0].network_info.ipv4_info.learned_ip_addresses[0].value }}"
+
+- name: Create template (no-NGT) from base VM - used for the negative deploy test
+  nutanix.ncp.ntnx_templates_v2:
+    template_name: "{{ template_name }}"
+    template_description: "Template (NGT not installed) for VM Guest
+      Customization Profile tests"
+    template_version_spec:
+      version_source:
+        template_vm_reference:
+          ext_id: "{{ vms_to_delete[0] }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify creation of template (no-NGT) from base VM
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id is defined
+      - result.response.template_version_spec.ext_id is defined
+      - result.response.template_name == template_name
+    fail_msg: "Failed to create template from base VM (NGT not installed yet)"
+    success_msg: "Template (NGT not yet installed) created successfully"
+
+- name: Save template ext_id (template1, used for negative deploy test)
+  ansible.builtin.set_fact:
+    template_ext_id: "{{ result.ext_id }}"
+
+########################################################################################
 # Check-mode: generate spec for creating a workgroup/sysprep profile
 ########################################################################################
 - name: Generate spec for creating VM Guest Customization Profile (sysprep
@@ -669,6 +798,776 @@
       - result.total_available_results >= 2
     fail_msg: "Failed listing VM Guest Customization Profiles with limit"
     success_msg: "VM Guest Customization Profiles listed with limit successfully"
+
+########################################################################################
+# Negative CRUD test: Create profile without name nor ext_id (state=present)
+# Expected: module-level required_if rejects the call with
+# "one of the following is required: name, ext_id".
+########################################################################################
+- name: Negative - Create profile without name nor ext_id
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    description: "should fail - no name and no ext_id"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name: {}
+              timezone: "UTC"
+              administrator_password: "admin123"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "workgroup"
+            network_settings:
+              nic_config_list:
+                - ipv4_config:
+                    use_dhcp: {}
+  register: result
+  ignore_errors: true
+
+- name: Verify create without name nor ext_id fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - >-
+        result.msg ==
+        "state is present but any of the following are missing: name, ext_id"
+    fail_msg: "Create profile without name nor ext_id did not fail as expected"
+    success_msg: "Create profile without name nor ext_id failed as expected"
+
+########################################################################################
+# Negative CRUD test: Create profile with name but without required `config`
+# Expected: module-level validate_required_params rejects the call with
+# "Missing required parameter(s): config".
+########################################################################################
+- name: Negative - Create profile without required `config` field
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    name: "vm_gc_profile_{{ suffix_name }}_no_config_{{ random_name }}"
+    description: "should fail - no config provided"
+  register: result
+  ignore_errors: true
+
+- name: Verify create without `config` fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): config"
+    fail_msg: "Create profile without `config` did not fail as expected"
+    success_msg: "Create profile without `config` failed as expected"
+
+########################################################################################
+# Negative CRUD test: Create profile with mutually-exclusive customization branches
+# (sysprep_params AND answer_file). Argspec mutual_exclusive constraint should reject.
+########################################################################################
+- name: Negative - Create profile with both sysprep_params and answer_file (mutually exclusive)
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    name: "vm_gc_profile_{{ suffix_name }}_mutex_{{ random_name }}"
+    description: "should fail - both sysprep_params and answer_file provided"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name: {}
+              timezone: "UTC"
+              administrator_password: "admin123"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "workgroup"
+            network_settings:
+              nic_config_list:
+                - ipv4_config:
+                    use_dhcp: {}
+          answer_file:
+            unattend_xml: "{{ sample_unattend_xml }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify create with both sysprep_params and answer_file fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg is search("parameters are mutually exclusive")
+      - result.msg is search("sysprep_params")
+      - result.msg is search("answer_file")
+    fail_msg: "Create with both sysprep_params and answer_file did not fail
+      as expected"
+    success_msg: "Create with both sysprep_params and answer_file failed
+      as expected"
+
+########################################################################################
+# Negative CRUD test: Create profile with mutually-exclusive workgroup AND domain_settings.
+########################################################################################
+- name: Negative - Create profile with both workgroup and domain_settings (mutually exclusive)
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    name: "vm_gc_profile_{{ suffix_name }}_wg_dom_{{ random_name }}"
+    description: "should fail - both workgroup and domain_settings provided"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name: {}
+              timezone: "UTC"
+              administrator_password: "admin123"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "workgroup"
+              domain_settings:
+                credentials:
+                  domain_name: "domain.example.local"
+                  username: "admin"
+                  password: "admin123"
+            network_settings:
+              nic_config_list:
+                - ipv4_config:
+                    use_dhcp: {}
+  register: result
+  ignore_errors: true
+
+- name: Verify create with both workgroup and domain_settings fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg is search("parameters are mutually exclusive")
+      - result.msg is search("workgroup")
+      - result.msg is search("domain_settings")
+    fail_msg: "Create with both workgroup and domain_settings did not fail
+      as expected"
+    success_msg: "Create with both workgroup and domain_settings failed
+      as expected"
+
+########################################################################################
+# Negative CRUD test: Fetch profile using a non-existent External ID
+# Expected: API exception with "Api Exception raised while fetching VM Guest
+# Customization Profile info using ext_id".
+########################################################################################
+- name: Negative - Fetch profile using non-existent External ID
+  nutanix.ncp.ntnx_vm_guest_customization_profiles_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Verify fetch with non-existent External ID fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching VM Guest Customization
+        Profile info using ext_id"
+      - result.response is defined
+      - result.response.data.error | length > 0
+    fail_msg: "Fetch profile with non-existent External ID did not fail as expected"
+    success_msg: "Fetch profile with non-existent External ID failed as expected"
+
+########################################################################################
+# Negative CRUD test: Update profile using a non-existent External ID
+# Expected: API exception (the module fetches current profile first to obtain etag).
+########################################################################################
+- name: Negative - Update profile using non-existent External ID
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: present
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    name: "vm_gc_profile_{{ suffix_name }}_update_neg_{{ random_name }}"
+    description: "should fail - non-existent External ID"
+    config:
+      sysprep:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                use_vm_name: {}
+              timezone: "UTC"
+              administrator_password: "admin123"
+            workgroup_or_domain_info:
+              workgroup:
+                name: "workgroup"
+            network_settings:
+              nic_config_list:
+                - ipv4_config:
+                    use_dhcp: {}
+  register: result
+  ignore_errors: true
+
+- name: Verify update with non-existent External ID fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching VM Guest Customization
+        Profile info using ext_id"
+      - result.response is defined
+      - result.response.data.error | length > 0
+    fail_msg: "Update profile with non-existent External ID did not fail as expected"
+    success_msg: "Update profile with non-existent External ID failed as expected"
+
+########################################################################################
+# Negative CRUD test: Delete profile using a non-existent External ID
+# Expected: API exception (delete also fetches current profile first to obtain etag).
+########################################################################################
+- name: Negative - Delete profile using non-existent External ID
+  nutanix.ncp.ntnx_vm_guest_customization_profile_v2:
+    state: absent
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Verify delete with non-existent External ID fails as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching VM Guest Customization
+        Profile info using ext_id"
+      - result.response is defined
+      - result.response.data.error | length > 0
+    fail_msg: "Delete profile with non-existent External ID did not fail as expected"
+    success_msg: "Delete profile with non-existent External ID failed as expected"
+
+########################################################################################
+# NEGATIVE TEST: Deploy from template using guest_customization_profile_config when
+# NGT is NOT installed on the source VM. The API rejects the request.
+########################################################################################
+- name: "Negative test - deploy template + profile config when NGT not installed"
+  nutanix.ncp.ntnx_templates_deploy_v2:
+    ext_id: "{{ template_ext_id }}"
+    cluster_reference: "{{ cluster.uuid }}"
+    override_vms_config:
+      - name: "{{ deployed_vm_name }}_neg"
+        guest_customization_profile_config:
+          profile:
+            ext_id: "{{ todelete[0] }}"
+  register: result
+  ignore_errors: true
+
+- name: Print result of negative deploy
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify negative deploy fails because NGT is not installed on the source VM
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.response is defined
+      - result.response.status == "FAILED"
+      - result.response.error_messages is defined
+      - result.response.error_messages | length > 0
+    fail_msg: "Negative deploy did not fail as expected (NGT-not-installed
+      precondition)"
+    success_msg: "Negative deploy correctly failed because NGT is not installed
+      on source VM"
+
+########################################################################################
+# NEGATIVE TEST: Clone the base VM with guest_customization_profile_config when NGT
+# is NOT installed on the source VM. The clone API enforces the same NGT
+# prerequisite as deploy and returns a FAILED task.
+########################################################################################
+- name: "Negative test - clone VM + profile config when NGT not installed"
+  nutanix.ncp.ntnx_vms_clone_v2:
+    ext_id: "{{ vms_to_delete[0] }}"
+    name: "{{ cloned_vm_name }}_neg"
+    guest_customization_profile_config:
+      profile:
+        ext_id: "{{ todelete[0] }}"
+  register: result
+  ignore_errors: true
+
+- name: Print result of negative clone
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify negative clone fails because NGT is not installed on the source VM
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.response is defined
+      - result.response.status == "FAILED"
+      - result.response.error_messages is defined
+      - result.response.error_messages | length > 0
+    fail_msg: "Negative clone did not fail as expected (NGT-not-installed
+      precondition)"
+    success_msg: "Negative clone correctly failed because NGT is not installed
+      on source VM"
+
+- name: Delete the no-NGT template (used only for the negative deploy test)
+  nutanix.ncp.ntnx_templates_v2:
+    state: absent
+    ext_id: "{{ template_ext_id }}"
+  register: template_delete_result
+  ignore_errors: true
+
+- name: Verify the no-NGT template was deleted
+  ansible.builtin.assert:
+    that:
+      - template_delete_result.changed == true
+      - template_delete_result.failed == false
+      - template_delete_result.response is defined
+      - template_delete_result.response.status == "SUCCEEDED"
+    fail_msg: "Failed to delete the no-NGT template after negative test"
+    success_msg: "No-NGT template deleted successfully"
+
+########################################################################################
+# Install NGT on the base VM so guest_customization_profile_config can be applied.
+########################################################################################
+- name: Install NGT on the base VM (reboot IMMEDIATE)
+  nutanix.ncp.ntnx_vms_ngt_v2:
+    state: present
+    ext_id: "{{ vms_to_delete[0] }}"
+    capabilities:
+      - VSS_SNAPSHOT
+    credential:
+      username: "{{ windows_image_config.username }}"
+      password: "{{ windows_image_config.password }}"
+    reboot_preference:
+      schedule_type: IMMEDIATE
+  register: result
+  ignore_errors: true
+
+- name: Verify NGT install was triggered
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.task_ext_id is defined
+      - result.ext_id == vms_to_delete[0]
+    fail_msg: "Failed to install NGT on base VM"
+    success_msg: "NGT install triggered on base VM"
+
+- name: Wait 2 minutes for NGT install to complete
+  ansible.builtin.pause:
+    minutes: 2
+
+- name: Fetch base VM info to confirm NGT install
+  nutanix.ncp.ntnx_vms_info_v2:
+    ext_id: "{{ vms_to_delete[0] }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify NGT is reported as installed on the base VM
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.failed == false
+      - result.response.guest_tools is defined
+      - result.response.guest_tools.is_installed == true
+      - result.response.guest_tools.is_enabled == true
+    fail_msg: "NGT not reported as installed on base VM after install task"
+    success_msg: "NGT confirmed as installed on base VM"
+
+########################################################################################
+# Create a new template (template2) from the NGT-installed base VM. The positive
+# deploy test below uses this template.
+########################################################################################
+- name: Create template from base VM (NGT now installed)
+  nutanix.ncp.ntnx_templates_v2:
+    template_name: "{{ template2_name }}"
+    template_description: "Template (NGT installed) for VM Guest Customization
+      Profile tests"
+    template_version_spec:
+      version_source:
+        template_vm_reference:
+          ext_id: "{{ vms_to_delete[0] }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify creation of NGT-installed template
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id is defined
+      - result.response.template_version_spec.ext_id is defined
+      - result.response.template_name == "{{ template2_name }}"
+    fail_msg: "Failed to create template after NGT install"
+    success_msg: "Template (NGT installed) created successfully"
+
+- name: Save template2 ext_id
+  ansible.builtin.set_fact:
+    template2_ext_id: "{{ result.ext_id }}"
+
+########################################################################################
+# POSITIVE TEST: Deploy from NGT-installed template with guest_customization_profile_config
+# + per-VM overrides (todelete[0] = updated workgroup-sysprep profile).
+########################################################################################
+- name: Deploy VM from NGT template with guest customization profile and overrides
+  nutanix.ncp.ntnx_templates_deploy_v2:
+    ext_id: "{{ template2_ext_id }}"
+    cluster_reference: "{{ cluster.uuid }}"
+    override_vms_config:
+      - name: "{{ deployed_vm_name }}"
+        num_sockets: 2
+        num_cores_per_socket: 2
+        guest_customization_profile_config:
+          profile:
+            ext_id: "{{ todelete[0] }}"
+          config_override_spec:
+            customization:
+              sysprep_params:
+                general_settings:
+                  computer_name:
+                    name:
+                      value: "deployed-host"
+                  timezone:
+                    value:
+                      value: "UTC"
+                  registered_owner:
+                    value:
+                      value: "deployed-owner"
+                workgroup_or_domain_info:
+                  workgroup:
+                    name: "DEPLOYED-WG"
+                network_settings:
+                  nic_config_list:
+                    - dns_config:
+                        preferred_dns_server_address: "10.0.0.100"
+                        alternate_dns_server_addresses:
+                          - "10.0.0.101"
+                      ipv4_config:
+                        use_dhcp: {}
+  register: result
+  ignore_errors: true
+
+- name: Print result of deploying VM with guest customization profile and overrides
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify deploy VM with guest customization profile and overrides
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.status == "SUCCEEDED"
+    fail_msg: "Failed to deploy VM with guest customization profile (NGT installed)"
+    success_msg: "Deployed VM with guest customization profile successfully"
+
+- name: Find deployed VM by name
+  nutanix.ncp.ntnx_vms_info_v2:
+    filter: "name eq '{{ deployed_vm_name }}'"
+  register: deployed_vm_info
+  ignore_errors: true
+
+- name: Verify deployed VM exists
+  ansible.builtin.assert:
+    that:
+      - deployed_vm_info.response is defined
+      - deployed_vm_info.response | length == 1
+      - deployed_vm_info.response[0].name == "{{ deployed_vm_name }}"
+      - deployed_vm_info.response[0].ext_id is defined
+    fail_msg: "Failed to locate the deployed VM by name after template deploy"
+    success_msg: "Deployed VM found by name successfully"
+
+- name: Track deployed VM for cleanup
+  ansible.builtin.set_fact:
+    vms_to_delete: "{{ vms_to_delete + [deployed_vm_info.response[0].ext_id] }}"
+
+- name: Fetch deployed VM by ext_id to inspect guest customization status
+  nutanix.ncp.ntnx_vms_info_v2:
+    ext_id: "{{ deployed_vm_info.response[0].ext_id }}"
+  register: deployed_vm
+  ignore_errors: true
+
+- name: Print fetched deployed VM details
+  ansible.builtin.debug:
+    var: deployed_vm
+
+- name: Verify deployed VM has guest customization pending and overrides applied
+  ansible.builtin.assert:
+    that:
+      - deployed_vm.response is defined
+      - deployed_vm.response.ext_id == deployed_vm_info.response[0].ext_id
+      - deployed_vm.response.name == "{{ deployed_vm_name }}"
+      - deployed_vm.response.vm_guest_customization_status == "PENDING"
+      - deployed_vm.response.power_state == "OFF"
+      - deployed_vm.response.num_sockets == 2
+      - deployed_vm.response.num_cores_per_socket == 2
+      - deployed_vm.response.memory_size_bytes == 8589934592
+      - deployed_vm.response.cluster.ext_id == "{{ cluster.uuid }}"
+      - deployed_vm.response.source is defined
+      - deployed_vm.response.source.entity_type == "VM"
+      - deployed_vm.response.source.ext_id is defined
+      - deployed_vm.response.disks | length == 1
+      - deployed_vm.response.nics | length == 1
+      - deployed_vm.response.cd_roms | length == 1
+    fail_msg: "Deployed VM did not have expected guest customization status or overrides"
+    success_msg: "Deployed VM is in PENDING guest customization state with overrides applied"
+
+########################################################################################
+# POSITIVE TEST: Clone the base VM using todelete[1] (domain-settings profile) + per-clone
+# overrides. computer_name and ipv4_config are marked must_provide_during_deployment in
+# the profile, so the override MUST supply both.
+########################################################################################
+- name: Clone base VM with guest customization profile and overrides
+  nutanix.ncp.ntnx_vms_clone_v2:
+    ext_id: "{{ vms_to_delete[0] }}"
+    name: "{{ cloned_vm_name }}"
+    guest_customization_profile_config:
+      profile:
+        ext_id: "{{ todelete[1] }}"
+      config_override_spec:
+        customization:
+          sysprep_params:
+            general_settings:
+              computer_name:
+                name:
+                  value: "cloned-host"
+              timezone:
+                value:
+                  value: "Pacific Standard Time"
+              registered_owner:
+                value:
+                  value: "cloned-owner"
+              registered_organization:
+                value:
+                  value: "cloned-org"
+            network_settings:
+              nic_config_list:
+                - dns_config:
+                    preferred_dns_server_address: "10.1.0.100"
+                    alternate_dns_server_addresses:
+                      - "10.1.0.101"
+                  ipv4_config:
+                    static_config:
+                      ip_address:
+                        value: "10.1.0.50"
+                        prefix_length: 24
+                      default_gateways:
+                        - "10.1.0.1"
+  register: result
+  ignore_errors: true
+
+- name: Print result of cloning VM with guest customization profile and overrides
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify clone VM with guest customization profile and overrides
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "{{ cloned_vm_name }}"
+      - result.response.ext_id is defined
+    fail_msg: "Failed to clone VM with guest customization profile (NGT installed)"
+    success_msg: "Cloned VM with guest customization profile successfully"
+
+- name: Track cloned VM for cleanup
+  ansible.builtin.set_fact:
+    vms_to_delete: "{{ vms_to_delete + [result.response.ext_id] }}"
+
+- name: Fetch cloned VM by ext_id to inspect guest customization status
+  nutanix.ncp.ntnx_vms_info_v2:
+    ext_id: "{{ vms_to_delete[2] }}"
+  register: cloned_vm
+  ignore_errors: true
+
+- name: Print fetched cloned VM details
+  ansible.builtin.debug:
+    var: cloned_vm
+
+- name: Verify cloned VM has guest customization pending and inherits base VM config
+  ansible.builtin.assert:
+    that:
+      - cloned_vm.response is defined
+      - cloned_vm.response.ext_id == vms_to_delete[2]
+      - cloned_vm.response.name == "{{ cloned_vm_name }}"
+      - cloned_vm.response.vm_guest_customization_status == "PENDING"
+      - cloned_vm.response.power_state == "OFF"
+      - cloned_vm.response.num_sockets == 2
+      - cloned_vm.response.num_cores_per_socket == 2
+      - cloned_vm.response.memory_size_bytes == 8589934592
+      - cloned_vm.response.cluster.ext_id == "{{ cluster.uuid }}"
+      - cloned_vm.response.source is defined
+      - cloned_vm.response.source.entity_type == "VM"
+      - cloned_vm.response.source.ext_id is defined
+      - cloned_vm.response.disks | length == 1
+      - cloned_vm.response.nics | length == 1
+      - cloned_vm.response.cd_roms | length == 1
+    fail_msg: "Cloned VM did not have expected guest customization status or inherited config"
+    success_msg: "Cloned VM is in PENDING guest customization state with inherited config"
+
+########################################################################################
+# Power on the deployed and cloned VMs so guest customization actually executes,
+# then wait for NGT to become reachable and assert post-customization state.
+# After the VM boots and customization runs, the API stops returning
+# vm_guest_customization_status (PENDING is the only meaningful enum value), and
+# guest_tools/NGT comes online with a learned IP on the NIC.
+########################################################################################
+- name: Power on the deployed VM to trigger guest customization
+  nutanix.ncp.ntnx_vms_power_actions_v2:
+    state: power_on
+    ext_id: "{{ vms_to_delete[1] }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify deployed VM powered on
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response.status == "SUCCEEDED"
+    fail_msg: "Failed to power on deployed VM"
+    success_msg: "Deployed VM powered on successfully"
+
+- name: Power on the cloned VM to trigger guest customization
+  nutanix.ncp.ntnx_vms_power_actions_v2:
+    state: power_on
+    ext_id: "{{ vms_to_delete[2] }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify cloned VM powered on
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response.status == "SUCCEEDED"
+    fail_msg: "Failed to power on cloned VM"
+    success_msg: "Cloned VM powered on successfully"
+
+- name: Wait for deployed VM NGT to become reachable after customization
+  nutanix.ncp.ntnx_vms_info_v2:
+    ext_id: "{{ vms_to_delete[1] }}"
+  register: deployed_vm_post
+  ignore_errors: true
+  retries: 60
+  delay: 10
+  until:
+    - deployed_vm_post.response is defined
+    - deployed_vm_post.response.power_state == "ON"
+    - deployed_vm_post.response.guest_tools is defined
+    - deployed_vm_post.response.guest_tools.is_reachable == true
+    - deployed_vm_post.response.nics[0].network_info.ipv4_info is defined
+    - deployed_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses is defined
+    - deployed_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses | length > 0
+
+- name: Print deployed VM post-customization details
+  ansible.builtin.debug:
+    var: deployed_vm_post
+
+- name: Verify deployed VM completed guest customization (NGT reachable, IP learned)
+  ansible.builtin.assert:
+    that:
+      - deployed_vm_post.response is defined
+      - deployed_vm_post.response.ext_id == vms_to_delete[1]
+      - deployed_vm_post.response.power_state == "ON"
+      - deployed_vm_post.response.vm_guest_customization_status is not defined or
+        deployed_vm_post.response.vm_guest_customization_status == None
+      - deployed_vm_post.response.host is defined
+      - deployed_vm_post.response.host.ext_id is defined
+      - deployed_vm_post.response.guest_tools.is_installed == true
+      - deployed_vm_post.response.guest_tools.is_reachable == true
+      - deployed_vm_post.response.guest_tools.is_enabled == true
+      - deployed_vm_post.response.guest_tools.version is defined
+      - deployed_vm_post.response.guest_tools.guest_os_version is defined
+      - "'windows' in deployed_vm_post.response.guest_tools.guest_os_version"
+      - deployed_vm_post.response.guest_tools.guest_info is defined
+      - deployed_vm_post.response.guest_tools.guest_info.guest_os_full_name is defined
+      - "'windows' in deployed_vm_post.response.guest_tools.guest_info.guest_os_full_name"
+    fail_msg: "Deployed VM did not reach the expected post-customization state"
+    success_msg: "Deployed VM completed guest customization"
+
+- name: Wait for cloned VM NGT to become reachable after customization
+  nutanix.ncp.ntnx_vms_info_v2:
+    ext_id: "{{ vms_to_delete[2] }}"
+  register: cloned_vm_post
+  ignore_errors: true
+  retries: 60
+  delay: 10
+  until:
+    - cloned_vm_post.response is defined
+    - cloned_vm_post.response.power_state == "ON"
+    - cloned_vm_post.response.guest_tools is defined
+    - cloned_vm_post.response.guest_tools.is_reachable == true
+    - cloned_vm_post.response.nics[0].network_info.ipv4_info is defined
+    - cloned_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses is defined
+    - cloned_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses | length > 0
+
+- name: Print cloned VM post-customization details
+  ansible.builtin.debug:
+    var: cloned_vm_post
+
+- name: Verify cloned VM completed guest customization (NGT reachable, IP learned)
+  ansible.builtin.assert:
+    that:
+      - cloned_vm_post.response is defined
+      - cloned_vm_post.response.ext_id == vms_to_delete[2]
+      - cloned_vm_post.response.power_state == "ON"
+      - cloned_vm_post.response.vm_guest_customization_status is not defined or
+        cloned_vm_post.response.vm_guest_customization_status == None
+      - cloned_vm_post.response.host is defined
+      - cloned_vm_post.response.host.ext_id is defined
+      - cloned_vm_post.response.guest_tools.is_installed == true
+      - cloned_vm_post.response.guest_tools.is_reachable == true
+      - cloned_vm_post.response.guest_tools.is_enabled == true
+      - cloned_vm_post.response.guest_tools.version is defined
+      - cloned_vm_post.response.guest_tools.guest_os_version is defined
+      - "'windows' in cloned_vm_post.response.guest_tools.guest_os_version"
+      - cloned_vm_post.response.guest_tools.guest_info is defined
+      - cloned_vm_post.response.guest_tools.guest_info.guest_os_full_name is defined
+      - "'windows' in cloned_vm_post.response.guest_tools.guest_info.guest_os_full_name"
+    fail_msg: "Cloned VM did not reach the expected post-customization state"
+    success_msg: "Cloned VM completed guest customization"
+
+########################################################################################
+# Cleanup VMs and template2 before deleting the guest customization profiles
+########################################################################################
+- name: Delete deployed/cloned/base VMs
+  nutanix.ncp.ntnx_vms_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  loop: "{{ vms_to_delete }}"
+  register: vms_delete_result
+  ignore_errors: true
+
+- name: Verify all VMs were deleted
+  ansible.builtin.assert:
+    that:
+      - item.changed == true
+      - item.failed == false
+      - item.ext_id in vms_to_delete
+      - vms_delete_result.results is defined
+      - vms_delete_result.results | length == vms_to_delete | length
+      - vms_delete_result.msg == "All items completed"
+    fail_msg: "Failed to delete one or more VMs created during the test"
+    success_msg: "All VMs deleted successfully"
+  loop: "{{ vms_delete_result.results }}"
+  loop_control:
+    label: "{{ item.ext_id }}"
+
+- name: Delete the NGT-installed template
+  nutanix.ncp.ntnx_templates_v2:
+    state: absent
+    ext_id: "{{ template2_ext_id }}"
+  register: template_delete_result
+  ignore_errors: true
+
+- name: Verify NGT-installed template was deleted
+  ansible.builtin.assert:
+    that:
+      - template_delete_result.changed == true
+      - template_delete_result.failed == false
+      - template_delete_result.response is defined
+      - template_delete_result.response.status == "SUCCEEDED"
+    fail_msg: "Failed to delete the NGT-installed VM Template"
+    success_msg: "NGT-installed VM Template is deleted successfully"
 
 ########################################################################################
 # Delete VM Guest Customization Profile

--- a/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/vm_guest_customization_profiles.yml
+++ b/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/tasks/vm_guest_customization_profiles.yml
@@ -81,9 +81,18 @@
       - result.ext_id is defined
       - result.response.name == base_vm_name
       - result.response.cluster.ext_id == cluster.uuid
-      - result.response.cd_roms[0].disk_address.bus_type == "IDE"
+      - result.response.num_sockets == 2
+      - result.response.num_cores_per_socket == 2
+      - result.response.memory_size_bytes == 8589934592
+      - result.response.boot_config is defined
+      - result.response.disks[0].backing_info.disk_size_bytes == 42949672960
+      - result.response.disks[0].backing_info.data_source.reference.image_ext_id == windows_image_config.image_uuid
       - result.response.disks[0].disk_address.bus_type == "SCSI"
+      - result.response.disks[0].disk_address.index == 0
+      - result.response.cd_roms[0].disk_address.bus_type == "IDE"
+      - result.response.cd_roms[0].disk_address.index == 0
       - result.response.nics[0].network_info.subnet.ext_id == network.dhcp.uuid
+      - result.response.nics[0].network_info.ipv4_config.should_assign_ip == true
     fail_msg: "Failed to create Windows base VM for guest-customization profile tests"
     success_msg: "Windows base VM created successfully"
 
@@ -115,7 +124,8 @@
   ignore_errors: true
   retries: 60
   delay: 5
-  until: result.response.nics[0].network_info.ipv4_info.learned_ip_addresses[0].value
+  until:
+    result.response.nics[0].network_info.ipv4_info.learned_ip_addresses[0].value
     is defined
 
 - name: Set base VM IP fact
@@ -195,11 +205,8 @@
   register: result
   ignore_errors: true
 
-- name: Print result of generated check-mode spec for sysprep params
-  ansible.builtin.debug:
-    var: result
-
-- name: Verify generated spec for creating VM Guest Customization Profile (sysprep
+- name:
+    Verify generated spec for creating VM Guest Customization Profile (sysprep
     params, Workgroup) using check mode
   ansible.builtin.assert:
     that:
@@ -272,11 +279,6 @@
   register: result
   ignore_errors: true
 
-- name: Print result of create VM Guest Customization Profile (sysprep params,
-    Sysprep params)
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify create VM Guest Customization Profile (sysprep params, Workgroup,
     Sysprep params)
   ansible.builtin.assert:
@@ -313,7 +315,8 @@
         == ["10.0.0.11"]
     fail_msg: "Failed to create VM Guest Customization Profile (sysprep params,
       Workgroup, DHCP)"
-    success_msg: "VM Guest Customization Profile (sysprep params, Workgroup, DHCP)
+    success_msg:
+      "VM Guest Customization Profile (sysprep params, Workgroup, DHCP)
       created successfully"
 
 - name: Save workgroup profile ext_id
@@ -362,11 +365,6 @@
   register: result
   ignore_errors: true
 
-- name: Print result of create VM Guest Customization Profile (sysprep params,
-    Domain settings)
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify create VM Guest Customization Profile (sysprep params, Domain
     settings) must-provide IP)
   ansible.builtin.assert:
@@ -401,7 +399,8 @@
         == ["10.1.0.11"]
     fail_msg: "Failed to create VM Guest Customization Profile (sysprep params,
       Domain settings)"
-    success_msg: "VM Guest Customization Profile (sysprep params, Domain settings)
+    success_msg:
+      "VM Guest Customization Profile (sysprep params, Domain settings)
       created successfully"
 
 - name: Save domain settings profile ext_id
@@ -423,10 +422,6 @@
             unattend_xml: "{{ sample_unattend_xml }}"
   register: result
   ignore_errors: true
-
-- name: Print result of create answer-file profile
-  ansible.builtin.debug:
-    var: result
 
 - name: Verify create answer-file profile
   ansible.builtin.assert:
@@ -487,10 +482,6 @@
   check_mode: true
   register: result
   ignore_errors: true
-
-- name: Print result of generated update spec for sysprep profile using check mode
-  ansible.builtin.debug:
-    var: result
 
 - name: Verify generated update spec for sysprep profile using check mode
   ansible.builtin.assert:
@@ -562,10 +553,6 @@
   register: result
   ignore_errors: true
 
-- name: Print result of update VM Guest Customization Profile
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify update VM Guest Customization Profile
   ansible.builtin.assert:
     that:
@@ -636,10 +623,6 @@
   register: result
   ignore_errors: true
 
-- name: Print result of idempotency on update VM Guest Customization Profile
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify idempotency on update VM Guest Customization Profile
   ansible.builtin.assert:
     that:
@@ -659,10 +642,6 @@
     ext_id: "{{ todelete[0] }}"
   register: result
   ignore_errors: true
-
-- name: Print result of fetch by ext_id
-  ansible.builtin.debug:
-    var: result
 
 - name: Verify fetch by ext_id
   ansible.builtin.assert:
@@ -707,10 +686,6 @@
   register: result
   ignore_errors: true
 
-- name: Print result of list VM Guest Customization Profiles
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify list VM Guest Customization Profiles
   ansible.builtin.assert:
     that:
@@ -731,10 +706,6 @@
     filter: "name eq '{{ profile_sysprep_name_updated }}'"
   register: result
   ignore_errors: true
-
-- name: Print result of list with filter
-  ansible.builtin.debug:
-    var: result
 
 - name: Verify list with filter
   ansible.builtin.assert:
@@ -782,10 +753,6 @@
     limit: 1
   register: result
   ignore_errors: true
-
-- name: Print result of list with limit
-  ansible.builtin.debug:
-    var: result
 
 - name: Verify list with limit
   ansible.builtin.assert:
@@ -1129,10 +1096,6 @@
   register: result
   ignore_errors: true
 
-- name: Print result of negative deploy
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify negative deploy fails because NGT is not installed on the source VM
   ansible.builtin.assert:
     that:
@@ -1143,7 +1106,8 @@
       - result.response.error_messages is defined
       - result.response.error_messages | length > 0
     fail_msg: "Negative deploy did not fail as expected (NGT-not-installed precondition)"
-    success_msg: "Negative deploy correctly failed because NGT is not installed on
+    success_msg:
+      "Negative deploy correctly failed because NGT is not installed on
       source VM"
 
 ########################################################################################
@@ -1160,10 +1124,6 @@
         ext_id: "{{ todelete[0] }}"
   register: result
   ignore_errors: true
-
-- name: Print result of negative clone
-  ansible.builtin.debug:
-    var: result
 
 - name: Verify negative clone fails because NGT is not installed on the source VM
   ansible.builtin.assert:
@@ -1220,11 +1180,8 @@
   register: result
   ignore_errors: true
 
-- name: Print result of negative deploy (must_provide fields missing)
-  ansible.builtin.debug:
-    var: result
-
-- name: Verify negative deploy fails because must_provide_during_deployment fields
+- name:
+    Verify negative deploy fails because must_provide_during_deployment fields
     are missing
   ansible.builtin.assert:
     that:
@@ -1236,14 +1193,16 @@
       - result.response.error_messages | length > 0
     fail_msg: "Negative deploy did not fail as expected
       (must_provide_during_deployment fields missing)"
-    success_msg: "Negative deploy correctly failed as expected because must_provide
+    success_msg:
+      "Negative deploy correctly failed as expected because must_provide
       fields were not supplied in the override"
 
 ########################################################################################
 # Negative CRUD test: Clone with must_provide profile, override missing computer_name and ipv4_config
 ########################################################################################
 
-- name: Negative - Clone with must_provide profile, override missing computer_name
+- name:
+    Negative - Clone with must_provide profile, override missing computer_name
     and ipv4_config
   nutanix.ncp.ntnx_vms_clone_v2:
     ext_id: "{{ vms_to_delete[0] }}"
@@ -1264,11 +1223,8 @@
   register: result
   ignore_errors: true
 
-- name: Print result of negative clone (must_provide fields missing)
-  ansible.builtin.debug:
-    var: result
-
-- name: Verify negative clone fails because must_provide_during_deployment fields
+- name:
+    Verify negative clone fails because must_provide_during_deployment fields
     are missing
   ansible.builtin.assert:
     that:
@@ -1280,7 +1236,8 @@
       - result.response.error_messages | length > 0
     fail_msg: "Negative clone did not fail as expected
       (must_provide_during_deployment fields missing)"
-    success_msg: "Negative clone correctly failed as expected because must_provide
+    success_msg:
+      "Negative clone correctly failed as expected because must_provide
       fields were not supplied in the override"
 
 ########################################################################################
@@ -1316,10 +1273,6 @@
                         use_dhcp: {}
   register: result
   ignore_errors: true
-
-- name: Print result of deploy (must_provide fields supplied)
-  ansible.builtin.debug:
-    var: result
 
 - name: Verify deploy succeeds when must_provide fields are supplied
   ansible.builtin.assert:
@@ -1389,10 +1342,6 @@
                         - "10.1.0.1"
   register: result
   ignore_errors: true
-
-- name: Print result of clone (must_provide fields supplied)
-  ansible.builtin.debug:
-    var: result
 
 - name: Verify clone succeeds when must_provide fields are supplied
   ansible.builtin.assert:
@@ -1464,10 +1413,6 @@
   register: result
   ignore_errors: true
 
-- name: Print result of deploying VM with guest customization profile and overrides
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify deploy VM with guest customization profile and overrides
   ansible.builtin.assert:
     that:
@@ -1504,10 +1449,6 @@
   register: deployed_vm
   ignore_errors: true
 
-- name: Print fetched deployed VM details
-  ansible.builtin.debug:
-    var: deployed_vm
-
 - name: Verify deployed VM has guest customization pending and overrides applied
   ansible.builtin.assert:
     that:
@@ -1527,7 +1468,8 @@
       - deployed_vm.response.nics | length == 1
       - deployed_vm.response.cd_roms | length == 1
     fail_msg: "Deployed VM did not have expected guest customization status or overrides"
-    success_msg: "Deployed VM is in PENDING guest customization state with overrides
+    success_msg:
+      "Deployed VM is in PENDING guest customization state with overrides
       applied"
 
 ########################################################################################
@@ -1574,10 +1516,6 @@
   register: result
   ignore_errors: true
 
-- name: Print result of cloning VM with guest customization profile and overrides
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify clone VM with guest customization profile and overrides
   ansible.builtin.assert:
     that:
@@ -1598,10 +1536,6 @@
     ext_id: "{{ vms_to_delete[2] }}"
   register: cloned_vm
   ignore_errors: true
-
-- name: Print fetched cloned VM details
-  ansible.builtin.debug:
-    var: cloned_vm
 
 - name: Verify cloned VM has guest customization pending and inherits base VM config
   ansible.builtin.assert:
@@ -1684,10 +1618,6 @@
     - deployed_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses
       | length > 0
 
-- name: Print deployed VM post-customization details
-  ansible.builtin.debug:
-    var: deployed_vm_post
-
 - name: Verify deployed VM completed guest customization (NGT reachable, IP learned)
   ansible.builtin.assert:
     that:
@@ -1729,10 +1659,6 @@
       is defined
     - cloned_vm_post.response.nics[0].network_info.ipv4_info.learned_ip_addresses
       | length > 0
-
-- name: Print cloned VM post-customization details
-  ansible.builtin.debug:
-    var: cloned_vm_post
 
 - name: Verify cloned VM completed guest customization (NGT reachable, IP learned)
   ansible.builtin.assert:
@@ -1812,10 +1738,6 @@
   register: result
   ignore_errors: true
 
-- name: Print result of delete VM Guest Customization Profile in check mode
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify delete VM Guest Customization Profile in check mode
   ansible.builtin.assert:
     that:
@@ -1834,10 +1756,6 @@
   loop: "{{ todelete }}"
   register: delete_results
   ignore_errors: true
-
-- name: Print result of delete VM Guest Customization Profiles
-  ansible.builtin.debug:
-    var: delete_results
 
 - name: Verify all VM Guest Customization Profiles deleted
   ansible.builtin.assert:

--- a/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/vars/unattend_xml_content.xml
+++ b/tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/vars/unattend_xml_content.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<unattend xmlns="urn:schemas-microsoft-com:unattend">
+    <settings pass="windowsPE">
+        <component name="Microsoft-Windows-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="en-US">
+            <UserData>
+                <ProductKey>
+                    <Key>XXXXX-XXXXX-XXXXX-XXXXX-XXXXX</Key>  <!-- Enter your product key here -->
+                    <WillShowUI>Never</WillShowUI>
+                </ProductKey>
+                <FullName>Admin</FullName>
+                <Organization>MyCompany</Organization>
+            </UserData>
+        </component>
+    </settings>
+
+    <settings pass="specialize">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="en-US">
+            <TimeZone>UTC</TimeZone>
+            <ComputerName>PC-%RAND%</ComputerName> <!-- Randomize computer name -->
+        </component>
+    </settings>
+
+    <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="en-US">
+            <OOBE>
+                <HideEULAPage>true</HideEULAPage>  <!-- Skip EULA -->
+                <NetworkLocation>Work</NetworkLocation>  <!-- Set network location -->
+                <ProtectYourPC>1</ProtectYourPC>  <!-- Automatically enable Windows Update -->
+            </OOBE>
+            <UserAccounts>
+                <AdministratorPassword>
+                    <Value>Password123</Value> <!-- Set Administrator password -->
+                    <PlainText>true</PlainText>
+                </AdministratorPassword>
+            </UserAccounts>
+        </component>
+    </settings>
+</unattend>


### PR DESCRIPTION
# VM Guest Customization Profile Modules

Adds Ansible modules for managing VM Guest Customization Profiles (reusable Windows Sysprep templates) on Nutanix Prism Central using v4 APIs.

## New Modules

| Module | Description |
|--------|-------------|
| `ntnx_vm_guest_customization_profile_v2` | Create, update, delete profiles (Sysprep params or unattend XML answer file) |
| `ntnx_vm_guest_customization_profiles_info_v2` | Fetch profile by ext_id or list with filter/limit |

## Features

- **Sysprep params**: general settings, locale, first-logon commands, network (DNS + IPv4 DHCP/must-provide)
- **Workgroup vs Domain join**: mutually exclusive `workgroup` / `domain_settings` with credentials
- **Answer file**: Base64-encoded unattend XML via `lookup('file', ...) | b64encode`
- **Check mode and idempotency**: full check-mode support; `no_log` secrets excluded from idempotency comparison

## Examples

- `examples/vmm_v2/vm_guest_customization_profiles_v2.yml`

## Integration Tests

- `tests/integration/targets/ntnx_vm_guest_customization_profiles_v2/` — full CRUD (Workgroup, Domain, answer-file) + idempotency, fetch, list (filter/limit), delete
