### PR TITLE
Directory Services Connection Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/iam_v2/directory_services_connection_v2.yml
+++ b/examples/iam_v2/directory_services_connection_v2.yml
@@ -1,0 +1,31 @@
+---
+# Summary:
+# This playbook will check the connection to an existing directory service using its external ID.
+
+- name: Directory Services Connection playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        directory_service:
+          ext_id: "12345678-1234-1234-1234-123456789012"
+          username: "admin@example.com"
+          password: "password"
+
+    - name: Check connection to directory service
+      nutanix.ncp.ntnx_directory_services_connection_v2:
+        ext_id: "{{ directory_service.ext_id }}"
+        username: "{{ directory_service.username }}"
+        password: "{{ directory_service.password }}"
+      register: connection_result
+
+    - name: Print connection check result
+      ansible.builtin.debug:
+        msg: "{{ connection_result.response }}"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -155,6 +155,7 @@ action_groups:
     - ntnx_roles_info_v2
     - ntnx_directory_services_v2
     - ntnx_directory_services_info_v2
+    - ntnx_directory_services_connection_v2
     - ntnx_saml_identity_providers_v2
     - ntnx_saml_identity_providers_info_v2
     - ntnx_user_groups_v2

--- a/plugins/modules/ntnx_directory_services_connection_v2.py
+++ b/plugins/modules/ntnx_directory_services_connection_v2.py
@@ -174,7 +174,6 @@ def check_directory_service_connection(module, directory_services, result):
         )
 
     result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
-    result["changed"] = True
 
 
 def run_module():
@@ -190,6 +189,7 @@ def run_module():
     remove_param_with_none_value(module.params)
     result = {
         "changed": False,
+        "failed": False,
         "response": None,
         "ext_id": None,
     }

