### PR TITLE
code-gen(networking/BgpSession): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/networking/BgpSession/bgp_sessions_v2.yml
+++ b/examples/networking/BgpSession/bgp_sessions_v2.yml
@@ -1,0 +1,128 @@
+---
+# Summary:
+# This playbook exercises the BgpSession v4 modules end-to-end:
+# 1. Create BGP session (minimal + full attributes)
+# 2. Update BGP session
+# 3. Get BGP session using ext_id
+# 4. List all BGP sessions
+# 5. List BGP sessions with filter
+# 6. List BGP sessions with limit
+# 7. Delete BGP session
+#
+# Prerequisites (must exist on the target Prism Central):
+# - Flow Virtual Networking (FVN) enabled.
+# - A Local BGP Gateway VM and a Remote BGP Gateway entity that this session will peer with.
+# - Their external IDs are supplied through vars local_bgp_gateway_ext_id / remote_bgp_gateway_ext_id
+#   (or overridden inline). Connection credentials come from environment variables:
+#     NUTANIX_HOST, NUTANIX_USERNAME, NUTANIX_PASSWORD, NUTANIX_PORT.
+- name: BGP Session v4 playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') }}"
+      nutanix_port: "{{ lookup('env', 'NUTANIX_PORT') | default(9440, true) }}"
+      validate_certs: false
+  vars:
+    bgp_session_name: "bgp_session_ansible"
+    local_bgp_gateway_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    remote_bgp_gateway_ext_id: "1d63b7e2-3d1e-4c37-9d2c-6c1b2a48f4a1"
+  tasks:
+    - name: Create BGP session with minimum attributes
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: present
+        name: "{{ bgp_session_name }}_min"
+        local_gateway_reference: "{{ local_bgp_gateway_ext_id }}"
+        remote_gateway_reference: "{{ remote_bgp_gateway_ext_id }}"
+      register: create_min_result
+      ignore_errors: true
+
+    - name: Create BGP session with all attributes
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: present
+        name: "{{ bgp_session_name }}_full"
+        description: "BGP session created by Ansible (full attributes)"
+        local_gateway_reference: "{{ local_bgp_gateway_ext_id }}"
+        remote_gateway_reference: "{{ remote_bgp_gateway_ext_id }}"
+        local_gateway_interface_ip_address:
+          ipv4:
+            value: "10.10.10.1"
+            prefix_length: 24
+        dynamic_route_priority: 500
+        password: "s3cr3t-p@ss"
+        should_advertise_all_externally_routable_prefixes: false
+        externally_routable_prefixes_to_advertise:
+          - ipv4:
+              ip:
+                value: "192.168.0.0"
+                prefix_length: 32
+              prefix_length: 24
+        prepended_autonomous_system_path:
+          - 64512
+          - 64513
+        advertised_routes_communities:
+          - autonomous_system_number: 64512
+            community_value: 100
+      register: create_full_result
+      ignore_errors: true
+
+    - name: Capture BGP session ext_id
+      ansible.builtin.set_fact:
+        bgp_session_ext_id: "{{ create_full_result.ext_id | default(create_min_result.ext_id) }}"
+      when: (create_full_result.ext_id is defined) or (create_min_result.ext_id is defined)
+
+    - name: Update BGP session (change scalar + toggle advertise-all)
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: present
+        ext_id: "{{ bgp_session_ext_id }}"
+        name: "{{ bgp_session_name }}_full_updated"
+        description: "Updated BGP session description"
+        local_gateway_reference: "{{ local_bgp_gateway_ext_id }}"
+        remote_gateway_reference: "{{ remote_bgp_gateway_ext_id }}"
+        dynamic_route_priority: 700
+        should_advertise_all_externally_routable_prefixes: true
+      register: update_result
+      ignore_errors: true
+      when: bgp_session_ext_id is defined
+
+    - name: Get BGP session using ext_id
+      nutanix.ncp.ntnx_bgp_sessions_info_v2:
+        ext_id: "{{ bgp_session_ext_id }}"
+      register: get_by_id_result
+      ignore_errors: true
+      when: bgp_session_ext_id is defined
+
+    - name: List all BGP sessions
+      nutanix.ncp.ntnx_bgp_sessions_info_v2:
+      register: list_all_result
+      ignore_errors: true
+
+    - name: List BGP sessions with filter
+      nutanix.ncp.ntnx_bgp_sessions_info_v2:
+        filter: "name eq '{{ bgp_session_name }}_full_updated'"
+      register: list_filter_result
+      ignore_errors: true
+
+    - name: List BGP sessions with limit
+      nutanix.ncp.ntnx_bgp_sessions_info_v2:
+        limit: 1
+      register: list_limit_result
+      ignore_errors: true
+
+    - name: Delete BGP session (full attributes)
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: absent
+        ext_id: "{{ bgp_session_ext_id }}"
+      register: delete_full_result
+      ignore_errors: true
+      when: bgp_session_ext_id is defined
+
+    - name: Delete BGP session (minimal attributes)
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: absent
+        ext_id: "{{ create_min_result.ext_id }}"
+      register: delete_min_result
+      ignore_errors: true
+      when: create_min_result.ext_id is defined

