### PR TITLE
Import/Export Security Rules Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/networks_v2/security_rules_export_import_v2.yml
+++ b/examples/networks_v2/security_rules_export_import_v2.yml
@@ -1,0 +1,58 @@
+---
+# Summary:
+# This playbook will do:
+# 1. Export specific network security policies and download them to a file
+# 2. Export all network security policies and download them to a file
+# 3. Dry-run import of all network security policies
+# 4. Import network security policies from a file
+# 5. Import network security policies and purge existing ones
+
+- name: Network Security Policies export/import playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        policy_ext_id: "d6b453b6-2c21-4672-9c16-a4b320e8bbeb"
+        export_file_path_specific: "/tmp/network_security_policies_export_specific.flw"
+        export_file_path_all: "/tmp/network_security_policies_export_all.flw"
+
+    - name: Export specific network security policies and download them to a file
+      nutanix.ncp.ntnx_security_rules_export_v2:
+        policy_references:
+          - "{{ policy_ext_id }}"
+        path: "{{ export_file_path_specific }}"
+      register: result
+      ignore_errors: true
+
+    - name: Export all network security policies and download them to a file
+      nutanix.ncp.ntnx_security_rules_export_v2:
+        path: "{{ export_file_path_all }}"
+      register: result
+      ignore_errors: true
+
+    - name: Dry-run import of all network security policies
+      nutanix.ncp.ntnx_security_rules_import_v2:
+        path: "{{ export_file_path_all }}"
+        dryrun: true
+      register: result_dryrun_all
+      ignore_errors: true
+
+    - name: Import network security policies from a file
+      nutanix.ncp.ntnx_security_rules_import_v2:
+        path: "{{ export_file_path_specific }}"
+      register: result
+      ignore_errors: true
+
+    - name: Import network security policies and purge existing ones
+      nutanix.ncp.ntnx_security_rules_import_v2:
+        path: "{{ export_file_path_all }}"
+        purge_policies: true
+      register: result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -166,6 +166,8 @@ action_groups:
     - ntnx_authorization_policies_info_v2
     - ntnx_security_rules_v2
     - ntnx_security_rules_info_v2
+    - ntnx_security_rules_export_v2
+    - ntnx_security_rules_import_v2
     - ntnx_service_groups_v2
     - ntnx_service_groups_info_v2
     - ntnx_address_groups_v2

--- a/plugins/modules/ntnx_security_rules_export_v2.py
+++ b/plugins/modules/ntnx_security_rules_export_v2.py
@@ -1,0 +1,294 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_security_rules_export_v2
+short_description: Export network security policies in Nutanix Prism Central
+version_added: "2.6.0"
+description:
+  - This module exports one or more Flow network security policies in Nutanix Prism Central.
+  - If C(policy_references) is not provided, all network security policies are exported.
+  - The exported content is always downloaded and saved to a local file. The local path is returned in C(path).
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Export Network Security Policies) -
+      Required Roles: Flow Admin, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=microseg)"
+options:
+  policy_references:
+    description:
+      - A list of network security policy external identifiers to export.
+      - If not provided, all network security policies are exported.
+    type: list
+    elements: str
+    required: false
+  path:
+    description:
+      - Local destination path where the exported network security policies file is saved.
+      - If not provided, the file is downloaded to a temporary directory and the resulting path is returned in C(path).
+      - The file can later be used by the C(ntnx_security_rules_import_v2) module to import the policies.
+      - The module always waits for the export task to complete in order to download the file.
+    type: path
+    required: false
+author:
+  - George Ghawali (@george-ghawali)
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+"""
+
+EXAMPLES = r"""
+- name: Export specific network security policies
+  nutanix.ncp.ntnx_security_rules_export_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    policy_references:
+      - "ac8e7c8a-3e6f-4f2a-8d2b-9f3a6b6f97e2"
+      - "18dbfce0-f7e1-4b19-a9e6-43b0be8c2507"
+  register: result
+  ignore_errors: true
+
+- name: Export all network security policies
+  nutanix.ncp.ntnx_security_rules_export_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+  register: result
+  ignore_errors: true
+
+- name: Export all network security policies and download them to a file
+  nutanix.ncp.ntnx_security_rules_export_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    path: "/tmp/network_security_policies_export.flw"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for exporting network security policies.
+    - If C(wait) is true, it returns the completed task details.
+    - If C(wait) is false, it returns the task reference details.
+  returned: always
+  type: dict
+  sample:
+
+task_ext_id:
+  description:
+    - The external id of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+
+path:
+  description:
+    - The local path of the downloaded export file.
+    - When C(path) is not provided, this is a path in a temporary directory.
+  returned: always
+  type: str
+  sample: "/tmp/network_security_policies_export.flw"
+"""
+
+import os  # noqa: E402
+import shutil  # noqa: E402
+import tempfile  # noqa: E402
+import traceback  # noqa: E402
+import uuid  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.flow.api_client import (  # noqa: E402
+    get_network_security_policy_api_instance,
+)
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_microseg_py_client as mic_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as mic_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        policy_references=dict(type="list", elements="str", required=False),
+        path=dict(type="path", required=False),
+    )
+    return module_args
+
+
+def download_export_file(module, network_security_policies, request_id, path, result):
+    if path:
+        dest_dir = os.path.dirname(os.path.abspath(path))
+    else:
+        dest_dir = tempfile.gettempdir()
+    if not os.path.isdir(dest_dir):
+        os.makedirs(dest_dir)
+
+    network_security_policies.api_client.configuration.download_directory = dest_dir
+
+    headers = {
+        "NTNX-Request-Id": request_id,
+        "Accept": "application/octet-stream",
+    }
+    resp = None
+    try:
+        resp = network_security_policies.list_network_security_policies(**headers)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while downloading network security policies export file",
+        )
+
+    data = resp.data
+    if isinstance(data, dict):
+        downloaded_path = data.get("path")
+    else:
+        downloaded_path = getattr(data, "path", None)
+
+    if not downloaded_path:
+        module.fail_json(
+            msg="Failed to determine the downloaded export file path", **result
+        )
+
+    downloaded_path = str(downloaded_path)
+    if path and os.path.abspath(downloaded_path) != os.path.abspath(path):
+        shutil.move(downloaded_path, path)
+        return path
+    return downloaded_path
+
+
+def export_policies(module, network_security_policies, result):
+    sg = SpecGenerator(module)
+    default_spec = mic_sdk.NetworkSecurityPolicyExportSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating network security policy export spec", **result
+        )
+
+    path = module.params.get("path")
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        if path:
+            result["path"] = path
+        return
+
+    request_id = str(uuid.uuid4())
+    kwargs = {"NTNX-Request-Id": request_id}
+    resp = None
+    try:
+        resp = network_security_policies.export_network_security_policy(
+            body=spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while exporting network security policies",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    # The export file can only be downloaded once the prepare-export task
+    # completes, so always wait for it before downloading.
+    if task_ext_id:
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+
+    result["path"] = download_export_file(
+        module, network_security_policies, request_id, path, result
+    )
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_microseg_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "failed": False,
+    }
+    network_security_policies = get_network_security_policy_api_instance(module)
+    export_policies(module, network_security_policies, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_security_rules_export_v2.py
+++ b/plugins/modules/ntnx_security_rules_export_v2.py
@@ -17,6 +17,7 @@ description:
   - This module exports one or more Flow network security policies in Nutanix Prism Central.
   - If C(policy_references) is not provided, all network security policies are exported.
   - The exported content is always downloaded and saved to a local file. The local path is returned in C(path).
+  - If C(path) is not provided, the file is saved to the current working directory using the server-provided file name.
   - This module uses PC v4 APIs based SDKs.
 notes:
     - >-
@@ -28,7 +29,7 @@ notes:
 options:
   policy_references:
     description:
-      - A list of network security policy external identifiers to export.
+      - A list of network security policy external ids to export.
       - If not provided, all network security policies are exported.
     type: list
     elements: str
@@ -38,8 +39,21 @@ options:
       - Local destination path where the exported network security policies file is saved.
       - The file can later be used by the C(ntnx_security_rules_import_v2) module to import the policies.
       - The module always waits for the export task to complete in order to download the file.
+      - If not provided, the file is downloaded to the current working directory using the
+        file name returned by the server. The final location is always returned in C(path).
     type: path
-    required: true
+    required: false
+  wait:
+    description:
+      - Wait for the export task to complete.
+      - This module must always wait for the export task to finish, because the exported
+        file can only be downloaded once the task is complete.
+      - Only C(true) is supported.
+    type: bool
+    required: false
+    default: true
+    choices:
+      - true
 author:
   - George Ghawali (@george-ghawali)
 extends_documentation_fragment:
@@ -72,17 +86,93 @@ EXAMPLES = r"""
     path: "/tmp/network_security_policies_export.flw"
   register: result
   ignore_errors: true
