### PR TITLE
Object Store statistics and certificate authority download Dev, Examples, and Tests

### DIFF
--- a/examples/objects_v2/deploy_objects_v2.yml
+++ b/examples/objects_v2/deploy_objects_v2.yml
@@ -6,12 +6,15 @@
 # 4. Create a certificate for an object store
 # 5. List all certificates for an object store
 # 5. Fetch certificate details using external ID
-# 6. List all object stores
-# 7. List all object stores with filter
-# 8. List object stores with limit
-# 9. Fetch object store details using external ID
-# 10. Delete bucket in object store
-# 11. Delete object store
+# 6. Download the certificate authority (CA) of a certificate to a destination path
+# 7. Download the certificate authority (CA) of a certificate to the default location
+# 8. List all object stores
+# 9. List all object stores with filter
+# 10. List object stores with limit
+# 11. Fetch object store details using external ID
+# 12. Fetch object store statistics for a time window
+# 13. Delete bucket in object store
+# 14. Delete object store
 
 - name: Deploy objects playbook
   hosts: localhost
@@ -108,6 +111,21 @@
         ext_id: "{{ certificate_ext_id }}"
       register: result
 
+    - name: Download the certificate authority (CA) of a certificate to a destination path
+      nutanix.ncp.ntnx_object_stores_certificate_info_v2:
+        object_store_ext_id: "{{ object_store_ext_id }}"
+        ext_id: "{{ certificate_ext_id }}"
+        download_ca: true
+        dest: "/tmp/object_store_ca.pem"
+      register: result
+
+    - name: Download the certificate authority (CA) of a certificate to the default location
+      nutanix.ncp.ntnx_object_stores_certificate_info_v2:
+        object_store_ext_id: "{{ object_store_ext_id }}"
+        ext_id: "{{ certificate_ext_id }}"
+        download_ca: true
+      register: result
+
     - name: List all object stores
       nutanix.ncp.ntnx_object_stores_info_v2:
       register: result
@@ -130,6 +148,20 @@
     - name: Fetch object store details using external ID
       nutanix.ncp.ntnx_object_stores_info_v2:
         ext_id: "{{ object_store_ext_id }}"
+      register: result
+
+    - name: Set time window for object store statistics
+      ansible.builtin.set_fact:
+        stats_start_time: "{{ lookup('pipe', 'date -u -d \"1 hour ago\" +%Y-%m-%dT%H:%M:%S.000+00:00') }}"
+        stats_end_time: "{{ lookup('pipe', 'date -u +%Y-%m-%dT%H:%M:%S.000+00:00') }}"
+
+    - name: Fetch object store statistics for the time window
+      nutanix.ncp.ntnx_object_stores_stats_info_v2:
+        ext_id: "{{ object_store_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+        sampling_interval: 300
+        stat_type: "SUM"
       register: result
 
     # for deleting an object store, you need to delete the bucket first

--- a/examples/objects_v2/deploy_objects_v2.yml
+++ b/examples/objects_v2/deploy_objects_v2.yml
@@ -112,18 +112,16 @@
       register: result
 
     - name: Download the certificate authority (CA) of a certificate to a destination path
-      nutanix.ncp.ntnx_object_stores_certificate_info_v2:
+      nutanix.ncp.ntnx_object_stores_certificate_download_v2:
         object_store_ext_id: "{{ object_store_ext_id }}"
         ext_id: "{{ certificate_ext_id }}"
-        download_ca: true
         dest: "/tmp/object_store_ca.pem"
       register: result
 
     - name: Download the certificate authority (CA) of a certificate to the default location
-      nutanix.ncp.ntnx_object_stores_certificate_info_v2:
+      nutanix.ncp.ntnx_object_stores_certificate_download_v2:
         object_store_ext_id: "{{ object_store_ext_id }}"
         ext_id: "{{ certificate_ext_id }}"
-        download_ca: true
       register: result
 
     - name: List all object stores

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -218,6 +218,7 @@ action_groups:
     - ntnx_object_stores_info_v2
     - ntnx_object_stores_certificate_v2
     - ntnx_object_stores_certificate_info_v2
+    - ntnx_object_stores_stats_info_v2
     - ntnx_password_managers_info_v2
     - ntnx_password_managers_v2
     - ntnx_ova_v2

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -220,6 +220,7 @@ action_groups:
     - ntnx_object_stores_info_v2
     - ntnx_object_stores_certificate_v2
     - ntnx_object_stores_certificate_info_v2
+    - ntnx_object_stores_certificate_download_v2
     - ntnx_object_stores_stats_info_v2
     - ntnx_password_managers_info_v2
     - ntnx_password_managers_v2

