### PR TITLE
BgpSession Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/networking/BgpSession/bgp_sessions.yml
+++ b/examples/networking/BgpSession/bgp_sessions.yml
@@ -1,0 +1,170 @@
+---
+- name: BGP Session Operations
+  hosts: localhost
+  gather_facts: false
+  vars:
+    ip: "10.0.0.1"
+    username: "admin"
+    password: "password"
+    local_gw_ref: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    remote_gw_ref: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+
+  tasks:
+    ########################################################################################
+    # Create BGP Session with minimum attributes
+    ########################################################################################
+    - name: Create BGP session with minimum attributes
+      nutanix.ncp.ntnx_BgpSession_v2:
+        nutanix_host: "{{ ip }}"
+        nutanix_username: "{{ username }}"
+        nutanix_password: "{{ password }}"
+        validate_certs: false
+        state: present
+        name: "bgp_session_min"
+        local_gateway_reference: "{{ local_gw_ref }}"
+        remote_gateway_reference: "{{ remote_gw_ref }}"
+      register: create_min_result
+      ignore_errors: true
+
+    ########################################################################################
+    # Create BGP Session with all attributes
+    ########################################################################################
+    - name: Create BGP session with all attributes
+      nutanix.ncp.ntnx_BgpSession_v2:
+        nutanix_host: "{{ ip }}"
+        nutanix_username: "{{ username }}"
+        nutanix_password: "{{ password }}"
+        validate_certs: false
+        state: present
+        name: "bgp_session_all"
+        description: "BGP session created with all attributes"
+        local_gateway_reference: "{{ local_gw_ref }}"
+        remote_gateway_reference: "{{ remote_gw_ref }}"
+        local_gateway_interface_ip_address:
+          ipv4:
+            value: "192.168.1.1"
+            prefix_length: 32
+        dynamic_route_priority: 100
+        password: "bgp_password"
+        should_advertise_all_externally_routable_prefixes: true
+        externally_routable_prefixes_to_advertise:
+          - ipv4:
+              ip:
+                value: "10.0.0.0"
+              prefix_length: 24
+        prepended_autonomous_system_path:
+          - 65000
+          - 65001
+        advertised_routes_communities:
+          - autonomous_system_number: 65000
+            community_value: 100
+      register: create_all_result
+      ignore_errors: true
+
+    ########################################################################################
+    # Get BGP Session by ext_id
+    ########################################################################################
+    - name: Get BGP session by ext_id
+      nutanix.ncp.ntnx_BgpSession_info_v2:
+        nutanix_host: "{{ ip }}"
+        nutanix_username: "{{ username }}"
+        nutanix_password: "{{ password }}"
+        validate_certs: false
+        ext_id: "{{ create_all_result.ext_id }}"
+      register: get_result
+      ignore_errors: true
+      when: create_all_result is succeeded
+
+    ########################################################################################
+    # List all BGP Sessions
+    ########################################################################################
+    - name: List all BGP sessions
+      nutanix.ncp.ntnx_BgpSession_info_v2:
+        nutanix_host: "{{ ip }}"
+        nutanix_username: "{{ username }}"
+        nutanix_password: "{{ password }}"
+        validate_certs: false
+      register: list_result
+      ignore_errors: true
+
+    ########################################################################################
+    # List BGP Sessions with filter
+    ########################################################################################
+    - name: List BGP sessions with filter
+      nutanix.ncp.ntnx_BgpSession_info_v2:
+        nutanix_host: "{{ ip }}"
+        nutanix_username: "{{ username }}"
+        nutanix_password: "{{ password }}"
+        validate_certs: false
+        filter: "name eq 'bgp_session_all'"
+      register: filter_result
+      ignore_errors: true
+
+    ########################################################################################
+    # List BGP Sessions with limit
+    ########################################################################################
+    - name: List BGP sessions with limit
+      nutanix.ncp.ntnx_BgpSession_info_v2:
+        nutanix_host: "{{ ip }}"
+        nutanix_username: "{{ username }}"
+        nutanix_password: "{{ password }}"
+        validate_certs: false
+        limit: 5
+      register: limit_result
+      ignore_errors: true
+
+    ########################################################################################
+    # Update BGP Session
+    ########################################################################################
+    - name: Update BGP session
+      nutanix.ncp.ntnx_BgpSession_v2:
+        nutanix_host: "{{ ip }}"
+        nutanix_username: "{{ username }}"
+        nutanix_password: "{{ password }}"
+        validate_certs: false
+        state: present
+        ext_id: "{{ create_all_result.ext_id }}"
+        name: "bgp_session_updated"
+        description: "Updated BGP session description"
+        dynamic_route_priority: 200
+        should_advertise_all_externally_routable_prefixes: false
+        externally_routable_prefixes_to_advertise:
+          - ipv4:
+              ip:
+                value: "172.16.0.0"
+              prefix_length: 16
+        advertised_routes_communities:
+          - autonomous_system_number: 65000
+            community_value: 200
+          - autonomous_system_number: 65001
+            community_value: 300
+      register: update_result
+      ignore_errors: true
+      when: create_all_result is succeeded
+
+    ########################################################################################
+    # Delete BGP Sessions
+    ########################################################################################
+    - name: Delete BGP session
+      nutanix.ncp.ntnx_BgpSession_v2:
+        nutanix_host: "{{ ip }}"
+        nutanix_username: "{{ username }}"
+        nutanix_password: "{{ password }}"
+        validate_certs: false
+        state: absent
+        ext_id: "{{ create_all_result.ext_id }}"
+      register: delete_result
+      ignore_errors: true
+      when: create_all_result is succeeded
+
+    - name: Delete BGP session with minimum attributes
+      nutanix.ncp.ntnx_BgpSession_v2:
+        nutanix_host: "{{ ip }}"
+        nutanix_username: "{{ username }}"
+        nutanix_password: "{{ password }}"
+        validate_certs: false
+        state: absent
+        ext_id: "{{ create_min_result.ext_id }}"
+      register: delete_min_result
+      ignore_errors: true
+      when: create_min_result is succeeded

