### PR TITLE
add get_categories_api_instance to pc_api_client for module ntnx_categories_v2 / ntnx_categories_info_v2

### DIFF
--- a/plugins/module_utils/v4/prism/helpers.py
+++ b/plugins/module_utils/v4/prism/helpers.py
@@ -98,6 +98,27 @@ def get_restore_point(
         )
 
 
+def get_category(module, api_instance, ext_id, expand=None):
+    """
+    This method will return category info using external ID.
+    Args:
+        module: Ansible module
+        api_instance: CategoriesApi instance from ntnx_prism_py_client sdk
+        ext_id (str): category external ID
+        expand (str): optional query param to expand the response with more details
+    return:
+        category_info (object): category info
+    """
+    try:
+        return api_instance.get_category_by_id(extId=ext_id, _expand=expand).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching category info using ext_id",
+        )
+
+
 def get_pc_task(
     module,
     api_instance,

--- a/plugins/module_utils/v4/prism/pc_api_client.py
+++ b/plugins/module_utils/v4/prism/pc_api_client.py
@@ -117,3 +117,15 @@ def get_tasks_api_instance(module):
     """
     api_client = get_pc_api_client(module)
     return ntnx_prism_py_client.TasksApi(api_client=api_client)
+
+
+def get_categories_api_instance(module):
+    """
+    This method will return categories api instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): categories api instance
+    """
+    api_client = get_pc_api_client(module)
+    return ntnx_prism_py_client.CategoriesApi(api_client=api_client)

--- a/plugins/modules/ntnx_categories_info_v2.py
+++ b/plugins/modules/ntnx_categories_info_v2.py
@@ -123,28 +123,19 @@ total_available_results:
     sample: 125
 """
 
-import traceback  # noqa: E402
 import warnings  # noqa: E402
-
-from ansible.module_utils.basic import missing_required_lib  # noqa: E402
 
 from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
 from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
-from ..module_utils.v4.prism.pc_api_client import get_pc_api_client  # noqa: E402
+from ..module_utils.v4.prism.helpers import get_category  # noqa: E402
+from ..module_utils.v4.prism.pc_api_client import (  # noqa: E402
+    get_categories_api_instance,
+)
 from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402
     raise_api_exception,
     strip_internal_attributes,
 )
-
-SDK_IMP_ERROR = None
-try:
-    import ntnx_prism_py_client as prism_sdk  # noqa: E402
-except ImportError:
-
-    from ..module_utils.v4.sdk_mock import mock_sdk as prism_sdk  # noqa: E402
-
-    SDK_IMP_ERROR = traceback.format_exc()
 
 # Suppress the InsecureRequestWarning
 warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
@@ -159,32 +150,17 @@ def get_module_spec():
     return module_args
 
 
-def get_category_api_instance(module):
-    api_client = get_pc_api_client(module)
-    return prism_sdk.CategoriesApi(api_client=api_client)
-
-
-def get_category(module, result):
-    categories = get_category_api_instance(module)
+def get_category_with_ext_id(module, categories, result):
     ext_id = module.params.get("ext_id")
     expand = module.params.get("expand")
 
-    try:
-        resp = categories.get_category_by_id(ext_id, expand)
-    except Exception as e:
-        raise_api_exception(
-            module=module,
-            exception=e,
-            msg="Api Exception raised while fetching category info",
-        )
+    resp = get_category(module, categories, ext_id, expand)
 
     result["ext_id"] = ext_id
-    result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    result["response"] = strip_internal_attributes(resp.to_dict())
 
 
-def get_categories(module, result):
-    categories = get_category_api_instance(module)
-
+def get_categories(module, categories, result):
     sg = SpecGenerator(module)
     kwargs, err = sg.get_info_spec(attr=module.params, extra_params=["expand"])
 
@@ -215,17 +191,14 @@ def run_module():
             ("ext_id", "filter"),
         ],
     )
-    if SDK_IMP_ERROR:
-        module.fail_json(
-            msg=missing_required_lib("ntnx_prism_py_client"), exception=SDK_IMP_ERROR
-        )
 
     remove_param_with_none_value(module.params)
     result = {"changed": False, "error": None, "response": None}
+    categories = get_categories_api_instance(module)
     if module.params.get("ext_id"):
-        get_category(module, result)
+        get_category_with_ext_id(module, categories, result)
     else:
-        get_categories(module, result)
+        get_categories(module, categories, result)
 
     module.exit_json(**result)
 

