### PR TITLE
Fix: ip_ranges should be optional in internal_networks (not external_networks) for PC deploy/restore

### DIFF
--- a/plugins/module_utils/v4/prism/spec/pc.py
+++ b/plugins/module_utils/v4/prism/spec/pc.py
@@ -124,7 +124,6 @@ class PrismSpecs:
             elements="dict",
             options=ip_ranges_spec,
             obj=prism_sdk.IpRange,
-            required=True,
         ),
         network_ext_id=dict(type="str", required=True),
     )

--- a/plugins/module_utils/v4/prism/spec/pc.py
+++ b/plugins/module_utils/v4/prism/spec/pc.py
@@ -98,10 +98,7 @@ class PrismSpecs:
             required=True,
         ),
         ip_ranges=dict(
-            type="list",
-            elements="dict",
-            options=ip_ranges_spec,
-            obj=prism_sdk.IpRange
+            type="list", elements="dict", options=ip_ranges_spec, obj=prism_sdk.IpRange
         ),
     )
 

--- a/plugins/module_utils/v4/prism/spec/pc.py
+++ b/plugins/module_utils/v4/prism/spec/pc.py
@@ -101,8 +101,7 @@ class PrismSpecs:
             type="list",
             elements="dict",
             options=ip_ranges_spec,
-            obj=prism_sdk.IpRange,
-            required=True,
+            obj=prism_sdk.IpRange
         ),
     )
 
@@ -124,6 +123,7 @@ class PrismSpecs:
             elements="dict",
             options=ip_ranges_spec,
             obj=prism_sdk.IpRange,
+            required=True,
         ),
         network_ext_id=dict(type="str", required=True),
     )

--- a/plugins/modules/ntnx_pc_deploy_v2.py
+++ b/plugins/modules/ntnx_pc_deploy_v2.py
@@ -491,7 +491,7 @@ options:
                         description: Range of IPs used for Prism Central network setup.
                         type: list
                         elements: dict
-                        required: true
+                        required: false
                         suboptions:
                             begin:
                                 description: An unique address that identifies a device on the internet or a local network in IPv4 or IPv6 format.

--- a/plugins/modules/ntnx_pc_deploy_v2.py
+++ b/plugins/modules/ntnx_pc_deploy_v2.py
@@ -323,7 +323,7 @@ options:
                         description: Range of IPs used for Prism Central network setup.
                         type: list
                         elements: dict
-                        required: true
+                        required: false
                         suboptions:
                             begin:
                                 description: An unique address that identifies a device on the internet or a local network in IPv4 or IPv6 format.
@@ -491,7 +491,7 @@ options:
                         description: Range of IPs used for Prism Central network setup.
                         type: list
                         elements: dict
-                        required: false
+                        required: true
                         suboptions:
                             begin:
                                 description: An unique address that identifies a device on the internet or a local network in IPv4 or IPv6 format.

--- a/plugins/modules/ntnx_pc_restore_v2.py
+++ b/plugins/modules/ntnx_pc_restore_v2.py
@@ -511,7 +511,7 @@ options:
                             ip_ranges:
                                 description: Range of IPs used for Prism Central network setup.
                                 type: list
-                                required: true
+                                required: false
                                 elements: dict
                                 suboptions:
                                     begin:

--- a/plugins/modules/ntnx_pc_restore_v2.py
+++ b/plugins/modules/ntnx_pc_restore_v2.py
@@ -341,7 +341,7 @@ options:
                             ip_ranges:
                                 description: Range of IPs used for Prism Central network setup.
                                 type: list
-                                required: true
+                                required: false
                                 elements: dict
                                 suboptions:
                                     begin:
@@ -511,7 +511,7 @@ options:
                             ip_ranges:
                                 description: Range of IPs used for Prism Central network setup.
                                 type: list
-                                required: false
+                                required: true
                                 elements: dict
                                 suboptions:
                                     begin:


### PR DESCRIPTION
## Summary

