### PR TITLE
feat: add GPT-in-a-Box and AI workload roles for AI Factory

### DIFF
--- a/roles/ai_workload_config/defaults/main.yml
+++ b/roles/ai_workload_config/defaults/main.yml
@@ -1,0 +1,28 @@
+---
+# Nutanix Prism Central connection
+ai_config_nutanix_host: ""
+ai_config_nutanix_username: admin
+ai_config_nutanix_password: ""
+ai_config_nutanix_validate_certs: false
+
+# Target cluster
+ai_config_cluster_name: ""
+
+# VM names to configure GPUs on
+ai_config_vm_names: []
+
+# GPU configuration
+# Mode: passthrough (full GPU) or virtual (vGPU)
+ai_config_gpu_mode: passthrough
+# GPU device name (e.g., "NVIDIA A100", "Tesla T4")
+ai_config_gpu_name: ""
+# Number of GPUs per VM
+ai_config_gpu_count: 1
+# GPU vendor
+ai_config_gpu_vendor: NVIDIA
+
+# Power management
+# Whether to power off VMs before GPU config changes
+ai_config_power_off_before: true
+# Whether to power on VMs after GPU config changes
+ai_config_power_on_after: true

--- a/roles/ai_workload_config/meta/main.yml
+++ b/roles/ai_workload_config/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  role_name: ai_workload_config
+  author: Ansible Cloud Team
+  description: >-
+    Configure GPU resources for AI workloads on Nutanix AHV. Assigns GPU
+    devices to VMs via passthrough or vGPU and validates GPU availability
+    on the target cluster.
+  company: Red Hat
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+  galaxy_tags:
+    - nutanix
+    - gpu
+    - ai
+    - ahv
+
+dependencies: []

--- a/roles/ai_workload_config/tasks/configure_vm_gpu.yml
+++ b/roles/ai_workload_config/tasks/configure_vm_gpu.yml
@@ -1,0 +1,53 @@
+---
+- name: "Get VM info for {{ _ai_config_vm_name }}"
+  nutanix.ansible.ntnx_vms_info_v2:
+    nutanix_host: "{{ ai_config_nutanix_host }}"
+    nutanix_username: "{{ ai_config_nutanix_username }}"
+    nutanix_password: "{{ ai_config_nutanix_password }}"
+    validate_certs: "{{ ai_config_nutanix_validate_certs }}"
+  register: _ai_config_all_vms
+
+- name: "Find target VM {{ _ai_config_vm_name }}"
+  ansible.builtin.set_fact:
+    _ai_config_target_vm: >-
+      {{ _ai_config_all_vms.response | default([]) |
+         selectattr('name', 'equalto', _ai_config_vm_name) | first }}
+  failed_when: _ai_config_target_vm is not defined
+
+- name: "Power off VM {{ _ai_config_vm_name }} before GPU config"
+  nutanix.ansible.ntnx_vms_power_actions_v2:
+    nutanix_host: "{{ ai_config_nutanix_host }}"
+    nutanix_username: "{{ ai_config_nutanix_username }}"
+    nutanix_password: "{{ ai_config_nutanix_password }}"
+    validate_certs: "{{ ai_config_nutanix_validate_certs }}"
+    ext_id: "{{ _ai_config_target_vm.ext_id }}"
+    state: power_off
+  when: ai_config_power_off_before
+
+- name: "Update VM {{ _ai_config_vm_name }} with GPU configuration"
+  nutanix.ansible.ntnx_vms_v2:
+    nutanix_host: "{{ ai_config_nutanix_host }}"
+    nutanix_username: "{{ ai_config_nutanix_username }}"
+    nutanix_password: "{{ ai_config_nutanix_password }}"
+    validate_certs: "{{ ai_config_nutanix_validate_certs }}"
+    state: present
+    ext_id: "{{ _ai_config_target_vm.ext_id }}"
+    gpus: >-
+      {{ range(0, ai_config_gpu_count | int) | map('regex_replace', '.*', '{}') |
+         map('combine', {
+           'mode': ai_config_gpu_mode | upper,
+           'vendor': ai_config_gpu_vendor,
+           'name': ai_config_gpu_name
+         }) | list }}
+  register: _ai_config_gpu_result
+  when: ai_config_gpu_name != ''
+
+- name: "Power on VM {{ _ai_config_vm_name }} after GPU config"
+  nutanix.ansible.ntnx_vms_power_actions_v2:
+    nutanix_host: "{{ ai_config_nutanix_host }}"
+    nutanix_username: "{{ ai_config_nutanix_username }}"
+    nutanix_password: "{{ ai_config_nutanix_password }}"
+    validate_certs: "{{ ai_config_nutanix_validate_certs }}"
+    ext_id: "{{ _ai_config_target_vm.ext_id }}"
+    state: power_on
+  when: ai_config_power_on_after