--- a/plugins/modules/ntnx_categories_v2.py
+++ b/plugins/modules/ntnx_categories_v2.py
@@ -168,9 +168,10 @@ from ansible.module_utils.basic import missing_required_lib  # noqa: E402
 
 from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
 from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.helpers import get_category  # noqa: E402
 from ..module_utils.v4.prism.pc_api_client import (  # noqa: E402
+    get_categories_api_instance,
     get_etag,
-    get_pc_api_client,
 )
 from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402
@@ -204,33 +205,7 @@ def get_module_spec():
     return module_args
 
 
-_PRISM_SDK = None
-
-
-def get_category_api_instance(module):
-    global _PRISM_SDK
-    if not _PRISM_SDK:
-        api_client = get_pc_api_client(module)
-        _PRISM_SDK = prism_sdk.CategoriesApi(api_client=api_client)
-
-    return _PRISM_SDK
-
-
-def get_category(module, ext_id):
-    categories = get_category_api_instance(module)
-    try:
-        return categories.get_category_by_id(extId=ext_id).data
-    except Exception as e:
-        raise_api_exception(
-            module=module,
-            exception=e,
-            msg="Api Exception raised while fetching category info using ext_id",
-        )
-
-
-def create_category(module, result):
-    categories = get_category_api_instance(module)
-
+def create_category(module, categories, result):
     sg = SpecGenerator(module)
     default_spec = prism_sdk.Category()
     spec, err = sg.generate_spec(obj=default_spec)
@@ -269,11 +244,11 @@ def check_categories_idempotency(old_spec, update_spec):
     return True
 
 
-def update_category(module, result):
+def update_category(module, categories, result):
     ext_id = module.params.get("ext_id")
     result["ext_id"] = ext_id
 
-    current_spec = get_category(module, ext_id=ext_id)
+    current_spec = get_category(module, categories, ext_id=ext_id)
     sg = SpecGenerator(module)
     update_spec, err = sg.generate_spec(obj=deepcopy(current_spec))
 
@@ -291,7 +266,6 @@ def update_category(module, result):
         return
 
     resp = None
-    categories = get_category_api_instance(module)
     try:
         resp = categories.update_category_by_id(extId=ext_id, body=update_spec)
     except Exception as e:
@@ -314,8 +288,7 @@ def update_category(module, result):
     result["changed"] = True
 
 
-def delete_category(module, result):
-    categories = get_category_api_instance(module)
+def delete_category(module, categories, result):
     ext_id = module.params.get("ext_id")
     result["ext_id"] = ext_id
 
@@ -323,7 +296,7 @@ def delete_category(module, result):
         result["msg"] = "Category with ext_id:{0} will be deleted.".format(ext_id)
         return
 
-    current_spec = get_category(module, ext_id=ext_id)
+    current_spec = get_category(module, categories, ext_id=ext_id)
 
     etag = get_etag(data=current_spec)
     if not etag:
@@ -366,13 +339,14 @@ def run_module():
         "ext_id": None,
     }
     state = module.params["state"]
+    categories = get_categories_api_instance(module)
     if state == "present":
         if module.params.get("ext_id"):
-            update_category(module, result)
+            update_category(module, categories, result)
         else:
-            create_category(module, result)
+            create_category(module, categories, result)
     else:
-        delete_category(module, result)
+        delete_category(module, categories, result)
     module.exit_json(**result)
 
 


### PR DESCRIPTION
Fixes #990

## Summary

Moves the `CategoriesApi` instantiation out of the category modules and into a single `get_categories_api_instance(module)` factory in `plugins/module_utils/v4/prism/pc_api_client.py`, matching the pattern used by every other v4 `api_client.py`. Also moves the shared `get_category` fetch logic into `prism/helpers.py`.

## Changes

- **`plugins/module_utils/v4/prism/pc_api_client.py`** — adds `get_categories_api_instance(module)` next to the other prism factories.
- **`plugins/module_utils/v4/prism/helpers.py`** — adds a shared `get_category(module, api_instance, ext_id, expand=None)` helper.
- **`plugins/modules/ntnx_categories_v2.py`** — uses the centralized factory and shared helper; removes the local `get_category_api_instance` and the module-level `_PRISM_SDK` global.
- **`plugins/modules/ntnx_categories_info_v2.py`** — uses the centralized factory and shared helper; removes the local `get_category_api_instance` and the now-redundant SDK import block.

## Test plan

- [ ] Sanity tests pass
- [ ] Integration tests pass (`ntnx_categories_v2`)