--- a/plugins/modules/ntnx_directory_services_connection_v2.py
+++ b/plugins/modules/ntnx_directory_services_connection_v2.py
@@ -1,0 +1,206 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_directory_services_connection_v2
+short_description: Check the connection to a directory service in Nutanix PC.
+version_added: "2.6.0"
+description:
+    - This module is used to verify the connection to a directory service in Nutanix PC.
+    - The connection is verified using the provided service account credentials.
+    - This module uses PC v4 APIs based SDKs
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Check directory service connection) -
+      Required Roles: Nutanix Central Admin, Prism Admin, Prism Viewer, Project Manager,
+      Super Admin, Self-Service Admin (deprecated)
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=iam)"
+options:
+    state:
+        description:
+            - State of the module.
+            - If state is present, the module will check the connection to the directory service.
+            - If state is not present, the module will fail.
+        type: str
+        choices:
+            - present
+        default: present
+    ext_id:
+        description:
+            - External ID of the directory service to check the connection for.
+        type: str
+        required: true
+    username:
+        description:
+            - Username used to connect to the directory service.
+        type: str
+        required: true
+    password:
+        description:
+            - Password used to connect to the directory service.
+        type: str
+        required: true
+extends_documentation_fragment:
+      - nutanix.ncp.ntnx_credentials
+      - nutanix.ncp.ntnx_operations_v2
+      - nutanix.ncp.ntnx_logger
+      - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Check connection to directory service
+  nutanix.ncp.ntnx_directory_services_connection_v2:
+    ext_id: "6863c60b-ae9d-5c32-b8c1-2d45b9ba343a"
+    username: "admin@example.com"
+    password: "password"
+  register: connection_result
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for checking the connection to the directory service.
+        - Contains the connection status message.
+    type: dict
+    returned: always
+    sample:
+        {
+            "message": "Directory Service connection check successful."
+        }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  returned: always
+  type: str
+
+failed:
+    description: This field indicates if the task execution failed
+    returned: always
+    type: bool
+    sample: false
+
+ext_id:
+  description: External ID of the directory service for which the connection was checked.
+  returned: always
+  type: str
+  sample: "6863c60b-ae9d-5c32-b8c1-2d45b9ba343a"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.iam.api_client import (  # noqa: E402
+    get_directory_service_api_instance,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_iam_py_client as iam_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as iam_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        ext_id=dict(type="str", required=True),
+        username=dict(type="str", required=True),
+        password=dict(type="str", required=True, no_log=True),
+    )
+    return module_args
+
+
+def check_directory_service_connection(module, directory_services, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    sg = SpecGenerator(module)
+    default_spec = iam_sdk.DirectoryServiceConnectionRequest()
+    spec, err = sg.generate_spec(obj=default_spec)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating directory service connection spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = directory_services.connection_status_directory_service(
+            extId=ext_id, body=spec
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while checking directory service connection",
+        )
+
+    result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_iam_py_client"), exception=SDK_IMP_ERROR
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+    }
+    directory_services = get_directory_service_api_instance(module)
+    check_directory_service_connection(module, directory_services, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/ntnx_directory_services_v2/tasks/all_operations.yml
+++ b/tests/integration/targets/ntnx_directory_services_v2/tasks/all_operations.yml
@@ -34,8 +34,8 @@
   ansible.builtin.assert:
     that:
       - result.response is defined
-      - result.changed == False
-      - result.failed == False
+      - result.changed == false
+      - result.failed == false
       - result.response.name == "{{ directory_service }}"
       - result.response.domain_name == "{{ active_directory.domain_name }}"
       - result.response.directory_type == "ACTIVE_DIRECTORY"
@@ -75,8 +75,8 @@
   ansible.builtin.assert:
     that:
       - result.response is defined
-      - result.changed == False
-      - result.failed == False
+      - result.changed == false
+      - result.failed == false
       - result.response.name == "{{ directory_service }}_name"
       - result.response.domain_name == "{{ directory_service }}_domain_name"
       - result.response.directory_type == "OPEN_LDAP"
@@ -115,7 +115,7 @@
     that:
       - result.response is defined
       - result.changed == true
-      - result.failed == False
+      - result.failed == false
       - result.response.name == "{{ directory_service }}"
       - result.response.directory_type == "ACTIVE_DIRECTORY"
       - result.response.url == "{{ active_directory.url }}"
@@ -153,8 +153,8 @@
   ansible.builtin.assert:
     that:
       - result.response is defined
-      - result.changed == False
-      - result.failed == True
+      - result.changed == false
+      - result.failed == true
       - result.response.data.error | length > 0
       - result.status == 409
     fail_msg: "Unable to create ACTIVE_DIRECTORY service "
@@ -184,7 +184,7 @@
     that:
       - result.response is defined
       - result.changed == true
-      - result.failed == False
+      - result.failed == false
       - result.ext_id == "{{ todelete }}"
       - result.response.name == "{{ directory_service }}"
       - result.response.directory_type == "ACTIVE_DIRECTORY"
@@ -216,7 +216,7 @@
     that:
       - result.response is defined
       - result.changed == true
-      - result.failed == False
+      - result.failed == false
       - result.ext_id == "{{ todelete }}"
       - result.response.group_search_type == "NON_RECURSIVE"
       - result.response.white_listed_groups[0] == "{{ white_listed_groups[0] }}"
@@ -246,8 +246,8 @@
   ansible.builtin.assert:
     that:
       - result.response is defined
-      - result.changed == True
-      - result.failed == False
+      - result.changed == true
+      - result.failed == false
       - result.response.name == "{{ directory_service }}"
       - result.response.directory_type == "ACTIVE_DIRECTORY"
       - result.response.url == "{{ active_directory.url }}"
@@ -280,8 +280,8 @@
   ansible.builtin.assert:
     that:
       - result.response is defined
-      - result.changed == False
-      - result.failed == False
+      - result.changed == false
+      - result.failed == false
       - result.ext_id == "{{ todelete }}"
       - result.msg == "Nothing to change."
     fail_msg: "Verify if module is idempotent if same config is provided failed "
@@ -299,8 +299,8 @@
   ansible.builtin.assert:
     that:
       - result.response is defined
-      - result.changed == False
-      - result.failed == False
+      - result.changed == false
+      - result.failed == false
       - result.response.ext_id == "{{ todelete }}"
       - result.response.name == "{{ directory_service }}"
       - result.response.directory_type == "ACTIVE_DIRECTORY"
@@ -324,8 +324,8 @@
   ansible.builtin.assert:
     that:
       - result.response is defined
-      - result.changed == False
-      - result.failed == False
+      - result.changed == false
+      - result.failed == false
       - result.response | length > 0
       - result.total_available_results is defined
       - result.total_available_results > 0
@@ -344,8 +344,8 @@
   ansible.builtin.assert:
     that:
       - result.response is defined
-      - result.changed == False
-      - result.failed == False
+      - result.changed == false
+      - result.failed == false
       - result.response | length == 1
       - result.response[0].name == "{{ directory_service }}"
     fail_msg: Unable to list all directory services with filter
@@ -363,11 +363,111 @@
   ansible.builtin.assert:
     that:
       - result.response is defined
-      - result.changed == False
-      - result.failed == False
+      - result.changed == false
+      - result.failed == false
       - result.response | length == 1
     fail_msg: Unable to list all directory services with limit
     success_msg: All directory services listed with limit successfully
+
+########################################################################
+
+- name: Generate spec for verifying directory service connection using check mode
+  nutanix.ncp.ntnx_directory_services_connection_v2:
+    ext_id: "{{ todelete }}"
+    username: "username"
+    password: "password"
+  register: result
+  ignore_errors: true
+  check_mode: true
+
+- name: Generate spec for verifying directory service connection using check mode status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ todelete }}"
+      - result.response.username == "username"
+    fail_msg: Generate spec for verifying directory service connection using check mode failed
+    success_msg: Generate spec for verifying directory service connection using check mode passed
+
+########################################################################
+
+- name: Check directory service connection
+  nutanix.ncp.ntnx_directory_services_connection_v2:
+    ext_id: "{{ todelete }}"
+    username: "{{ active_directory.username }}"
+    password: "{{ active_directory.password }}"
+  register: result
+  ignore_errors: true
+
+- name: Status of directory service connection check
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == "{{ todelete }}"
+      - result.response.message == "Directory Service connection check successful."
+    fail_msg: Directory service connection check failed
+    success_msg: Directory service connection check passed
+
+########################################################################
+
+- name: Check directory service connection with missing required attributes
+  nutanix.ncp.ntnx_directory_services_connection_v2:
+    ext_id: "{{ todelete }}"
+  register: result
+  ignore_errors: true
+
+- name: Status of directory service connection check with missing attributes
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - '"missing required arguments: password, username" in result.msg'
+    fail_msg: Directory service connection check should fail when required attributes are missing
+    success_msg: Directory service connection check failed as expected with missing attributes
+
+########################################################################
+
+- name: Check directory service connection with wrong external ID
+  nutanix.ncp.ntnx_directory_services_connection_v2:
+    ext_id: "54681525-3227-5144-b1b3-155057984061"
+    username: "{{ active_directory.username }}"
+    password: "{{ active_directory.password }}"
+  register: result
+  ignore_errors: true
+
+- name: Status of directory service connection check with wrong external ID
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while checking directory service connection"
+      - result.response.data.error | length > 0
+    fail_msg: Directory service connection check should fail when wrong external ID is provided
+    success_msg: Directory service connection check failed as expected with wrong external ID
+
+########################################################################
+
+- name: Check directory service connection with wrong username and password
+  nutanix.ncp.ntnx_directory_services_connection_v2:
+    ext_id: "{{ todelete }}"
+    username: "wrong_username"
+    password: "wrong_password"
+  register: result
+  ignore_errors: true
+
+- name: Status of directory service connection check with wrong username and password
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while checking directory service connection"
+      - result.response.data.message == "Directory Service connection check failed."
+    fail_msg: Directory service connection check should fail when wrong username and password are provided
+    success_msg: Directory service connection check failed as expected with wrong username and password
 
 ########################################################################
 