--- a/plugins/module_utils/v4/objects/api_client.py
+++ b/plugins/module_utils/v4/objects/api_client.py
@@ -99,3 +99,15 @@ def get_objects_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_objects_py_client.ObjectStoresApi(api_client)
+
+
+def get_objects_stats_api_instance(module):
+    """
+    This method will return api instance to be used for object store stats api calls.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): StatsApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_objects_py_client.StatsApi(api_client)

--- a/plugins/module_utils/v4/objects/helpers.py
+++ b/plugins/module_utils/v4/objects/helpers.py
@@ -51,3 +51,29 @@ def get_object_store_certificate(
             exception=e,
             msg="Api Exception raised while fetching object store certificate info using ext_id",
         )
+
+
+def get_object_store_certificate_authority(
+    module, object_stores_api, ext_id, object_store_ext_id
+):
+    """
+    This method will return the certificate authority (CA) of an object store
+    certificate using external ID.
+    Args:
+        module: Ansible module
+        object_stores_api: ObjectStoresApi instance from ntnx_objects_py_client sdk
+        ext_id (str): object store certificate external ID
+        object_store_ext_id (str): object store external ID
+    return:
+        ca_response (object): GetCaApiResponse instance
+    """
+    try:
+        return object_stores_api.get_ca_by_certificate_id(
+            certificateExtId=ext_id, objectStoreExtId=object_store_ext_id
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching object store certificate authority using ext_id",
+        )

--- a/plugins/modules/ntnx_object_stores_certificate_download_v2.py
+++ b/plugins/modules/ntnx_object_stores_certificate_download_v2.py
@@ -173,7 +173,7 @@ def run_module():
         skip_info_args=True,
     )
     remove_param_with_none_value(module.params)
-    result = {"changed": False, "response": None}
+    result = {"changed": False, "failed": False, "response": None}
     object_stores_api = get_objects_api_instance(module)
     download_object_store_certificate_ca(module, object_stores_api, result)
     module.exit_json(**result)

--- a/plugins/modules/ntnx_object_stores_certificate_download_v2.py
+++ b/plugins/modules/ntnx_object_stores_certificate_download_v2.py
@@ -38,6 +38,11 @@ options:
             - The parent directory is created if it does not already exist.
             - If not provided, the CA is saved to the SDK default download location and that path is returned.
         type: path
+    read_timeout:
+        description: Read timeout in milliseconds for API calls.
+        type: int
+        required: false
+        default: 30000
 extends_documentation_fragment:
     - nutanix.ncp.ntnx_credentials
     - nutanix.ncp.ntnx_logger

--- a/plugins/modules/ntnx_object_stores_certificate_download_v2.py
+++ b/plugins/modules/ntnx_object_stores_certificate_download_v2.py
@@ -1,0 +1,182 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+module: ntnx_object_stores_certificate_download_v2
+short_description: Download Object Stores certificate authority
+version_added: 2.6.0
+description:
+    - Download the certificate authority (CA) for a specific object store certificate.
+    - The certificate authority is returned as an C(application/octet-stream) download and saved to a local file.
+    - The local downloaded file path is returned under C(response.path).
+    - This module uses PC v4 APIs based GA SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Download the certificate authority of an Object store certificate) -
+      Required Roles: Objects Admin, Objects Editor, Objects Viewer, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=objects)"
+options:
+    object_store_ext_id:
+        description: Object store External ID.
+        type: str
+        required: true
+    ext_id:
+        description: External ID of certificate whose certificate authority should be downloaded.
+        type: str
+        required: true
+    dest:
+        description:
+            - Local destination file path where the downloaded certificate authority (CA) should be saved.
+            - The parent directory is created if it does not already exist.
+            - If not provided, the CA is saved to the SDK default download location and that path is returned.
+        type: path
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Download the certificate authority (CA) of an object store certificate
+  nutanix.ncp.ntnx_object_stores_certificate_download_v2:
+    object_store_ext_id: "cda893b8-2aee-34bf-817d-d2ee6026790b"
+    ext_id: "f3197423-f486-4037-6037-95442e58484e"
+  register: result
+
+- name: Download the certificate authority (CA) to a specific destination path
+  nutanix.ncp.ntnx_object_stores_certificate_download_v2:
+    object_store_ext_id: "cda893b8-2aee-34bf-817d-d2ee6026790b"
+    ext_id: "f3197423-f486-4037-6037-95442e58484e"
+    dest: "/tmp/object_store_ca.pem"
+  register: result
+"""
+
+RETURN = r"""
+response:
+    description: A dict containing local path of downloaded certificate authority file.
+    type: dict
+    returned: always
+    sample:
+        {
+            "path": "/tmp/object_store_ca.pem"
+        }
+
+ext_id:
+    description: External ID of the object store certificate.
+    returned: always
+    type: str
+    sample: "f3197423-f486-4037-6037-95442e58484e"
+
+changed:
+    description: This indicates whether the task resulted in any changes.
+    returned: always
+    type: bool
+    sample: false
+
+msg:
+    description: Message returned when an error occurs.
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while downloading object store certificate authority"
+
+error:
+    description: Details about errors that occurred during task execution.
+    returned: When an error occurs
+    type: str
+
+failed:
+    description: This field indicates whether the task failed.
+    returned: always
+    type: bool
+    sample: false
+"""
+
+import os  # noqa: E402
+import shutil  # noqa: E402
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.objects.api_client import get_objects_api_instance  # noqa: E402
+from ..module_utils.v4.objects.helpers import (  # noqa: E402
+    get_object_store_certificate_authority,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        object_store_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+        dest=dict(type="path"),
+    )
+    return module_args
+
+
+def download_object_store_certificate_ca(module, object_stores_api, result):
+    ext_id = module.params.get("ext_id")
+    object_store_ext_id = module.params.get("object_store_ext_id")
+    dest = module.params.get("dest")
+    result["ext_id"] = ext_id
+
+    if dest:
+        dest_dir = os.path.dirname(os.path.abspath(dest))
+        if not os.path.isdir(dest_dir):
+            os.makedirs(dest_dir)
+        object_stores_api.api_client.configuration.download_directory = dest_dir
+
+    resp = get_object_store_certificate_authority(
+        module, object_stores_api, ext_id, object_store_ext_id
+    )
+
+    data = resp.data
+    if isinstance(data, dict):
+        downloaded_path = data.get("path")
+    else:
+        downloaded_path = getattr(data, "path", None)
+
+    if not downloaded_path:
+        module.fail_json(
+            msg="Failed to determine the downloaded certificate authority file path",
+            **result,
+        )
+
+    downloaded_path = str(downloaded_path)
+    if dest and os.path.abspath(downloaded_path) != os.path.abspath(dest):
+        shutil.move(downloaded_path, dest)
+        downloaded_path = dest
+
+    result["response"] = {"path": downloaded_path}
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None}
+    object_stores_api = get_objects_api_instance(module)
+    download_object_store_certificate_ca(module, object_stores_api, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_object_stores_certificate_info_v2.py
+++ b/plugins/modules/ntnx_object_stores_certificate_info_v2.py
@@ -54,7 +54,7 @@ EXAMPLES = r"""
     object_store_ext_id: "cda893b8-2aee-34bf-817d-d2ee6026790b"
     ext_id: "f3197423-f486-4037-6037-95442e58484e"
   register: result
-
+  ignore_errors: true
 """
 
 RETURN = r"""
@@ -128,9 +128,7 @@ import warnings  # noqa: E402
 from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
 from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
 from ..module_utils.v4.objects.api_client import get_objects_api_instance  # noqa: E402
-from ..module_utils.v4.objects.helpers import (  # noqa: E402
-    get_object_store_certificate,
-)
+from ..module_utils.v4.objects.helpers import get_object_store_certificate  # noqa: E402
 from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402
     raise_api_exception,

--- a/plugins/modules/ntnx_object_stores_certificate_info_v2.py
+++ b/plugins/modules/ntnx_object_stores_certificate_info_v2.py
@@ -13,6 +13,8 @@ version_added: 2.2.0
 description:
     - Fetch specific object store certificate info if external ID is provided
     - Fetch list of multiple object store certificates info if external ID is not provided with optional filters
+    - Download the certificate authority (CA) of a specific object store certificate when C(download_ca) is set to true
+    - The certificate authority is returned as an C(application/octet-stream) download and is saved to a local file, whose path is returned in the response
     - This module uses PC v4 APIs based GA SDKs
 notes:
     - >-
@@ -23,15 +25,35 @@ notes:
     - >-
       B(Get a list of the SSL certificates of an Object store) -
       Required Roles: Objects Admin, Objects Editor, Objects Viewer, Prism Admin, Super Admin
+    - >-
+      B(Download the certificate authority of an Object store certificate) -
+      Required Roles: Objects Admin, Objects Editor, Objects Viewer, Prism Admin, Super Admin
     - "Ref: U(https://developers.nutanix.com/api-reference?namespace=objects)"
 options:
     object_store_ext_id:
-        description: object store external ID
+        description: Object store External ID
         type: str
         required: true
     ext_id:
-        description: external ID of certificate to fetch
+        description:
+            - External ID of certificate to fetch
+            - Required when C(download_ca) is set to true
         type: str
+    download_ca:
+        description:
+            - Download the certificate authority (CA) of the object store certificate identified by C(ext_id)
+            - The CA is returned as an C(application/octet-stream) download and saved to a local file
+            - The path of the downloaded file is returned under C(response.path)
+            - Requires C(ext_id) to be set
+        type: bool
+        default: false
+    dest:
+        description:
+            - Local destination file path where the downloaded certificate authority (CA) should be saved.
+            - Only used when C(download_ca) is set to true
+            - The parent directory is created if it does not already exist
+            - If not provided, the CA is saved to the SDK default download location and that path is returned
+        type: path
 extends_documentation_fragment:
     - nutanix.ncp.ntnx_credentials
     - nutanix.ncp.ntnx_info_v2
@@ -53,6 +75,21 @@ EXAMPLES = r"""
     object_store_ext_id: "cda893b8-2aee-34bf-817d-d2ee6026790b"
     ext_id: "f3197423-f486-4037-6037-95442e58484e"
   register: result
+
+- name: Download the certificate authority (CA) of an object store certificate
+  nutanix.ncp.ntnx_object_stores_certificate_info_v2:
+    object_store_ext_id: "cda893b8-2aee-34bf-817d-d2ee6026790b"
+    ext_id: "f3197423-f486-4037-6037-95442e58484e"
+    download_ca: true
+  register: result
+
+- name: Download the certificate authority (CA) to a specific destination path
+  nutanix.ncp.ntnx_object_stores_certificate_info_v2:
+    object_store_ext_id: "cda893b8-2aee-34bf-817d-d2ee6026790b"
+    ext_id: "f3197423-f486-4037-6037-95442e58484e"
+    download_ca: true
+    dest: "/tmp/object_store_ca.pem"
+  register: result
 """
 
 RETURN = r"""
@@ -61,6 +98,7 @@ response:
         - Response for fetching object store certificate info
         - Object store certificate info if external ID is provided
         - List of multiple object store certificates info if external ID is not provided
+        - When C(download_ca) is set to true, a dict with the local C(path) of the downloaded certificate authority file
     type: dict
     returned: always
     sample:
@@ -121,12 +159,17 @@ total_available_results:
     sample: 125
 """
 
+import os  # noqa: E402
+import shutil  # noqa: E402
 import warnings  # noqa: E402
 
 from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
 from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
 from ..module_utils.v4.objects.api_client import get_objects_api_instance  # noqa: E402
-from ..module_utils.v4.objects.helpers import get_object_store_certificate  # noqa: E402
+from ..module_utils.v4.objects.helpers import (  # noqa: E402
+    get_object_store_certificate,
+    get_object_store_certificate_authority,
+)
 from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402
     raise_api_exception,
@@ -141,6 +184,8 @@ def get_module_spec():
     module_args = dict(
         object_store_ext_id=dict(type="str", required=True),
         ext_id=dict(type="str"),
+        download_ca=dict(type="bool", default=False),
+        dest=dict(type="path"),
     )
     return module_args
 
@@ -153,6 +198,42 @@ def get_object_store_certificate_with_ext_id(module, object_stores_api, result):
     )
     result["ext_id"] = ext_id
     result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_object_store_certificate_ca(module, object_stores_api, result):
+    ext_id = module.params.get("ext_id")
+    object_store_ext_id = module.params.get("object_store_ext_id")
+    dest = module.params.get("dest")
+    result["ext_id"] = ext_id
+
+    if dest:
+        dest_dir = os.path.dirname(os.path.abspath(dest))
+        if not os.path.isdir(dest_dir):
+            os.makedirs(dest_dir)
+        object_stores_api.api_client.configuration.download_directory = dest_dir
+
+    resp = get_object_store_certificate_authority(
+        module, object_stores_api, ext_id, object_store_ext_id
+    )
+
+    data = resp.data
+    if isinstance(data, dict):
+        downloaded_path = data.get("path")
+    else:
+        downloaded_path = getattr(data, "path", None)
+
+    if not downloaded_path:
+        module.fail_json(
+            msg="Failed to determine the downloaded certificate authority file path",
+            **result
+        )
+
+    downloaded_path = str(downloaded_path)
+    if dest and os.path.abspath(downloaded_path) != os.path.abspath(dest):
+        shutil.move(downloaded_path, dest)
+        downloaded_path = dest
+
+    result["response"] = {"path": downloaded_path}
 
 
 def get_object_store_certificates(module, object_stores_api, result):
@@ -192,11 +273,16 @@ def run_module():
         mutually_exclusive=[
             ("ext_id", "filter"),
         ],
+        required_if=[
+            ("download_ca", True, ("ext_id",)),
+        ],
     )
     remove_param_with_none_value(module.params)
     result = {"changed": False, "response": None}
     object_stores_api = get_objects_api_instance(module)
-    if module.params.get("ext_id"):
+    if module.params.get("download_ca"):
+        get_object_store_certificate_ca(module, object_stores_api, result)
+    elif module.params.get("ext_id"):
         get_object_store_certificate_with_ext_id(module, object_stores_api, result)
     else:
         get_object_store_certificates(module, object_stores_api, result)

--- a/plugins/modules/ntnx_object_stores_certificate_info_v2.py
+++ b/plugins/modules/ntnx_object_stores_certificate_info_v2.py
@@ -13,8 +13,6 @@ version_added: 2.2.0
 description:
     - Fetch specific object store certificate info if external ID is provided
     - Fetch list of multiple object store certificates info if external ID is not provided with optional filters
-    - Download the certificate authority (CA) of a specific object store certificate when C(download_ca) is set to true
-    - The certificate authority is returned as an C(application/octet-stream) download and is saved to a local file, whose path is returned in the response
     - This module uses PC v4 APIs based GA SDKs
 notes:
     - >-
@@ -25,9 +23,6 @@ notes:
     - >-
       B(Get a list of the SSL certificates of an Object store) -
       Required Roles: Objects Admin, Objects Editor, Objects Viewer, Prism Admin, Super Admin
-    - >-
-      B(Download the certificate authority of an Object store certificate) -
-      Required Roles: Objects Admin, Objects Editor, Objects Viewer, Prism Admin, Super Admin
     - "Ref: U(https://developers.nutanix.com/api-reference?namespace=objects)"
 options:
     object_store_ext_id:
@@ -37,23 +32,7 @@ options:
     ext_id:
         description:
             - External ID of certificate to fetch
-            - Required when C(download_ca) is set to true
         type: str
-    download_ca:
-        description:
-            - Download the certificate authority (CA) of the object store certificate identified by C(ext_id)
-            - The CA is returned as an C(application/octet-stream) download and saved to a local file
-            - The path of the downloaded file is returned under C(response.path)
-            - Requires C(ext_id) to be set
-        type: bool
-        default: false
-    dest:
-        description:
-            - Local destination file path where the downloaded certificate authority (CA) should be saved.
-            - Only used when C(download_ca) is set to true
-            - The parent directory is created if it does not already exist
-            - If not provided, the CA is saved to the SDK default download location and that path is returned
-        type: path
 extends_documentation_fragment:
     - nutanix.ncp.ntnx_credentials
     - nutanix.ncp.ntnx_info_v2
@@ -76,20 +55,6 @@ EXAMPLES = r"""
     ext_id: "f3197423-f486-4037-6037-95442e58484e"
   register: result
 
-- name: Download the certificate authority (CA) of an object store certificate
-  nutanix.ncp.ntnx_object_stores_certificate_info_v2:
-    object_store_ext_id: "cda893b8-2aee-34bf-817d-d2ee6026790b"
-    ext_id: "f3197423-f486-4037-6037-95442e58484e"
-    download_ca: true
-  register: result
-
-- name: Download the certificate authority (CA) to a specific destination path
-  nutanix.ncp.ntnx_object_stores_certificate_info_v2:
-    object_store_ext_id: "cda893b8-2aee-34bf-817d-d2ee6026790b"
-    ext_id: "f3197423-f486-4037-6037-95442e58484e"
-    download_ca: true
-    dest: "/tmp/object_store_ca.pem"
-  register: result
 """
 
 RETURN = r"""
@@ -98,7 +63,6 @@ response:
         - Response for fetching object store certificate info
         - Object store certificate info if external ID is provided
         - List of multiple object store certificates info if external ID is not provided
-        - When C(download_ca) is set to true, a dict with the local C(path) of the downloaded certificate authority file
     type: dict
     returned: always
     sample:
@@ -159,8 +123,6 @@ total_available_results:
     sample: 125
 """
 
-import os  # noqa: E402
-import shutil  # noqa: E402
 import warnings  # noqa: E402
 
 from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
@@ -168,7 +130,6 @@ from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
 from ..module_utils.v4.objects.api_client import get_objects_api_instance  # noqa: E402
 from ..module_utils.v4.objects.helpers import (  # noqa: E402
     get_object_store_certificate,
-    get_object_store_certificate_authority,
 )
 from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402
@@ -184,8 +145,6 @@ def get_module_spec():
     module_args = dict(
         object_store_ext_id=dict(type="str", required=True),
         ext_id=dict(type="str"),
-        download_ca=dict(type="bool", default=False),
-        dest=dict(type="path"),
     )
     return module_args
 
@@ -198,42 +157,6 @@ def get_object_store_certificate_with_ext_id(module, object_stores_api, result):
     )
     result["ext_id"] = ext_id
     result["response"] = strip_internal_attributes(resp.to_dict())
-
-
-def get_object_store_certificate_ca(module, object_stores_api, result):
-    ext_id = module.params.get("ext_id")
-    object_store_ext_id = module.params.get("object_store_ext_id")
-    dest = module.params.get("dest")
-    result["ext_id"] = ext_id
-
-    if dest:
-        dest_dir = os.path.dirname(os.path.abspath(dest))
-        if not os.path.isdir(dest_dir):
-            os.makedirs(dest_dir)
-        object_stores_api.api_client.configuration.download_directory = dest_dir
-
-    resp = get_object_store_certificate_authority(
-        module, object_stores_api, ext_id, object_store_ext_id
-    )
-
-    data = resp.data
-    if isinstance(data, dict):
-        downloaded_path = data.get("path")
-    else:
-        downloaded_path = getattr(data, "path", None)
-
-    if not downloaded_path:
-        module.fail_json(
-            msg="Failed to determine the downloaded certificate authority file path",
-            **result,
-        )
-
-    downloaded_path = str(downloaded_path)
-    if dest and os.path.abspath(downloaded_path) != os.path.abspath(dest):
-        shutil.move(downloaded_path, dest)
-        downloaded_path = dest
-
-    result["response"] = {"path": downloaded_path}
 
 
 def get_object_store_certificates(module, object_stores_api, result):
@@ -273,16 +196,11 @@ def run_module():
         mutually_exclusive=[
             ("ext_id", "filter"),
         ],
-        required_if=[
-            ("download_ca", True, ("ext_id",)),
-        ],
     )
     remove_param_with_none_value(module.params)
     result = {"changed": False, "response": None}
     object_stores_api = get_objects_api_instance(module)
-    if module.params.get("download_ca"):
-        get_object_store_certificate_ca(module, object_stores_api, result)
-    elif module.params.get("ext_id"):
+    if module.params.get("ext_id"):
         get_object_store_certificate_with_ext_id(module, object_stores_api, result)
     else:
         get_object_store_certificates(module, object_stores_api, result)

--- a/plugins/modules/ntnx_object_stores_certificate_info_v2.py
+++ b/plugins/modules/ntnx_object_stores_certificate_info_v2.py
@@ -225,7 +225,7 @@ def get_object_store_certificate_ca(module, object_stores_api, result):
     if not downloaded_path:
         module.fail_json(
             msg="Failed to determine the downloaded certificate authority file path",
-            **result
+            **result,
         )
 
     downloaded_path = str(downloaded_path)

--- a/plugins/modules/ntnx_object_stores_stats_info_v2.py
+++ b/plugins/modules/ntnx_object_stores_stats_info_v2.py
@@ -1,0 +1,330 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2025, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+DOCUMENTATION = r"""
+module: ntnx_object_stores_stats_info_v2
+short_description: Get Object Store statistics
+version_added: 2.6.0
+description:
+    - Fetch statistics of an object store for a given time window
+    - This module uses PC v4 APIs based GA SDKs
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get the stats of an Object store) -
+      Required Roles: Objects Admin, Objects Editor, Objects Viewer, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=objects)"
+options:
+    ext_id:
+        description: External ID of the object store to fetch statistics for
+        type: str
+        required: true
+    start_time:
+        description:
+            - The start time of the period for which stats should be reported.
+            - The value should be in extended ISO-8601 format.
+            - >-
+              For example, start time of C(2022-04-23T01:23:45.678+09:00) would consider
+              all stats starting at 1:23:45.678 on the 23rd of April 2022.
+            - Details around ISO-8601 format can be found at U(https://www.iso.org/standard/70907.html)
+        type: str
+        required: true
+    end_time:
+        description:
+            - The end time of the period for which stats should be reported.
+            - The value should be in extended ISO-8601 format.
+            - >-
+              For example, end time of C(2022-04-23T13:23:45.678+09:00) would consider
+              all stats till 13:23:45.678 on the 23rd of April 2022.
+            - Details around ISO-8601 format can be found at U(https://www.iso.org/standard/70907.html)
+        type: str
+        required: true
+    sampling_interval:
+        description:
+            - The sampling interval in seconds at which statistical data should be collected.
+            - For example, if you want performance statistics every 30 seconds, then provide the value as 30.
+        type: int
+    stat_type:
+        description:
+            - The operator to use while performing down-sampling on stats data.
+            - Allowed values are SUM, MIN, MAX, AVG, COUNT and LAST.
+            - C(SUM) - Aggregation with sum of all values.
+            - C(MIN) - Aggregation containing lowest of all values.
+            - C(MAX) - Aggregation containing highest of all values.
+            - C(AVG) - Aggregation indicating mean or average of all values.
+            - C(COUNT) - Aggregation containing total count of values.
+            - C(LAST) - Aggregation containing only the last recorded value.
+        type: str
+        choices:
+            - SUM
+            - MIN
+            - MAX
+            - AVG
+            - COUNT
+            - LAST
+    select:
+        description:
+            - A URL query parameter that allows clients to request a specific set of properties for each entity or complex type.
+            - >-
+              Expression specified with the C($select) must conform to the OData V4.01 URL conventions.
+            - >-
+              If a C($select) expression consists of a single select item that is an asterisk (i.e., *),
+              then all properties on the matching resource will be returned.
+        type: str
+    read_timeout:
+        description: Read timeout in milliseconds for API calls.
+        type: int
+        required: false
+        default: 30000
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch object store statistics for the last hour
+  nutanix.ncp.ntnx_object_stores_stats_info_v2:
+    ext_id: "cda893b8-2aee-34bf-817d-d2ee6026790b"
+    start_time: "2025-05-04T10:30:10.000+00:00"
+    end_time: "2025-05-04T11:30:10.000+00:00"
+    sampling_interval: 300
+    stat_type: "SUM"
+  register: result
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for fetching object store statistics
+    type: dict
+    returned: always
+    sample:
+        {
+            "bucket_count": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 1
+                }
+            ],
+            "delete_requests_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "ext_id": null,
+            "get_bucket_operations_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "get_object_ttfb_msecs": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "get_request_throughput_bytes_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "get_requests_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "head_requests_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "inbound_bytes_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "links": null,
+            "list_multipart_uploads_operations_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "multipart_upload_start_operations_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "nfs_read_requests_per_second": null,
+            "nfs_read_throughput_bytes_per_second": null,
+            "nfs_write_requests_per_second": null,
+            "nfs_write_throughput_bytes_per_second": null,
+            "object_count": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 138
+                }
+            ],
+            "object_operations_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "outbound_bytes_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "post_requests_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "put_request_throughput_bytes_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "put_requests_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "select_object_content_operations_per_second": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 0.0
+                }
+            ],
+            "storage_usage_bytes": [
+                {
+                    "timestamp": "2026-06-11T12:40:00+00:00",
+                    "value": 2859830
+                }
+            ],
+            "tenant_id": null
+        }
+
+ext_id:
+    description: External ID of the object store
+    returned: always
+    type: str
+    sample: "cda893b8-2aee-34bf-817d-d2ee6026790b"
+
+changed:
+    description: This indicates whether the task resulted in any changes
+    returned: always
+    type: bool
+    sample: false
+
+msg:
+    description: This indicates the message if any message occurred
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while fetching object store stats info"
+
+failed:
+    description: This field typically holds information about if the task have failed
+    returned: always
+    type: bool
+    sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.objects.api_client import (  # noqa: E402
+    get_objects_stats_api_instance,
+)
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int"),
+        stat_type=dict(
+            type="str",
+            choices=["SUM", "MIN", "MAX", "AVG", "COUNT", "LAST"],
+        ),
+        select=dict(type="str"),
+    )
+    return module_args
+
+
+def get_object_store_stats(module, stats_api, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    kwargs = {
+        "_startTime": module.params.get("start_time"),
+        "_endTime": module.params.get("end_time"),
+    }
+    if module.params.get("sampling_interval") is not None:
+        kwargs["_samplingInterval"] = module.params.get("sampling_interval")
+    if module.params.get("stat_type") is not None:
+        kwargs["_statType"] = module.params.get("stat_type")
+    if module.params.get("select") is not None:
+        kwargs["_select"] = module.params.get("select")
+
+    try:
+        resp = stats_api.get_objectstore_stats_by_id(extId=ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching object store stats info",
+        )
+
+    result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None}
+    stats_api = get_objects_stats_api_instance(module)
+    get_object_store_stats(module, stats_api, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/ntnx_objects_v2/tasks/deploy_objects.yml
+++ b/tests/integration/targets/ntnx_objects_v2/tasks/deploy_objects.yml
@@ -271,10 +271,9 @@
     fail_msg: "Certificate details are not fetched successfully using external ID"
 
 - name: Download certificate authority (CA) for the certificate to a destination path
-  nutanix.ncp.ntnx_object_stores_certificate_info_v2:
+  nutanix.ncp.ntnx_object_stores_certificate_download_v2:
     object_store_ext_id: "{{ object_store_ext_id_1 }}"
     ext_id: "{{ certificate_ext_id }}"
-    download_ca: true
     dest: "/tmp/object_store_ca.pem"
   register: result
   ignore_errors: true
@@ -319,10 +318,9 @@
     fail_msg: "Certificate authority (CA) file is not removed successfully"
 
 - name: Download certificate authority (CA) for the certificate without a destination path
-  nutanix.ncp.ntnx_object_stores_certificate_info_v2:
+  nutanix.ncp.ntnx_object_stores_certificate_download_v2:
     object_store_ext_id: "{{ object_store_ext_id_1 }}"
     ext_id: "{{ certificate_ext_id }}"
-    download_ca: true
   register: result
   ignore_errors: true
 
@@ -371,9 +369,8 @@
     fail_msg: "Certificate authority (CA) file at the default location is not removed successfully"
 
 - name: Download certificate authority (CA) for the certificate to a destination path without ext_id
-  nutanix.ncp.ntnx_object_stores_certificate_info_v2:
+  nutanix.ncp.ntnx_object_stores_certificate_download_v2:
     object_store_ext_id: "{{ object_store_ext_id_1 }}"
-    download_ca: true
   register: result
   ignore_errors: true
 
@@ -383,8 +380,7 @@
       - result.changed is false
       - result.failed is true
       - >-
-        result.msg == "download_ca is True but all of the following are
-        missing: ext_id"
+        result.msg == "missing required arguments: ext_id"
     success_msg: "Download certificate authority (CA) for the certificate to a destination path without ext_id failed as expected"
     fail_msg: "Download certificate authority (CA) for the certificate to a destination path without ext_id did not fail as expected"
 

--- a/tests/integration/targets/ntnx_objects_v2/tasks/deploy_objects.yml
+++ b/tests/integration/targets/ntnx_objects_v2/tasks/deploy_objects.yml
@@ -303,14 +303,13 @@
   ansible.builtin.file:
     path: "/tmp/object_store_ca.pem"
     state: absent
-  register: result
-  ignore_errors: true
+  failed_when: false
 
 - name: Stat the certificate authority (CA) file after removal
   ansible.builtin.stat:
     path: "/tmp/object_store_ca.pem"
   register: ca_file_stat_after_removal
-  ignore_errors: true
+  failed_when: false
 
 - name: Verify certificate authority (CA) file is removed status
   ansible.builtin.assert:
@@ -327,12 +326,17 @@
   register: result
   ignore_errors: true
 
+- name: Set the default location certificate authority (CA) file path
+  ansible.builtin.set_fact:
+    ca_default_path: "{{ result.response.path }}"
+  when: result.response.path is defined
+
 - name: Stat the downloaded certificate authority (CA) file at the default location
   ansible.builtin.stat:
-    path: "{{ result.response.path }}"
+    path: "{{ ca_default_path }}"
   register: ca_default_file_stat
-  when: result.response.path is defined
-  ignore_errors: true
+  when: ca_default_path is defined
+  failed_when: false
 
 - name: Download certificate authority (CA) for the certificate without a destination path status
   ansible.builtin.assert:
@@ -349,16 +353,15 @@
 
 - name: Remove the downloaded certificate authority (CA) file from the default location
   ansible.builtin.file:
-    path: "{{ result.response.path }}"
+    path: "{{ ca_default_path }}"
     state: absent
-  register: result
-  ignore_errors: true
+  failed_when: false
 
 - name: Stat the certificate authority (CA) file at the default location after removal
   ansible.builtin.stat:
-    path: "{{ result.response.path }}"
+    path: "{{ ca_default_path }}"
   register: ca_default_file_stat_after_removal
-  ignore_errors: true
+  failed_when: false
 
 - name: Verify certificate authority (CA) file at the default location is removed status
   ansible.builtin.assert:

--- a/tests/integration/targets/ntnx_objects_v2/tasks/deploy_objects.yml
+++ b/tests/integration/targets/ntnx_objects_v2/tasks/deploy_objects.yml
@@ -270,6 +270,134 @@
     success_msg: "Certificate details are fetched successfully using external ID"
     fail_msg: "Certificate details are not fetched successfully using external ID"
 
+- name: Download certificate authority (CA) for the certificate to a destination path
+  nutanix.ncp.ntnx_object_stores_certificate_info_v2:
+    object_store_ext_id: "{{ object_store_ext_id_1 }}"
+    ext_id: "{{ certificate_ext_id }}"
+    download_ca: true
+    dest: "/tmp/object_store_ca.pem"
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Stat the downloaded certificate authority (CA) file
+  ansible.builtin.stat:
+    path: "{{ result.response.path }}"
+  register: ca_file_stat
+  when: result.response.path is defined
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: ca_file_stat
+
+- name: Download certificate authority (CA) for the certificate to a destination path status
+  ansible.builtin.assert:
+    that:
+      - result.changed is false
+      - result.failed is false
+      - result.ext_id == "{{ certificate_ext_id }}"
+      - result.response is defined
+      - result.response.path == "/tmp/object_store_ca.pem"
+      - ca_file_stat.stat.exists
+      - ca_file_stat.stat.size > 0
+    success_msg: "Certificate authority (CA) is downloaded successfully to destination path"
+    fail_msg: "Certificate authority (CA) is not downloaded successfully to destination path"
+
+- name: Remove the downloaded certificate authority (CA) file
+  ansible.builtin.file:
+    path: "/tmp/object_store_ca.pem"
+    state: absent
+  ignore_errors: true
+
+- name: Stat the certificate authority (CA) file after removal
+  ansible.builtin.stat:
+    path: "/tmp/object_store_ca.pem"
+  register: ca_file_stat_after_removal
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: ca_file_stat_after_removal
+
+- name: Verify certificate authority (CA) file is removed status
+  ansible.builtin.assert:
+    that:
+      - not ca_file_stat_after_removal.stat.exists
+    success_msg: "Certificate authority (CA) file is removed successfully"
+    fail_msg: "Certificate authority (CA) file is not removed successfully"
+
+- name: Download certificate authority (CA) for the certificate without a destination path
+  nutanix.ncp.ntnx_object_stores_certificate_info_v2:
+    object_store_ext_id: "{{ object_store_ext_id_1 }}"
+    ext_id: "{{ certificate_ext_id }}"
+    download_ca: true
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Stat the downloaded certificate authority (CA) file at the default location
+  ansible.builtin.stat:
+    path: "{{ result.response.path }}"
+  register: ca_default_file_stat
+  when: result.response.path is defined
+  ignore_errors: true
+
+- name: Download certificate authority (CA) for the certificate without a destination path status
+  ansible.builtin.assert:
+    that:
+      - result.changed is false
+      - result.failed is false
+      - result.ext_id == "{{ certificate_ext_id }}"
+      - result.response is defined
+      - result.response.path is defined
+      - ca_default_file_stat.stat.exists
+      - ca_default_file_stat.stat.size > 0
+    success_msg: "Certificate authority (CA) is downloaded successfully to the default location"
+    fail_msg: "Certificate authority (CA) is not downloaded successfully to the default location"
+
+- name: Remove the downloaded certificate authority (CA) file from the default location
+  ansible.builtin.file:
+    path: "{{ result.response.path }}"
+    state: absent
+  ignore_errors: true
+
+- name: Stat the certificate authority (CA) file at the default location after removal
+  ansible.builtin.stat:
+    path: "{{ result.response.path }}"
+  register: ca_default_file_stat_after_removal
+  ignore_errors: true
+
+- name: Verify certificate authority (CA) file at the default location is removed status
+  ansible.builtin.assert:
+    that:
+      - not ca_default_file_stat_after_removal.stat.exists
+    success_msg: "Certificate authority (CA) file at the default location is removed successfully"
+    fail_msg: "Certificate authority (CA) file at the default location is not removed successfully"
+
+- name: Download certificate authority (CA) for the certificate to a destination path without ext_id
+  nutanix.ncp.ntnx_object_stores_certificate_info_v2:
+    object_store_ext_id: "{{ object_store_ext_id_1 }}"
+    download_ca: true
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Download certificate authority (CA) for the certificate to a destination path without ext_id status
+  ansible.builtin.assert:
+    that:
+      - result.changed is false
+      - result.failed is true
+      - >-
+        result.msg == "download_ca is True but all of the following are
+        missing: ext_id"
+    success_msg: "Download certificate authority (CA) for the certificate to a destination path without ext_id failed as expected"
+    fail_msg: "Download certificate authority (CA) for the certificate to a destination path without ext_id did not fail as expected"
+
 - name: List all object stores
   nutanix.ncp.ntnx_object_stores_info_v2:
   register: result
@@ -351,3 +479,31 @@
       - result.response.cluster_ext_id == "{{ cluster.uuid }}"
     success_msg: "Object store details are fetched successfully using external ID"
     fail_msg: "Object store details are not fetched successfully using external ID"
+
+- name: Set time window for object store statistics
+  ansible.builtin.set_fact:
+    stats_start_time: "{{ lookup('pipe', 'date -u -d \"1 hour ago\" +%Y-%m-%dT%H:%M:%S.000+00:00') }}"
+    stats_end_time: "{{ lookup('pipe', 'date -u +%Y-%m-%dT%H:%M:%S.000+00:00') }}"
+
+- name: Fetch object store statistics for the time window
+  nutanix.ncp.ntnx_object_stores_stats_info_v2:
+    ext_id: "{{ object_store_ext_id_1 }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+    sampling_interval: 300
+    stat_type: "SUM"
+  register: result
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- name: Fetch object store statistics for the time window status
+  ansible.builtin.assert:
+    that:
+      - result.changed is false
+      - result.failed is false
+      - result.ext_id == "{{ object_store_ext_id_1 }}"
+      - result.response is defined
+    success_msg: "Object store statistics are fetched successfully for the time window"
+    fail_msg: "Object store statistics are not fetched successfully for the time window"

--- a/tests/integration/targets/ntnx_objects_v2/tasks/deploy_objects.yml
+++ b/tests/integration/targets/ntnx_objects_v2/tasks/deploy_objects.yml
@@ -303,6 +303,7 @@
   ansible.builtin.file:
     path: "/tmp/object_store_ca.pem"
     state: absent
+  register: result
   ignore_errors: true
 
 - name: Stat the certificate authority (CA) file after removal
@@ -350,6 +351,7 @@
   ansible.builtin.file:
     path: "{{ result.response.path }}"
     state: absent
+  register: result
   ignore_errors: true
 
 - name: Stat the certificate authority (CA) file at the default location after removal

--- a/tests/integration/targets/ntnx_objects_v2/tasks/deploy_objects.yml
+++ b/tests/integration/targets/ntnx_objects_v2/tasks/deploy_objects.yml
@@ -279,18 +279,12 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.debug:
-    var: result
-
 - name: Stat the downloaded certificate authority (CA) file
   ansible.builtin.stat:
     path: "{{ result.response.path }}"
   register: ca_file_stat
   when: result.response.path is defined
   ignore_errors: true
-
-- ansible.builtin.debug:
-    var: ca_file_stat
 
 - name: Download certificate authority (CA) for the certificate to a destination path status
   ansible.builtin.assert:
@@ -317,9 +311,6 @@
   register: ca_file_stat_after_removal
   ignore_errors: true
 
-- ansible.builtin.debug:
-    var: ca_file_stat_after_removal
-
 - name: Verify certificate authority (CA) file is removed status
   ansible.builtin.assert:
     that:
@@ -334,9 +325,6 @@
     download_ca: true
   register: result
   ignore_errors: true
-
-- ansible.builtin.debug:
-    var: result
 
 - name: Stat the downloaded certificate authority (CA) file at the default location
   ansible.builtin.stat:
@@ -383,9 +371,6 @@
     download_ca: true
   register: result
   ignore_errors: true
-
-- ansible.builtin.debug:
-    var: result
 
 - name: Download certificate authority (CA) for the certificate to a destination path without ext_id status
   ansible.builtin.assert:
@@ -482,7 +467,7 @@
 
 - name: Set time window for object store statistics
   ansible.builtin.set_fact:
-    stats_start_time: "{{ lookup('pipe', 'date -u -d \"1 hour ago\" +%Y-%m-%dT%H:%M:%S.000+00:00') }}"
+    stats_start_time: '{{ lookup(''pipe'', ''date -u -d "1 hour ago" +%Y-%m-%dT%H:%M:%S.000+00:00'') }}'
     stats_end_time: "{{ lookup('pipe', 'date -u +%Y-%m-%dT%H:%M:%S.000+00:00') }}"
 
 - name: Fetch object store statistics for the time window
@@ -494,9 +479,6 @@
     stat_type: "SUM"
   register: result
   ignore_errors: true
-
-- ansible.builtin.debug:
-    var: result
 
 - name: Fetch object store statistics for the time window status
   ansible.builtin.assert:

--- a/tests/integration/targets/ntnx_objects_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_objects_v2/tasks/main.yml
@@ -10,13 +10,13 @@
       nutanix_debug: "{{ nutanix_debug | default(omit) }}"
       nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
   block:
-    # - name: Import deploy_objects.yml
-    #   ansible.builtin.import_tasks: "deploy_objects.yml"
+    - name: Import deploy_objects.yml
+      ansible.builtin.import_tasks: "deploy_objects.yml"
     - name: Import objects_images.yml
       ansible.builtin.import_tasks: "objects_images.yml"
-    # - name: Import objects_ovas.yml
-    #   ansible.builtin.import_tasks: "objects_ovas.yml"
-    # - name: Import delete_objects.yml
-    #   ansible.builtin.import_tasks: "delete_objects.yml"
-    # - name: Import update_objects.yml
-    #   ansible.builtin.import_tasks: "update_objects.yml"
+    - name: Import objects_ovas.yml
+      ansible.builtin.import_tasks: "objects_ovas.yml"
+    - name: Import delete_objects.yml
+      ansible.builtin.import_tasks: "delete_objects.yml"
+    - name: Import update_objects.yml
+      ansible.builtin.import_tasks: "update_objects.yml"

--- a/tests/integration/targets/ntnx_objects_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_objects_v2/tasks/main.yml
@@ -10,13 +10,13 @@
       nutanix_debug: "{{ nutanix_debug | default(omit) }}"
       nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
   block:
-    - name: Import deploy_objects.yml
-      ansible.builtin.import_tasks: "deploy_objects.yml"
+    # - name: Import deploy_objects.yml
+    #   ansible.builtin.import_tasks: "deploy_objects.yml"
     - name: Import objects_images.yml
       ansible.builtin.import_tasks: "objects_images.yml"
-    - name: Import objects_ovas.yml
-      ansible.builtin.import_tasks: "objects_ovas.yml"
-    - name: Import delete_objects.yml
-      ansible.builtin.import_tasks: "delete_objects.yml"
-    - name: Import update_objects.yml
-      ansible.builtin.import_tasks: "update_objects.yml"
+    # - name: Import objects_ovas.yml
+    #   ansible.builtin.import_tasks: "objects_ovas.yml"
+    # - name: Import delete_objects.yml
+    #   ansible.builtin.import_tasks: "delete_objects.yml"
+    # - name: Import update_objects.yml
+    #   ansible.builtin.import_tasks: "update_objects.yml"

--- a/tests/integration/targets/ntnx_objects_v2/tasks/objects_images.yml
+++ b/tests/integration/targets/ntnx_objects_v2/tasks/objects_images.yml
@@ -85,7 +85,7 @@
 
 - name: Upload image to object store bucket using AWS CLI
   ansible.builtin.shell: |
-    aws s3api put-object --bucket vmm-images --body {{ disk_image.dest }} --key {{ object_1_name }} --no-verify-ssl
+    aws s3api put-object --bucket vmm-images --body {{ cirros_image.dest }} --key {{ object_1_name }} --no-verify-ssl
   register: upload_result
   ignore_errors: true
   changed_when: "'ETag' in upload_result.stdout"

--- a/tests/integration/targets/ntnx_objects_v2/tasks/objects_images.yml
+++ b/tests/integration/targets/ntnx_objects_v2/tasks/objects_images.yml
@@ -90,6 +90,10 @@
   ignore_errors: true
   changed_when: "'ETag' in upload_result.stdout"
 
+- name: Debug upload result
+  ansible.builtin.debug:
+    msg: "{{ upload_result }}"
+
 - name: Assert image upload to object store bucket succeeded
   ansible.builtin.assert:
     that:

--- a/tests/integration/targets/ntnx_objects_v2/tasks/objects_images.yml
+++ b/tests/integration/targets/ntnx_objects_v2/tasks/objects_images.yml
@@ -90,10 +90,6 @@
   ignore_errors: true
   changed_when: "'ETag' in upload_result.stdout"
 
-- name: Debug upload result
-  ansible.builtin.debug:
-    msg: "{{ upload_result }}"
-
 - name: Assert image upload to object store bucket succeeded
   ansible.builtin.assert:
     that:

--- a/tests/integration/targets/prepare_env/playbooks/prepare_env.yml
+++ b/tests/integration/targets/prepare_env/playbooks/prepare_env.yml
@@ -193,11 +193,31 @@
     #           name: "{{dr_vm_name}}"
     #           uuid: "{{result.vm_uuid}}"
 
+    - name: Check if cirros image already exists locally
+      ansible.builtin.stat:
+        path: "{{ cirros_image.dest }}"
+      register: cirros_image_stat
+
+    - name: Downloading small cirros image for object store upload tests
+      ansible.builtin.get_url:
+        mode: "0644"
+        url: "{{ cirros_image.url }}"
+        dest: "{{ cirros_image.dest }}"
+        timeout: 120
+      when: not cirros_image_stat.stat.exists
+
+    - name: Check if disk image already exists locally
+      ansible.builtin.stat:
+        path: "{{ disk_image.dest }}"
+      register: disk_image_stat
+
     - name: Downloading disk image for image related tests
       ansible.builtin.get_url:
         mode: "0644"
         url: "{{ disk_image.url }}"
         dest: "{{ disk_image.dest }}"
+        timeout: 120
+      when: not disk_image_stat.stat.exists
     #   # - name: create address group for network security policy related tests
     #   #   nutanix.ncp.ntnx_address_groups:
     #   #     state: present


### PR DESCRIPTION
# Object Store Statistics and Certificate Authority Download for Nutanix Prism Central

Adds Object Store statistics retrieval and certificate authority (CA) download support to the Objects modules on Nutanix Prism Central using v4 APIs.

## New Modules

| Module | Description |
|--------|-------------|
| `ntnx_object_stores_stats_info_v2` | Fetch statistics of an object store for a given time window (sampling interval, down-sampling operator, property selection) |

## Updated Modules

| Module | Description |
|--------|-------------|
| `ntnx_object_stores_certificate_info_v2` | Adds `download_ca` to download the certificate authority (CA) of a certificate, with an optional `dest` path (in addition to existing fetch/list of certificates) |

## Features

- **Object Store statistics**: Fetch stats by `ext_id` over a time window with required `start_time`/`end_time` (extended ISO-8601), optional `sampling_interval`, `stat_type` (`SUM`, `MIN`, `MAX`, `AVG`, `COUNT`, `LAST`), and `select` for choosing specific properties
- **Certificate authority download**: Download the CA of a certificate with `download_ca`, returned as an `application/octet-stream` file; `download_ca` requires `ext_id`
- **Configurable destination**: Provide `dest` to save the CA to an explicit path (parent directory is created if missing), or omit it to download to the SDK default location, with the chosen path returned under `response.path`
- **No breaking changes**: New parameters and a new module only; existing certificate fetch/list behavior is preserved

## Examples

- `examples/objects_v2/deploy_objects_v2.yml`

## Integration Tests

- `tests/integration/targets/ntnx_objects_v2/` — CA download to a destination path and to the default location (with file existence/size verification and post-removal checks), negative test for `download_ca` without `ext_id`, and object store statistics fetch over a time window