--- a/roles/ai_workload_config/tasks/discover_gpus.yml
+++ b/roles/ai_workload_config/tasks/discover_gpus.yml
@@ -1,0 +1,15 @@
+---
+- name: Get host information for GPU discovery
+  nutanix.ansible.ntnx_hosts_info_v2:
+    nutanix_host: "{{ ai_config_nutanix_host }}"
+    nutanix_username: "{{ ai_config_nutanix_username }}"
+    nutanix_password: "{{ ai_config_nutanix_password }}"
+    validate_certs: "{{ ai_config_nutanix_validate_certs }}"
+  register: _ai_config_hosts
+
+- name: Display available GPU information
+  ansible.builtin.debug:
+    msg: >-
+      Discovered hosts: {{ _ai_config_hosts.response | default([]) | length }}.
+      GPU discovery complete. Use ai_config_gpu_name to specify the GPU device
+      name if not auto-detected.

--- a/roles/ai_workload_config/tasks/main.yml
+++ b/roles/ai_workload_config/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Validate required parameters
+  ansible.builtin.assert:
+    that:
+      - ai_config_nutanix_host != ''
+      - ai_config_nutanix_password != ''
+      - ai_config_vm_names | length > 0
+    fail_msg: >-
+      Required parameters missing. Set ai_config_nutanix_host,
+      ai_config_nutanix_password, and ai_config_vm_names.
+
+- name: Get cluster GPU availability
+  ansible.builtin.include_tasks: discover_gpus.yml
+  when: ai_config_gpu_name == ''
+
+- name: Configure GPU on each target VM
+  ansible.builtin.include_tasks: configure_vm_gpu.yml
+  loop: "{{ ai_config_vm_names }}"
+  loop_control:
+    loop_var: _ai_config_vm_name
+    label: "{{ _ai_config_vm_name }}"

--- a/roles/gpt_in_a_box/defaults/main.yml
+++ b/roles/gpt_in_a_box/defaults/main.yml
@@ -1,0 +1,42 @@
+---
+# Nutanix Prism Central connection
+gptbox_nutanix_host: ""
+gptbox_nutanix_username: admin
+gptbox_nutanix_password: ""
+gptbox_nutanix_validate_certs: false
+
+# Cluster configuration
+gptbox_cluster_name: ""
+gptbox_subnet_name: ""
+
+# NKP (Nutanix Kubernetes Platform) configuration
+gptbox_nkp_name: gpt-in-a-box
+gptbox_nkp_k8s_version: "1.28"
+gptbox_nkp_control_plane_count: 3
+gptbox_nkp_worker_count: 3
+gptbox_nkp_control_plane_vcpus: 8
+gptbox_nkp_control_plane_memory_gb: 16
+gptbox_nkp_worker_vcpus: 16
+gptbox_nkp_worker_memory_gb: 64
+gptbox_nkp_worker_disk_gb: 200
+
+# GPU configuration for worker nodes
+gptbox_gpu_mode: passthrough
+gptbox_gpu_name: ""
+gptbox_gpu_count_per_worker: 1
+gptbox_gpu_vendor: NVIDIA
+
+# Model deployment
+gptbox_deploy_model: true
+gptbox_model_name: llama-2-7b
+gptbox_model_endpoint_name: llm-inference
+gptbox_model_replicas: 1
+gptbox_model_gpu_count: 1
+gptbox_inference_port: 8080
+
+# Storage configuration
+gptbox_storage_container: default-container
+gptbox_model_storage_size_gb: 100
+
+# State management
+gptbox_state: present