--- a/examples/networking/BgpSession/bgp_sessions_example_logs.txt
+++ b/examples/networking/BgpSession/bgp_sessions_example_logs.txt
@@ -1,0 +1,4 @@
+<Need to add sample>
+
+No PC endpoint is available to run examples against.
+Example logs will be populated once executed against a live Nutanix PC environment.

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -47,6 +47,7 @@ class Tasks:
         CLUSTER_PROFILE = "clustermgmt:config:cluster-profile"
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
+        BGP_SESSION = "networking:config:bgp-session"
         ENTITY_GROUP = "microseg:config:entity-group"
 
     class CompletetionDetailsName:

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_bgp_sessions_api_instance(module):
+    """
+    This method will return BgpSessionsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): BGP Sessions Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.BgpSessionsApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,23 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_bgp_session(module, api_instance, ext_id):
+    """
+    This method will return BGP session info using its ext_id.
+    Args:
+        module: Ansible module
+        api_instance: BgpSessionsApi instance from ntnx_networking_py_client sdk
+        ext_id (str): BGP session external ID
+    return:
+        info (object): BGP session info
+    """
+    try:
+        return api_instance.get_bgp_session_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching BGP session info using ext_id",
+        )

--- a/plugins/modules/ntnx_BgpSession_info_v2.py
+++ b/plugins/modules/ntnx_BgpSession_info_v2.py
@@ -1,0 +1,202 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_BgpSession_info_v2
+short_description: Fetch BGP session info in Nutanix Prism Central
+version_added: 2.6.0
+description:
+  - This module allows you to fetch BGP session info or list BGP sessions in Nutanix Prism Central.
+  - If ext_id is provided, fetch a particular BGP session info using external ID.
+  - If ext_id is not provided, fetch multiple BGP sessions with optional filter or limit.
+  - This module uses PC v4 APIs based SDKs
+options:
+  ext_id:
+    description:
+      - The external identifier of the BGP session.
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+EXAMPLES = r"""
+- name: Get BGP session using ext_id
+  nutanix.ncp.ntnx_BgpSession_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "c3d4e5f6-a7b8-9012-cdef-123456789012"
+  register: result
+  ignore_errors: true
+
+- name: List all BGP sessions
+  nutanix.ncp.ntnx_BgpSession_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+  register: result
+  ignore_errors: true
+
+- name: List BGP sessions with filter
+  nutanix.ncp.ntnx_BgpSession_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    filter: "name eq 'bgp_session_1'"
+  register: result
+  ignore_errors: true
+
+- name: List BGP sessions with limit
+  nutanix.ncp.ntnx_BgpSession_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    limit: 5
+  register: result
+  ignore_errors: true
+"""
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC BgpSession info v4 API.
+    - It can be a single BgpSession if external ID is provided.
+    - List of multiple BgpSession if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the BGP session
+  type: str
+  returned: when external ID is provided
+  sample: "7bea69e9-684c-4736-7805-d658ee17c1b6"
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+total_available_results:
+  description: The total number of available BGP sessions in PC.
+  type: int
+  returned: when all BGP sessions are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_bgp_sessions_api_instance,
+)
+from ..module_utils.v4.network.helpers import get_bgp_session  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_bgp_session_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_bgp_session(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_bgp_sessions(module, api_instance, result):
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating BGP sessions info spec", **result)
+
+    try:
+        resp = api_instance.list_bgp_sessions(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching BGP sessions info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_bgp_sessions_api_instance(module)
+    if module.params.get("ext_id"):
+        get_bgp_session_using_ext_id(module, api_instance, result)
+    else:
+        get_bgp_sessions(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_BgpSession_v2.py
+++ b/plugins/modules/ntnx_BgpSession_v2.py
@@ -1,0 +1,607 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_BgpSession_v2
+short_description: Create, Update, Delete BGP sessions in Nutanix Prism Central
+version_added: 2.6.0
+description:
+  - This module allows you to create, update, and delete BGP sessions in Nutanix Prism Central.
+  - This module uses PC v4 APIs based SDKs
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and ext_id is not provided then the operation will be create BGP session.
+      - If C(state) is set to C(present) and ext_id is provided then the operation will be update BGP session.
+      - If C(state) is set to C(absent) and ext_id is provided then the operation will be delete BGP session.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the BGP session. Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - BGP session name.
+    type: str
+    required: false
+  description:
+    description:
+      - Description of the BGP session.
+    type: str
+    required: false
+  local_gateway_reference:
+    description:
+      - Reference to the local gateway.
+    type: str
+    required: false
+  remote_gateway_reference:
+    description:
+      - Reference to the remote gateway.
+    type: str
+    required: false
+  local_gateway_interface_ip_address:
+    description:
+      - Local gateway interface IP address.
+    type: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 address configuration.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv4 address of the host.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the network.
+            type: int
+            required: false
+      ipv6:
+        description:
+          - IPv6 address configuration.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv6 address of the host.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the network.
+            type: int
+            required: false
+  dynamic_route_priority:
+    description:
+      - Dynamic route priority for the BGP session.
+    type: int
+    required: false
+  password:
+    description:
+      - BGP session password for authentication.
+    type: str
+    required: false
+    no_log: true
+  should_advertise_all_externally_routable_prefixes:
+    description:
+      - Whether to advertise all externally routable prefixes.
+    type: bool
+    required: false
+  externally_routable_prefixes_to_advertise:
+    description:
+      - List of externally routable prefixes to advertise.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 subnet configuration.
+        type: dict
+        required: false
+        suboptions:
+          ip:
+            description:
+              - IPv4 address specification.
+            type: dict
+            required: true
+            suboptions:
+              value:
+                description:
+                  - The IPv4 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the network.
+                type: int
+                required: false
+          prefix_length:
+            description:
+              - Prefix length of the IPv4 subnet.
+            type: int
+            required: true
+      ipv6:
+        description:
+          - IPv6 subnet configuration.
+        type: dict
+        required: false
+        suboptions:
+          ip:
+            description:
+              - IPv6 address specification.
+            type: dict
+            required: true
+            suboptions:
+              value:
+                description:
+                  - The IPv6 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the network.
+                type: int
+                required: false
+          prefix_length:
+            description:
+              - Prefix length of the IPv6 subnet.
+            type: int
+            required: true
+  prepended_autonomous_system_path:
+    description:
+      - List of autonomous system numbers to prepend to the AS path.
+    type: list
+    elements: int
+    required: false
+  advertised_routes_communities:
+    description:
+      - List of BGP communities for advertised routes.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      autonomous_system_number:
+        description:
+          - Autonomous System Number that originated the community.
+        type: int
+        required: true
+      community_value:
+        description:
+          - BGP community value.
+        type: int
+        required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create a BGP session
+  nutanix.ncp.ntnx_BgpSession_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "bgp_session_1"
+    description: "BGP session created by Ansible"
+    local_gateway_reference: "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    remote_gateway_reference: "b2c3d4e5-f6a7-8901-bcde-f12345678901"
+    local_gateway_interface_ip_address:
+      ipv4:
+        value: "192.168.1.1"
+        prefix_length: 32
+    dynamic_route_priority: 100
+    password: "bgp_password"
+    should_advertise_all_externally_routable_prefixes: true
+    externally_routable_prefixes_to_advertise:
+      - ipv4:
+          ip:
+            value: "10.0.0.0"
+          prefix_length: 24
+    prepended_autonomous_system_path:
+      - 65000
+      - 65001
+    advertised_routes_communities:
+      - autonomous_system_number: 65000
+        community_value: 100
+  register: result
+  ignore_errors: true
+
+- name: Update a BGP session
+  nutanix.ncp.ntnx_BgpSession_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "c3d4e5f6-a7b8-9012-cdef-123456789012"
+    name: "bgp_session_1_updated"
+    description: "Updated BGP session"
+    dynamic_route_priority: 200
+  register: result
+  ignore_errors: true
+
+- name: Delete a BGP session
+  nutanix.ncp.ntnx_BgpSession_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "c3d4e5f6-a7b8-9012-cdef-123456789012"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting BGP session
+    - If the operation is create or update and C(wait) is true, it will return the BGP session details
+    - If the operation is create or update and C(wait) is false, it will return the task details
+    - If the operation is delete, it will return the task details
+  returned: always
+  type: dict
+
+task_ext_id:
+  description:
+    - The external id of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external id of the BGP session.
+  returned: always
+  type: str
+  sample: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped due to idempotency
+  returned: when applicable
+  type: str
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: always
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Status or error message
+  returned: contextual
+  type: str
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_bgp_sessions_api_instance,
+    get_etag,
+)
+from ..module_utils.v4.network.helpers import get_bgp_session  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_networking_py_client as networking_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as networking_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    ipv4_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False),
+    )
+
+    ipv6_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False),
+    )
+
+    ip_address_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_address_spec,
+            required=False,
+            obj=networking_sdk.IPv4Address,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_address_spec,
+            required=False,
+            obj=networking_sdk.IPv6Address,
+        ),
+    )
+
+    ipv4_subnet_spec = dict(
+        ip=dict(
+            type="dict",
+            options=ipv4_address_spec,
+            required=True,
+            obj=networking_sdk.IPv4Address,
+        ),
+        prefix_length=dict(type="int", required=True),
+    )
+
+    ipv6_subnet_spec = dict(
+        ip=dict(
+            type="dict",
+            options=ipv6_address_spec,
+            required=True,
+            obj=networking_sdk.IPv6Address,
+        ),
+        prefix_length=dict(type="int", required=True),
+    )
+
+    ip_subnet_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_subnet_spec,
+            required=False,
+            obj=networking_sdk.IPv4Subnet,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_subnet_spec,
+            required=False,
+            obj=networking_sdk.IPv6Subnet,
+        ),
+    )
+
+    bgp_community_spec = dict(
+        autonomous_system_number=dict(type="int", required=True),
+        community_value=dict(type="int", required=True),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        description=dict(type="str"),
+        local_gateway_reference=dict(type="str"),
+        remote_gateway_reference=dict(type="str"),
+        local_gateway_interface_ip_address=dict(
+            type="dict",
+            options=ip_address_spec,
+            obj=networking_sdk.IPAddress,
+        ),
+        dynamic_route_priority=dict(type="int"),
+        password=dict(type="str", no_log=True),
+        should_advertise_all_externally_routable_prefixes=dict(type="bool"),
+        externally_routable_prefixes_to_advertise=dict(
+            type="list",
+            elements="dict",
+            options=ip_subnet_spec,
+            obj=networking_sdk.IPSubnet,
+        ),
+        prepended_autonomous_system_path=dict(
+            type="list",
+            elements="int",
+        ),
+        advertised_routes_communities=dict(
+            type="list",
+            elements="dict",
+            options=bgp_community_spec,
+            obj=networking_sdk.BgpCommunity,
+        ),
+    )
+    return module_args
+
+
+def create_BgpSession(module, result, api_instance):
+    sg = SpecGenerator(module)
+    default_spec = networking_sdk.BgpSession()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create BGP session spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_bgp_session(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating BGP session",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        resp = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            resp, rel=TASK_CONSTANTS.RelEntityType.BGP_SESSION
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            resp = get_bgp_session(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    old_spec_dict = strip_internal_attributes(old_spec_dict)
+    update_spec_dict = strip_internal_attributes(update_spec_dict)
+    return old_spec_dict == update_spec_dict
+
+
+def update_BgpSession(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    old_spec = get_bgp_session(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            "Unable to fetch etag for updating BGP session", **result
+        )
+    kwargs = {"if_match": etag}
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update BGP session spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.")
+
+    resp = None
+    try:
+        resp = api_instance.update_bgp_session_by_id(
+            extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating BGP session",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_bgp_session(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def delete_BgpSession(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "BGP session with ext_id:{0} will be deleted.".format(ext_id)
+        return
+
+    resp = None
+    try:
+        resp = api_instance.delete_bgp_session_by_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting BGP session",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+            ("state", "present", ("name", "ext_id"), True),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_networking_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_bgp_sessions_api_instance(module)
+    state = module.params.get("state")
+
+    if state == "absent":
+        delete_BgpSession(module, result, api_instance)
+    elif module.params.get("ext_id"):
+        update_BgpSession(module, result, api_instance)
+    else:
+        create_BgpSession(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_bgp_sessions_v2/aliases
+++ b/tests/integration/targets/ntnx_bgp_sessions_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_bgp_sessions_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_bgp_sessions_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/bgp_sessions.yml
+++ b/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/bgp_sessions.yml
@@ -1,0 +1,510 @@
+---
+- name: Start BGP Sessions tests
+  ansible.builtin.debug:
+    msg: Start BGP Sessions tests
+
+- name: Generate random names
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+    todelete: []
+
+- name: Set names for BGP session
+  ansible.builtin.set_fact:
+    bgp_session_name: "bgp_{{ suffix_name }}_{{ random_name }}"
+
+- name: Set gateway references
+  ansible.builtin.set_fact:
+    local_gw_ref: "{{ bgp_session.local_gateway_reference }}"
+    remote_gw_ref: "{{ bgp_session.remote_gateway_reference }}"
+
+########################################################################################
+# Create BGP Session - Check Mode Tests (all fields)
+########################################################################################
+
+- name: Generate spec for creating BGP session using check mode with all attributes
+  nutanix.ncp.ntnx_BgpSession_v2:
+    name: "check_mode_bgp_full"
+    description: "BGP session created in check mode with all attributes"
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+    local_gateway_interface_ip_address:
+      ipv4:
+        value: "192.168.1.1"
+        prefix_length: 32
+    dynamic_route_priority: 100
+    password: "test_password"
+    should_advertise_all_externally_routable_prefixes: true
+    externally_routable_prefixes_to_advertise:
+      - ipv4:
+          ip:
+            value: "10.0.0.0"
+          prefix_length: 24
+    prepended_autonomous_system_path:
+      - 65000
+      - 65001
+    advertised_routes_communities:
+      - autonomous_system_number: 65000
+        community_value: 100
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for creating BGP session using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_bgp_full"
+      - result.response.description == "BGP session created in check mode with all attributes"
+      - result.response.local_gateway_reference == local_gw_ref
+      - result.response.remote_gateway_reference == remote_gw_ref
+      - result.response.local_gateway_interface_ip_address is defined
+      - result.response.local_gateway_interface_ip_address.ipv4.value == "192.168.1.1"
+      - result.response.local_gateway_interface_ip_address.ipv4.prefix_length == 32
+      - result.response.dynamic_route_priority == 100
+      - result.response.password == "test_password"
+      - result.response.should_advertise_all_externally_routable_prefixes == true
+      - result.response.externally_routable_prefixes_to_advertise | length == 1
+      - result.response.externally_routable_prefixes_to_advertise[0].ipv4.ip.value == "10.0.0.0"
+      - result.response.externally_routable_prefixes_to_advertise[0].ipv4.prefix_length == 24
+      - result.response.prepended_autonomous_system_path | length == 2
+      - result.response.prepended_autonomous_system_path[0] == 65000
+      - result.response.prepended_autonomous_system_path[1] == 65001
+      - result.response.advertised_routes_communities | length == 1
+      - result.response.advertised_routes_communities[0].autonomous_system_number == 65000
+      - result.response.advertised_routes_communities[0].community_value == 100
+    success_msg: "Spec for creating BGP session using check mode with all attributes is generated successfully"
+    fail_msg: "Spec for creating BGP session using check mode with all attributes is not generated successfully"
+
+########################################################################################
+# Create BGP Session Tests
+########################################################################################
+
+- name: Create BGP session with minimum attributes
+  nutanix.ncp.ntnx_BgpSession_v2:
+    name: "{{ bgp_session_name }}_min"
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+  register: result
+  ignore_errors: true
+
+- name: Create BGP session with minimum attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.name == "{{ bgp_session_name }}_min"
+    success_msg: "BGP session with minimum attributes created successfully"
+    fail_msg: "BGP session with minimum attributes creation failed"
+
+- name: Add BGP session to todelete list
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+- name: Create BGP session with all attributes
+  nutanix.ncp.ntnx_BgpSession_v2:
+    name: "{{ bgp_session_name }}_all"
+    description: "BGP session created by Ansible integration tests with all attributes"
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+    local_gateway_interface_ip_address:
+      ipv4:
+        value: "192.168.1.1"
+        prefix_length: 32
+    dynamic_route_priority: 100
+    password: "bgp_test_password"
+    should_advertise_all_externally_routable_prefixes: true
+    externally_routable_prefixes_to_advertise:
+      - ipv4:
+          ip:
+            value: "10.0.0.0"
+          prefix_length: 24
+    prepended_autonomous_system_path:
+      - 65000
+      - 65001
+    advertised_routes_communities:
+      - autonomous_system_number: 65000
+        community_value: 100
+  register: result
+  ignore_errors: true
+
+- name: Create BGP session with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.name == "{{ bgp_session_name }}_all"
+      - result.response.description == "BGP session created by Ansible integration tests with all attributes"
+      - result.response.local_gateway_reference == local_gw_ref
+      - result.response.remote_gateway_reference == remote_gw_ref
+      - result.response.dynamic_route_priority == 100
+      - result.response.should_advertise_all_externally_routable_prefixes == true
+      - result.response.externally_routable_prefixes_to_advertise | length == 1
+      - result.response.externally_routable_prefixes_to_advertise[0].ipv4.ip.value == "10.0.0.0"
+      - result.response.externally_routable_prefixes_to_advertise[0].ipv4.prefix_length == 24
+      - result.response.prepended_autonomous_system_path | length == 2
+      - result.response.prepended_autonomous_system_path[0] == 65000
+      - result.response.prepended_autonomous_system_path[1] == 65001
+      - result.response.advertised_routes_communities | length == 1
+      - result.response.advertised_routes_communities[0].autonomous_system_number == 65000
+      - result.response.advertised_routes_communities[0].community_value == 100
+    success_msg: "BGP session with all attributes created successfully"
+    fail_msg: "BGP session with all attributes creation failed"
+
+- name: Add BGP session to todelete list
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+########################################################################################
+# Negative Create Tests
+########################################################################################
+
+- name: Create BGP session with missing name
+  nutanix.ncp.ntnx_BgpSession_v2:
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+  register: result
+  ignore_errors: true
+
+- name: Create BGP session with missing name status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "state is present but any of the following are missing: name, ext_id"
+    success_msg: "Create BGP session with missing name failed as expected"
+    fail_msg: "Create BGP session with missing name did not fail as expected"
+
+########################################################################################
+# Update BGP Session - Check Mode Tests (all fields)
+########################################################################################
+
+- name: Generate spec for updating BGP session using check mode with all attributes
+  nutanix.ncp.ntnx_BgpSession_v2:
+    ext_id: "{{ todelete[1] }}"
+    name: "{{ bgp_session_name }}_updated"
+    description: "Updated description for BGP session with all attributes"
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+    local_gateway_interface_ip_address:
+      ipv4:
+        value: "10.0.0.100"
+        prefix_length: 24
+    dynamic_route_priority: 200
+    password: "updated_password"
+    should_advertise_all_externally_routable_prefixes: false
+    externally_routable_prefixes_to_advertise:
+      - ipv4:
+          ip:
+            value: "172.16.0.0"
+          prefix_length: 16
+    prepended_autonomous_system_path:
+      - 65002
+    advertised_routes_communities:
+      - autonomous_system_number: 65001
+        community_value: 200
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for updating BGP session using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "{{ bgp_session_name }}_updated"
+      - result.response.description == "Updated description for BGP session with all attributes"
+      - result.response.local_gateway_reference == local_gw_ref
+      - result.response.remote_gateway_reference == remote_gw_ref
+      - result.response.local_gateway_interface_ip_address.ipv4.value == "10.0.0.100"
+      - result.response.local_gateway_interface_ip_address.ipv4.prefix_length == 24
+      - result.response.dynamic_route_priority == 200
+      - result.response.password == "updated_password"
+      - result.response.should_advertise_all_externally_routable_prefixes == false
+      - result.response.externally_routable_prefixes_to_advertise | length == 1
+      - result.response.externally_routable_prefixes_to_advertise[0].ipv4.ip.value == "172.16.0.0"
+      - result.response.externally_routable_prefixes_to_advertise[0].ipv4.prefix_length == 16
+      - result.response.prepended_autonomous_system_path | length == 1
+      - result.response.prepended_autonomous_system_path[0] == 65002
+      - result.response.advertised_routes_communities | length == 1
+      - result.response.advertised_routes_communities[0].autonomous_system_number == 65001
+      - result.response.advertised_routes_communities[0].community_value == 200
+    success_msg: "Spec for updating BGP session using check mode with all attributes is generated successfully"
+    fail_msg: "Spec for updating BGP session using check mode with all attributes is not generated successfully"
+
+########################################################################################
+# Update BGP Session Tests
+########################################################################################
+
+- name: Update BGP session with all attributes
+  nutanix.ncp.ntnx_BgpSession_v2:
+    ext_id: "{{ todelete[1] }}"
+    name: "{{ bgp_session_name }}_updated"
+    description: "Updated description for BGP session"
+    dynamic_route_priority: 200
+    should_advertise_all_externally_routable_prefixes: false
+    externally_routable_prefixes_to_advertise:
+      - ipv4:
+          ip:
+            value: "172.16.0.0"
+          prefix_length: 16
+    prepended_autonomous_system_path:
+      - 65002
+    advertised_routes_communities:
+      - autonomous_system_number: 65001
+        community_value: 200
+  register: result
+  ignore_errors: true
+
+- name: Update BGP session with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "{{ bgp_session_name }}_updated"
+      - result.response.description == "Updated description for BGP session"
+      - result.response.dynamic_route_priority == 200
+      - result.response.should_advertise_all_externally_routable_prefixes == false
+      - result.response.externally_routable_prefixes_to_advertise | length == 1
+      - result.response.externally_routable_prefixes_to_advertise[0].ipv4.ip.value == "172.16.0.0"
+      - result.response.externally_routable_prefixes_to_advertise[0].ipv4.prefix_length == 16
+      - result.response.prepended_autonomous_system_path | length == 1
+      - result.response.prepended_autonomous_system_path[0] == 65002
+      - result.response.advertised_routes_communities | length == 1
+      - result.response.advertised_routes_communities[0].autonomous_system_number == 65001
+      - result.response.advertised_routes_communities[0].community_value == 200
+    success_msg: "Update BGP session with all attributes passed"
+    fail_msg: "Update BGP session with all attributes failed"
+
+- name: Update BGP session with same values (idempotency test)
+  nutanix.ncp.ntnx_BgpSession_v2:
+    ext_id: "{{ todelete[1] }}"
+    name: "{{ bgp_session_name }}_updated"
+    description: "Updated description for BGP session"
+    dynamic_route_priority: 200
+    should_advertise_all_externally_routable_prefixes: false
+    externally_routable_prefixes_to_advertise:
+      - ipv4:
+          ip:
+            value: "172.16.0.0"
+          prefix_length: 16
+    prepended_autonomous_system_path:
+      - 65002
+    advertised_routes_communities:
+      - autonomous_system_number: 65001
+        community_value: 200
+  register: result
+  ignore_errors: true
+
+- name: Update BGP session with same values to test idempotency status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.msg == "Nothing to change."
+    success_msg: "Update BGP session with same values to test idempotency passed"
+    fail_msg: "Update BGP session with same values to test idempotency failed"
+
+- name: Update BGP session with wrong external ID
+  nutanix.ncp.ntnx_BgpSession_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+    name: "test_wrong_ext_id"
+    description: "test description"
+  register: result
+  ignore_errors: true
+
+- name: Update BGP session with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Update BGP session with wrong external ID failed as expected"
+    fail_msg: "Update BGP session with wrong external ID did not fail as expected"
+
+########################################################################################
+# Info Module Tests - Get Single BGP Session
+########################################################################################
+
+- name: Fetch BGP session using external ID
+  nutanix.ncp.ntnx_BgpSession_info_v2:
+    ext_id: "{{ todelete[1] }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch BGP session using external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "{{ bgp_session_name }}_updated"
+      - result.response.description == "Updated description for BGP session"
+      - result.response.dynamic_route_priority == 200
+      - result.response.should_advertise_all_externally_routable_prefixes == false
+      - result.ext_id == todelete[1]
+    success_msg: "Fetch BGP session using external ID passed"
+    fail_msg: "Fetch BGP session using external ID failed"
+
+- name: Fetch BGP session using wrong external ID
+  nutanix.ncp.ntnx_BgpSession_info_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+  register: result
+  ignore_errors: true
+
+- name: Fetch BGP session using wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Fetch BGP session using wrong external ID failed as expected"
+    fail_msg: "Fetch BGP session using wrong external ID did not fail as expected"
+
+########################################################################################
+# Info Module Tests - List BGP Sessions
+########################################################################################
+
+- name: List all BGP sessions
+  nutanix.ncp.ntnx_BgpSession_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List all BGP sessions status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 2
+    success_msg: "List all BGP sessions passed"
+    fail_msg: "List all BGP sessions failed"
+
+- name: List BGP sessions with filter
+  nutanix.ncp.ntnx_BgpSession_info_v2:
+    filter: "name eq '{{ bgp_session_name }}_updated'"
+  register: result
+  ignore_errors: true
+
+- name: List BGP sessions with filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+      - result.response[0].name == "{{ bgp_session_name }}_updated"
+    success_msg: "List BGP sessions with filter passed"
+    fail_msg: "List BGP sessions with filter failed"
+
+- name: List BGP sessions with limit
+  nutanix.ncp.ntnx_BgpSession_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List BGP sessions with limit status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    success_msg: "List BGP sessions with limit passed"
+    fail_msg: "List BGP sessions with limit failed"
+
+########################################################################################
+# Delete BGP Session - Check Mode Tests (all fields)
+########################################################################################
+
+- name: Delete BGP session with check mode
+  nutanix.ncp.ntnx_BgpSession_v2:
+    ext_id: "{{ todelete[0] }}"
+    state: absent
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Delete BGP session with check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+    success_msg: "Delete BGP session with check mode passed"
+    fail_msg: "Delete BGP session with check mode failed"
+
+########################################################################################
+# Delete BGP Session Tests
+########################################################################################
+
+- name: Delete all created BGP sessions
+  nutanix.ncp.ntnx_BgpSession_v2:
+    ext_id: "{{ item }}"
+    state: absent
+  register: result
+  ignore_errors: true
+  loop: "{{ todelete }}"
+
+- name: Deletion Status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.results | length == todelete | length
+      - result.msg == "All items completed"
+    fail_msg: "Unable to delete all BGP sessions"
+    success_msg: "All BGP sessions are deleted successfully"
+
+- name: Delete BGP session with wrong external ID
+  nutanix.ncp.ntnx_BgpSession_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Delete BGP session with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Delete BGP session with wrong external ID failed as expected"
+    fail_msg: "Delete BGP session with wrong external ID did not fail as expected"
+
+- name: Delete BGP session with missing external ID
+  nutanix.ncp.ntnx_BgpSession_v2:
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Delete BGP session with missing external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete BGP session with missing external ID failed as expected"
+    fail_msg: "Delete BGP session with missing external ID did not fail as expected"

--- a/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import bgp_sessions.yml
+      ansible.builtin.import_tasks: bgp_sessions.yml

--- a/tests/integration/targets/ntnx_bgp_sessions_v2/test_logs.txt
+++ b/tests/integration/targets/ntnx_bgp_sessions_v2/test_logs.txt
@@ -1,0 +1,4 @@
+<Need to add sample>
+
+No PC endpoint is available to run tests against.
+Test logs will be populated once executed against a live Nutanix PC environment.


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**BgpSession**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_BgpSession_v2`, `ntnx_BgpSession_info_v2`
- API methods covered: 5 (CreateBgpSession, GetBgpSessionById, UpdateBgpSessionById, DeleteBgpSessionById, ListBgpSessions)

## Files changed

- **plugins/modules/**
  - `ntnx_BgpSession_v2.py` — CRUD module (create, update, delete)
  - `ntnx_BgpSession_info_v2.py` — Info module (get by ID, list)
- **plugins/module_utils/v4/network/**
  - `api_client.py` — Added `get_bgp_sessions_api_instance()`
  - `helpers.py` — Added `get_bgp_session()` helper
- **plugins/module_utils/v4/**
  - `constants.py` — Added `BGP_SESSION` task relation entity type
- **examples/networking/BgpSession/**
  - `bgp_sessions.yml` — Example playbook covering all operations
  - `bgp_sessions_example_logs.txt` — Placeholder for execution logs
- **tests/integration/targets/ntnx_bgp_sessions_v2/**
  - `tasks/bgp_sessions.yml` — Integration tests with check_mode, CRUD, info, negative scenarios
  - `tasks/main.yml` — Test entry point
  - `meta/main.yml` — Test dependencies
  - `aliases` — Test alias (disabled)
  - `test_logs.txt` — Placeholder for test execution logs

## Test execution

| Metric              | Value                                |
|---------------------|--------------------------------------|
| Command             | `ansible-lint` + `black --check` + `isort --check` + `flake8` |
| Total tests         | N/A (no live PC endpoint available)  |
| Passed              | N/A                                  |
| Failed              | N/A                                  |
| Duration            | N/A                                  |

### Test logs (tail)

<details>
<summary>tail -n 500 test logs</summary>

```text
No PC endpoint is available to run integration tests against.
Test logs will be populated once executed against a live Nutanix PC environment.

Linting results:
- black: All files formatted correctly
- isort: All imports sorted correctly
- flake8: No issues found
- ansible-lint: Passed (0 failures, 0 warnings on module files)
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
