### PR TITLE
code-gen(flow_management/SecurityPolicy): ansible v2

### DIFF
--- a/examples/security_policy_crud.yml
+++ b/examples/security_policy_crud.yml
@@ -1,0 +1,84 @@
+- name: Security Policy CRUD operations using ntnx_SecurityPolicy_v2 and ntnx_SecurityPolicys_info_v2
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: 10.0.0.1
+      nutanix_username: admin
+      nutanix_password: Nutanix.123
+      validate_certs: false
+  tasks:
+    - name: Create an application security policy with MONITOR state
+      nutanix.ncp.ntnx_SecurityPolicy_v2:
+        name: "example-security-policy"
+        description: "Example security policy created by Ansible"
+        type: "APPLICATION"
+        policy_state: "MONITOR"
+        scope: "ALL_VLAN"
+        is_hitlog_enabled: true
+        is_ipv6_traffic_allowed: false
+      register: create_result
+
+    - name: Print create result
+      ansible.builtin.debug:
+        var: create_result
+
+    - name: Get the created security policy by ext_id
+      nutanix.ncp.ntnx_SecurityPolicys_info_v2:
+        ext_id: "{{ create_result.ext_id }}"
+      register: get_result
+
+    - name: Print get result
+      ansible.builtin.debug:
+        var: get_result
+
+    - name: List all security policies
+      nutanix.ncp.ntnx_SecurityPolicys_info_v2:
+      register: list_result
+
+    - name: Print total available results
+      ansible.builtin.debug:
+        msg: "Total security policies: {{ list_result.total_available_results }}"
+
+    - name: List security policies with limit
+      nutanix.ncp.ntnx_SecurityPolicys_info_v2:
+        limit: 2
+      register: list_limited_result
+
+    - name: Print limited list result
+      ansible.builtin.debug:
+        var: list_limited_result
+
+    - name: Update the security policy name and description
+      nutanix.ncp.ntnx_SecurityPolicy_v2:
+        ext_id: "{{ create_result.ext_id }}"
+        name: "example-security-policy-updated"
+        description: "Updated example security policy"
+      register: update_result
+
+    - name: Print update result
+      ansible.builtin.debug:
+        var: update_result
+
+    - name: Verify the update via info module
+      nutanix.ncp.ntnx_SecurityPolicys_info_v2:
+        ext_id: "{{ create_result.ext_id }}"
+      register: verify_result
+
+    - name: Assert update was applied
+      ansible.builtin.assert:
+        that:
+          - verify_result.response.name == "example-security-policy-updated"
+          - verify_result.response.description == "Updated example security policy"
+        success_msg: "Security policy update verified successfully"
+        fail_msg: "Security policy update verification failed"
+
+    - name: Delete the security policy
+      nutanix.ncp.ntnx_SecurityPolicy_v2:
+        state: absent
+        ext_id: "{{ create_result.ext_id }}"
+      register: delete_result
+
+    - name: Print delete result
+      ansible.builtin.debug:
+        var: delete_result

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_SecurityPolicy_v2
+    - ntnx_SecurityPolicys_info_v2

