### PR TITLE
Ansible Collection Certification Review Fixes - nutanix.ncp:2.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 nutanix-ncp-*
 .ansible/
+py3.12_virt

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -23,3 +23,4 @@ build_ignore:
   - changelogs/.plugin-cache.yaml
   - .github
   - .vscode
+  - py3.12_virt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pip>=23.0
 setuptools>=65.0
-ansible-core>=2.16.0
 requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2


### PR DESCRIPTION
## Summary

Ansible Collection Certification Review Fixes for `nutanix.ncp:2.5.0`.

### Changes

1. Add `py3.12_virt` to `.gitignore`.
2. Add `py3.12_virt` to `galaxy.yml` `build_ignore` to avoid the venv directory being included in the collection tarball.
3. Remove `ansible-core` dependency from `requirements.txt`.  