Fixes [#982](https://github.com/nutanix/nutanix.ansible/issues/982) — with a corrected scope based on actual API behavior observed during testing.

### Background

Issue #982 reported that `network.external_networks.ip_ranges` was incorrectly marked as required in `ntnx_pc_deploy_v2`, citing the [`createDomainManager` API spec](https://developers.nutanix.com/api-reference?namespace=prism&version=v4.3#tag/DomainManager/operation/createDomainManager) which lists it as optional.

While verifying this against a real Prism Central deploy, we found that the **server-side validation contradicts the spec**:

- `external_networks.ip_ranges` — **the API actually rejects requests without a valid IP range**:

  ```
  TASK [ntnx_prism_v2 : Deploy PC] ***********************************************
  fatal: [testhost]: FAILED! => {
    "changed": false,
    "error": "BAD REQUEST",
    "status": 400,
    "msg": "Api Exception raised while deploying prism central",
    "response": {
      "data": {
        "error": [
          {
            "code": "GURUPE-55022",
            "errorGroup": "INTERNAL_ERROR",
            "severity": "ERROR",
            "message": "Domain Manager Deployment failed due to reason - Exception 400 : Bad Request\nException message : Please provide a valid Ip Range."
          }
        ]
      }
    }
  }
  ```
  Endpoint: `POST https://<pc>:9440/api/prism/v4.2/config/domain-managers` → `GURUPE-55022 / "Please provide a valid Ip Range."`

- `internal_networks.ip_ranges` — accepted by the server when omitted, i.e. **genuinely optional**.

So the fix is the opposite of what #982 originally suggested: keep `external_networks.ip_ranges` required (the current Ansible behavior already matches the real API contract — making it optional in Ansible would only push the failure later, into a confusing 400 from PC), and instead make `internal_networks.ip_ranges` optional.

| Field | API spec/docs | Server actually | Module before this PR | Module after this PR |
| --- | --- | --- | --- | --- |
| `network.external_networks.ip_ranges` | optional | **required** (`GURUPE-55022`) | required | required (unchanged) |
| `network.internal_networks.ip_ranges` | optional | optional | required | **optional** |

## What changed

### `plugins/module_utils/v4/prism/spec/pc.py`
- Removed `required=True` from `ip_ranges` inside `internal_networks_spec`. This is the runtime argument spec Ansible uses to validate user input.
- This spec is shared by both `ntnx_pc_deploy_v2` and `ntnx_pc_restore_v2` (via `PrismSpecs.prism_spec`), so runtime behavior is consistent across both modules.
- `external_networks_spec.ip_ranges` is left as `required=True` to match real server behavior.

### `plugins/modules/ntnx_pc_deploy_v2.py`
- `DOCUMENTATION` for `network.internal_networks.ip_ranges` changed from `required: true` to `required: false` to match the corrected spec.
- `network.external_networks.ip_ranges` documentation is left as `required: true` (unchanged).

### `plugins/modules/ntnx_pc_restore_v2.py`
- `DOCUMENTATION` for `domain_manager.network.internal_networks.ip_ranges` changed from `required: true` to `required: false` to keep docs in sync with the shared spec and avoid an `ansible-test sanity` (`validate-modules`) `doc-required-mismatch` failure.
- `domain_manager.network.external_networks.ip_ranges` documentation is left as `required: true` (unchanged).

## Behavior change

| Field | Before | After |
| --- | --- | --- |
| `network.internal_networks.ip_ranges` (deploy) | Required (Ansible would fail if omitted) | Optional (matches actual API behavior) |
| `domain_manager.network.internal_networks.ip_ranges` (restore) | Required | Optional |
| `network.external_networks.ip_ranges` (deploy) | Required | Required (no change — matches actual API behavior) |
| `domain_manager.network.external_networks.ip_ranges` (restore) | Required | Required (no change) |

Existing playbooks that already pass `internal_networks.ip_ranges` continue to work without any change.

## Note for the API team / docs

The API reference currently lists `network.external_networks.ip_ranges` as optional, but the deploy endpoint enforces it as required (`GURUPE-55022 / "Please provide a valid Ip Range."`). The API spec/docs likely need to be updated to mark this field as required so that downstream SDKs and tooling can reflect the real contract. Tracked under #982 — would appreciate confirmation from the relevant API team.

## Test plan

- [ ] Run `ntnx_pc_deploy_v2` without `network.internal_networks.ip_ranges` and confirm the module no longer fails argument validation.
- [ ] Run `ntnx_pc_deploy_v2` with `network.internal_networks.ip_ranges` provided and confirm existing behavior is preserved.
- [ ] Run `ntnx_pc_restore_v2` without `domain_manager.network.internal_networks.ip_ranges` and confirm the module no longer fails argument validation.
- [ ] Run `ntnx_pc_deploy_v2` without `network.external_networks.ip_ranges` and confirm Ansible still rejects it as required (consistent with server enforcement).
- [ ] Run `ansible-test sanity` (in particular `validate-modules` and `yamllint`) and confirm both pass.
- [ ] Verify generated module documentation reflects `required: false` for `internal_networks.ip_ranges` and `required: true` for `external_networks.ip_ranges` in both modules.