+
+- name: Export all network security policies without specifying a path
+  nutanix.ncp.ntnx_security_rules_export_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+  register: result
+  ignore_errors: true
 """
 
 RETURN = r"""
 response:
   description:
     - Response for exporting network security policies.
-    - If C(wait) is true, it returns the completed task details.
-    - If C(wait) is false, it returns the task reference details.
+    - It returns the completed task details.
   returned: always
   type: dict
   sample:
+    {
+      "app_name": null,
+      "batch_summary": null,
+      "cluster_ext_ids": null,
+      "completed_time": "2026-06-18T12:34:19.213650+00:00",
+      "completion_details": null,
+      "created_time": "2026-06-18T12:34:19.124020+00:00",
+      "entities_affected": [
+          {
+              "ext_id": "38d9f279-c0d7-4951-ae52-33925ac4dd11",
+              "name": "Quarantine Strict Policy",
+              "rel": "microseg:config:policy"
+          },
+          {
+              "ext_id": "6c8c9d38-c39c-4626-9b88-85f45e700a33",
+              "name": "ansible-nsr-kxigsDsDbiLt1",
+              "rel": "microseg:config:policy"
+          },
+          {
+              "ext_id": "d376aa6f-e5ad-4052-890e-e56d4b1b1b09",
+              "name": "Quarantine Forensic Policy",
+              "rel": "microseg:config:policy"
+          },
+          {
+              "ext_id": "7329e3d6-5eac-4395-6671-4ca9527780ba",
+              "name": "AnsibleSecurityRuleTest:AnsibleSecurityRuleTestkxigsDsDbiLt1",
+              "rel": "prism:config:category"
+          },
+          {
+              "ext_id": "4c313d99-ad50-5480-ae34-6c29ee35ed92",
+              "name": "Quarantine:Default",
+              "rel": "prism:config:category"
+          },
+          {
+              "ext_id": "252887b5-1462-501e-9e1d-aac971085a45",
+              "name": "Quarantine:Forensics",
+              "rel": "prism:config:category"
+          },
+          {
+              "ext_id": "8714753a-18d7-4bf7-5912-3ba62952f829",
+              "name": "AnsibleSecurityRuleTest:AnsibleSecurityRuleTestkxigsDsDbiLt0",
+              "rel": "prism:config:category"
+          }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:4c34bfa3-294d-4ac4-933a-b527e03f7f9a",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-06-18T12:34:19.213649+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 7,
+      "number_of_subtasks": 0,
+      "operation": "kNetworkSecurityPolicyExportAsync",
+      "operation_description": "Export Network Security Policy and Associated entities",
+      "owned_by": {
+          "ext_id": "00000000-0000-0000-0000-000000000000",
+          "name": "admin"
+      },
+      "parent_task": null,
+      "progress_percentage": 100,
+      "resource_links": null,
+      "root_task": null,
+      "started_time": "2026-06-18T12:34:19.135460+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
 
 task_ext_id:
   description:
@@ -112,6 +202,7 @@ msg:
   description: This indicates the message if any message occurred
   returned: When there is an error
   type: str
+  sample: "Failed to determine the downloaded export file path"
 
 path:
   description:
@@ -157,17 +248,21 @@ warnings.filterwarnings("ignore", message="Unverified HTTPS request is being mad
 def get_module_spec():
     module_args = dict(
         policy_references=dict(type="list", elements="str", required=False),
-        path=dict(type="path", required=True),
+        path=dict(type="path", required=False),
+        wait=dict(type="bool", default=True, choices=[True]),
     )
     return module_args
 
 
 def download_export_file(module, network_security_policies, request_id, path, result):
-    dest_dir = os.path.dirname(os.path.abspath(path))
-    if not os.path.isdir(dest_dir):
-        os.makedirs(dest_dir)
+    # When the user provides a path, download into its directory; otherwise let
+    # the SDK use its default download directory (the current working directory).
+    if path:
+        dest_dir = os.path.dirname(os.path.abspath(path))
+        if not os.path.isdir(dest_dir):
+            os.makedirs(dest_dir)
 
-    network_security_policies.api_client.configuration.download_directory = dest_dir
+        network_security_policies.api_client.configuration.download_directory = dest_dir
 
     headers = {
         "NTNX-Request-Id": request_id,
@@ -195,7 +290,9 @@ def download_export_file(module, network_security_policies, request_id, path, re
         )
 
     downloaded_path = str(downloaded_path)
-    if os.path.abspath(downloaded_path) != os.path.abspath(path):
+    # If a destination path was requested, move the downloaded file there;
+    # otherwise return the SDK default location as-is.
+    if path and os.path.abspath(downloaded_path) != os.path.abspath(path):
         shutil.move(downloaded_path, path)
         return path
     return downloaded_path
@@ -262,7 +359,6 @@ def run_module():
     remove_param_with_none_value(module.params)
     result = {
         "changed": False,
-        "error": None,
         "response": None,
         "failed": False,
     }

--- a/plugins/modules/ntnx_security_rules_export_v2.py
+++ b/plugins/modules/ntnx_security_rules_export_v2.py
@@ -36,11 +36,10 @@ options:
   path:
     description:
       - Local destination path where the exported network security policies file is saved.
-      - If not provided, the file is downloaded to a temporary directory and the resulting path is returned in C(path).
       - The file can later be used by the C(ntnx_security_rules_import_v2) module to import the policies.
       - The module always waits for the export task to complete in order to download the file.
     type: path
-    required: false
+    required: true
 author:
   - George Ghawali (@george-ghawali)
 extends_documentation_fragment:
@@ -51,7 +50,7 @@ extends_documentation_fragment:
 """
 
 EXAMPLES = r"""
-- name: Export specific network security policies
+- name: Export specific network security policies to a file
   nutanix.ncp.ntnx_security_rules_export_v2:
     nutanix_host: "{{ ip }}"
     nutanix_username: "{{ username }}"
@@ -60,19 +59,11 @@ EXAMPLES = r"""
     policy_references:
       - "ac8e7c8a-3e6f-4f2a-8d2b-9f3a6b6f97e2"
       - "18dbfce0-f7e1-4b19-a9e6-43b0be8c2507"
+    path: "/tmp/network_security_policies_export.flw"
   register: result
   ignore_errors: true
 
-- name: Export all network security policies
-  nutanix.ncp.ntnx_security_rules_export_v2:
-    nutanix_host: "{{ ip }}"
-    nutanix_username: "{{ username }}"
-    nutanix_password: "{{ password }}"
-    validate_certs: false
-  register: result
-  ignore_errors: true
-
-- name: Export all network security policies and download them to a file
+- name: Export all network security policies to a file
   nutanix.ncp.ntnx_security_rules_export_v2:
     nutanix_host: "{{ ip }}"
     nutanix_username: "{{ username }}"
@@ -125,7 +116,6 @@ msg:
 path:
   description:
     - The local path of the downloaded export file.
-    - When C(path) is not provided, this is a path in a temporary directory.
   returned: always
   type: str
   sample: "/tmp/network_security_policies_export.flw"
@@ -133,7 +123,6 @@ path:
 
 import os  # noqa: E402
 import shutil  # noqa: E402
-import tempfile  # noqa: E402
 import traceback  # noqa: E402
 import uuid  # noqa: E402
 import warnings  # noqa: E402
@@ -168,16 +157,13 @@ warnings.filterwarnings("ignore", message="Unverified HTTPS request is being mad
 def get_module_spec():
     module_args = dict(
         policy_references=dict(type="list", elements="str", required=False),
-        path=dict(type="path", required=False),
+        path=dict(type="path", required=True),
     )
     return module_args
 
 
 def download_export_file(module, network_security_policies, request_id, path, result):
-    if path:
-        dest_dir = os.path.dirname(os.path.abspath(path))
-    else:
-        dest_dir = tempfile.gettempdir()
+    dest_dir = os.path.dirname(os.path.abspath(path))
     if not os.path.isdir(dest_dir):
         os.makedirs(dest_dir)
 
@@ -209,7 +195,7 @@ def download_export_file(module, network_security_policies, request_id, path, re
         )
 
     downloaded_path = str(downloaded_path)
-    if path and os.path.abspath(downloaded_path) != os.path.abspath(path):
+    if os.path.abspath(downloaded_path) != os.path.abspath(path):
         shutil.move(downloaded_path, path)
         return path
     return downloaded_path
@@ -229,8 +215,7 @@ def export_policies(module, network_security_policies, result):
 
     if module.check_mode:
         result["response"] = strip_internal_attributes(spec.to_dict())
-        if path:
-            result["path"] = path
+        result["path"] = path
         return
 
     request_id = str(uuid.uuid4())

--- a/plugins/modules/ntnx_security_rules_import_v2.py
+++ b/plugins/modules/ntnx_security_rules_import_v2.py
@@ -39,7 +39,7 @@ options:
     description:
       - Whether to execute in a dry-run mode providing ability to identify trouble spots and system failures without performing the actual operation.
       - This mode offers a summary snapshot of the resultant system in order to better understand how things fit together.
-      -The operation runs in dry-run mode only if the provided value is true.
+      - The operation runs in dry-run mode only if the provided value is true.
     type: bool
     required: false
 author:

--- a/plugins/modules/ntnx_security_rules_import_v2.py
+++ b/plugins/modules/ntnx_security_rules_import_v2.py
@@ -14,7 +14,7 @@ module: ntnx_security_rules_import_v2
 short_description: Import network security policies into Nutanix Prism Central
 version_added: "2.6.0"
 description:
-  - This module imports Flow network security policies into Nutanix Prism Central from a previously exported file.
+  - This module imports Flow network security policies into Nutanix Prism Central from a data file.
   - This module uses PC v4 APIs based SDKs.
 notes:
     - >-
@@ -27,7 +27,6 @@ options:
   path:
     description:
       - Local path to the network security policies file to import.
-      - Path to exported file from ``ntnx_security_rules_export_v2`` module.
     type: path
     required: true
   purge_policies:
@@ -94,6 +93,38 @@ response:
   returned: always
   type: dict
   sample:
+    {
+      "app_name": null,
+      "batch_summary": null,
+      "cluster_ext_ids": null,
+      "completed_time": "2026-06-18T12:46:31.475401+00:00",
+      "completion_details": null,
+      "created_time": "2026-06-18T12:46:31.399813+00:00",
+      "entities_affected": null,
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:9bfb6e09-8cdf-4c80-94de-affc5292cded",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-06-18T12:46:31.475400+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 0,
+      "number_of_subtasks": 0,
+      "operation": "kNetworkSecurityPolicyImportApply",
+      "operation_description": "Import Network Security Policy and Associated entities",
+      "owned_by": {
+          "ext_id": "00000000-0000-0000-0000-000000000000",
+          "name": "admin"
+      },
+      "parent_task": null,
+      "progress_percentage": 100,
+      "resource_links": null,
+      "root_task": null,
+      "started_time": "2026-06-18T12:46:31.411897+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
 
 task_ext_id:
   description:
@@ -221,7 +252,6 @@ def run_module():
     remove_param_with_none_value(module.params)
     result = {
         "changed": False,
-        "error": None,
         "response": None,
         "failed": False,
     }

--- a/plugins/modules/ntnx_security_rules_import_v2.py
+++ b/plugins/modules/ntnx_security_rules_import_v2.py
@@ -1,0 +1,238 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_security_rules_import_v2
+short_description: Import network security policies into Nutanix Prism Central
+version_added: "2.6.0"
+description:
+  - This module imports Flow network security policies into Nutanix Prism Central from a previously exported file.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Import Network Security Policies) -
+      Required Roles: Flow Admin, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=microseg)"
+options:
+  path:
+    description:
+      - Local path to the network security policies file to import.
+      - Path to exported file from ``ntnx_security_rules_export_v2`` module.
+    type: path
+    required: true
+  purge_policies:
+    description:
+      - Specifies whether the existing policies need to be deleted (C(true)) or retained (C(false)) upon import.
+    type: bool
+    required: false
+  dryrun:
+    description:
+      - Whether to execute in a dry-run mode providing ability to identify trouble spots and system failures without performing the actual operation.
+      - This mode offers a summary snapshot of the resultant system in order to better understand how things fit together.
+      -The operation runs in dry-run mode only if the provided value is true.
+    type: bool
+    required: false
+author:
+  - George Ghawali (@george-ghawali)
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+"""
+
+EXAMPLES = r"""
+- name: Import network security policies from a file
+  nutanix.ncp.ntnx_security_rules_import_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    path: "/tmp/network_security_policies_export.flw"
+  register: result
+  ignore_errors: true
+
+- name: Import network security policies and purge existing ones
+  nutanix.ncp.ntnx_security_rules_import_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    path: "/tmp/network_security_policies_export.flw"
+    purge_policies: true
+  register: result
+  ignore_errors: true
+
+- name: Dry-run import of network security policies
+  nutanix.ncp.ntnx_security_rules_import_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    path: "/tmp/network_security_policies_export.flw"
+    dryrun: true
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for importing network security policies.
+    - If C(wait) is true, it returns the completed task details.
+    - If C(wait) is false, it returns the task reference details.
+  returned: always
+  type: dict
+  sample:
+
+task_ext_id:
+  description:
+    - The external id of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error or in check mode
+  type: str
+
+path:
+  description: The path of the file that was used for the import.
+  returned: always
+  type: str
+  sample: "/tmp/network_security_policies_export.flw"
+"""
+
+import warnings  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.flow.api_client import (  # noqa: E402
+    get_network_security_policy_api_instance,
+)
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        path=dict(type="path", required=True),
+        purge_policies=dict(type="bool", required=False),
+        dryrun=dict(type="bool", required=False),
+    )
+    return module_args
+
+
+def import_policies(module, network_security_policies, result):
+    file_path = Path(module.params.get("path"))
+    result["path"] = str(file_path)
+
+    if module.check_mode:
+        result["msg"] = (
+            "Network security policies from file:{0} will be imported.".format(
+                str(file_path)
+            )
+        )
+        return
+
+    if not file_path.is_file():
+        module.fail_json(
+            msg="The provided path '{0}' is not a valid file".format(str(file_path)),
+            **result,
+        )
+
+    kwargs = {}
+    if module.params.get("purge_policies") is not None:
+        kwargs["NTNX_Purge_Policies"] = module.params.get("purge_policies")
+    if module.params.get("dryrun") is not None:
+        kwargs["_dryrun"] = module.params.get("dryrun")
+
+    resp = None
+    try:
+        resp = network_security_policies.apply_network_security_policy_import(
+            path=file_path, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while importing network security policies",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_microseg_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "failed": False,
+    }
+    network_security_policies = get_network_security_policy_api_instance(module)
+    import_policies(module, network_security_policies, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/ntnx_security_rules_export_import_v2/aliases
+++ b/tests/integration/targets/ntnx_security_rules_export_import_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_security_rules_export_import_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_security_rules_export_import_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_security_rules_export_import_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_security_rules_export_import_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import security_rules_export_import.yml
+      ansible.builtin.import_tasks: security_rules_export_import.yml

--- a/tests/integration/targets/ntnx_security_rules_export_import_v2/tasks/security_rules_export_import.yml
+++ b/tests/integration/targets/ntnx_security_rules_export_import_v2/tasks/security_rules_export_import.yml
@@ -6,6 +6,7 @@
 - name: Set export/import file paths
   ansible.builtin.set_fact:
     export_file: "/tmp/ntnx_nsp_export_{{ 999999 | random }}.flw"
+    export_file_all: "/tmp/ntnx_nsp_export_all_{{ 999999 | random }}.flw"
     missing_export_file: "/tmp/ntnx_nsp_export_does_not_exist_{{ 999999 | random }}.flw"
 
 ########################################################################################
@@ -122,6 +123,32 @@
     policy_ext_id_2: "{{ result.ext_id }}"
 
 ########################################################################################
+# Export - negative: missing required path
+########################################################################################
+
+- name: Export of network security policies without the required path
+  nutanix.ncp.ntnx_security_rules_export_v2:
+    policy_references:
+      - "{{ policy_ext_id_1 }}"
+  register: result
+  ignore_errors: true
+
+- name: Print export without the required path result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify export without the required path fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - result.msg is defined
+      - result.msg == "missing required arguments: path"
+    success_msg: "Export without the required path failed as expected"
+    fail_msg: "Export without the required path did not fail as expected"
+
+########################################################################################
 # Export - check mode
 ########################################################################################
 
@@ -129,6 +156,7 @@
   nutanix.ncp.ntnx_security_rules_export_v2:
     policy_references:
       - "{{ policy_ext_id_1 }}"
+    path: "{{ export_file }}"
   register: result
   check_mode: true
   ignore_errors: true
@@ -147,6 +175,7 @@
       - result.response.policy_references is defined
       - result.response.policy_references | length == 1
       - result.response.policy_references[0] == policy_ext_id_1
+      - result.path == export_file
     success_msg: "Export of network security policy check mode passed"
     fail_msg: "Export of network security policy check mode failed"
 
@@ -198,11 +227,12 @@
     fail_msg: "Export file was not downloaded to the provided file path"
 
 ########################################################################################
-# Export of all policies without a file path (downloads to a default temporary path)
+# Export of all policies to a provided file path
 ########################################################################################
 
-- name: Export of all network security policies without a file path
+- name: Export of all network security policies to a provided file path
   nutanix.ncp.ntnx_security_rules_export_v2:
+    path: "{{ export_file_all }}"
   register: result
   ignore_errors: true
 
@@ -218,32 +248,27 @@
       - result.failed == false
       - result.task_ext_id is defined
       - result.response.status == "SUCCEEDED"
-      - result.path is defined
-      - result.path | length > 0
+      - result.path == export_file_all
     success_msg: "Export of all network security policies succeeded"
     fail_msg: "Export of all network security policies failed"
 
-- name: Set default downloaded export file path
-  ansible.builtin.set_fact:
-    default_export_file: "{{ result.path }}"
-
-- name: Stat the default downloaded export file
+- name: Stat the downloaded export-all file
   ansible.builtin.stat:
-    path: "{{ default_export_file }}"
-  register: default_export_file_stat
+    path: "{{ export_file_all }}"
+  register: export_file_all_stat
 
-- name: Print the default downloaded export file
+- name: Print the downloaded export-all file
   ansible.builtin.debug:
-    var: default_export_file_stat
+    var: export_file_all_stat
 
-- name: Verify the export file was downloaded to a default path
+- name: Verify the export file was downloaded to the provided file path
   ansible.builtin.assert:
     that:
-      - default_export_file_stat.stat.exists
-      - default_export_file_stat.stat.size > 0
-      - default_export_file_stat.stat.path == default_export_file
-    success_msg: "Export file downloaded successfully to a default path ({{ default_export_file }})"
-    fail_msg: "Export file was not downloaded to a default path"
+      - export_file_all_stat.stat.exists
+      - export_file_all_stat.stat.size > 0
+      - export_file_all_stat.stat.path == export_file_all
+    success_msg: "Export-all file downloaded successfully to the provided file path ({{ export_file_all }})"
+    fail_msg: "Export-all file was not downloaded to the provided file path"
 
 ########################################################################################
 # Export - negative: non-existent policy reference
@@ -253,6 +278,7 @@
   nutanix.ncp.ntnx_security_rules_export_v2:
     policy_references:
       - "00000000-0000-0000-0000-000000000000"
+    path: "{{ export_file }}"
   register: result
   ignore_errors: true
 
@@ -484,7 +510,7 @@
   register: result
   loop:
     - "{{ export_file }}"
-    - "{{ default_export_file | default('') }}"
+    - "{{ export_file_all }}"
 
 - name: Stat the downloaded export files after deletion
   ansible.builtin.stat:
@@ -492,7 +518,7 @@
   register: deleted_export_files_stat
   loop:
     - "{{ export_file }}"
-    - "{{ default_export_file | default('') }}"
+    - "{{ export_file_all }}"
 
 - name: Verify the downloaded export files were deleted
   ansible.builtin.assert:

--- a/tests/integration/targets/ntnx_security_rules_export_import_v2/tasks/security_rules_export_import.yml
+++ b/tests/integration/targets/ntnx_security_rules_export_import_v2/tasks/security_rules_export_import.yml
@@ -8,6 +8,7 @@
     export_file: "/tmp/ntnx_nsp_export_{{ 999999 | random }}.flw"
     export_file_all: "/tmp/ntnx_nsp_export_all_{{ 999999 | random }}.flw"
     missing_export_file: "/tmp/ntnx_nsp_export_does_not_exist_{{ 999999 | random }}.flw"
+    export_file_no_path: ""
 
 ########################################################################################
 # Test Setup - create categories and two network security policies for export
@@ -123,30 +124,45 @@
     policy_ext_id_2: "{{ result.ext_id }}"
 
 ########################################################################################
-# Export - negative: missing required path
+# Export without a path - file is downloaded to the default location (current dir)
 ########################################################################################
 
-- name: Export of network security policies without the required path
+- name: Export of network security policies without specifying a path
   nutanix.ncp.ntnx_security_rules_export_v2:
     policy_references:
       - "{{ policy_ext_id_1 }}"
   register: result
   ignore_errors: true
 
-- name: Print export without the required path result
-  ansible.builtin.debug:
-    var: result
+- name: Set the export file path returned when no path is provided
+  ansible.builtin.set_fact:
+    export_file_no_path: "{{ result.path | default('') }}"
 
-- name: Verify export without the required path fails
+- name: Verify export without a path succeeds and downloads to the default location
   ansible.builtin.assert:
     that:
       - result is defined
-      - result.failed == true
-      - result.changed == false
-      - result.msg is defined
-      - result.msg == "missing required arguments: path"
-    success_msg: "Export without the required path failed as expected"
-    fail_msg: "Export without the required path did not fail as expected"
+      - result.changed == true
+      - result.failed == false
+      - result.task_ext_id is defined
+      - result.response.status == "SUCCEEDED"
+      - result.path is defined
+      - result.path | length > 0
+    success_msg: "Export without a path succeeded and downloaded to the default location"
+    fail_msg: "Export without a path did not succeed as expected"
+
+- name: Stat the export file downloaded to the default location
+  ansible.builtin.stat:
+    path: "{{ export_file_no_path }}"
+  register: export_file_no_path_stat
+
+- name: Verify the export file was downloaded to the default location
+  ansible.builtin.assert:
+    that:
+      - export_file_no_path_stat.stat.exists
+      - export_file_no_path_stat.stat.size > 0
+    success_msg: "Export file downloaded successfully to the default location ({{ export_file_no_path }})"
+    fail_msg: "Export file was not downloaded to the default location"
 
 ########################################################################################
 # Export - check mode
@@ -160,10 +176,6 @@
   register: result
   check_mode: true
   ignore_errors: true
-
-- name: Print export check mode result
-  ansible.builtin.debug:
-    var: result
 
 - name: Verify export of network security policy check mode
   ansible.builtin.assert:
@@ -192,10 +204,6 @@
   register: result
   ignore_errors: true
 
-- name: Print export of the two created network security policies result
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify export of the two created network security policies
   ansible.builtin.assert:
     that:
@@ -212,10 +220,6 @@
   ansible.builtin.stat:
     path: "{{ export_file }}"
   register: export_file_stat
-
-- name: Print the downloaded export file
-  ansible.builtin.debug:
-    var: export_file_stat
 
 - name: Verify the export file was downloaded to the provided file path
   ansible.builtin.assert:
@@ -236,10 +240,6 @@
   register: result
   ignore_errors: true
 
-- name: Print export of all network security policies result
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify export of all network security policies
   ansible.builtin.assert:
     that:
@@ -256,10 +256,6 @@
   ansible.builtin.stat:
     path: "{{ export_file_all }}"
   register: export_file_all_stat
-
-- name: Print the downloaded export-all file
-  ansible.builtin.debug:
-    var: export_file_all_stat
 
 - name: Verify the export file was downloaded to the provided file path
   ansible.builtin.assert:
@@ -281,10 +277,6 @@
     path: "{{ export_file }}"
   register: result
   ignore_errors: true
-
-- name: Print export with a non-existent policy reference result
-  ansible.builtin.debug:
-    var: result
 
 - name: Verify export with a non-existent policy reference fails
   ansible.builtin.assert:
@@ -310,10 +302,6 @@
   check_mode: true
   ignore_errors: true
 
-- name: Print import check mode result
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify import of network security policy check mode
   ansible.builtin.assert:
     that:
@@ -337,10 +325,6 @@
     dryrun: true
   register: result
   ignore_errors: true
-
-- name: Print import dry-run result
-  ansible.builtin.debug:
-    var: result
 
 - name: Verify import of network security policy dry-run
   ansible.builtin.assert:
@@ -370,6 +354,9 @@
 - name: Verify deletion before import
   ansible.builtin.assert:
     that:
+      - result.changed == true
+      - result.msg == "All items completed"
+      - result.results | length == 2
       - item.changed == true
       - item.failed == false
       - item.response.status == "SUCCEEDED"
@@ -382,10 +369,6 @@
     path: "{{ export_file }}"
   register: result
   ignore_errors: true
-
-- name: Print import result
-  ansible.builtin.debug:
-    var: result
 
 - name: Verify import succeeded
   ansible.builtin.assert:
@@ -439,10 +422,6 @@
   register: result
   ignore_errors: true
 
-- name: Print import from a non-existent file result
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify import from a non-existent file fails
   ansible.builtin.assert:
     that:
@@ -471,6 +450,9 @@
 - name: Verify network security policies deletion status
   ansible.builtin.assert:
     that:
+      - result.changed == true
+      - result.msg == "All items completed"
+      - result.results | length == 2
       - item.changed == true
       - item.failed == false
       - item.response.status == "SUCCEEDED"
@@ -487,10 +469,6 @@
     - "{{ category1_ext_id }}"
     - "{{ category2_ext_id }}"
 
-- name: Print categories deletion result
-  ansible.builtin.debug:
-    var: result
-
 - name: Verify categories deletion status
   ansible.builtin.assert:
     that:
@@ -502,6 +480,12 @@
     fail_msg: Failed to delete category with external ID {{ item.ext_id }}
     success_msg: Successfully deleted category with external ID {{ item.ext_id }}
   loop: "{{ result.results }}"
+
+- name: Delete the export file downloaded to the default location
+  ansible.builtin.file:
+    path: "{{ export_file_no_path }}"
+    state: absent
+  when: export_file_no_path | length > 0
 
 - name: Delete the downloaded export files
   ansible.builtin.file:

--- a/tests/integration/targets/ntnx_security_rules_export_import_v2/tasks/security_rules_export_import.yml
+++ b/tests/integration/targets/ntnx_security_rules_export_import_v2/tasks/security_rules_export_import.yml
@@ -1,0 +1,503 @@
+---
+- name: Start network security policies export/import tests
+  ansible.builtin.debug:
+    msg: Start network security policies export/import tests
+
+- name: Set export/import file paths
+  ansible.builtin.set_fact:
+    export_file: "/tmp/ntnx_nsp_export_{{ 999999 | random }}.flw"
+    missing_export_file: "/tmp/ntnx_nsp_export_does_not_exist_{{ 999999 | random }}.flw"
+
+########################################################################################
+# Test Setup - create categories and two network security policies for export
+########################################################################################
+
+- name: Generate random name for test entities
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set entity names
+  ansible.builtin.set_fact:
+    prefix: ansible-nsp-export-
+    policy_name_1: "ansible-nsp-export-{{ random_name }}1"
+    policy_name_2: "ansible-nsp-export-{{ random_name }}2"
+
+- name: Create categories to be used in the test policies
+  nutanix.ncp.ntnx_categories_v2:
+    key: AnsibleCategoryKey{{ random_name }}{{ item }}
+    value: AnsibleCategoryValue{{ random_name }}{{ item }}
+    description: ansible export/import test
+  register: categories_result
+  loop: [0, 1]
+
+- name: Verify category creation status
+  ansible.builtin.assert:
+    that:
+      - item.changed == true
+      - item.failed == false
+      - item.ext_id is defined
+      - item.ext_id == item.response.ext_id
+      - item.response is defined
+      - item.response.key == "AnsibleCategoryKey" ~ random_name ~ item.item
+      - item.response.value == "AnsibleCategoryValue" ~ random_name ~ item.item
+    fail_msg: Failed to create category
+    success_msg: Successfully created category
+  loop: "{{ categories_result.results }}"
+
+- name: Set categories to be used in the test policies
+  ansible.builtin.set_fact:
+    category1_ext_id: "{{ categories_result.results[0].response.ext_id }}"
+    category2_ext_id: "{{ categories_result.results[1].response.ext_id }}"
+
+- name: Create first network security policy
+  nutanix.ncp.ntnx_security_rules_v2:
+    name: "{{ policy_name_1 }}"
+    description: Ansible created policy for export and import tests
+    type: APPLICATION
+    policy_state: MONITOR
+    scope: ALL_VLAN
+    rules:
+      - description: intra group rule
+        type: INTRA_GROUP
+        spec:
+          intra_entity_group_rule_spec:
+            secured_group_category_references:
+              - "{{ category1_ext_id }}"
+            secured_group_action: ALLOW
+  register: result
+
+- name: Verify first network security policy creation status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.ext_id == result.response.ext_id
+      - result.response.name == policy_name_1
+      - result.response.type == "APPLICATION"
+      - result.response.state == "MONITOR"
+      - result.response.scope == "ALL_VLAN"
+    fail_msg: Failed to create first network security policy
+    success_msg: Successfully created first network security policy
+
+- name: Set first policy external ID
+  ansible.builtin.set_fact:
+    policy_ext_id_1: "{{ result.ext_id }}"
+
+- name: Create second network security policy
+  nutanix.ncp.ntnx_security_rules_v2:
+    name: "{{ policy_name_2 }}"
+    description: Ansible created policy for export and import tests
+    type: APPLICATION
+    policy_state: MONITOR
+    scope: ALL_VLAN
+    rules:
+      - description: intra group rule
+        type: INTRA_GROUP
+        spec:
+          intra_entity_group_rule_spec:
+            secured_group_category_references:
+              - "{{ category2_ext_id }}"
+            secured_group_action: ALLOW
+  register: result
+
+- name: Verify second network security policy creation status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.ext_id == result.response.ext_id
+      - result.response.name == policy_name_2
+      - result.response.type == "APPLICATION"
+      - result.response.state == "MONITOR"
+      - result.response.scope == "ALL_VLAN"
+    fail_msg: Failed to create second network security policy
+    success_msg: Successfully created second network security policy
+
+- name: Set second policy external ID
+  ansible.builtin.set_fact:
+    policy_ext_id_2: "{{ result.ext_id }}"
+
+########################################################################################
+# Export - check mode
+########################################################################################
+
+- name: Export of network security policies - check mode
+  nutanix.ncp.ntnx_security_rules_export_v2:
+    policy_references:
+      - "{{ policy_ext_id_1 }}"
+  register: result
+  check_mode: true
+  ignore_errors: true
+
+- name: Print export check mode result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify export of network security policy check mode
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.policy_references is defined
+      - result.response.policy_references | length == 1
+      - result.response.policy_references[0] == policy_ext_id_1
+    success_msg: "Export of network security policy check mode passed"
+    fail_msg: "Export of network security policy check mode failed"
+
+########################################################################################
+# Export of the two created policies and download to a provided file path
+########################################################################################
+
+- name: Export of the two created network security policies to a provided file path
+  nutanix.ncp.ntnx_security_rules_export_v2:
+    policy_references:
+      - "{{ policy_ext_id_1 }}"
+      - "{{ policy_ext_id_2 }}"
+    path: "{{ export_file }}"
+  register: result
+  ignore_errors: true
+
+- name: Print export of the two created network security policies result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify export of the two created network security policies
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.task_ext_id is defined
+      - result.response.status == "SUCCEEDED"
+      - result.path == export_file
+    success_msg: "Export of the two created network security policies succeeded"
+    fail_msg: "Export of the two created network security policies failed"
+
+- name: Stat the downloaded export file
+  ansible.builtin.stat:
+    path: "{{ export_file }}"
+  register: export_file_stat
+
+- name: Print the downloaded export file
+  ansible.builtin.debug:
+    var: export_file_stat
+
+- name: Verify the export file was downloaded to the provided file path
+  ansible.builtin.assert:
+    that:
+      - export_file_stat.stat.exists
+      - export_file_stat.stat.size > 0
+      - export_file_stat.stat.path == export_file
+    success_msg: "Export file downloaded successfully to the provided file path"
+    fail_msg: "Export file was not downloaded to the provided file path"
+
+########################################################################################
+# Export of all policies without a file path (downloads to a default temporary path)
+########################################################################################
+
+- name: Export of all network security policies without a file path
+  nutanix.ncp.ntnx_security_rules_export_v2:
+  register: result
+  ignore_errors: true
+
+- name: Print export of all network security policies result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify export of all network security policies
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.task_ext_id is defined
+      - result.response.status == "SUCCEEDED"
+      - result.path is defined
+      - result.path | length > 0
+    success_msg: "Export of all network security policies succeeded"
+    fail_msg: "Export of all network security policies failed"
+
+- name: Set default downloaded export file path
+  ansible.builtin.set_fact:
+    default_export_file: "{{ result.path }}"
+
+- name: Stat the default downloaded export file
+  ansible.builtin.stat:
+    path: "{{ default_export_file }}"
+  register: default_export_file_stat
+
+- name: Print the default downloaded export file
+  ansible.builtin.debug:
+    var: default_export_file_stat
+
+- name: Verify the export file was downloaded to a default path
+  ansible.builtin.assert:
+    that:
+      - default_export_file_stat.stat.exists
+      - default_export_file_stat.stat.size > 0
+      - default_export_file_stat.stat.path == default_export_file
+    success_msg: "Export file downloaded successfully to a default path ({{ default_export_file }})"
+    fail_msg: "Export file was not downloaded to a default path"
+
+########################################################################################
+# Export - negative: non-existent policy reference
+########################################################################################
+
+- name: Export with a non-existent policy reference
+  nutanix.ncp.ntnx_security_rules_export_v2:
+    policy_references:
+      - "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Print export with a non-existent policy reference result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify export with a non-existent policy reference fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - result.response is defined
+      - result.response.status == "FAILED"
+      - result.response.error_messages is defined
+      - result.response.error_messages | length > 0
+    success_msg: "Export with a non-existent policy reference failed as expected"
+    fail_msg: "Export with a non-existent policy reference did not fail as expected"
+
+########################################################################################
+# Import - check mode using the downloaded export file
+########################################################################################
+
+- name: Import network security policies - check mode
+  nutanix.ncp.ntnx_security_rules_import_v2:
+    path: "{{ export_file }}"
+  register: result
+  check_mode: true
+  ignore_errors: true
+
+- name: Print import check mode result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify import of network security policy check mode
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.msg is defined
+      - >-
+        result.msg == "Network security policies from file:" ~ export_file ~ " will be imported."
+      - result.path == export_file
+    success_msg: "Import of network security policy check mode passed"
+    fail_msg: "Import of network security policy check mode failed"
+
+########################################################################################
+# Import - dry-run using the downloaded export file
+########################################################################################
+
+- name: Import network security policies - dry-run
+  nutanix.ncp.ntnx_security_rules_import_v2:
+    path: "{{ export_file }}"
+    dryrun: true
+  register: result
+  ignore_errors: true
+
+- name: Print import dry-run result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify import of network security policy dry-run
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.task_ext_id is defined
+      - result.response.status == "SUCCEEDED"
+      - result.path == export_file
+    success_msg: "Import of network security policy dry-run passed"
+    fail_msg: "Import of network security policy dry-run failed"
+
+########################################################################################
+# Delete the created policies then import them back from the file
+########################################################################################
+
+- name: Delete the two created network security policies before importing them back
+  nutanix.ncp.ntnx_security_rules_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  register: result
+  loop:
+    - "{{ policy_ext_id_1 }}"
+    - "{{ policy_ext_id_2 }}"
+
+- name: Verify deletion before import
+  ansible.builtin.assert:
+    that:
+      - item.changed == true
+      - item.failed == false
+      - item.response.status == "SUCCEEDED"
+    fail_msg: Failed to delete network security policy before import
+    success_msg: Successfully deleted network security policy before import
+  loop: "{{ result.results }}"
+
+- name: Import the network security policies from the downloaded file
+  nutanix.ncp.ntnx_security_rules_import_v2:
+    path: "{{ export_file }}"
+  register: result
+  ignore_errors: true
+
+- name: Print import result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify import succeeded
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.task_ext_id is defined
+      - result.response.status == "SUCCEEDED"
+      - result.path == export_file
+    success_msg: "Import of network security policies succeeded"
+    fail_msg: "Import of network security policies failed"
+
+- name: Get the first policy after import
+  nutanix.ncp.ntnx_security_rules_info_v2:
+    ext_id: "{{ policy_ext_id_1 }}"
+  register: imported_policy_1
+  ignore_errors: true
+
+- name: Get the second policy after import
+  nutanix.ncp.ntnx_security_rules_info_v2:
+    ext_id: "{{ policy_ext_id_2 }}"
+  register: imported_policy_2
+  ignore_errors: true
+
+- name: Verify both policies were restored with the same external IDs
+  ansible.builtin.assert:
+    that:
+      - imported_policy_1.failed == false
+      - imported_policy_1.response.ext_id == policy_ext_id_1
+      - imported_policy_1.response.name == policy_name_1
+      - imported_policy_1.response.type == "APPLICATION"
+      - imported_policy_1.response.state == "MONITOR"
+      - imported_policy_1.response.scope == "ALL_VLAN"
+      - imported_policy_2.failed == false
+      - imported_policy_2.response.ext_id == policy_ext_id_2
+      - imported_policy_2.response.name == policy_name_2
+      - imported_policy_2.response.type == "APPLICATION"
+      - imported_policy_2.response.state == "MONITOR"
+      - imported_policy_2.response.scope == "ALL_VLAN"
+    success_msg: "Both network security policies were restored by the import"
+    fail_msg: "Imported network security policies were not restored as expected"
+
+########################################################################################
+# Import - negative: non-existent file path
+########################################################################################
+
+- name: Import network security policies from a non-existent file
+  nutanix.ncp.ntnx_security_rules_import_v2:
+    path: "{{ missing_export_file }}"
+  register: result
+  ignore_errors: true
+
+- name: Print import from a non-existent file result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify import from a non-existent file fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - >-
+        result.msg == "The provided path '" ~ missing_export_file ~ "' is not a valid file"
+      - result.path == missing_export_file
+    success_msg: "Import from a non-existent file failed as expected"
+    fail_msg: "Import from a non-existent file did not fail as expected"
+
+########################################################################################
+# Cleanup - delete the created policies and categories
+########################################################################################
+
+- name: Delete the two created network security policies
+  nutanix.ncp.ntnx_security_rules_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  register: result
+  loop:
+    - "{{ policy_ext_id_1 }}"
+    - "{{ policy_ext_id_2 }}"
+
+- name: Verify network security policies deletion status
+  ansible.builtin.assert:
+    that:
+      - item.changed == true
+      - item.failed == false
+      - item.response.status == "SUCCEEDED"
+    fail_msg: Failed to delete network security policy with external ID {{ item.ext_id }}
+    success_msg: Successfully deleted network security policy with external ID {{ item.ext_id }}
+  loop: "{{ result.results }}"
+
+- name: Delete the created categories
+  nutanix.ncp.ntnx_categories_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  register: result
+  loop:
+    - "{{ category1_ext_id }}"
+    - "{{ category2_ext_id }}"
+
+- name: Print categories deletion result
+  ansible.builtin.debug:
+    var: result
+
+- name: Verify categories deletion status
+  ansible.builtin.assert:
+    that:
+      - item.changed == true
+      - item.failed == false
+      - result.changed == true
+      - result.msg == "All items completed"
+      - result.results | length == 2
+    fail_msg: Failed to delete category with external ID {{ item.ext_id }}
+    success_msg: Successfully deleted category with external ID {{ item.ext_id }}
+  loop: "{{ result.results }}"
+
+- name: Delete the downloaded export files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  register: result
+  loop:
+    - "{{ export_file }}"
+    - "{{ default_export_file | default('') }}"
+
+- name: Stat the downloaded export files after deletion
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  register: deleted_export_files_stat
+  loop:
+    - "{{ export_file }}"
+    - "{{ default_export_file | default('') }}"
+
+- name: Verify the downloaded export files were deleted
+  ansible.builtin.assert:
+    that:
+      - item.stat.exists == false
+    fail_msg: "Export file {{ item.item }} was not deleted"
+    success_msg: "Export file {{ item.item }} was deleted successfully"
+  loop: "{{ deleted_export_files_stat.results }}"


### PR DESCRIPTION
# Network Security Policies Export/Import Modules for Nutanix Prism Central

Adds Ansible modules for exporting and importing Flow network security policies on Nutanix Prism Central using v4 APIs.

## New Modules

| Module | Description |
|--------|-------------|
| `ntnx_security_rules_export_v2` | Export one, several, or all Flow network security policies and download them to a local `.flw` file |
| `ntnx_security_rules_import_v2` | Import Flow network security policies from a previously exported `.flw` file, with optional purge and dry-run |

## Features

- **Export**: Export specific policies via `policy_references`, or omit it to export all network security policies.
- **Always downloads the file**: The export task is always awaited and the resulting `.flw` content is downloaded to disk; the saved location is returned in `path`.
- **Configurable destination**: Provide `path` to save the export to an explicit location, or omit it to download to a temporary directory (the chosen path is returned either way).
- **Import**: Import from a local `.flw` file via `path`, with `purge_policies` to delete existing policies on import and `dryrun` to preview the impact without applying changes.
- **Round-trip safe**: Exported policies re-import with their original external IDs, names, types, states, and scopes.
- **Request-ID correlation**: The export uses a single `NTNX-Request-Id` to prepare and download the file in one consistent flow.
- **Check mode**: Both modules support check mode (export reports the selected references, import reports the file that would be imported).

## Examples

- `examples/networks_v2/security_rules_export_import_v2.yml`

## Integration Tests

- `tests/integration/targets/ntnx_security_rules_export_import_v2/` — full export → delete → import round-trip with restoration verification, plus check mode, dry-run import, and negative tests (non-existent policy reference, non-existent import file), and download/cleanup verification