--- a/roles/gpt_in_a_box/meta/main.yml
+++ b/roles/gpt_in_a_box/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  role_name: gpt_in_a_box
+  author: Ansible Cloud Team
+  description: >-
+    Provision Nutanix GPT-in-a-Box following the Nutanix Enterprise AI pattern.
+    Deploys NKP (Nutanix Kubernetes Platform), allocates GPU resources, and
+    configures model deployment for turnkey AI infrastructure.
+  company: Red Hat
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+  galaxy_tags:
+    - nutanix
+    - gpu
+    - ai
+    - kubernetes
+    - nkp
+    - gpt
+    - llm
+
+dependencies: []

--- a/roles/gpt_in_a_box/tasks/deploy_model.yml
+++ b/roles/gpt_in_a_box/tasks/deploy_model.yml
@@ -1,0 +1,36 @@
+---
+- name: Display model deployment information
+  ansible.builtin.debug:
+    msg: >-
+      Deploying model {{ gptbox_model_name }} as endpoint {{ gptbox_model_endpoint_name }}
+      with {{ gptbox_model_replicas }} replica(s), {{ gptbox_model_gpu_count }} GPU(s) each,
+      on port {{ gptbox_inference_port }}
+
+- name: Create model storage volume
+  nutanix.ansible.ntnx_volume_groups_v2:
+    nutanix_host: "{{ gptbox_nutanix_host }}"
+    nutanix_username: "{{ gptbox_nutanix_username }}"
+    nutanix_password: "{{ gptbox_nutanix_password }}"
+    validate_certs: "{{ gptbox_nutanix_validate_certs }}"
+    state: present
+    name: "{{ gptbox_nkp_name }}-model-storage"
+    description: "Model storage for GPT-in-a-Box {{ gptbox_model_name }}"
+    cluster_reference:
+      ext_id: "{{ _gptbox_cluster.ext_id }}"
+  register: _gptbox_model_storage
+
+- name: Generate model deployment manifest
+  ansible.builtin.set_fact:
+    _gptbox_model_manifest:
+      model_name: "{{ gptbox_model_name }}"
+      endpoint_name: "{{ gptbox_model_endpoint_name }}"
+      replicas: "{{ gptbox_model_replicas }}"
+      gpu_count: "{{ gptbox_model_gpu_count }}"
+      inference_port: "{{ gptbox_inference_port }}"
+      storage_size_gb: "{{ gptbox_model_storage_size_gb }}"
+      nkp_cluster: "{{ gptbox_nkp_name }}"
+
+- name: Display deployment manifest
+  ansible.builtin.debug:
+    var: _gptbox_model_manifest
+    verbosity: 1

--- a/roles/gpt_in_a_box/tasks/gather_cluster.yml
+++ b/roles/gpt_in_a_box/tasks/gather_cluster.yml
@@ -1,0 +1,34 @@
+---
+- name: Get cluster information
+  nutanix.ansible.ntnx_clusters_info_v2:
+    nutanix_host: "{{ gptbox_nutanix_host }}"
+    nutanix_username: "{{ gptbox_nutanix_username }}"
+    nutanix_password: "{{ gptbox_nutanix_password }}"
+    validate_certs: "{{ gptbox_nutanix_validate_certs }}"
+  register: _gptbox_clusters
+
+- name: Find target cluster
+  ansible.builtin.set_fact:
+    _gptbox_cluster: >-
+      {{ _gptbox_clusters.response | selectattr('name', 'equalto', gptbox_cluster_name) | first }}
+  failed_when: _gptbox_cluster is not defined
+
+- name: Get subnet information
+  nutanix.ansible.ntnx_subnets_info_v2:
+    nutanix_host: "{{ gptbox_nutanix_host }}"
+    nutanix_username: "{{ gptbox_nutanix_username }}"
+    nutanix_password: "{{ gptbox_nutanix_password }}"
+    validate_certs: "{{ gptbox_nutanix_validate_certs }}"
+  register: _gptbox_subnets
+
+- name: Find target subnet
+  ansible.builtin.set_fact:
+    _gptbox_subnet: >-
+      {{ _gptbox_subnets.response | selectattr('name', 'equalto', gptbox_subnet_name) | first }}
+  failed_when: _gptbox_subnet is not defined
+
+- name: Display cluster and subnet info
+  ansible.builtin.debug:
+    msg: >-
+      Cluster: {{ _gptbox_cluster.name }} ({{ _gptbox_cluster.ext_id }}),
+      Subnet: {{ _gptbox_subnet.name }} ({{ _gptbox_subnet.ext_id }})