--- a/plugins/modules/ntnx_SecurityPolicy_v2.py
+++ b/plugins/modules/ntnx_SecurityPolicy_v2.py
@@ -1,0 +1,1074 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+module: ntnx_SecurityPolicy_v2
+short_description: Manage network security policies in Nutanix Prism Central
+version_added: "2.6.0"
+description:
+  - This module allows you to create, update, and delete network security policies in Nutanix Prism Central.
+  - During update, the rules provided under C(rules) will replace existing rules.
+  - This module uses PC v4 APIs based SDKs
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Create a Network Security Policy) -
+      Operation Name: Create Flow Policy -
+      Required Roles: Flow Admin, Prism Admin, Super Admin
+    - >-
+      B(Delete a Network Security Policy by ExtID) -
+      Operation Name: Delete Flow Policy -
+      Required Roles: Flow Admin, Prism Admin, Super Admin
+    - >-
+      B(Update a Network Security Policy by ExtID) -
+      Operation Name: Update Flow Policy -
+      Required Roles: Flow Admin, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=microseg)"
+options:
+  wait:
+    description:
+      - Wait for the task to complete.
+    type: bool
+    default: true
+  state:
+    description:
+      - The state of the network security policy.
+      - If C(present) and C(ext_id) is not provided, the network security policy will be created.
+      - If C(present) and C(ext_id) is provided, the network security policy will be updated.
+      - If C(absent) and C(ext_id) is provided, the network security policy will be deleted.
+    type: str
+  ext_id:
+    description:
+      - External ID of the Flow Network Security Policy.
+    type: str
+  name:
+    description:
+      - Name of the Flow Network Security Policy.
+    required: false
+    type: str
+  is_ipv6_traffic_allowed:
+    description:
+      - If Ipv6 Traffic needs to be allowed.
+    type: bool
+  is_hitlog_enabled:
+    description:
+      - If Hitlog needs to be enabled.
+    type: bool
+  description:
+    description:
+      - Description of policy
+    required: false
+    type: str
+  vpc_references:
+    description:
+      - A list of external ids for VPCs, used only when the scope of policy is a list of VPCs.
+    required: false
+    type: list
+    elements: str
+  scope_references:
+    description:
+      - A list of external ids for scope references, used only when the scope of policy is a list of scope references.
+    required: false
+    type: list
+    elements: str
+  type:
+    description:
+      - Defines the type of rules that can be used in a policy.
+    required: false
+    type: str
+    choices:
+      - QUARANTINE
+      - ISOLATION
+      - APPLICATION
+      - SHAREDSERVICE
+  policy_state:
+    description:
+      - Whether the policy is just to be saved, applied, monitored.
+    required: false
+    type: str
+    choices:
+      - SAVE
+      - MONITOR
+      - ENFORCE
+  scope:
+    description:
+      - Defines the scope of the policy. Currently, ALL_VLAN, VPC_LIST, GLOBAL, and VPC_AS_CATEGORY are supported.
+        If a scope is not provided, the default value is determined by the presence or absence of
+        the vpcReferences or scopeReferences fields.
+    required: false
+    type: str
+    choices:
+      - ALL_VLAN
+      - ALL_VPC
+      - VPC_LIST
+      - GLOBAL
+      - VPC_AS_CATEGORY
+  rules:
+    description:
+      - A list of rules that form a policy. For isolation policies, use isolation rules.
+      - For application or quarantine policies, use application rules.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      ext_id:
+        description:
+          - External ID of the rule.
+        required: false
+        type: str
+      description:
+        description:
+          - Description of rule
+        required: false
+        type: str
+      type:
+        description:
+          - The type for a rule - the value chosen here restricts which specification can be chosen.
+        type: str
+        choices:
+          - QUARANTINE
+          - TWO_ENV_ISOLATION
+          - APPLICATION
+          - INTRA_GROUP
+          - MULTI_ENV_ISOLATION
+          - SHARED_SERVICE
+      spec:
+        description:
+          - The specification of the rule.
+        type: dict
+        suboptions:
+          two_env_isolation_rule_spec:
+            description:
+              - The specification of the two environment isolation rule.
+            required: false
+            type: dict
+            suboptions:
+              first_isolation_group:
+                description:
+                  - Denotes the first group of category uuids that will be used in an isolation policy.
+                type: list
+                elements: str
+              second_isolation_group:
+                description:
+                  - Denotes the second group of category uuids that will be used in an isolation policy.
+                type: list
+                elements: str
+          application_rule_spec:
+            description:
+              - The specification of the application rule.
+              - This can be used for application or quarantine policies.
+            required: false
+            type: dict
+            suboptions:
+              secured_group_category_references:
+                description:
+                  - A set of categories of vms which is protected by a Network Security Policy and defined as a list of categories.
+                type: list
+                elements: str
+              secured_group_entity_group_reference:
+                description:
+                  - A reference to the secured group entity group.
+                type: str
+              src_allow_spec:
+                description:
+                  - A specification to how allow mode traffic should be applied, either ALL or NONE.
+                type: str
+                choices:
+                  - ALL
+                  - NONE
+              dest_allow_spec:
+                description:
+                  - A specification to how allow mode traffic should be applied, either ALL or NONE.
+                type: str
+                choices:
+                  - ALL
+                  - NONE
+              src_category_references:
+                description:
+                  - List of categories that define a set of network endpoints as inbound.
+                type: list
+                elements: str
+              dest_category_references:
+                description:
+                  - List of categories that define a set of network endpoints as outbound.
+                type: list
+                elements: str
+              dest_entity_group_reference:
+                description:
+                  - A reference to the destination entity group.
+                type: str
+              secured_group_category_associated_entity_type:
+                description:
+                  - The type of entity associated with the secured group category.
+                  - Will have value only if secured_group_category_references is provided.
+                type: str
+                choices:
+                  - VM
+                  - SUBNET
+                  - VPC
+                default: VM
+                required: false
+              src_category_associated_entity_type:
+                description:
+                  - The type of entity associated with the source category.
+                  - Will have value only if src_category_references is provided.
+                type: str
+                choices:
+                  - VM
+                  - SUBNET
+                  - VPC
+                default: VM
+                required: false
+              src_entity_group_reference:
+                description:
+                  - A reference to the source entity group.
+                type: str
+              dest_category_associated_entity_type:
+                description:
+                  - The type of entity associated with the destination category.
+                  - Will have value only if dest_category_references is provided.
+                type: str
+                choices:
+                  - VM
+                  - SUBNET
+                  - VPC
+                default: VM
+                required: false
+              src_subnet:
+                description:
+                  - The source subnet/IP specification.
+                type: dict
+                suboptions:
+                  value:
+                    description:
+                      - The value of the source subnet.
+                    type: str
+                  prefix_length:
+                    description:
+                      - The prefix length of the source subnet.
+                    type: int
+              dest_subnet:
+                description:
+                  - The destination subnet/IP specification.
+                type: dict
+                suboptions:
+                  value:
+                    description:
+                      - The value of the destination subnet.
+                    type: str
+                  prefix_length:
+                    description:
+                      - The prefix length of the destination subnet.
+                    type: int
+              src_address_group_references:
+                description:
+                  - A list of address group references.
+                type: list
+                elements: str
+              dest_address_group_references:
+                description:
+                  - A list of address group references.
+                type: list
+                elements: str
+              service_group_references:
+                description:
+                  - The list of service group references.
+                type: list
+                elements: str
+              is_all_protocol_allowed:
+                description:
+                  - Denotes whether the rule allows traffic for all protocols.
+                  - If set to true, the rule allows traffic for all protocols.
+                  - If set to false or not specified, specifying at least one protocol service or service group is mandatory.
+                type: bool
+              tcp_services:
+                description:
+                  - The list of TCP services.
+                type: list
+                elements: dict
+                suboptions:
+                  start_port:
+                    description:
+                      - The start port of the TCP service.
+                    type: int
+                  end_port:
+                    description:
+                      - The end port of the TCP service.
+                    type: int
+              udp_services:
+                description:
+                  - The list of UDP services.
+                type: list
+                elements: dict
+                suboptions:
+                  start_port:
+                    description:
+                      - The start port of the UDP service.
+                    type: int
+                  end_port:
+                    description:
+                      - The end port of the UDP service.
+                    type: int
+              icmp_services:
+                description:
+                  - Icmp Type Code List.
+                type: list
+                elements: dict
+                suboptions:
+                  is_all_allowed:
+                    description:
+                      - Icmp service All Allowed.
+                    type: bool
+                  type:
+                    description:
+                      - Icmp service Type. Ignore this field if Type has to be ANY.
+                    type: int
+                  code:
+                    description:
+                      - Icmp service Code. Ignore this field if Code has to be ANY.
+                    type: int
+              network_function_chain_reference:
+                description:
+                  - A reference to the network function chain in the rule.
+                type: str
+              network_function_reference:
+                description:
+                  - A reference to the network function in the rule.
+                type: str
+          intra_entity_group_rule_spec:
+            description:
+              - The specification of the intra entity group rule.
+            required: false
+            type: dict
+            suboptions:
+              secured_group_category_references:
+                description:
+                  - The list of secured group category references.
+                type: list
+                elements: str
+              secured_group_action:
+                description:
+                  - A specification to whether traffic between intra secured group entities should be allowed or denied.
+                type: str
+                choices:
+                  - ALLOW
+                  - DENY
+                required: true
+              secured_group_category_associated_entity_type:
+                description:
+                  - The type of entity associated with the secured group category.
+                  - Will have value only if secured_group_category_references is provided.
+                type: str
+                choices:
+                  - VM
+                  - SUBNET
+                  - VPC
+                default: VM
+                required: false
+              secured_group_entity_group_reference:
+                description:
+                  - The reference to the secured group entity group.
+                type: str
+                required: false
+              secured_group_service_references:
+                description:
+                  - The list of secured group service references.
+                type: list
+                elements: str
+                required: false
+              tcp_services:
+                description:
+                  - The list of TCP services.
+                type: list
+                elements: dict
+                suboptions:
+                  start_port:
+                    description:
+                      - The start port of the TCP service.
+                    type: int
+                  end_port:
+                    description:
+                      - The end port of the TCP service.
+                    type: int
+              udp_services:
+                description:
+                  - The list of UDP services.
+                type: list
+                elements: dict
+                suboptions:
+                  start_port:
+                    description:
+                      - The start port of the UDP service.
+                    type: int
+                  end_port:
+                    description:
+                      - The end port of the UDP service.
+                    type: int
+              icmp_services:
+                description:
+                  - Icmp Type Code List.
+                type: list
+                elements: dict
+                suboptions:
+                  is_all_allowed:
+                    description:
+                      - Icmp service All Allowed.
+                    type: bool
+                  type:
+                    description:
+                      - Icmp service Type. Ignore this field if Type has to be ANY.
+                    type: int
+                  code:
+                    description:
+                      - Icmp service Code. Ignore this field if Code has to be ANY.
+                    type: int
+          multi_env_isolation_rule_spec:
+            description:
+              - The specification of the multi environment isolation rule.
+            required: false
+            type: dict
+            suboptions:
+              spec:
+                description:
+                  - The specification of the multi environment isolation rule.
+                type: dict
+                suboptions:
+                  all_to_all_isolation_group:
+                    description:
+                      - The specification of the all to all isolation group.
+                    type: dict
+                    suboptions:
+                      isolation_groups:
+                        description:
+                          - The list of isolation groups.
+                        type: list
+                        elements: dict
+                        required: true
+                        suboptions:
+                          group_category_associated_entity_type:
+                            description:
+                              - The type of entity associated with the group category.
+                            type: str
+                            choices:
+                              - VM
+                              - SUBNET
+                              - VPC
+                            default: VM
+                          group_category_references:
+                            description:
+                              - The list of group category references.
+                            type: list
+                            elements: str
+                          group_entity_group_reference:
+                            description:
+                              - The reference to the group entity group.
+                            type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+
+"""
+
+EXAMPLES = r"""
+- name: Create an application security policy with ALL_VLAN scope
+  nutanix.ncp.ntnx_SecurityPolicy_v2:
+    nutanix_host: "<pc_ip>"
+    nutanix_username: "<pc_username>"
+    nutanix_password: "<pc_password>"
+    name: "app-security-policy"
+    description: "Ansible created security policy"
+    type: "APPLICATION"
+    policy_state: "MONITOR"
+    scope: "ALL_VLAN"
+    is_hitlog_enabled: true
+    is_ipv6_traffic_allowed: false
+    rules:
+      - description: "Intra group rule"
+        type: "INTRA_GROUP"
+        spec:
+          intra_entity_group_rule_spec:
+            secured_group_category_references:
+              - "f83d766b-f3e8-42f0-a32f-24983848d032"
+            secured_group_action: "DENY"
+      - description: "Inbound application rule"
+        type: "APPLICATION"
+        spec:
+          application_rule_spec:
+            secured_group_category_references:
+              - "f83d766b-f3e8-42f0-a32f-24983848d032"
+            src_category_references:
+              - "f83d766b-f3e8-42f0-a32f-24983848d035"
+            is_all_protocol_allowed: true
+  register: result
+
+- name: Update a security policy
+  nutanix.ncp.ntnx_SecurityPolicy_v2:
+    nutanix_host: "<pc_ip>"
+    nutanix_username: "<pc_username>"
+    nutanix_password: "<pc_password>"
+    ext_id: "{{ result.ext_id }}"
+    name: "app-security-policy-updated"
+    policy_state: "ENFORCE"
+  register: result
+
+- name: Delete a security policy
+  nutanix.ncp.ntnx_SecurityPolicy_v2:
+    nutanix_host: "<pc_ip>"
+    nutanix_username: "<pc_username>"
+    nutanix_password: "<pc_password>"
+    state: absent
+    ext_id: "{{ result.ext_id }}"
+  register: result
+"""
+
+
+RETURN = r"""
+response:
+  description:
+    - If C(wait) is set to C(true), the response will contain the security policy details.
+    - If C(wait) is set to C(false), the response will contain the task details.
+    - For delete operation, the response will contain the task details.
+  returned: always
+  type: dict
+  sample: {
+            "created_by": "00000000-0000-0000-0000-000000000000",
+            "creation_time": "2024-07-19T12:55:54.945000+00:00",
+            "description": "Ansible created policy",
+            "ext_id": "e8347a03-28a0-4eaa-9f43-64fd74cdee9e",
+            "is_hitlog_enabled": false,
+            "is_ipv6_traffic_allowed": false,
+            "is_system_defined": false,
+            "last_update_time": "2024-07-19T12:56:21.167000+00:00",
+            "links": null,
+            "name": "ansible-policy-1",
+            "rules": [],
+            "scope": "ALL_VLAN",
+            "secured_groups": null,
+            "state": "MONITOR",
+            "tenant_id": null,
+            "type": "APPLICATION",
+            "vpc_references": null
+        }
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating network security policy"
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  returned: always
+  type: bool
+  sample: false
+skipped:
+  description: Flag is module operation is skipped due to no state changes
+  returned: always
+  type: bool
+  sample: false
+ext_id:
+  description: The created security policy ext_id
+  returned: always
+  type: str
+  sample: "00000000-0000-0000-0000-000000000000"
+task_ext_id:
+  description: The task ext_id for the operation
+  returned: always
+  type: str
+  sample: "00000000-0000-0000-0000-000000000000"
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.flow.api_client import (  # noqa: E402
+    get_etag,
+    get_network_security_policy_api_instance,
+)
+from ..module_utils.v4.flow.helpers import get_network_security_policy  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_microseg_py_client as mic_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as mic_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    rule_spec_obj_map = {
+        "two_env_isolation_rule_spec": mic_sdk.TwoEnvIsolationRuleSpec,
+        "application_rule_spec": mic_sdk.ApplicationRuleSpec,
+        "intra_entity_group_rule_spec": mic_sdk.IntraEntityGroupRuleSpec,
+        "multi_env_isolation_rule_spec": mic_sdk.MultiEnvIsolationRuleSpec,
+    }
+    multi_env_isolation_rule_spec_obj_map = {
+        "all_to_all_isolation_group": mic_sdk.AllToAllIsolationGroup,
+    }
+
+    icmp_service_spec = dict(
+        is_all_allowed=dict(type="bool"),
+        type=dict(type="int"),
+        code=dict(type="int"),
+    )
+
+    range_spec = dict(
+        start_port=dict(type="int"),
+        end_port=dict(type="int"),
+    )
+
+    ip_address_sub_spec = dict(
+        value=dict(type="str"),
+        prefix_length=dict(type="int"),
+    )
+
+    isolation_rule_spec = dict(
+        first_isolation_group=dict(type="list", elements="str"),
+        second_isolation_group=dict(type="list", elements="str"),
+    )
+    application_rule_spec = dict(
+        secured_group_category_references=dict(type="list", elements="str"),
+        secured_group_entity_group_reference=dict(type="str"),
+        secured_group_category_associated_entity_type=dict(
+            type="str", choices=["VM", "SUBNET", "VPC"], default="VM"
+        ),
+        src_category_associated_entity_type=dict(
+            type="str", choices=["VM", "SUBNET", "VPC"], default="VM"
+        ),
+        src_entity_group_reference=dict(type="str"),
+        dest_category_associated_entity_type=dict(
+            type="str", choices=["VM", "SUBNET", "VPC"], default="VM"
+        ),
+        src_allow_spec=dict(type="str", choices=["ALL", "NONE"]),
+        dest_allow_spec=dict(type="str", choices=["ALL", "NONE"]),
+        src_category_references=dict(type="list", elements="str"),
+        dest_category_references=dict(type="list", elements="str"),
+        dest_entity_group_reference=dict(type="str"),
+        src_subnet=dict(
+            type="dict", options=ip_address_sub_spec, obj=mic_sdk.IPv4Address
+        ),
+        dest_subnet=dict(
+            type="dict", options=ip_address_sub_spec, obj=mic_sdk.IPv4Address
+        ),
+        src_address_group_references=dict(type="list", elements="str"),
+        dest_address_group_references=dict(type="list", elements="str"),
+        service_group_references=dict(type="list", elements="str"),
+        is_all_protocol_allowed=dict(type="bool"),
+        tcp_services=dict(
+            type="list",
+            elements="dict",
+            options=range_spec,
+            obj=mic_sdk.TcpPortRangeSpec,
+        ),
+        udp_services=dict(
+            type="list",
+            elements="dict",
+            options=range_spec,
+            obj=mic_sdk.UdpPortRangeSpec,
+        ),
+        icmp_services=dict(
+            type="list",
+            elements="dict",
+            options=icmp_service_spec,
+            obj=mic_sdk.IcmpTypeCodeSpec,
+        ),
+        network_function_chain_reference=dict(type="str"),
+        network_function_reference=dict(type="str"),
+    )
+    entity_group_rule_spec = dict(
+        secured_group_category_references=dict(type="list", elements="str"),
+        secured_group_action=dict(type="str", choices=["ALLOW", "DENY"], required=True),
+        secured_group_category_associated_entity_type=dict(
+            type="str", choices=["VM", "SUBNET", "VPC"], default="VM"
+        ),
+        secured_group_entity_group_reference=dict(type="str"),
+        secured_group_service_references=dict(type="list", elements="str"),
+        tcp_services=dict(
+            type="list",
+            elements="dict",
+            options=range_spec,
+            obj=mic_sdk.TcpPortRangeSpec,
+        ),
+        udp_services=dict(
+            type="list",
+            elements="dict",
+            options=range_spec,
+            obj=mic_sdk.UdpPortRangeSpec,
+        ),
+        icmp_services=dict(
+            type="list",
+            elements="dict",
+            options=icmp_service_spec,
+            obj=mic_sdk.IcmpTypeCodeSpec,
+        ),
+    )
+
+    isolation_groups_spec = dict(
+        group_category_references=dict(type="list", elements="str"),
+        group_category_associated_entity_type=dict(
+            type="str", choices=["VM", "SUBNET", "VPC"], default="VM"
+        ),
+        group_entity_group_reference=dict(type="str"),
+    )
+
+    all_to_all_spec = dict(
+        isolation_groups=dict(
+            type="list",
+            elements="dict",
+            obj=mic_sdk.IsolationGroup,
+            options=isolation_groups_spec,
+            required=True,
+        )
+    )
+
+    all_to_all_isolation_group_spec = dict(
+        all_to_all_isolation_group=dict(
+            type="dict",
+            obj=mic_sdk.AllToAllIsolationGroup,
+            options=all_to_all_spec,
+        )
+    )
+
+    multi_env_isolation_rule_spec = dict(
+        spec=dict(
+            type="dict",
+            options=all_to_all_isolation_group_spec,
+            obj=multi_env_isolation_rule_spec_obj_map,
+        )
+    )
+
+    rule_spec = dict(
+        two_env_isolation_rule_spec=dict(type="dict", options=isolation_rule_spec),
+        application_rule_spec=dict(type="dict", options=application_rule_spec),
+        intra_entity_group_rule_spec=dict(type="dict", options=entity_group_rule_spec),
+        multi_env_isolation_rule_spec=dict(
+            type="dict", options=multi_env_isolation_rule_spec
+        ),
+    )
+
+    policy_rule = dict(
+        ext_id=dict(type="str"),
+        description=dict(type="str"),
+        type=dict(
+            type="str",
+            choices=[
+                "QUARANTINE",
+                "TWO_ENV_ISOLATION",
+                "APPLICATION",
+                "INTRA_GROUP",
+                "MULTI_ENV_ISOLATION",
+                "SHARED_SERVICE",
+            ],
+        ),
+        spec=dict(
+            type="dict",
+            options=rule_spec,
+            obj=rule_spec_obj_map,
+            mutually_exclusive=[
+                (
+                    "two_env_isolation_rule_spec",
+                    "application_rule_spec",
+                    "intra_entity_group_rule_spec",
+                    "multi_env_isolation_rule_spec",
+                )
+            ],
+        ),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        description=dict(type="str"),
+        type=dict(
+            type="str",
+            choices=["QUARANTINE", "ISOLATION", "APPLICATION", "SHAREDSERVICE"],
+        ),
+        policy_state=dict(type="str", choices=["SAVE", "MONITOR", "ENFORCE"]),
+        rules=dict(
+            type="list",
+            elements="dict",
+            options=policy_rule,
+            obj=mic_sdk.NetworkSecurityPolicyRule,
+        ),
+        scope=dict(
+            type="str",
+            choices=["ALL_VLAN", "ALL_VPC", "VPC_LIST", "GLOBAL", "VPC_AS_CATEGORY"],
+        ),
+        vpc_references=dict(type="list", elements="str"),
+        scope_references=dict(type="list", elements="str"),
+        is_ipv6_traffic_allowed=dict(type="bool"),
+        is_hitlog_enabled=dict(type="bool"),
+    )
+
+    return module_args
+
+
+def create_security_policy(module, api_instance, result):
+    """Create a new network security policy."""
+    sg = SpecGenerator(module)
+    default_spec = mic_sdk.NetworkSecurityPolicy()
+    spec, err = sg.generate_spec(obj=default_spec)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating create network security policy spec", **result
+        )
+
+    if module.params.get("policy_state"):
+        spec.state = module.params.get("policy_state")
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_network_security_policy(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating network security policy",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task_status, rel=TASK_CONSTANTS.RelEntityType.SECURITY_POLICY
+        )
+        if ext_id:
+            resp = get_network_security_policy(module, api_instance, ext_id)
+            result["ext_id"] = ext_id
+            result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+def check_security_policy_idempotency(old_spec, update_spec):
+    """Check if the update spec is same as the current spec."""
+    if len(old_spec.get("rules", [])) != len(update_spec.get("rules", [])):
+        return False
+
+    for rule in old_spec.get("rules", []):
+        rule["ext_id"] = None
+
+    for rule in update_spec.get("rules", []):
+        rule["ext_id"] = None
+        spec = rule.get("spec", {})
+        if (
+            "src_category_references" in spec
+            and spec["src_category_references"] is None
+        ):
+            spec["src_category_associated_entity_type"] = None
+        if (
+            "dest_category_references" in spec
+            and spec["dest_category_references"] is None
+        ):
+            spec["dest_category_associated_entity_type"] = None
+        if (
+            "secured_group_category_references" in spec
+            and spec["secured_group_category_references"] is None
+        ):
+            spec["secured_group_category_associated_entity_type"] = None
+
+    old_rules = old_spec.pop("rules")
+    update_rules = update_spec.pop("rules")
+
+    for rule in update_rules:
+        if rule not in old_rules:
+            return False
+
+    if old_spec != update_spec:
+        return False
+    return True
+
+
+def update_security_policy(module, api_instance, result):
+    """Update an existing network security policy."""
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    current_spec = get_network_security_policy(module, api_instance, ext_id=ext_id)
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(current_spec))
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating network security policy update spec", **result
+        )
+
+    if module.params.get("policy_state"):
+        update_spec.state = module.params.get("policy_state")
+    else:
+        update_spec.state = current_spec.state
+
+    current_spec_dict = strip_internal_attributes(current_spec.to_dict())
+    update_spec_dict = strip_internal_attributes(update_spec.to_dict())
+    if check_security_policy_idempotency(current_spec_dict, update_spec_dict):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    etag = get_etag(data=current_spec)
+    kwargs = {}
+    if etag:
+        kwargs["if_match"] = etag
+
+    resp = None
+    try:
+        resp = api_instance.update_network_security_policy_by_id(
+            extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating network security policy",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_network_security_policy(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+def delete_security_policy(module, api_instance, result):
+    """Delete an existing network security policy."""
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "Network security policy with ext_id:{0} will be deleted.".format(ext_id)
+        )
+        return
+
+    current_spec = get_network_security_policy(module, api_instance, ext_id=ext_id)
+
+    etag = get_etag(data=current_spec)
+    if not etag:
+        return module.fail_json(
+            "Unable to fetch etag for deleting network security policy", **result
+        )
+
+    kwargs = {"if_match": etag}
+
+    try:
+        resp = api_instance.delete_network_security_policy_by_id(extId=ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting network security policy",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        resp = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "present", ("name", "ext_id"), True),
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_microseg_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+    }
+
+    api_instance = get_network_security_policy_api_instance(module)
+
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_security_policy(module, api_instance, result)
+        else:
+            create_security_policy(module, api_instance, result)
+    else:
+        delete_security_policy(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_SecurityPolicys_info_v2.py
+++ b/plugins/modules/ntnx_SecurityPolicys_info_v2.py
@@ -1,0 +1,225 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_SecurityPolicys_info_v2
+short_description: Fetch network security policies info from Nutanix PC.
+version_added: 2.6.0
+description:
+    - Fetch list of multiple network security policies info.
+    - Fetch specific network security policy info by ext_id.
+    - This module uses PC v4 APIs based SDKs
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Get a Network Security Policy by ExtID) -
+      Operation Name: View Flow Policy -
+      Required Roles: Flow Admin, Flow Viewer, Prism Admin, Prism Viewer, Super Admin
+    - >-
+      B(List all the Network Security Policies) -
+      Operation Name: View Flow Policy -
+      Required Roles: Flow Admin, Flow Viewer, Prism Admin, Prism Viewer, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=microseg)"
+options:
+    ext_id:
+        description:
+            - External id to fetch specific network security policy info.
+        type: str
+extends_documentation_fragment:
+      - nutanix.ncp.ntnx_credentials
+      - nutanix.ncp.ntnx_info_v2
+      - nutanix.ncp.ntnx_logger
+      - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+EXAMPLES = r"""
+- name: Get all security policies
+  nutanix.ncp.ntnx_SecurityPolicys_info_v2:
+    nutanix_host: "<pc_ip>"
+    nutanix_username: "<pc_username>"
+    nutanix_password: "<pc_password>"
+  register: result
+
+- name: Get a specific security policy by ext_id
+  nutanix.ncp.ntnx_SecurityPolicys_info_v2:
+    nutanix_host: "<pc_ip>"
+    nutanix_username: "<pc_username>"
+    nutanix_password: "<pc_password>"
+    ext_id: "569a018e-18ac-4813-b00f-2aa0d0005042"
+  register: result
+
+- name: Fetch security policies using filter
+  nutanix.ncp.ntnx_SecurityPolicys_info_v2:
+    nutanix_host: "<pc_ip>"
+    nutanix_username: "<pc_username>"
+    nutanix_password: "<pc_password>"
+    filter: "name eq 'my-policy'"
+  register: result
+
+- name: Fetch only 5 security policies
+  nutanix.ncp.ntnx_SecurityPolicys_info_v2:
+    nutanix_host: "<pc_ip>"
+    nutanix_username: "<pc_username>"
+    nutanix_password: "<pc_password>"
+    limit: 5
+  register: result
+"""
+RETURN = r"""
+response:
+  description:
+    - Network security policy info if ext_id is provided
+    - List of network security policies if ext_id is not provided
+  returned: always
+  type: dict
+  sample: {
+            "created_by": "00000000-0000-0000-0000-000000000000",
+            "creation_time": "2024-07-19T12:55:54.945000+00:00",
+            "description": "Ansible created policy",
+            "ext_id": "e8347a03-28a0-4eaa-9f43-64fd74cdee9e",
+            "is_hitlog_enabled": false,
+            "is_ipv6_traffic_allowed": false,
+            "is_system_defined": false,
+            "last_update_time": "2024-07-19T12:56:21.167000+00:00",
+            "links": null,
+            "name": "ansible-policy-1",
+            "rules": [],
+            "scope": "ALL_VLAN",
+            "secured_groups": null,
+            "state": "MONITOR",
+            "tenant_id": null,
+            "type": "APPLICATION",
+            "vpc_references": null
+        }
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching network security policy info"
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  returned: always
+  type: bool
+  sample: false
+ext_id:
+    description: External id of the network security policy if fetched by ext_id
+    returned: always
+    type: str
+    sample: "e8347a03-28a0-4eaa-9f43-64fd74cdee9e"
+failed:
+    description: This field typically holds information about if the task have failed
+    returned: always
+    type: bool
+    sample: false
+total_available_results:
+    description:
+        - The total number of available network security policies in PC.
+    type: int
+    returned: when all network security policies are fetched
+    sample: 125
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.flow.api_client import (  # noqa: E402
+    get_network_security_policy_api_instance,
+)
+from ..module_utils.v4.flow.helpers import get_network_security_policy  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_security_policy_by_ext_id(module, api_instance, result):
+    """Fetch a single network security policy by its external ID."""
+    ext_id = module.params.get("ext_id")
+    resp = get_network_security_policy(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def list_security_policies(module, api_instance, result):
+    """List network security policies with pagination support."""
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating network security policies info spec", **result
+        )
+
+    try:
+        resp = api_instance.list_network_security_policies(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching network security policies info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "error": None, "response": None}
+
+    api_instance = get_network_security_policy_api_instance(module)
+
+    if module.params.get("ext_id"):
+        get_security_policy_by_ext_id(module, api_instance, result)
+    else:
+        list_security_policies(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/ntnx_SecurityPolicy_v2/aliases
+++ b/tests/integration/targets/ntnx_SecurityPolicy_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_SecurityPolicy_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_SecurityPolicy_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_SecurityPolicy_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_SecurityPolicy_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import security_policy tests
+      ansible.builtin.import_tasks: security_policy.yml

--- a/tests/integration/targets/ntnx_SecurityPolicy_v2/tasks/security_policy.yml
+++ b/tests/integration/targets/ntnx_SecurityPolicy_v2/tasks/security_policy.yml
@@ -1,0 +1,284 @@
+---
+- name: Start testing ntnx_SecurityPolicy_v2 and ntnx_SecurityPolicys_info_v2 modules
+  ansible.builtin.debug:
+    msg: Start testing ntnx_SecurityPolicy_v2 and ntnx_SecurityPolicys_info_v2 modules
+
+- name: Generate random name
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set security policy name
+  ansible.builtin.set_fact:
+    policy_name: "ansible-sp-{{ random_name }}"
+
+- name: Set todelete list
+  ansible.builtin.set_fact:
+    todelete: []
+
+#####################################################################
+# Create with check_mode
+#####################################################################
+- name: Create application security policy with check mode enabled
+  nutanix.ncp.ntnx_SecurityPolicy_v2:
+    name: "{{ policy_name }}_1"
+    description: "Ansible test security policy"
+    type: "APPLICATION"
+    policy_state: "MONITOR"
+    scope: "ALL_VLAN"
+    is_hitlog_enabled: true
+    is_ipv6_traffic_allowed: false
+  register: result
+  ignore_errors: true
+  check_mode: true
+
+- name: Create check mode status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.failed == false
+      - result.changed == false
+      - result.response.name == "{{ policy_name }}_1"
+      - result.response.description == "Ansible test security policy"
+    fail_msg: "Fail: Unable to create security policy with check mode enabled"
+    success_msg: "Pass: Security policy check mode create passed"
+
+#####################################################################
+# Create security policy
+#####################################################################
+- name: Create application security policy
+  nutanix.ncp.ntnx_SecurityPolicy_v2:
+    name: "{{ policy_name }}_1"
+    description: "Ansible test security policy"
+    type: "APPLICATION"
+    policy_state: "MONITOR"
+    scope: "ALL_VLAN"
+    is_hitlog_enabled: true
+    is_ipv6_traffic_allowed: false
+  register: result
+  ignore_errors: true
+
+- name: Creation status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.response.name == "{{ policy_name }}_1"
+      - result.response.description == "Ansible test security policy"
+      - result.response.type == "APPLICATION"
+      - result.response.state == "MONITOR"
+      - result.response.is_hitlog_enabled == true
+      - result.response.is_ipv6_traffic_allowed == false
+    fail_msg: "Fail: Unable to create application security policy"
+    success_msg: "Pass: Application security policy created successfully"
+
+- name: Add policy to delete list
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+#####################################################################
+# Get by ext_id using info module
+#####################################################################
+- name: Get security policy by ext_id
+  nutanix.ncp.ntnx_SecurityPolicys_info_v2:
+    ext_id: "{{ todelete[0] }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch security policy status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.ext_id is defined
+      - result.failed == false
+      - result.changed == false
+      - result.response.name == "{{ policy_name }}_1"
+      - result.response.description == "Ansible test security policy"
+    fail_msg: "Fail: Unable to fetch security policy by ext_id"
+    success_msg: "Pass: Security policy fetched successfully by ext_id"
+
+#####################################################################
+# List all security policies
+#####################################################################
+- name: List all security policies
+  nutanix.ncp.ntnx_SecurityPolicys_info_v2:
+  register: list_result
+  ignore_errors: true
+
+- name: List all security policies status
+  ansible.builtin.assert:
+    that:
+      - list_result.response is defined
+      - list_result.changed == false
+      - list_result.failed == false
+      - list_result.response | length > 0
+      - list_result.total_available_results is defined
+      - list_result.total_available_results > 0
+    fail_msg: "Fail: Unable to list all security policies"
+    success_msg: "Pass: All security policies listed successfully"
+
+#####################################################################
+# List with limit
+#####################################################################
+- name: List security policies using limit
+  nutanix.ncp.ntnx_SecurityPolicys_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List with limit status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response | length == 1
+    fail_msg: "Fail: Unable to list security policies using limit"
+    success_msg: "Pass: Security policies listed successfully using limit"
+
+#####################################################################
+# Update with check_mode
+#####################################################################
+- name: Update security policy with check mode enabled
+  nutanix.ncp.ntnx_SecurityPolicy_v2:
+    ext_id: "{{ todelete[0] }}"
+    name: "{{ policy_name }}_1_updated"
+    description: "Updated ansible test security policy"
+  register: result
+  ignore_errors: true
+  check_mode: true
+
+- name: Update check mode status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.failed == false
+      - result.changed == false
+      - result.response.name == "{{ policy_name }}_1_updated"
+      - result.response.description == "Updated ansible test security policy"
+    fail_msg: "Fail: Unable to update security policy with check mode enabled"
+    success_msg: "Pass: Security policy check mode update passed"
+
+#####################################################################
+# Update security policy
+#####################################################################
+- name: Update security policy name and description
+  nutanix.ncp.ntnx_SecurityPolicy_v2:
+    ext_id: "{{ todelete[0] }}"
+    name: "{{ policy_name }}_1_updated"
+    description: "Updated ansible test security policy"
+  register: result
+  ignore_errors: true
+
+- name: Update status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.failed == false
+      - result.changed == true
+      - result.ext_id is defined
+      - result.response.name == "{{ policy_name }}_1_updated"
+      - result.response.description == "Updated ansible test security policy"
+    fail_msg: "Fail: Unable to update security policy"
+    success_msg: "Pass: Security policy updated successfully"
+
+#####################################################################
+# Idempotency check - update with same values
+#####################################################################
+- name: Update security policy with same values (idempotency)
+  nutanix.ncp.ntnx_SecurityPolicy_v2:
+    ext_id: "{{ todelete[0] }}"
+    name: "{{ policy_name }}_1_updated"
+    description: "Updated ansible test security policy"
+  register: result
+  ignore_errors: true
+
+- name: Idempotency status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.msg == "Nothing to change."
+    fail_msg: "Fail: Security policy updated with same values (idempotency failed)"
+    success_msg: "Pass: Idempotency check passed"
+
+#####################################################################
+# Delete with check_mode
+#####################################################################
+- name: Delete security policy with check mode enabled
+  nutanix.ncp.ntnx_SecurityPolicy_v2:
+    state: absent
+    ext_id: "{{ todelete[0] }}"
+  register: result
+  ignore_errors: true
+  check_mode: true
+
+- name: Delete check mode status
+  ansible.builtin.assert:
+    that:
+      - result.msg is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ todelete[0] }}"
+      - result.msg == "Network security policy with ext_id:{{ todelete[0] }} will be deleted."
+    fail_msg: "Fail: Delete security policy with check mode failed"
+    success_msg: "Pass: Delete security policy with check mode passed"
+
+#####################################################################
+# Negative test - delete with invalid ext_id
+#####################################################################
+- name: Delete security policy with invalid ext_id
+  nutanix.ncp.ntnx_SecurityPolicy_v2:
+    state: absent
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Negative delete status
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+    fail_msg: "Fail: Expected error for invalid ext_id deletion"
+    success_msg: "Pass: Got expected error for invalid ext_id deletion"
+
+#####################################################################
+# Negative test - create without required fields
+#####################################################################
+- name: Create security policy without name (should fail)
+  nutanix.ncp.ntnx_SecurityPolicy_v2:
+    description: "This should fail"
+    type: "APPLICATION"
+  register: result
+  ignore_errors: true
+
+- name: Negative create status
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+    fail_msg: "Fail: Expected error when creating without name"
+    success_msg: "Pass: Got expected error when creating without name"
+
+#####################################################################
+# Delete all created security policies
+#####################################################################
+- name: Delete all created security policies
+  nutanix.ncp.ntnx_SecurityPolicy_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  register: result
+  loop: "{{ todelete }}"
+  ignore_errors: true
+
+- name: Delete security policies status
+  ansible.builtin.assert:
+    that:
+      - result.changed is defined
+      - result.changed == true
+      - result.msg == "All items completed"
+    fail_msg: "Fail: Unable to delete all created security policies"
+    success_msg: "Pass: All security policies deleted successfully"
+
+- name: Set todelete to empty list
+  ansible.builtin.set_fact:
+    todelete: []


### PR DESCRIPTION
## Summary
- Added `ntnx_SecurityPolicy_v2` CRUD module for managing network security policies (create, update, delete) with idempotency and check_mode support
- Added `ntnx_SecurityPolicys_info_v2` info module for fetching security policies (get by ext_id and list with pagination)
- Registered new modules in `meta/runtime.yml` action groups
- Added example playbook (`examples/security_policy_crud.yml`) and integration tests (`tests/integration/targets/ntnx_SecurityPolicy_v2/`)

## Test plan
- [x] Ansible sanity test (validate-modules) passes
- [x] black, isort, flake8, ansible-lint pass
- [x] Check mode tests for create, update, and delete verified
- [x] Integration tests cover CRUD operations, idempotency, info module (get/list), and negative scenarios
- [ ] Full integration tests require reachable PC endpoint (10.0.0.1)


Made with [Cursor](https://cursor.com)