@@ -406,8 +506,8 @@
 - name: Deletion Status
   ansible.builtin.assert:
     that:
-      - result.changed == True
-      - result.failed == False
+      - result.changed == true
+      - result.failed == false
       - result.ext_id == "{{ todelete }}"
       - result.msg == "{{ msg }}"
     fail_msg: Unable to delete directory service


### PR DESCRIPTION
# Add PC v4 Directory Services Connection module

## Summary

Adds a new PC v4 IAM module `ntnx_directory_services_connection_v2` to verify the connection to an existing directory service using its `ext_id` and service account `username`/`password`.

## Changes

- **New module** `plugins/modules/ntnx_directory_services_connection_v2.py` — checks a directory service connection via the `ntnx_iam_py_client` SDK, with check-mode support and full documentation.
- **`meta/runtime.yml`** — registers the module under the `nutanix.ncp.ntnx` action group.
- **Example** `examples/iam_v2/directory_services_connection_v2.yml`.
- **Integration tests** added to `ntnx_directory_services_v2/tasks/all_operations.yml` covering success, check mode, missing arguments, wrong `ext_id`, and wrong credentials.

## Test plan

- [x] Sanity tests pass
- [x] Integration tests pass (success, check mode, missing args, wrong `ext_id`, wrong credentials)