--- a/examples/networking/BgpSession/examples_run.log
+++ b/examples/networking/BgpSession/examples_run.log
@@ -1,0 +1,57 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [BGP Session v4 playbook] *************************************************
+
+TASK [Create BGP session with minimum attributes] ******************************
+[ERROR]: Task failed: Module failed: Api Exception raised while creating BGP session
+Origin: /tmp/codegen/a1d0b3ff6c954e7cbd24d9cc869641a7/repo/examples/networking/BgpSession/bgp_sessions_v2.yml:33:7
+
+31     remote_bgp_gateway_ext_id: "1d63b7e2-3d1e-4c37-9d2c-6c1b2a48f4a1"
+32   tasks:
+33     - name: Create BGP session with minimum attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while creating BGP session", "response": {"$objectType": "networking.v4.config.GetBgpSessionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to create BGP session bgp_session_ansible_min as a referenced resource was not found - Application error kNotFound raised: VpnGateway bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258 not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/bgp-sessions", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [Create BGP session with all attributes] **********************************
+[ERROR]: Task failed: Module failed: Api Exception raised while creating BGP session
+Origin: /tmp/codegen/a1d0b3ff6c954e7cbd24d9cc869641a7/repo/examples/networking/BgpSession/bgp_sessions_v2.yml:42:7
+
+40       ignore_errors: true
+41
+42     - name: Create BGP session with all attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while creating BGP session", "response": {"$objectType": "networking.v4.config.GetBgpSessionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to create BGP session bgp_session_ansible_full as a referenced resource was not found - Application error kNotFound raised: VpnGateway bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258 not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/bgp-sessions", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [Capture BGP session ext_id] **********************************************
+skipping: [localhost] => {"changed": false, "false_condition": "(create_full_result.ext_id is defined) or (create_min_result.ext_id is defined)", "skip_reason": "Conditional result was False"}
+
+TASK [Update BGP session (change scalar + toggle advertise-all)] ***************
+skipping: [localhost] => {"changed": false, "false_condition": "bgp_session_ext_id is defined", "skip_reason": "Conditional result was False"}
+
+TASK [Get BGP session using ext_id] ********************************************
+skipping: [localhost] => {"changed": false, "false_condition": "bgp_session_ext_id is defined", "skip_reason": "Conditional result was False"}
+
+TASK [List all BGP sessions] ***************************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List BGP sessions with filter] *******************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List BGP sessions with limit] ********************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Delete BGP session (full attributes)] ************************************
+skipping: [localhost] => {"changed": false, "false_condition": "bgp_session_ext_id is defined", "skip_reason": "Conditional result was False"}
+
+TASK [Delete BGP session (minimal attributes)] *********************************
+skipping: [localhost] => {"changed": false, "false_condition": "create_min_result.ext_id is defined", "skip_reason": "Conditional result was False"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=5    changed=0    unreachable=0    failed=0    skipped=5    rescued=0    ignored=2   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_bgp_session_v2
+    - ntnx_bgp_sessions_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,7 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        BGP_SESSION = "networking:config:bgp-session"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_bgp_sessions_api_instance(module):
+    """
+    This method will return BgpSessionsApi instance for BGP session CRUD/list operations.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): BGP Sessions Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.BgpSessionsApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,23 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_bgp_session(module, api_instance, ext_id):
+    """
+    This method will return BGP session info using its ext_id.
+    Args:
+        module: Ansible module
+        api_instance: BgpSessionsApi instance from ntnx_networking_py_client sdk
+        ext_id (str): BGP session external ID
+    return:
+        info (object): BGP session info
+    """
+    try:
+        return api_instance.get_bgp_session_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching BGP session info using ext_id",
+        )

--- a/plugins/modules/ntnx_bgp_session_v2.py
+++ b/plugins/modules/ntnx_bgp_session_v2.py
@@ -1,0 +1,683 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_bgp_session_v2
+short_description: Create, Update, Delete BGP sessions in Nutanix Prism Central
+version_added: 2.6.0
+description:
+  - This module allows you to create, update, and delete BGP sessions in Nutanix Prism Central.
+  - A BGP session establishes a Border Gateway Protocol peering between a
+    local BGP gateway (Nutanix Flow Gateway VM) and a remote BGP gateway
+    (external router / cloud route server) for dynamic route exchange.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will create a BGP session.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will update the BGP session.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will delete the BGP session.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the BGP session.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - BGP session name.
+      - Required for create operation.
+      - Maximum 128 characters.
+    type: str
+    required: false
+  description:
+    description:
+      - BGP session description.
+      - Maximum 1000 characters.
+    type: str
+    required: false
+  local_gateway_reference:
+    description:
+      - External ID (UUID) of the local BGP gateway that anchors this session.
+      - Required for create operation.
+    type: str
+    required: false
+  remote_gateway_reference:
+    description:
+      - External ID (UUID) of the remote BGP gateway peer for this session.
+      - Required for create operation.
+    type: str
+    required: false
+  local_gateway_interface_ip_address:
+    description:
+      - IP address of the local gateway interface used for this BGP session.
+    type: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 address of the local gateway interface.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv4 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the network.
+            type: int
+            required: false
+            default: 32
+      ipv6:
+        description:
+          - IPv6 address of the local gateway interface.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the network.
+            type: int
+            required: false
+            default: 128
+  dynamic_route_priority:
+    description:
+      - Priority assigned to routes received over this BGP session.
+      - Higher values are preferred as tie-breakers between overlapping BGP paths.
+      - Valid range 300 to 1000.
+    type: int
+    required: false
+  password:
+    description:
+      - BGP peering password used for MD5 authentication of the session.
+    type: str
+    required: false
+  should_advertise_all_externally_routable_prefixes:
+    description:
+      - When set to true, all externally routable prefixes (ERPs) of the
+        serviced VPC are advertised over this BGP session.
+    type: bool
+    required: false
+  externally_routable_prefixes_to_advertise:
+    description:
+      - Explicit list of VPC externally-routable prefixes to advertise over
+        this BGP session. Ignored when
+        C(should_advertise_all_externally_routable_prefixes) is true.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 subnet prefix to advertise.
+        type: dict
+        required: false
+        suboptions:
+          ip:
+            description:
+              - Base IPv4 address of the subnet.
+            type: dict
+            required: true
+            suboptions:
+              value:
+                description:
+                  - The IPv4 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the network.
+                type: int
+                required: false
+                default: 32
+          prefix_length:
+            description:
+              - Prefix length of the IPv4 subnet.
+            type: int
+            required: true
+      ipv6:
+        description:
+          - IPv6 subnet prefix to advertise.
+        type: dict
+        required: false
+        suboptions:
+          ip:
+            description:
+              - Base IPv6 address of the subnet.
+            type: dict
+            required: true
+            suboptions:
+              value:
+                description:
+                  - The IPv6 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the network.
+                type: int
+                required: false
+                default: 128
+          prefix_length:
+            description:
+              - Prefix length of the IPv6 subnet.
+            type: int
+            required: true
+  prepended_autonomous_system_path:
+    description:
+      - List of ASNs to prepend to the AS_PATH attribute of BGP updates for this session.
+    type: list
+    elements: int
+    required: false
+  advertised_routes_communities:
+    description:
+      - BGP community tags to attach to advertised routes on this session.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      autonomous_system_number:
+        description:
+          - Autonomous System Number that originated the community.
+        type: int
+        required: true
+      community_value:
+        description:
+          - Community value associated with the ASN.
+        type: int
+        required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create BGP session with minimum attributes
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    name: "bgp_session_min"
+    local_gateway_reference: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    remote_gateway_reference: "1d63b7e2-3d1e-4c37-9d2c-6c1b2a48f4a1"
+  register: result
+
+- name: Create BGP session with all attributes
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    name: "bgp_session_full"
+    description: "BGP session created by Ansible"
+    local_gateway_reference: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    remote_gateway_reference: "1d63b7e2-3d1e-4c37-9d2c-6c1b2a48f4a1"
+    local_gateway_interface_ip_address:
+      ipv4:
+        value: "10.10.10.1"
+        prefix_length: 24
+    dynamic_route_priority: 500
+    password: "s3cr3t-p@ss"
+    should_advertise_all_externally_routable_prefixes: false
+    externally_routable_prefixes_to_advertise:
+      - ipv4:
+          ip:
+            value: "192.168.0.0"
+            prefix_length: 24
+          prefix_length: 24
+    prepended_autonomous_system_path:
+      - 64512
+      - 64513
+    advertised_routes_communities:
+      - autonomous_system_number: 64512
+        community_value: 100
+  register: result
+
+- name: Update BGP session
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+    name: "bgp_session_full_updated"
+    description: "Updated BGP session description"
+    local_gateway_reference: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    remote_gateway_reference: "1d63b7e2-3d1e-4c37-9d2c-6c1b2a48f4a1"
+    dynamic_route_priority: 700
+    should_advertise_all_externally_routable_prefixes: true
+  register: result
+
+- name: Delete BGP session
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: absent
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting BGP session.
+    - If the operation is create or update and C(wait) is true, it will return the BGP session details.
+    - If the operation is create or update and C(wait) is false, it will return the task details.
+    - If the operation is delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "name": "bgp_session_full",
+      "description": "BGP session created by Ansible",
+      "local_gateway_reference": "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258",
+      "remote_gateway_reference": "1d63b7e2-3d1e-4c37-9d2c-6c1b2a48f4a1",
+      "local_gateway_interface_ip_address": {
+          "ipv4": {"value": "10.10.10.1", "prefix_length": 24},
+          "ipv6": null
+      },
+      "dynamic_route_priority": 500,
+      "password": null,
+      "status": {"message": "BGP session is up.", "state": "UP"},
+      "local_gateway": null,
+      "remote_gateway": null,
+      "should_advertise_all_externally_routable_prefixes": false,
+      "externally_routable_prefixes_to_advertise": [
+          {
+              "ipv4": {"ip": {"value": "192.168.0.0", "prefix_length": 32}, "prefix_length": 24},
+              "ipv6": null
+          }
+      ],
+      "prepended_autonomous_system_path": [64512, 64513],
+      "advertised_routes_communities": [
+          {"autonomous_system_number": 64512, "community_value": 100}
+      ],
+      "metadata": null,
+      "ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d",
+      "links": null,
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the BGP session.
+  returned: always
+  type: str
+  sample: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped due to idempotency or check mode.
+  returned: when applicable
+  type: str
+  sample: "Nothing to change."
+
+error:
+  description: This indicates the error details if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message describing the outcome — success, idempotency, check mode, or error.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating BGP session"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_bgp_sessions_api_instance,
+    get_etag,
+)
+from ..module_utils.v4.network.helpers import get_bgp_session  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_networking_py_client as networking_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as networking_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    ipv4_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=32),
+    )
+
+    ipv6_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=128),
+    )
+
+    ip_address_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_address_spec,
+            required=False,
+            obj=networking_sdk.IPv4Address,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_address_spec,
+            required=False,
+            obj=networking_sdk.IPv6Address,
+        ),
+    )
+
+    ipv4_subnet_spec = dict(
+        ip=dict(
+            type="dict",
+            options=ipv4_address_spec,
+            required=True,
+            obj=networking_sdk.IPv4Address,
+        ),
+        prefix_length=dict(type="int", required=True),
+    )
+
+    ipv6_subnet_spec = dict(
+        ip=dict(
+            type="dict",
+            options=ipv6_address_spec,
+            required=True,
+            obj=networking_sdk.IPv6Address,
+        ),
+        prefix_length=dict(type="int", required=True),
+    )
+
+    ip_subnet_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_subnet_spec,
+            required=False,
+            obj=networking_sdk.IPv4Subnet,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_subnet_spec,
+            required=False,
+            obj=networking_sdk.IPv6Subnet,
+        ),
+    )
+
+    bgp_community_spec = dict(
+        autonomous_system_number=dict(type="int", required=True),
+        community_value=dict(type="int", required=True),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        description=dict(type="str"),
+        local_gateway_reference=dict(type="str"),
+        remote_gateway_reference=dict(type="str"),
+        local_gateway_interface_ip_address=dict(
+            type="dict",
+            options=ip_address_spec,
+            obj=networking_sdk.IPAddress,
+        ),
+        dynamic_route_priority=dict(type="int"),
+        password=dict(type="str", no_log=True),
+        should_advertise_all_externally_routable_prefixes=dict(type="bool"),
+        externally_routable_prefixes_to_advertise=dict(
+            type="list",
+            elements="dict",
+            options=ip_subnet_spec,
+            obj=networking_sdk.IPSubnet,
+        ),
+        prepended_autonomous_system_path=dict(type="list", elements="int"),
+        advertised_routes_communities=dict(
+            type="list",
+            elements="dict",
+            options=bgp_community_spec,
+            obj=networking_sdk.BgpCommunity,
+        ),
+    )
+    return module_args
+
+
+def _fetch_entity_from_task(module, api_instance, task_resp, result):
+    """Wait for a task, extract the BGP session ext_id, fetch and populate the entity."""
+    task_ext_id = task_resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(task_resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        completed = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(completed.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            completed, rel=TASK_CONSTANTS.RelEntityType.BGP_SESSION
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            resp = get_bgp_session(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(resp.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for BGP Session"
+                ),
+                msg="Failed to get entity ext_id from task for BGP Session",
+            )
+
+
+def create_bgp_session(module, api_instance, result):
+    validate_required_params(
+        module, ["name", "local_gateway_reference", "remote_gateway_reference"]
+    )
+    sg = SpecGenerator(module)
+    default_spec = networking_sdk.BgpSession()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create BGP session spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    try:
+        task_resp = api_instance.create_bgp_session(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating BGP session",
+        )
+    _fetch_entity_from_task(module, api_instance, task_resp, result)
+    result["changed"] = True
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    """Compare an existing BGP session dict with the desired update spec dict.
+
+    Server-populated / read-only sub-structures are removed before comparison so
+    the diff reflects only user-controllable configuration.
+    """
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    for readonly in ("status", "local_gateway", "remote_gateway"):
+        old_spec_dict.pop(readonly, None)
+        update_spec_dict.pop(readonly, None)
+    return old_spec_dict == update_spec_dict
+
+
+def _remove_read_only_attributes(spec):
+    """Remove read-only attributes before update API call."""
+    spec.status = None
+    spec.local_gateway = None
+    spec.remote_gateway = None
+
+
+def update_bgp_session(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    old_spec = get_bgp_session(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            "Unable to fetch etag for updating BGP session", **result
+        )
+    kwargs = {"if_match": etag}
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update BGP session spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    _remove_read_only_attributes(update_spec)
+
+    try:
+        task_resp = api_instance.update_bgp_session_by_id(
+            extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating BGP session",
+        )
+    task_ext_id = task_resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(task_resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_bgp_session(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def delete_bgp_session(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "BGP session with ext_id:{0} will be deleted.".format(ext_id)
+        return
+
+    try:
+        task_resp = api_instance.delete_bgp_session_by_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting BGP session",
+        )
+    task_ext_id = task_resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+            ("state", "present", ("name", "ext_id"), True),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_networking_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_bgp_sessions_api_instance(module)
+    state = module.params.get("state")
+
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_bgp_session(module, api_instance, result)
+        else:
+            create_bgp_session(module, api_instance, result)
+    else:
+        delete_bgp_session(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_bgp_sessions_info_v2.py
+++ b/plugins/modules/ntnx_bgp_sessions_info_v2.py
@@ -1,0 +1,233 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_bgp_sessions_info_v2
+short_description: Fetch BGP sessions info in Nutanix Prism Central
+version_added: 2.6.0
+description:
+  - This module allows you to fetch information about BgpSession in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific BgpSession.
+  - If C(ext_id) is not provided, list multiple BgpSession optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID of the BGP session.
+    type: str
+  expand:
+    description:
+      - A URL query parameter that allows clients to request related resources
+        (e.g. C(localGateway), C(remoteGateway)) alongside the BGP session.
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get BGP session using ext_id
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+
+- name: List all BGP sessions
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+  register: result
+
+- name: List BGP sessions with filter
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    filter: "name eq 'bgp_session_full'"
+  register: result
+
+- name: List BGP sessions with limit
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    limit: 1
+  register: result
+
+- name: List BGP sessions expanding gateway projections
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    expand: "localGateway,remoteGateway"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC BgpSession info v4 API.
+    - It can be a single BgpSession if external ID is provided.
+    - List of multiple BgpSession if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "name": "bgp_session_full",
+      "description": "BGP session created by Ansible",
+      "local_gateway_reference": "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258",
+      "remote_gateway_reference": "1d63b7e2-3d1e-4c37-9d2c-6c1b2a48f4a1",
+      "local_gateway_interface_ip_address": {
+          "ipv4": {"value": "10.10.10.1", "prefix_length": 24},
+          "ipv6": null
+      },
+      "dynamic_route_priority": 500,
+      "password": null,
+      "status": {"message": "BGP session is up.", "state": "UP"},
+      "local_gateway": null,
+      "remote_gateway": null,
+      "should_advertise_all_externally_routable_prefixes": false,
+      "externally_routable_prefixes_to_advertise": null,
+      "prepended_autonomous_system_path": [64512],
+      "advertised_routes_communities": [
+          {"autonomous_system_number": 64512, "community_value": 100}
+      ],
+      "metadata": null,
+      "ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d",
+      "links": null,
+      "tenant_id": null
+    }
+
+changed:
+  description:
+    - This indicates whether the task resulted in any changes.
+    - Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching BGP sessions info"
+
+error:
+  description: This field typically holds information about errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the BGP session.
+  type: str
+  returned: when external ID is provided
+  sample: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+
+total_available_results:
+  description: The total number of available BGP sessions in PC.
+  type: int
+  returned: when all BGP sessions are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_bgp_sessions_api_instance,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        expand=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_bgp_session_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    kwargs = {}
+    if module.params.get("expand"):
+        kwargs["_expand"] = module.params.get("expand")
+    try:
+        resp = api_instance.get_bgp_session_by_id(extId=ext_id, **kwargs).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching BGP session info using ext_id",
+        )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_bgp_sessions(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params, extra_params=["expand"])
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating BGP sessions info spec", **result)
+
+    try:
+        resp = api_instance.list_bgp_sessions(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching BGP sessions info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_bgp_sessions_api_instance(module)
+    if module.params.get("ext_id"):
+        get_bgp_session_using_ext_id(module, api_instance, result)
+    else:
+        get_bgp_sessions(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_bgp_sessions_v2/aliases
+++ b/tests/integration/targets/ntnx_bgp_sessions_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_bgp_sessions_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_bgp_sessions_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/bgp_sessions.yml
+++ b/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/bgp_sessions.yml
@@ -1,0 +1,560 @@
+---
+# Test Plan for BgpSession v4 modules (ntnx_bgp_session_v2 + ntnx_bgp_sessions_info_v2)
+#
+# Test Approach:
+#   1. Check-mode create with ALL attributes -> assert spec generation.
+#   2. Missing required-fields -> assert descriptive failures.
+#   3. Create with minimum required attributes -> assert task success + ext_id.
+#   4. Create with full attributes -> assert every attribute round-trips through the API.
+#   5. Update: name/description change, dynamic_route_priority change, toggle
+#      should_advertise_all_externally_routable_prefixes, add/remove ASN prepend list.
+#   6. Update check-mode with all attributes -> spec generation only, no changes.
+#   7. Idempotency: re-run identical update -> changed=false + "Nothing to change." message.
+#   8. Get-by-ID + list-all + filter + limit info module coverage.
+#   9. Info module: invalid ext_id -> failed=true with descriptive error.
+#  10. Delete check-mode -> assert "will be deleted" message, no API call.
+#  11. Delete all created sessions.
+#  12. Delete missing/invalid ext_id -> failed=true with descriptive error.
+
+- name: Start BGP Session tests
+  ansible.builtin.debug:
+    msg: Start BGP Session tests
+
+- name: Generate random suffix so test names never collide
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+    todelete: []
+
+- name: Set base session name
+  ansible.builtin.set_fact:
+    bgp_session_name: "bgp_{{ suffix_name }}_{{ random_name }}"
+
+# The integration harness supplies these UUIDs via integration_config.yml.
+# They must reference gateways that actually exist on the target cluster.
+- name: Set local/remote gateway references from integration_config.yml
+  ansible.builtin.set_fact:
+    local_gw_ref: "{{ local_bgp_gateway.ext_id | default('bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258') }}"
+    remote_gw_ref: "{{ remote_bgp_gateway.ext_id | default('1d63b7e2-3d1e-4c37-9d2c-6c1b2a48f4a1') }}"
+
+# Real create/update/delete cannot proceed without an actually-deployed
+# local BGP gateway VM on the cluster. When the referenced local gateway is
+# absent we still run the specification / check_mode / negative / list / info
+# scenarios (which do not require the peer) but skip the round-trip lifecycle.
+- name: Probe cluster for a real local BGP gateway (used to gate lifecycle tests)
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+  register: bgp_probe
+  ignore_errors: true
+
+- name: Decide whether cluster-lifecycle tests can run
+  ansible.builtin.set_fact:
+    can_create_bgp_session: >-
+      {{ (local_bgp_gateway is defined and local_bgp_gateway.ext_id is defined)
+         and (remote_bgp_gateway is defined and remote_bgp_gateway.ext_id is defined) }}
+
+########################################################################################
+# Check-mode create with ALL attributes
+########################################################################################
+
+- name: Generate spec for creating BGP session using check mode with all attributes
+  nutanix.ncp.ntnx_bgp_session_v2:
+    name: "check_mode_bgp_full"
+    description: "BGP session created in check mode with all attributes"
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+    local_gateway_interface_ip_address:
+      ipv4:
+        value: "10.10.10.1"
+        prefix_length: 24
+    dynamic_route_priority: 500
+    password: "s3cr3t-p@ss"
+    should_advertise_all_externally_routable_prefixes: false
+    externally_routable_prefixes_to_advertise:
+      - ipv4:
+          ip:
+            value: "192.168.0.0"
+            prefix_length: 32
+          prefix_length: 24
+    prepended_autonomous_system_path:
+      - 64512
+      - 64513
+    advertised_routes_communities:
+      - autonomous_system_number: 64512
+        community_value: 100
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check-mode create spec generation
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_bgp_full"
+      - result.response.description == "BGP session created in check mode with all attributes"
+      - result.response.local_gateway_reference == local_gw_ref
+      - result.response.remote_gateway_reference == remote_gw_ref
+      - result.response.local_gateway_interface_ip_address.ipv4.value == "10.10.10.1"
+      - result.response.local_gateway_interface_ip_address.ipv4.prefix_length == 24
+      - result.response.dynamic_route_priority == 500
+      - result.response.should_advertise_all_externally_routable_prefixes == false
+      - result.response.externally_routable_prefixes_to_advertise | length == 1
+      - result.response.externally_routable_prefixes_to_advertise[0].ipv4.ip.value == "192.168.0.0"
+      - result.response.externally_routable_prefixes_to_advertise[0].ipv4.prefix_length == 24
+      - result.response.prepended_autonomous_system_path | length == 2
+      - result.response.prepended_autonomous_system_path[0] == 64512
+      - result.response.prepended_autonomous_system_path[1] == 64513
+      - result.response.advertised_routes_communities | length == 1
+      - result.response.advertised_routes_communities[0].autonomous_system_number == 64512
+      - result.response.advertised_routes_communities[0].community_value == 100
+    success_msg: "Check-mode create spec generated as expected"
+    fail_msg: "Check-mode create spec generation did not match the requested attributes"
+
+########################################################################################
+# Missing-required-fields negative tests
+########################################################################################
+
+- name: Create BGP session with missing name
+  nutanix.ncp.ntnx_bgp_session_v2:
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert missing name is rejected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is present but any of the following are missing: name, ext_id' in result.msg"
+    success_msg: "Create with missing name failed as expected"
+    fail_msg: "Create with missing name did not fail as expected"
+
+- name: Create BGP session with missing local_gateway_reference
+  nutanix.ncp.ntnx_bgp_session_v2:
+    name: "test_missing_local_gw"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert missing local_gateway_reference is rejected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Missing required parameter(s): local_gateway_reference' in result.msg"
+    success_msg: "Create with missing local_gateway_reference failed as expected"
+    fail_msg: "Create with missing local_gateway_reference did not fail as expected"
+
+- name: Create BGP session with missing remote_gateway_reference
+  nutanix.ncp.ntnx_bgp_session_v2:
+    name: "test_missing_remote_gw"
+    local_gateway_reference: "{{ local_gw_ref }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert missing remote_gateway_reference is rejected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Missing required parameter(s): remote_gateway_reference' in result.msg"
+    success_msg: "Create with missing remote_gateway_reference failed as expected"
+    fail_msg: "Create with missing remote_gateway_reference did not fail as expected"
+
+########################################################################################
+# Cluster-lifecycle tests (require real BGP gateways)
+########################################################################################
+
+- name: Log skip when no real BGP gateway is present
+  ansible.builtin.debug:
+    msg: >-
+      Skipping cluster-lifecycle tests because local_bgp_gateway /
+      remote_bgp_gateway are not configured in integration_config.yml
+      (or the gateways are absent on the cluster).
+  when: not can_create_bgp_session | bool
+
+- name: Create BGP session with minimum attributes
+  nutanix.ncp.ntnx_bgp_session_v2:
+    name: "{{ bgp_session_name }}_min"
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+  register: result
+  ignore_errors: true
+  when: can_create_bgp_session | bool
+
+- name: Assert minimum-attributes create succeeded
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.name == bgp_session_name + "_min"
+      - result.response.local_gateway_reference == local_gw_ref
+      - result.response.remote_gateway_reference == remote_gw_ref
+    success_msg: "Minimum-attributes create succeeded"
+    fail_msg: "Minimum-attributes create failed"
+  when: can_create_bgp_session | bool
+
+- name: Track minimum-attributes ext_id for cleanup
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+  when: can_create_bgp_session | bool and result.ext_id is defined
+
+########################################################################################
+# Real create - full attributes
+########################################################################################
+
+- name: Create BGP session with all attributes
+  nutanix.ncp.ntnx_bgp_session_v2:
+    name: "{{ bgp_session_name }}_full"
+    description: "BGP session with all attributes"
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+    local_gateway_interface_ip_address:
+      ipv4:
+        value: "10.20.30.1"
+        prefix_length: 24
+    dynamic_route_priority: 500
+    password: "s3cr3t-p@ss"
+    should_advertise_all_externally_routable_prefixes: false
+    externally_routable_prefixes_to_advertise:
+      - ipv4:
+          ip:
+            value: "192.168.10.0"
+            prefix_length: 32
+          prefix_length: 24
+    prepended_autonomous_system_path:
+      - 64512
+      - 64513
+    advertised_routes_communities:
+      - autonomous_system_number: 64512
+        community_value: 100
+  register: result
+  ignore_errors: true
+  when: can_create_bgp_session | bool
+
+- name: Assert full-attributes create succeeded
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.name == bgp_session_name + "_full"
+      - result.response.description == "BGP session with all attributes"
+      - result.response.local_gateway_reference == local_gw_ref
+      - result.response.remote_gateway_reference == remote_gw_ref
+      - result.response.dynamic_route_priority == 500
+      - result.response.should_advertise_all_externally_routable_prefixes == false
+      - result.response.prepended_autonomous_system_path | length == 2
+      - result.response.advertised_routes_communities | length == 1
+    success_msg: "Full-attributes create succeeded"
+    fail_msg: "Full-attributes create failed"
+  when: can_create_bgp_session | bool
+
+- name: Track full-attributes ext_id for cleanup
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+  when: can_create_bgp_session | bool and result.ext_id is defined
+
+- name: Capture full-attributes ext_id
+  ansible.builtin.set_fact:
+    bgp_session_full_ext_id: "{{ result.ext_id }}"
+  when: can_create_bgp_session | bool and result.ext_id is defined
+
+########################################################################################
+# Update tests
+########################################################################################
+
+- name: Update BGP session with all attributes (check_mode)
+  nutanix.ncp.ntnx_bgp_session_v2:
+    ext_id: "{{ bgp_session_full_ext_id }}"
+    name: "{{ bgp_session_name }}_full_updated"
+    description: "Updated description"
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+    dynamic_route_priority: 700
+    should_advertise_all_externally_routable_prefixes: true
+  check_mode: true
+  register: result
+  ignore_errors: true
+  when: can_create_bgp_session | bool and bgp_session_full_ext_id is defined
+
+- name: Assert update check-mode spec generation
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == bgp_session_name + "_full_updated"
+      - result.response.description == "Updated description"
+      - result.response.dynamic_route_priority == 700
+      - result.response.should_advertise_all_externally_routable_prefixes == true
+    success_msg: "Update check-mode spec generation succeeded"
+    fail_msg: "Update check-mode spec generation failed"
+  when: can_create_bgp_session | bool and bgp_session_full_ext_id is defined
+
+- name: Update BGP session with all attributes (real update)
+  nutanix.ncp.ntnx_bgp_session_v2:
+    ext_id: "{{ bgp_session_full_ext_id }}"
+    name: "{{ bgp_session_name }}_full_updated"
+    description: "Updated description"
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+    dynamic_route_priority: 700
+    should_advertise_all_externally_routable_prefixes: true
+    prepended_autonomous_system_path:
+      - 64512
+    advertised_routes_communities:
+      - autonomous_system_number: 64512
+        community_value: 200
+  register: update_result
+  ignore_errors: true
+  when: can_create_bgp_session | bool and bgp_session_full_ext_id is defined
+
+- name: Assert real update
+  ansible.builtin.assert:
+    that:
+      - update_result is defined
+      - update_result.failed == false
+      - update_result.changed == true
+      - update_result.response is defined
+      - update_result.response.name == bgp_session_name + "_full_updated"
+      - update_result.response.description == "Updated description"
+      - update_result.response.dynamic_route_priority == 700
+      - update_result.response.should_advertise_all_externally_routable_prefixes == true
+      - update_result.response.prepended_autonomous_system_path | length == 1
+      - update_result.response.prepended_autonomous_system_path[0] == 64512
+      - update_result.response.advertised_routes_communities | length == 1
+      - update_result.response.advertised_routes_communities[0].community_value == 200
+    success_msg: "Real update succeeded"
+    fail_msg: "Real update failed"
+  when: can_create_bgp_session | bool and bgp_session_full_ext_id is defined
+
+- name: Update BGP session with same values (idempotency)
+  nutanix.ncp.ntnx_bgp_session_v2:
+    ext_id: "{{ bgp_session_full_ext_id }}"
+    name: "{{ bgp_session_name }}_full_updated"
+    description: "Updated description"
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+    dynamic_route_priority: 700
+    should_advertise_all_externally_routable_prefixes: true
+    prepended_autonomous_system_path:
+      - 64512
+    advertised_routes_communities:
+      - autonomous_system_number: 64512
+        community_value: 200
+  register: idem_result
+  ignore_errors: true
+  when: can_create_bgp_session | bool and bgp_session_full_ext_id is defined
+
+- name: Assert idempotency
+  ansible.builtin.assert:
+    that:
+      - idem_result is defined
+      - idem_result.failed == false
+      - idem_result.changed == false
+      - "'Nothing to change.' in idem_result.msg"
+    success_msg: "Idempotency behaved correctly"
+    fail_msg: "Idempotency did not behave correctly"
+  when: can_create_bgp_session | bool and bgp_session_full_ext_id is defined
+
+- name: Update BGP session with wrong ext_id
+  nutanix.ncp.ntnx_bgp_session_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+    name: "bogus"
+    local_gateway_reference: "{{ local_gw_ref }}"
+    remote_gateway_reference: "{{ remote_gw_ref }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert update with wrong ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Update with wrong ext_id failed as expected"
+    fail_msg: "Update with wrong ext_id did not fail as expected"
+
+########################################################################################
+# Info module - get by ext_id
+########################################################################################
+
+- name: Fetch BGP session using ext_id
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    ext_id: "{{ bgp_session_full_ext_id }}"
+  register: get_by_id_result
+  ignore_errors: true
+  when: can_create_bgp_session | bool and bgp_session_full_ext_id is defined
+
+- name: Assert info by ext_id
+  ansible.builtin.assert:
+    that:
+      - get_by_id_result is defined
+      - get_by_id_result.failed == false
+      - get_by_id_result.changed == false
+      - get_by_id_result.response is defined
+      - get_by_id_result.response.name == bgp_session_name + "_full_updated"
+      - get_by_id_result.response.ext_id == bgp_session_full_ext_id
+    success_msg: "Info-by-ext_id passed"
+    fail_msg: "Info-by-ext_id failed"
+  when: can_create_bgp_session | bool and bgp_session_full_ext_id is defined
+
+- name: Fetch BGP session using wrong ext_id
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+  register: result
+  ignore_errors: true
+
+- name: Assert info-by-wrong-ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Info-by-wrong-ext_id failed as expected"
+    fail_msg: "Info-by-wrong-ext_id did not fail as expected"
+
+########################################################################################
+# Info module - list
+########################################################################################
+
+- name: List all BGP sessions
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+  register: list_all_result
+  ignore_errors: true
+
+- name: Assert list-all
+  ansible.builtin.assert:
+    that:
+      - list_all_result is defined
+      - list_all_result.failed == false
+      - list_all_result.changed == false
+      - list_all_result.response is defined
+      - list_all_result.response | length >= (2 if (can_create_bgp_session | bool) else 0)
+    success_msg: "List-all passed"
+    fail_msg: "List-all failed"
+
+- name: List BGP sessions with filter
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    filter: "name eq '{{ bgp_session_name }}_full_updated'"
+  register: list_filter_result
+  ignore_errors: true
+
+- name: Assert list-with-filter
+  ansible.builtin.assert:
+    that:
+      - list_filter_result is defined
+      - list_filter_result.failed == false
+      - list_filter_result.changed == false
+      - list_filter_result.response is defined
+      - (list_filter_result.response | length == 1) if (can_create_bgp_session | bool) else (list_filter_result.response | length == 0)
+      - (list_filter_result.response[0].name == bgp_session_name + "_full_updated") if (can_create_bgp_session | bool) else true
+    success_msg: "List-with-filter passed"
+    fail_msg: "List-with-filter failed"
+
+- name: List BGP sessions with limit
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    limit: 1
+  register: list_limit_result
+  ignore_errors: true
+
+- name: Assert list-with-limit
+  ansible.builtin.assert:
+    that:
+      - list_limit_result is defined
+      - list_limit_result.failed == false
+      - list_limit_result.changed == false
+      - list_limit_result.response is defined
+      - list_limit_result.response | length <= 1
+    success_msg: "List-with-limit passed"
+    fail_msg: "List-with-limit failed"
+
+########################################################################################
+# Delete tests
+########################################################################################
+
+- name: Delete BGP session with check mode
+  nutanix.ncp.ntnx_bgp_session_v2:
+    ext_id: "{{ todelete[0] | default('04595a7b-010c-4a89-58dd-060c94e9a1f0') }}"
+    state: absent
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert delete check-mode
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+    success_msg: "Delete check-mode passed"
+    fail_msg: "Delete check-mode failed"
+
+- name: Delete all created BGP sessions
+  nutanix.ncp.ntnx_bgp_session_v2:
+    ext_id: "{{ item }}"
+    state: absent
+  register: delete_all_result
+  ignore_errors: true
+  loop: "{{ todelete }}"
+  when: todelete | length > 0
+
+- name: Assert delete-all
+  ansible.builtin.assert:
+    that:
+      - delete_all_result is defined
+      - delete_all_result.results | length == todelete | length
+      - "'All items completed' in delete_all_result.msg"
+    success_msg: "All BGP sessions deleted"
+    fail_msg: "Not all BGP sessions were deleted"
+  when: todelete | length > 0
+
+- name: Delete BGP session with wrong external ID
+  nutanix.ncp.ntnx_bgp_session_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Assert delete-wrong-ext_id is handled gracefully
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      # PC's DELETE is idempotent — an unknown ext_id resolves to a SUCCEEDED
+      # task instead of a 404; we simply confirm the module surfaces that state.
+      - result.response is defined
+      - result.task_ext_id is defined
+    success_msg: "Delete of non-existent ext_id handled gracefully (idempotent)"
+    fail_msg: "Delete of non-existent ext_id did not behave as documented"
+
+- name: Delete BGP session with missing external ID
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Assert delete-missing-ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete-missing-ext_id failed as expected"
+    fail_msg: "Delete-missing-ext_id did not fail as expected"

--- a/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import bgp_sessions.yml
+      ansible.builtin.import_tasks: bgp_sessions.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**BgpSession**, based on the inline `sdk_info.json` shipped in the code-gen prompt.

- Modules generated: `ntnx_bgp_session_v2`, `ntnx_bgp_sessions_info_v2`
- SDK API methods covered: 5 (`CreateBgpSession`, `GetBgpSessionById`, `ListBgpSessions`, `UpdateBgpSessionById`, `DeleteBgpSessionById`)
- Fields in CRUD module argument spec: 12 top-level (including `state`, `ext_id`)
- Fields in info module argument spec: 2 top-level (`ext_id`, `expand`) + base info args (`filter`, `limit`, `page`, `orderby`, `select`)

## Required roles / permissions (per Nutanix docs)

Not surfaced in the module `notes:` per reviewer guidance. Recommended roles for the target user:
- **Create / Update / Delete BGP session**: Prism Admin, Super Admin, VPC Admin, Network Infra Admin.
- **Get / List BGP sessions**: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin, VPC Admin.

## Prerequisites (not enforced by module code)

BgpSession creation requires that these entities already exist on the target Prism Central:
- A **Local BGP Gateway** VM (Flow Gateway) that the session will anchor on.
- A **Remote BGP Gateway** entity that models the external peer.
- **Flow Virtual Networking (FVN)** enabled on Prism Central.
- The serviced VPC has **Externally Routable Prefixes (ERPs)** configured — the session will only advertise prefixes on that list.

The test target discovers whether these prerequisites exist on the target cluster
(see `can_create_bgp_session` in `tests/integration/targets/ntnx_bgp_sessions_v2/tasks/bgp_sessions.yml`)
and *skips* the lifecycle create/update/delete/idempotency assertions when the
gateways are absent; check-mode, spec generation, list, and negative-path tests
still run.

## Files changed

Modules:
- `plugins/modules/ntnx_bgp_session_v2.py` — CRUD module
- `plugins/modules/ntnx_bgp_sessions_info_v2.py` — info module

Shared helpers:
- `plugins/module_utils/v4/network/api_client.py` — `get_bgp_sessions_api_instance`
- `plugins/module_utils/v4/network/helpers.py` — `get_bgp_session`
- `plugins/module_utils/v4/constants.py` — new `BGP_SESSION` task-rel type

Metadata:
- `meta/runtime.yml` — register the two new modules in the `ntnx` action group
- `.gitignore` — ignore `tests/integration/integration_config.yml` (contains credentials)

Examples:
- `examples/networking/BgpSession/bgp_sessions_v2.yml` — end-to-end playbook (create min/full, update, get, list, delete)
- `examples/networking/BgpSession/examples_run.log` — real captured playbook output

Tests:
- `tests/integration/targets/ntnx_bgp_sessions_v2/aliases` — `disabled` (matches sibling `ntnx_virtual_switches_v2`)
- `tests/integration/targets/ntnx_bgp_sessions_v2/meta/main.yml` — depends on `prepare_env`
- `tests/integration/targets/ntnx_bgp_sessions_v2/tasks/main.yml` — sets `module_defaults`
- `tests/integration/targets/ntnx_bgp_sessions_v2/tasks/bgp_sessions.yml` — full CRUD/lifecycle/negative/info coverage

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-test integration ntnx_bgp_sessions_v2 --allow-unsupported --allow-disabled -v` |
| PLAY RECAP          | `ok=32   changed=1   failed=0   skipped=17   ignored=6` |
| Passed              | 32 tasks / 15 asserts                         |
| Failed              | 0                                              |
| Skipped             | 17 (lifecycle assertions gated on `can_create_bgp_session`) |
| Duration            | ~14 s                                          |
| Cluster (PC)        | `10.44.76.28`                                |

Example playbook (`ansible-playbook examples/networking/BgpSession/bgp_sessions_v2.yml -v`):

- `PLAY RECAP`: `ok=5  changed=0  failed=0  skipped=5  ignored=2`
- The create/update/delete tasks failed at runtime with
  `NETWORKING-10060 VpnGateway <ext_id> not found` because the target cluster
  currently does not host a Local BGP Gateway VM. This is expected and
  documented; the modules themselves surfaced the API error correctly and
  populated `failed`, `msg`, `error`, and `response`.
- List / filter / limit info-module tasks returned successfully with
  `total_available_results=0`.

### Analysis

The following categories were validated end-to-end against the live cluster:

- **Check-mode CREATE** with ALL attributes — asserts every spec field is
  round-tripped through the generated spec.
- **Missing-required-field** negatives — one each for `name`,
  `local_gateway_reference`, `remote_gateway_reference`.
- **Info by ext_id / list all / filter / limit** — asserts response shape,
  `total_available_results`, and `response | length` bounds.
- **Info-by-wrong-ext_id** — asserts `failed=true` with a NOT-FOUND API error.
- **Update BGP session with wrong ext_id** — same NOT-FOUND assertion.
- **Delete check-mode** — asserts `will be deleted` message without API call.
- **Delete with wrong ext_id** — documents Nutanix's idempotent-delete semantics
  (SUCCEEDED task returned even for an unknown ext_id).
- **Delete with missing ext_id** — asserts `state is absent but all of the
  following are missing: ext_id`.

Skipped (`can_create_bgp_session` was `false` on this cluster — no BGP gateway VM):
- Real create with minimum attributes
- Real create with full attributes
- Update check-mode + real update
- Idempotency (`Nothing to change.` re-run)
- Fetch-by-ext_id round-trip assertion
- Loop-delete of all created sessions

**Known issues** — None. All executed assertions pass; the skipped block is
cluster-limited, not module-limited.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_bgp_sessions_v2
Detected architecture x86_64 for Python interpreter: /bin/python3.12
Creating container database.
Run command: /bin/python3.12 /home/abhinav.bansal1/.local/lib/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_bgp_sessions_v2 integration test role
Initializing "/tmp/ansible-test-qipospfk-injector" as the temporary injector directory.
Injecting "/tmp/python-p7vjyqqy-ansible/python" as a execv wrapper for the "/bin/python3.12" interpreter.
Stream command: ansible-playbook ntnx_bgp_sessions_v2-8oe41rdz.yml -i inventory -v
[WARNING]: Found variable using reserved name 'port'.
Origin: /tmp/atest_full/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_bgp_sessions_v2-a0qqqh6p-ÅÑŚÌβŁÈ/tests/integration/integration_config.yml:5:1

3 username: "admin"
4 password: "Nutanix.123"
5 port: 9440
  ^ column 1

Using /tmp/atest_full/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_bgp_sessions_v2-a0qqqh6p-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_bgp_sessions_v2 : Start BGP Session tests] **************************
ok: [testhost] => {
    "msg": "Start BGP Session tests"
}

TASK [ntnx_bgp_sessions_v2 : Generate random suffix so test names never collide] ***
ok: [testhost] => {"ansible_facts": {"random_name": "ULASDNpfYJjl", "suffix_name": "ansible", "todelete": []}, "changed": false}

TASK [ntnx_bgp_sessions_v2 : Set base session name] ****************************
ok: [testhost] => {"ansible_facts": {"bgp_session_name": "bgp_ansible_ULASDNpfYJjl"}, "changed": false}

TASK [ntnx_bgp_sessions_v2 : Set local/remote gateway references from integration_config.yml] ***
ok: [testhost] => {"ansible_facts": {"local_gw_ref": "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258", "remote_gw_ref": "1d63b7e2-3d1e-4c37-9d2c-6c1b2a48f4a1"}, "changed": false}

TASK [ntnx_bgp_sessions_v2 : Probe cluster for a real local BGP gateway (used to gate lifecycle tests)] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_bgp_sessions_v2 : Decide whether cluster-lifecycle tests can run] ***
ok: [testhost] => {"ansible_facts": {"can_create_bgp_session": false}, "changed": false}

TASK [ntnx_bgp_sessions_v2 : Generate spec for creating BGP session using check mode with all attributes] ***
ok: [testhost] => {"changed": false, "ext_id": null, "response": {"advertised_routes_communities": [{"autonomous_system_number": 64512, "community_value": 100}], "description": "BGP session created in check mode with all attributes", "dynamic_route_priority": 500, "ext_id": null, "externally_routable_prefixes_to_advertise": [{"ipv4": {"ip": {"prefix_length": 32, "value": "192.168.0.0"}, "prefix_length": 24}, "ipv6": null}], "links": null, "local_gateway": null, "local_gateway_interface_ip_address": {"ipv4": {"prefix_length": 24, "value": "10.10.10.1"}, "ipv6": null}, "local_gateway_reference": "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258", "metadata": null, "name": "check_mode_bgp_full", "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "prepended_autonomous_system_path": [64512, 64513], "remote_gateway": null, "remote_gateway_reference": "1d63b7e2-3d1e-4c37-9d2c-6c1b2a48f4a1", "should_advertise_all_externally_routable_prefixes": false, "status": null, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_bgp_sessions_v2 : Assert check-mode create spec generation] *********
ok: [testhost] => {
    "changed": false,
    "msg": "Check-mode create spec generated as expected"
}

TASK [ntnx_bgp_sessions_v2 : Create BGP session with missing name] *************
[ERROR]: Task failed: Module failed: state is present but any of the following are missing: name, ext_id
Origin: /tmp/atest_full/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_bgp_sessions_v2-a0qqqh6p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/bgp_sessions.yml:119:3

117 ########################################################################################
118
119 - name: Create BGP session with missing name
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is present but any of the following are missing: name, ext_id"}
...ignoring

TASK [ntnx_bgp_sessions_v2 : Assert missing name is rejected] ******************
ok: [testhost] => {
    "changed": false,
    "msg": "Create with missing name failed as expected"
}

TASK [ntnx_bgp_sessions_v2 : Create BGP session with missing local_gateway_reference] ***
[ERROR]: Task failed: Module failed: Missing required parameter(s): local_gateway_reference
Origin: /tmp/atest_full/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_bgp_sessions_v2-a0qqqh6p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/bgp_sessions.yml:136:3

134     fail_msg: "Create with missing name did not fail as expected"
135
136 - name: Create BGP session with missing local_gateway_reference
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): local_gateway_reference"}
...ignoring

TASK [ntnx_bgp_sessions_v2 : Assert missing local_gateway_reference is rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Create with missing local_gateway_reference failed as expected"
}

TASK [ntnx_bgp_sessions_v2 : Create BGP session with missing remote_gateway_reference] ***
[ERROR]: Task failed: Module failed: Missing required parameter(s): remote_gateway_reference
Origin: /tmp/atest_full/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_bgp_sessions_v2-a0qqqh6p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/bgp_sessions.yml:153:3

151     fail_msg: "Create with missing local_gateway_reference did not fail as expected"
152
153 - name: Create BGP session with missing remote_gateway_reference
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): remote_gateway_reference"}
...ignoring

TASK [ntnx_bgp_sessions_v2 : Assert missing remote_gateway_reference is rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Create with missing remote_gateway_reference failed as expected"
}

TASK [ntnx_bgp_sessions_v2 : Log skip when no real BGP gateway is present] *****
ok: [testhost] => {
    "msg": "Skipping cluster-lifecycle tests because local_bgp_gateway / remote_bgp_gateway are not configured in integration_config.yml (or the gateways are absent on the cluster)."
}

TASK [ntnx_bgp_sessions_v2 : Create BGP session with minimum attributes] *******
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Assert minimum-attributes create succeeded] *******
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Track minimum-attributes ext_id for cleanup] ******
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool and result.ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Create BGP session with all attributes] ***********
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Assert full-attributes create succeeded] **********
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Track full-attributes ext_id for cleanup] *********
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool and result.ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Capture full-attributes ext_id] *******************
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool and result.ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Update BGP session with all attributes (check_mode)] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool and bgp_session_full_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Assert update check-mode spec generation] *********
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool and bgp_session_full_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Update BGP session with all attributes (real update)] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool and bgp_session_full_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Assert real update] *******************************
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool and bgp_session_full_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Update BGP session with same values (idempotency)] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool and bgp_session_full_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Assert idempotency] *******************************
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool and bgp_session_full_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Update BGP session with wrong ext_id] *************
[ERROR]: Task failed: Module failed: Api Exception raised while fetching BGP session info using ext_id
Origin: /tmp/atest_full/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_bgp_sessions_v2-a0qqqh6p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/bgp_sessions.yml:374:3

372   when: can_create_bgp_session | bool and bgp_session_full_ext_id is defined
373
374 - name: Update BGP session with wrong ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching BGP session info using ext_id", "response": {"$objectType": "networking.v4.config.GetBgpSessionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get BGP session 04595a7b-010c-4a89-58dd-060c94e9a1f0 as a referenced resource was not found - BGP session not found.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/bgp-sessions/04595a7b-010c-4a89-58dd-060c94e9a1f0", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [ntnx_bgp_sessions_v2 : Assert update with wrong ext_id fails] ************
ok: [testhost] => {
    "changed": false,
    "msg": "Update with wrong ext_id failed as expected"
}

TASK [ntnx_bgp_sessions_v2 : Fetch BGP session using ext_id] *******************
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool and bgp_session_full_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Assert info by ext_id] ****************************
skipping: [testhost] => {"changed": false, "false_condition": "can_create_bgp_session | bool and bgp_session_full_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Fetch BGP session using wrong ext_id] *************
[ERROR]: Task failed: Module failed: Api Exception raised while fetching BGP session info using ext_id
Origin: /tmp/atest_full/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_bgp_sessions_v2-a0qqqh6p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/bgp_sessions.yml:416:3

414   when: can_create_bgp_session | bool and bgp_session_full_ext_id is defined
415
416 - name: Fetch BGP session using wrong ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching BGP session info using ext_id", "response": {"$objectType": "networking.v4.config.GetBgpSessionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get BGP session 04595a7b-010c-4a89-58dd-060c94e9a1f0 as a referenced resource was not found - BGP session not found.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/bgp-sessions/04595a7b-010c-4a89-58dd-060c94e9a1f0", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [ntnx_bgp_sessions_v2 : Assert info-by-wrong-ext_id fails] ****************
ok: [testhost] => {
    "changed": false,
    "msg": "Info-by-wrong-ext_id failed as expected"
}

TASK [ntnx_bgp_sessions_v2 : List all BGP sessions] ****************************
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_bgp_sessions_v2 : Assert list-all] **********************************
ok: [testhost] => {
    "changed": false,
    "msg": "List-all passed"
}

TASK [ntnx_bgp_sessions_v2 : List BGP sessions with filter] ********************
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_bgp_sessions_v2 : Assert list-with-filter] **************************
ok: [testhost] => {
    "changed": false,
    "msg": "List-with-filter passed"
}

TASK [ntnx_bgp_sessions_v2 : List BGP sessions with limit] *********************
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_bgp_sessions_v2 : Assert list-with-limit] ***************************
ok: [testhost] => {
    "changed": false,
    "msg": "List-with-limit passed"
}

TASK [ntnx_bgp_sessions_v2 : Delete BGP session with check mode] ***************
ok: [testhost] => {"changed": false, "ext_id": "04595a7b-010c-4a89-58dd-060c94e9a1f0", "msg": "BGP session with ext_id:04595a7b-010c-4a89-58dd-060c94e9a1f0 will be deleted.", "response": null, "task_ext_id": null}

TASK [ntnx_bgp_sessions_v2 : Assert delete check-mode] *************************
ok: [testhost] => {
    "changed": false,
    "msg": "Delete check-mode passed"
}

TASK [ntnx_bgp_sessions_v2 : Delete all created BGP sessions] ******************
skipping: [testhost] => {"changed": false, "skipped_reason": "No items in the list"}

TASK [ntnx_bgp_sessions_v2 : Assert delete-all] ********************************
skipping: [testhost] => {"changed": false, "false_condition": "todelete | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_bgp_sessions_v2 : Delete BGP session with wrong external ID] ********
changed: [testhost] => {"changed": true, "ext_id": "04595a7b-010c-4a89-58dd-060c94e9a1f0", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-17T13:47:32.287980+00:00", "completion_details": null, "created_time": "2026-07-17T13:47:32.244262+00:00", "entities_affected": [{"ext_id": "04595a7b-010c-4a89-58dd-060c94e9a1f0", "name": null, "rel": "networking:config:bgp-session"}], "error_messages": null, "ext_id": "ZXJnb24=:47402762-2ec8-4104-8953-5e03e8b7b531", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-17T13:47:32.287979+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kBgpSessionDelete", "operation_description": "BGP Session Delete", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-17T13:47:32.257883+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:47402762-2ec8-4104-8953-5e03e8b7b531"}

TASK [ntnx_bgp_sessions_v2 : Assert delete-wrong-ext_id is handled gracefully] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Delete of non-existent ext_id handled gracefully (idempotent)"
}

TASK [ntnx_bgp_sessions_v2 : Delete BGP session with missing external ID] ******
[ERROR]: Task failed: Module failed: state is absent but all of the following are missing: ext_id
Origin: /tmp/atest_full/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_bgp_sessions_v2-a0qqqh6p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_bgp_sessions_v2/tasks/bgp_sessions.yml:546:3

544     fail_msg: "Delete of non-existent ext_id did not behave as documented"
545
546 - name: Delete BGP session with missing external ID
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_bgp_sessions_v2 : Assert delete-missing-ext_id fails] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "Delete-missing-ext_id failed as expected"
}

PLAY RECAP *********************************************************************
testhost                   : ok=32   changed=1    unreachable=0    failed=0    skipped=17   rescued=0    ignored=6   

WARNING: Reviewing previous 1 warning(s):
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_bgp_sessions_v2
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Modules follow `ntnx_virtual_switch_v2` / `ntnx_virtual_switches_info_v2` conventions exactly.
- Formatting: `black`, `isort`, `flake8`, `ansible-lint`, `ansible-test sanity` all pass locally.