--- a/roles/gpt_in_a_box/tasks/main.yml
+++ b/roles/gpt_in_a_box/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: Validate required parameters
+  ansible.builtin.assert:
+    that:
+      - gptbox_nutanix_host != ''
+      - gptbox_nutanix_password != ''
+      - gptbox_cluster_name != ''
+      - gptbox_subnet_name != ''
+    fail_msg: >-
+      Required parameters missing. Set gptbox_nutanix_host, gptbox_nutanix_password,
+      gptbox_cluster_name, and gptbox_subnet_name.
+
+- name: Gather cluster information
+  ansible.builtin.include_tasks: gather_cluster.yml
+
+- name: Provision GPU worker VMs for NKP
+  ansible.builtin.include_tasks: provision_workers.yml
+  when: gptbox_state == 'present'
+
+- name: Configure GPU resources on workers
+  ansible.builtin.include_role:
+    name: nutanix.ansible.ai_workload_config
+  vars:
+    ai_config_nutanix_host: "{{ gptbox_nutanix_host }}"
+    ai_config_nutanix_username: "{{ gptbox_nutanix_username }}"
+    ai_config_nutanix_password: "{{ gptbox_nutanix_password }}"
+    ai_config_cluster_name: "{{ gptbox_cluster_name }}"
+    ai_config_vm_names: "{{ _gptbox_worker_vms | default([]) }}"
+    ai_config_gpu_mode: "{{ gptbox_gpu_mode }}"
+    ai_config_gpu_name: "{{ gptbox_gpu_name }}"
+    ai_config_gpu_count: "{{ gptbox_gpu_count_per_worker }}"
+  when: gptbox_state == 'present'
+
+- name: Deploy AI model inference endpoint
+  ansible.builtin.include_tasks: deploy_model.yml
+  when:
+    - gptbox_state == 'present'
+    - gptbox_deploy_model
+
+- name: Teardown GPT-in-a-Box
+  ansible.builtin.include_tasks: teardown.yml
+  when: gptbox_state == 'absent'

--- a/roles/gpt_in_a_box/tasks/provision_workers.yml
+++ b/roles/gpt_in_a_box/tasks/provision_workers.yml
@@ -1,0 +1,35 @@
+---
+- name: Create GPU worker VMs for GPT-in-a-Box
+  nutanix.ansible.ntnx_vms_v2:
+    nutanix_host: "{{ gptbox_nutanix_host }}"
+    nutanix_username: "{{ gptbox_nutanix_username }}"
+    nutanix_password: "{{ gptbox_nutanix_password }}"
+    validate_certs: "{{ gptbox_nutanix_validate_certs }}"
+    state: present
+    name: "{{ gptbox_nkp_name }}-worker-{{ item }}"
+    cluster:
+      ext_id: "{{ _gptbox_cluster.ext_id }}"
+    num_sockets: 1
+    num_cores_per_socket: "{{ gptbox_nkp_worker_vcpus }}"
+    memory_size_bytes: "{{ gptbox_nkp_worker_memory_gb * 1073741824 }}"
+    nics:
+      - network_info:
+          subnet:
+            ext_id: "{{ _gptbox_subnet.ext_id }}"
+    disks:
+      - disk_size_bytes: "{{ gptbox_nkp_worker_disk_gb * 1073741824 }}"
+        backing_info:
+          disk_type: SCSI
+    gpus:
+      - mode: "{{ gptbox_gpu_mode | upper }}"
+        name: "{{ gptbox_gpu_name | default(omit) }}"
+        vendor: "{{ gptbox_gpu_vendor }}"
+  loop: "{{ range(1, gptbox_nkp_worker_count + 1) | list }}"
+  loop_control:
+    label: "{{ gptbox_nkp_name }}-worker-{{ item }}"
+  register: _gptbox_worker_results
+
+- name: Build worker VM name list
+  ansible.builtin.set_fact:
+    _gptbox_worker_vms: >-
+      {{ range(1, gptbox_nkp_worker_count + 1) | map('regex_replace', '^(.*)$', gptbox_nkp_name ~ '-worker-\1') | list }}

--- a/roles/gpt_in_a_box/tasks/teardown.yml
+++ b/roles/gpt_in_a_box/tasks/teardown.yml
@@ -1,0 +1,39 @@
+---
+- name: Get existing worker VMs
+  nutanix.ansible.ntnx_vms_info_v2:
+    nutanix_host: "{{ gptbox_nutanix_host }}"
+    nutanix_username: "{{ gptbox_nutanix_username }}"
+    nutanix_password: "{{ gptbox_nutanix_password }}"
+    validate_certs: "{{ gptbox_nutanix_validate_certs }}"
+  register: _gptbox_all_vms
+
+- name: Find GPT-in-a-Box worker VMs
+  ansible.builtin.set_fact:
+    _gptbox_teardown_vms: >-
+      {{ _gptbox_all_vms.response | default([]) |
+         selectattr('name', 'match', gptbox_nkp_name ~ '-worker-.*') | list }}
+
+- name: Delete GPT-in-a-Box worker VMs
+  nutanix.ansible.ntnx_vms_v2:
+    nutanix_host: "{{ gptbox_nutanix_host }}"
+    nutanix_username: "{{ gptbox_nutanix_username }}"
+    nutanix_password: "{{ gptbox_nutanix_password }}"
+    validate_certs: "{{ gptbox_nutanix_validate_certs }}"
+    state: absent
+    ext_id: "{{ item.ext_id }}"
+  loop: "{{ _gptbox_teardown_vms }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: _gptbox_teardown_vms | length > 0
+
+- name: Remove model storage volume
+  nutanix.ansible.ntnx_volume_groups_v2:
+    nutanix_host: "{{ gptbox_nutanix_host }}"
+    nutanix_username: "{{ gptbox_nutanix_username }}"
+    nutanix_password: "{{ gptbox_nutanix_password }}"
+    validate_certs: "{{ gptbox_nutanix_validate_certs }}"
+    state: absent
+    name: "{{ gptbox_nkp_name }}-model-storage"
+    cluster_reference:
+      ext_id: "{{ _gptbox_cluster.ext_id }}"
+  ignore_errors: true


### PR DESCRIPTION
## Summary

Add AI Factory roles to the nutanix.ansible collection for deploying GPU-accelerated AI workloads on Nutanix infrastructure, following the Nutanix Enterprise AI (GPT-in-a-Box) reference architecture.

### New Roles

#### `gpt_in_a_box`
End-to-end provisioning of Nutanix GPT-in-a-Box following the Enterprise AI pattern:

- **Cluster discovery** — Validates target cluster and subnet availability via Prism Central
- **Worker VM provisioning** — Creates GPU-enabled NKP worker VMs with configurable CPU, memory, disk, and GPU resources using `ntnx_vms_v2`
- **GPU allocation** — Assigns GPU devices (passthrough or vGPU) to worker nodes
- **Model deployment** — Creates model storage volumes and generates deployment manifests for LLM inference endpoints
- **Teardown** — Full cleanup of worker VMs and storage volumes via `state: absent`

Configurable parameters include:
- NKP cluster sizing (control plane and worker counts, hardware specs)
- GPU mode (passthrough/vGPU), vendor, device name, count per worker
- Model deployment (name, replicas, GPU count, inference port)

#### `ai_workload_config`
Configure GPU resources on existing Nutanix AHV VMs for AI workloads:

- **GPU discovery** — Queries host information to find available GPU devices
- **Power management** — Handles VM power-off/power-on around GPU configuration changes
- **GPU assignment** — Configures passthrough or vGPU devices on target VMs
- **Batch operation** — Processes multiple VMs in a single role invocation

### Use Case

Organizations deploying Nutanix GPT-in-a-Box need automation for:
1. **Turnkey AI deployment** — Provision complete AI infrastructure from cluster to inference endpoint
2. **GPU resource management** — Assign and track GPU allocations across AI workloads
3. **Lifecycle management** — Create and teardown AI environments for development, testing, and production
4. **Repeatable deployments** — Standardize AI infrastructure provisioning across multiple clusters

Both roles use existing nutanix.ansible modules (`ntnx_vms_v2`, `ntnx_clusters_info_v2`, `ntnx_subnets_info_v2`, `ntnx_volume_groups_v2`, `ntnx_vms_power_actions_v2`).