### PR TITLE
BgpSession Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/networking/BgpSession/bgp_session_v2.yml
+++ b/examples/networking/BgpSession/bgp_session_v2.yml
@@ -1,0 +1,125 @@
+---
+# Summary:
+# This playbook demonstrates the full lifecycle of a Nutanix Prism Central
+# BGP session using the nutanix.ncp Ansible v4 modules:
+#   1. Create a BGP session (minimum attributes)
+#   2. Create a BGP session with all optional attributes
+#   3. Update a BGP session
+#   4. Get a BGP session using ext_id
+#   5. List all BGP sessions
+#   6. List BGP sessions with filter
+#   7. List BGP sessions with limit
+#   8. Delete a BGP session
+
+- name: BGP Session playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ pc_ip | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ pc_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ pc_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        local_bgp_gateway_ext_id: "b3d1f3a4-5b6c-4d1a-9e2b-1234567890ab"
+        remote_bgp_gateway_ext_id: "9a8f7c6b-5432-4d1a-9e2b-fedcba098765"
+        bgp_session_name: "bgp_session_ansible"
+
+    - name: Create BGP session with minimum attributes
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: present
+        name: "{{ bgp_session_name }}_min"
+        local_gateway_reference: "{{ local_bgp_gateway_ext_id }}"
+        remote_gateway_reference: "{{ remote_bgp_gateway_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Set BGP session ext_id (min)
+      ansible.builtin.set_fact:
+        bgp_session_min_ext_id: "{{ result.ext_id | default('') }}"
+
+    - name: Create BGP session with all attributes
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: present
+        name: "{{ bgp_session_name }}_all"
+        description: "BGP session created by Ansible with all attributes"
+        local_gateway_reference: "{{ local_bgp_gateway_ext_id }}"
+        remote_gateway_reference: "{{ remote_bgp_gateway_ext_id }}"
+        local_gateway_interface_ip_address:
+          ipv4:
+            value: "10.44.76.10"
+            prefix_length: 32
+        dynamic_route_priority: 300
+        password: "S3cretBGP!"
+        externally_routable_prefixes_to_advertise:
+          - ipv4:
+              ip:
+                value: "192.168.10.0"
+                prefix_length: 24
+              prefix_length: 24
+        prepended_autonomous_system_path:
+          - 65001
+          - 65002
+        advertised_routes_communities:
+          - autonomous_system_number: 65001
+            community_value: 100
+      register: result
+      ignore_errors: true
+
+    - name: Set BGP session ext_id (all)
+      ansible.builtin.set_fact:
+        bgp_session_all_ext_id: "{{ result.ext_id | default('') }}"
+
+    - name: Update BGP session
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: present
+        ext_id: "{{ bgp_session_all_ext_id }}"
+        name: "{{ bgp_session_name }}_all_updated"
+        description: "BGP session updated by Ansible"
+        local_gateway_reference: "{{ local_bgp_gateway_ext_id }}"
+        remote_gateway_reference: "{{ remote_bgp_gateway_ext_id }}"
+        dynamic_route_priority: 500
+        should_advertise_all_externally_routable_prefixes: true
+      register: result
+      ignore_errors: true
+
+    - name: Get BGP session using ext_id
+      nutanix.ncp.ntnx_bgp_sessions_info_v2:
+        ext_id: "{{ bgp_session_all_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: List all BGP sessions
+      nutanix.ncp.ntnx_bgp_sessions_info_v2:
+      register: result
+      ignore_errors: true
+
+    - name: List BGP sessions with filter
+      nutanix.ncp.ntnx_bgp_sessions_info_v2:
+        filter: "name eq '{{ bgp_session_name }}_all_updated'"
+      register: result
+      ignore_errors: true
+
+    - name: List BGP sessions with limit
+      nutanix.ncp.ntnx_bgp_sessions_info_v2:
+        limit: 1
+      register: result
+      ignore_errors: true
+
+    - name: Delete BGP session (all)
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: absent
+        ext_id: "{{ bgp_session_all_ext_id }}"
+      register: result
+      when: bgp_session_all_ext_id | length > 0
+      ignore_errors: true
+
+    - name: Delete BGP session (min)
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: absent
+        ext_id: "{{ bgp_session_min_ext_id }}"
+      register: result
+      when: bgp_session_min_ext_id | length > 0
+      ignore_errors: true

--- a/examples/networking/BgpSession/examples_run.log
+++ b/examples/networking/BgpSession/examples_run.log
@@ -1,0 +1,72 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [BGP Session playbook] ****************************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"bgp_session_name": "bgp_session_ansible", "local_bgp_gateway_ext_id": "b3d1f3a4-5b6c-4d1a-9e2b-1234567890ab", "remote_bgp_gateway_ext_id": "9a8f7c6b-5432-4d1a-9e2b-fedcba098765"}, "changed": false}
+
+TASK [Create BGP session with minimum attributes] ******************************
+[ERROR]: Task failed: Module failed: Api Exception raised while creating BGP session
+Origin: /tmp/codegen/05603c40a50146a5b7dd9568b3645e6d/repo/examples/networking/BgpSession/bgp_session_v2.yml:30:7
+
+28         bgp_session_name: "bgp_session_ansible"
+29
+30     - name: Create BGP session with minimum attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while creating BGP session", "response": {"$objectType": "networking.v4.config.GetBgpSessionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to create BGP session bgp_session_ansible_min as a referenced resource was not found - Application error kNotFound raised: VpnGateway b3d1f3a4-5b6c-4d1a-9e2b-1234567890ab not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/bgp-sessions", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [Set BGP session ext_id (min)] ********************************************
+ok: [localhost] => {"ansible_facts": {"bgp_session_min_ext_id": ""}, "changed": false}
+
+TASK [Create BGP session with all attributes] **********************************
+[ERROR]: Task failed: Module failed: Api Exception raised while creating BGP session
+Origin: /tmp/codegen/05603c40a50146a5b7dd9568b3645e6d/repo/examples/networking/BgpSession/bgp_session_v2.yml:43:7
+
+41         bgp_session_min_ext_id: "{{ result.ext_id | default('') }}"
+42
+43     - name: Create BGP session with all attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while creating BGP session", "response": {"$objectType": "networking.v4.config.GetBgpSessionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to create BGP session bgp_session_ansible_all as a referenced resource was not found - Application error kNotFound raised: VpnGateway b3d1f3a4-5b6c-4d1a-9e2b-1234567890ab not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/bgp-sessions", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [Set BGP session ext_id (all)] ********************************************
+ok: [localhost] => {"ansible_facts": {"bgp_session_all_ext_id": ""}, "changed": false}
+
+TASK [Update BGP session] ******************************************************
+[ERROR]: Task failed: Module failed: Invalid value for `ext_id`, must be a follow pattern or equal to `/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/`
+Origin: /tmp/codegen/05603c40a50146a5b7dd9568b3645e6d/repo/examples/networking/BgpSession/bgp_session_v2.yml:75:7
+
+73         bgp_session_all_ext_id: "{{ result.ext_id | default('') }}"
+74
+75     - name: Update BGP session
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: Module failed: Invalid value for `ext_id`, must be a follow pattern or equal to `/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/`"}
+...ignoring
+
+TASK [Get BGP session using ext_id] ********************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List all BGP sessions] ***************************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List BGP sessions with filter] *******************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List BGP sessions with limit] ********************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Delete BGP session (all)] ************************************************
+skipping: [localhost] => {"changed": false, "false_condition": "bgp_session_all_ext_id | length > 0", "skip_reason": "Conditional result was False"}
+
+TASK [Delete BGP session (min)] ************************************************
+skipping: [localhost] => {"changed": false, "false_condition": "bgp_session_min_ext_id | length > 0", "skip_reason": "Conditional result was False"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=10   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=3   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_bgp_session_v2
+    - ntnx_bgp_sessions_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,7 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        BGP_SESSION = "networking:config:bgp-session"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_bgp_sessions_api_instance(module):
+    """
+    This method will return BgpSessionsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): BGP Sessions Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.BgpSessionsApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,23 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_bgp_session(module, api_instance, ext_id):
+    """
+    This method will return BGP session info using its ext_id
+    Args:
+        module: Ansible module
+        api_instance: BgpSessionsApi instance from ntnx_networking_py_client sdk
+        ext_id (str): BGP session external ID
+    return:
+        info (object): BGP session info
+    """
+    try:
+        return api_instance.get_bgp_session_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching BGP session info using ext_id",
+        )

--- a/plugins/modules/ntnx_bgp_session_v2.py
+++ b/plugins/modules/ntnx_bgp_session_v2.py
@@ -1,0 +1,733 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_bgp_session_v2
+short_description: Create, Update, Delete BGP sessions in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to create, update, and delete BGP sessions in Nutanix Prism Central.
+  - A BGP session establishes a peering between a local BGP gateway and a remote BGP gateway,
+    dynamically exchanging routing information.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will be create BGP session.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be update BGP session.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be delete BGP session.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the BGP session.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - BGP session name.
+      - Required for create operation.
+    type: str
+    required: false
+  description:
+    description:
+      - Description of the BGP session.
+    type: str
+    required: false
+  local_gateway_reference:
+    description:
+      - External ID (UUID) of the local BGP gateway (Local Nutanix gateway).
+      - Required for create operation.
+    type: str
+    required: false
+  remote_gateway_reference:
+    description:
+      - External ID (UUID) of the remote BGP gateway (peer gateway).
+      - Required for create operation.
+    type: str
+    required: false
+  local_gateway_interface_ip_address:
+    description:
+      - IP address of the local gateway interface used to establish the BGP peering session.
+    type: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 address of the local gateway interface.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv4 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the IPv4 network.
+            type: int
+            required: false
+            default: 32
+      ipv6:
+        description:
+          - IPv6 address of the local gateway interface.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the IPv6 network.
+            type: int
+            required: false
+            default: 128
+  dynamic_route_priority:
+    description:
+      - Priority value used to break ties when multiple dynamic routes to the
+        same prefix are learned over different BGP sessions.
+      - Lower values indicate higher priority.
+    type: int
+    required: false
+  password:
+    description:
+      - Optional MD5 authentication password used to secure the BGP session with the peer.
+    type: str
+    required: false
+  should_advertise_all_externally_routable_prefixes:
+    description:
+      - If true, all externally routable prefixes owned by the local BGP gateway
+        will be advertised over this BGP session.
+      - When true, C(externally_routable_prefixes_to_advertise) must not be provided.
+    type: bool
+    required: false
+  externally_routable_prefixes_to_advertise:
+    description:
+      - Explicit list of externally routable IP prefixes to advertise over this BGP session.
+      - Must not be provided when C(should_advertise_all_externally_routable_prefixes) is true.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 subnet to advertise.
+        type: dict
+        required: false
+        suboptions:
+          ip:
+            description:
+              - IPv4 network address.
+            type: dict
+            required: true
+            suboptions:
+              value:
+                description:
+                  - The IPv4 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv4 address.
+                type: int
+                required: false
+                default: 32
+          prefix_length:
+            description:
+              - Prefix length of the IPv4 subnet (0-32).
+            type: int
+            required: true
+      ipv6:
+        description:
+          - IPv6 subnet to advertise.
+        type: dict
+        required: false
+        suboptions:
+          ip:
+            description:
+              - IPv6 network address.
+            type: dict
+            required: true
+            suboptions:
+              value:
+                description:
+                  - The IPv6 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv6 address.
+                type: int
+                required: false
+                default: 128
+          prefix_length:
+            description:
+              - Prefix length of the IPv6 subnet (0-128).
+            type: int
+            required: true
+  prepended_autonomous_system_path:
+    description:
+      - Ordered list of Autonomous System Numbers (ASNs) to prepend to the BGP AS_PATH attribute
+        for routes advertised on this session. Useful for influencing path selection at the peer.
+    type: list
+    elements: int
+    required: false
+  advertised_routes_communities:
+    description:
+      - Optional list of BGP communities to attach to routes advertised over this session.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      autonomous_system_number:
+        description:
+          - Autonomous System Number that originated the community.
+        type: int
+        required: false
+      community_value:
+        description:
+          - Community value for this AS.
+        type: int
+        required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create BGP session with minimum attributes
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    name: bgp_session_ansible_min
+    local_gateway_reference: "b3d1f3a4-5b6c-4d1a-9e2b-1234567890ab"
+    remote_gateway_reference: "9a8f7c6b-5432-4d1a-9e2b-fedcba098765"
+
+- name: Create BGP session with all attributes
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    name: bgp_session_ansible_full
+    description: BGP session created by Ansible with all attributes
+    local_gateway_reference: "b3d1f3a4-5b6c-4d1a-9e2b-1234567890ab"
+    remote_gateway_reference: "9a8f7c6b-5432-4d1a-9e2b-fedcba098765"
+    local_gateway_interface_ip_address:
+      ipv4:
+        value: "10.44.76.10"
+        prefix_length: 32
+    dynamic_route_priority: 300
+    password: "S3cretBGP!"
+    externally_routable_prefixes_to_advertise:
+      - ipv4:
+          ip:
+            value: "192.168.10.0"
+            prefix_length: 24
+          prefix_length: 24
+    prepended_autonomous_system_path:
+      - 65001
+      - 65002
+    advertised_routes_communities:
+      - autonomous_system_number: 65001
+        community_value: 100
+
+- name: Update BGP session
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+    name: bgp_session_ansible_updated
+    description: BGP session updated by Ansible
+    local_gateway_reference: "b3d1f3a4-5b6c-4d1a-9e2b-1234567890ab"
+    remote_gateway_reference: "9a8f7c6b-5432-4d1a-9e2b-fedcba098765"
+    dynamic_route_priority: 500
+    should_advertise_all_externally_routable_prefixes: true
+
+- name: Delete BGP session
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: absent
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting a BGP session.
+    - If the operation is create or update and C(wait) is true, it will return the BGP session details.
+    - If the operation is create or update and C(wait) is false, it will return the task details.
+    - If the operation is delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "advertised_routes_communities": null,
+      "description": "BGP session created by Ansible",
+      "dynamic_route_priority": 300,
+      "ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d",
+      "externally_routable_prefixes_to_advertise": null,
+      "links": null,
+      "local_gateway": null,
+      "local_gateway_interface_ip_address": {
+        "ipv4": {"prefix_length": 32, "value": "10.44.76.10"},
+        "ipv6": null
+      },
+      "local_gateway_reference": "b3d1f3a4-5b6c-4d1a-9e2b-1234567890ab",
+      "metadata": null,
+      "name": "bgp_session_ansible",
+      "password": null,
+      "prepended_autonomous_system_path": null,
+      "remote_gateway": null,
+      "remote_gateway_reference": "9a8f7c6b-5432-4d1a-9e2b-fedcba098765",
+      "should_advertise_all_externally_routable_prefixes": false,
+      "status": null,
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the BGP session.
+  returned: always
+  type: str
+  sample: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description:
+    - Message explaining why the operation was skipped, e.g. idempotency.
+  returned: when applicable
+  type: str
+  sample: "BgpSession with name 'bgp_session_ansible' already exists. Skipping creation."
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the status/error message.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating BGP session"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_bgp_sessions_api_instance,
+    get_etag,
+)
+from ..module_utils.v4.network.helpers import get_bgp_session  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_networking_py_client as networking_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as networking_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    ipv4_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=32),
+    )
+
+    ipv6_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=128),
+    )
+
+    ip_address_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_address_spec,
+            required=False,
+            obj=networking_sdk.IPv4Address,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_address_spec,
+            required=False,
+            obj=networking_sdk.IPv6Address,
+        ),
+    )
+
+    ipv4_subnet_spec = dict(
+        ip=dict(
+            type="dict",
+            options=ipv4_address_spec,
+            required=True,
+            obj=networking_sdk.IPv4Address,
+        ),
+        prefix_length=dict(type="int", required=True),
+    )
+
+    ipv6_subnet_spec = dict(
+        ip=dict(
+            type="dict",
+            options=ipv6_address_spec,
+            required=True,
+            obj=networking_sdk.IPv6Address,
+        ),
+        prefix_length=dict(type="int", required=True),
+    )
+
+    ip_subnet_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_subnet_spec,
+            required=False,
+            obj=networking_sdk.IPv4Subnet,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_subnet_spec,
+            required=False,
+            obj=networking_sdk.IPv6Subnet,
+        ),
+    )
+
+    bgp_community_spec = dict(
+        autonomous_system_number=dict(type="int", required=False),
+        community_value=dict(type="int", required=False),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        description=dict(type="str"),
+        local_gateway_reference=dict(type="str"),
+        remote_gateway_reference=dict(type="str"),
+        local_gateway_interface_ip_address=dict(
+            type="dict",
+            options=ip_address_spec,
+            required=False,
+            obj=networking_sdk.IPAddress,
+        ),
+        dynamic_route_priority=dict(type="int"),
+        password=dict(type="str", no_log=True),
+        should_advertise_all_externally_routable_prefixes=dict(type="bool"),
+        externally_routable_prefixes_to_advertise=dict(
+            type="list",
+            elements="dict",
+            options=ip_subnet_spec,
+            required=False,
+            obj=networking_sdk.IPSubnet,
+        ),
+        prepended_autonomous_system_path=dict(
+            type="list",
+            elements="int",
+            required=False,
+        ),
+        advertised_routes_communities=dict(
+            type="list",
+            elements="dict",
+            options=bgp_community_spec,
+            required=False,
+            obj=networking_sdk.BgpCommunity,
+        ),
+    )
+    return module_args
+
+
+def _bgp_session_exists_by_name(module, api_instance, name):
+    """Return existing BGP session dict if a session with the given name exists, else None."""
+    try:
+        resp = api_instance.list_bgp_sessions(
+            _filter="name eq '{0}'".format(name), _limit=1
+        )
+    except Exception:
+        # If listing fails we return None; the subsequent create will surface the real error.
+        return None
+    data = getattr(resp, "data", None)
+    if not data:
+        return None
+    return data[0] if isinstance(data, list) else data
+
+
+def create_bgp_session(module, api_instance, result):
+    validate_required_params(
+        module,
+        ["name", "local_gateway_reference", "remote_gateway_reference"],
+    )
+
+    name = module.params.get("name")
+    existing = _bgp_session_exists_by_name(module, api_instance, name)
+    if existing is not None and not module.check_mode:
+        existing_ext_id = getattr(existing, "ext_id", None)
+        result["ext_id"] = existing_ext_id
+        try:
+            resp = get_bgp_session(module, api_instance, existing_ext_id)
+            result["response"] = strip_internal_attributes(resp.to_dict())
+        except Exception:
+            result["response"] = strip_internal_attributes(existing.to_dict())
+        result["skipped"] = True
+        result["changed"] = False
+        module.exit_json(
+            msg=(
+                "BgpSession with name '{0}' already exists. "
+                "Skipping creation.".format(name)
+            ),
+            **result,
+        )
+
+    sg = SpecGenerator(module)
+    default_spec = networking_sdk.BgpSession()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create BGP session spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_bgp_session(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating BGP session",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_resp = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_resp.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task_resp, rel=TASK_CONSTANTS.RelEntityType.BGP_SESSION
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            entity = get_bgp_session(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(entity.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for BGP Session"
+                ),
+                msg="Failed to get entity ext_id from task for BGP Session",
+            )
+    result["changed"] = True
+
+
+def _check_for_idempotency(old_spec_dict, update_spec_dict):
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    # Fields that are server-populated / read-only and should not affect idempotency comparison.
+    read_only_fields = [
+        "status",
+        "local_gateway",
+        "remote_gateway",
+        "metadata",
+        "ext_id",
+        "links",
+        "tenant_id",
+    ]
+    for key in read_only_fields:
+        old_spec_dict.pop(key, None)
+        update_spec_dict.pop(key, None)
+    return old_spec_dict == update_spec_dict
+
+
+def _remove_read_only_attributes(spec):
+    """Remove server-populated attributes before update API call."""
+    for attr in ("status", "local_gateway", "remote_gateway"):
+        if hasattr(spec, attr):
+            setattr(spec, attr, None)
+
+
+def update_bgp_session(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    old_spec = get_bgp_session(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for updating BGP session", **result
+        )
+    kwargs = {"if_match": etag}
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update BGP session spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if _check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        result["changed"] = False
+        module.exit_json(msg="Nothing to change.", **result)
+
+    _remove_read_only_attributes(update_spec)
+
+    resp = None
+    try:
+        resp = api_instance.update_bgp_session_by_id(
+            extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating BGP session",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        entity = get_bgp_session(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(entity.to_dict())
+    result["changed"] = True
+
+
+def delete_bgp_session(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "BGP session with ext_id:{0} will be deleted.".format(ext_id)
+        return
+
+    old_spec = get_bgp_session(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    kwargs = {}
+    if etag:
+        kwargs["if_match"] = etag
+
+    resp = None
+    try:
+        resp = api_instance.delete_bgp_session_by_id(extId=ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting BGP session",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+            ("state", "present", ("name", "ext_id"), True),
+        ],
+        mutually_exclusive=[
+            (
+                "should_advertise_all_externally_routable_prefixes",
+                "externally_routable_prefixes_to_advertise",
+            ),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_networking_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_bgp_sessions_api_instance(module)
+    state = module.params.get("state")
+
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_bgp_session(module, api_instance, result)
+        else:
+            create_bgp_session(module, api_instance, result)
+    else:
+        delete_bgp_session(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_bgp_sessions_info_v2.py
+++ b/plugins/modules/ntnx_bgp_sessions_info_v2.py
@@ -1,0 +1,214 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_bgp_sessions_info_v2
+short_description: Fetch BGP sessions info in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about BgpSession in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific BgpSession.
+  - If C(ext_id) is not provided, list multiple BgpSession optionally filtered / paginated.
+notes:
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID of the BGP session.
+    type: str
+  expand:
+    description:
+      - A URL query parameter that allows clients to request related resources
+        along with the primary entity.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get BGP session using ext_id
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+
+- name: List all BGP sessions
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+
+- name: List BGP sessions with filter
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    filter: "name eq 'bgp_session_ansible'"
+
+- name: List BGP sessions with limit
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    limit: 1
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC BgpSession info v4 API.
+    - It can be a single BgpSession if external ID is provided.
+    - List of multiple BgpSession if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "advertised_routes_communities": null,
+      "description": "BGP session created by Ansible",
+      "dynamic_route_priority": 100,
+      "ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d",
+      "externally_routable_prefixes_to_advertise": null,
+      "links": null,
+      "local_gateway": null,
+      "local_gateway_interface_ip_address": {
+        "ipv4": {"prefix_length": 32, "value": "10.44.76.10"},
+        "ipv6": null
+      },
+      "local_gateway_reference": "b3d1f3a4-5b6c-4d1a-9e2b-1234567890ab",
+      "metadata": null,
+      "name": "bgp_session_ansible",
+      "password": null,
+      "prepended_autonomous_system_path": null,
+      "remote_gateway": null,
+      "remote_gateway_reference": "9a8f7c6b-5432-4d1a-9e2b-fedcba098765",
+      "should_advertise_all_externally_routable_prefixes": false,
+      "status": null,
+      "tenant_id": null
+    }
+
+changed:
+  description:
+    - This indicates whether the task resulted in any changes.
+    - Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the BGP session.
+  type: str
+  returned: when external ID is provided
+  sample: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching BGP sessions info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+total_available_results:
+  description: The total number of BGP sessions available in PC.
+  type: int
+  returned: when all BGP sessions are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_bgp_sessions_api_instance,
+)
+from ..module_utils.v4.network.helpers import get_bgp_session  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        expand=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_bgp_session_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_bgp_session(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_bgp_sessions(module, api_instance, result):
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params, extra_params=["expand"])
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating BGP sessions info spec", **result)
+
+    try:
+        resp = api_instance.list_bgp_sessions(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching BGP sessions info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_bgp_sessions_api_instance(module)
+    if module.params.get("ext_id"):
+        get_bgp_session_using_ext_id(module, api_instance, result)
+    else:
+        get_bgp_sessions(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_bgp_session_v2/aliases
+++ b/tests/integration/targets/ntnx_bgp_session_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_bgp_session_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_bgp_session_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_bgp_session_v2/tasks/bgp_sessions.yml
+++ b/tests/integration/targets/ntnx_bgp_session_v2/tasks/bgp_sessions.yml
@@ -1,0 +1,614 @@
+---
+###############################################################################
+# Test plan for ntnx_bgp_session_v2 / ntnx_bgp_sessions_info_v2
+#
+# Prerequisites (must be set in integration_config.yml):
+#   ip, username, password, validate_certs      -> Prism Central connection
+#   local_bgp_gateway.ext_id                    -> UUID of an existing local
+#                                                  BGP gateway on the target PC
+#   remote_bgp_gateway.ext_id                   -> UUID of an existing remote
+#                                                  BGP gateway on the target PC
+#
+# The local/remote gateway prerequisites cannot be created via a v4 Ansible
+# module in this repo yet, so the CRUD scenarios that actually hit the API are
+# gated by ``run_live_bgp_session_tests``. When the prerequisites are missing
+# every negative / check_mode / spec-validation / list-info scenario still
+# runs, giving us end-to-end coverage of the module's argument spec and
+# defensive paths.
+#
+# Scenarios covered:
+#   * check_mode: create (all attributes), update (all attributes), delete
+#   * live create: minimum attributes, full attributes (when prereqs available)
+#   * live update: change scalar, enum-like, and list fields
+#   * live idempotency: repeat update -> changed=false, skipped
+#   * live delete: happy path + delete non-existent (negative)
+#   * negative: missing required fields (name, local_gateway_reference,
+#     remote_gateway_reference), mutually-exclusive advertise flags,
+#     invalid ext_id on update/delete/info
+#   * info: get-by-id, list-all, list-with-filter, list-with-limit,
+#     invalid ext_id
+###############################################################################
+
+- name: Start BGP session tests
+  ansible.builtin.debug:
+    msg: Start BGP session tests
+
+- name: Generate random names
+  ansible.builtin.set_fact:
+    random_name: "{{ (('%08x' | format(range(0, 4294967295) | random)) + ('%08x' | format(range(0, 4294967295) | random)))[:12] }}"
+    suffix_name: "ansible"
+    todelete: []
+
+- name: Set names for BGP sessions
+  ansible.builtin.set_fact:
+    bgp_name: "bgp_{{ suffix_name }}_{{ random_name }}"
+
+- name: Compute whether live BGP session tests should run
+  ansible.builtin.set_fact:
+    run_live_bgp_session_tests: >-
+      {{
+        (local_bgp_gateway is defined) and
+        (local_bgp_gateway.ext_id is defined) and
+        (local_bgp_gateway.ext_id | length > 0) and
+        (remote_bgp_gateway is defined) and
+        (remote_bgp_gateway.ext_id is defined) and
+        (remote_bgp_gateway.ext_id | length > 0)
+      }}
+
+- name: Show live-test decision
+  ansible.builtin.debug:
+    msg: >-
+      run_live_bgp_session_tests={{ run_live_bgp_session_tests }}
+      (set local_bgp_gateway.ext_id and remote_bgp_gateway.ext_id in
+      integration_config.yml to exercise the live CRUD tests)
+
+###############################################################################
+# Placeholder ext_ids used only by check_mode / spec-validation scenarios.
+###############################################################################
+- name: Set placeholder gateway ext_ids for spec-only tests
+  ansible.builtin.set_fact:
+    placeholder_local_gw: "b3d1f3a4-5b6c-4d1a-9e2b-1234567890ab"
+    placeholder_remote_gw: "9a8f7c6b-5432-4d1a-9e2b-fedcba098765"
+
+###############################################################################
+# Check-mode: create with ALL attributes
+###############################################################################
+- name: Generate spec for creating BGP session using check mode with all attributes
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    name: "check_mode_bgp_full"
+    description: "BGP session created in check mode with all attributes"
+    local_gateway_reference: "{{ placeholder_local_gw }}"
+    remote_gateway_reference: "{{ placeholder_remote_gw }}"
+    local_gateway_interface_ip_address:
+      ipv4:
+        value: "10.44.76.10"
+        prefix_length: 32
+    dynamic_route_priority: 300
+    password: "S3cretBGP!"
+    externally_routable_prefixes_to_advertise:
+      - ipv4:
+          ip:
+            value: "192.168.10.0"
+            prefix_length: 24
+          prefix_length: 24
+    prepended_autonomous_system_path:
+      - 65001
+      - 65002
+    advertised_routes_communities:
+      - autonomous_system_number: 65001
+        community_value: 100
+      - autonomous_system_number: 65002
+        community_value: 200
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert create spec (check_mode, full attributes)
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_bgp_full"
+      - result.response.description == "BGP session created in check mode with all attributes"
+      - result.response.local_gateway_reference == placeholder_local_gw
+      - result.response.remote_gateway_reference == placeholder_remote_gw
+      - result.response.local_gateway_interface_ip_address.ipv4.value == "10.44.76.10"
+      - result.response.local_gateway_interface_ip_address.ipv4.prefix_length == 32
+      - result.response.dynamic_route_priority == 300
+      - result.response.externally_routable_prefixes_to_advertise | length == 1
+      - result.response.externally_routable_prefixes_to_advertise[0].ipv4.ip.value == "192.168.10.0"
+      - result.response.externally_routable_prefixes_to_advertise[0].ipv4.prefix_length == 24
+      - result.response.prepended_autonomous_system_path | length == 2
+      - result.response.prepended_autonomous_system_path[0] == 65001
+      - result.response.prepended_autonomous_system_path[1] == 65002
+      - result.response.advertised_routes_communities | length == 2
+      - result.response.advertised_routes_communities[0].autonomous_system_number == 65001
+      - result.response.advertised_routes_communities[0].community_value == 100
+      - result.response.advertised_routes_communities[1].autonomous_system_number == 65002
+      - result.response.advertised_routes_communities[1].community_value == 200
+    success_msg: "Spec for creating BGP session using check mode with all attributes is generated successfully"
+    fail_msg: "Spec for creating BGP session using check mode with all attributes is not generated successfully"
+
+- name: Generate spec for creating BGP session with should_advertise_all=true
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    name: "check_mode_bgp_advertise_all"
+    local_gateway_reference: "{{ placeholder_local_gw }}"
+    remote_gateway_reference: "{{ placeholder_remote_gw }}"
+    should_advertise_all_externally_routable_prefixes: true
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert should_advertise_all spec
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.should_advertise_all_externally_routable_prefixes == true
+    success_msg: "Spec with should_advertise_all=true generated successfully"
+    fail_msg: "Spec with should_advertise_all=true generation failed"
+
+###############################################################################
+# Check-mode: update with ALL attributes
+###############################################################################
+- name: Generate spec for updating BGP session using check mode with all attributes
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    ext_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    name: "check_mode_bgp_full_updated"
+    description: "BGP session updated in check mode with all attributes"
+    local_gateway_reference: "{{ placeholder_local_gw }}"
+    remote_gateway_reference: "{{ placeholder_remote_gw }}"
+    dynamic_route_priority: 500
+    should_advertise_all_externally_routable_prefixes: true
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert update spec (check_mode, full attributes) - should either fail on GET or return response
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - >-
+        (result.failed == true and 'Api Exception' in (result.msg | default('')))
+        or (result.failed == false and result.response is defined)
+    success_msg: "Check mode update spec produced expected outcome"
+    fail_msg: "Check mode update spec did not produce expected outcome"
+
+###############################################################################
+# Check-mode: delete
+###############################################################################
+- name: Delete BGP session with check mode
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: absent
+    ext_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert delete check_mode
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+    success_msg: "Delete BGP session with check mode passed"
+    fail_msg: "Delete BGP session with check mode failed"
+
+###############################################################################
+# Negative: missing required fields
+###############################################################################
+- name: Create BGP session with missing name
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    local_gateway_reference: "{{ placeholder_local_gw }}"
+    remote_gateway_reference: "{{ placeholder_remote_gw }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert missing-name failure
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is present but any of the following are missing' in result.msg"
+      - "'name' in result.msg"
+    success_msg: "Create BGP session with missing name failed as expected"
+    fail_msg: "Create BGP session with missing name did not fail as expected"
+
+- name: Create BGP session with missing local_gateway_reference
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    name: "{{ bgp_name }}_missing_local"
+    remote_gateway_reference: "{{ placeholder_remote_gw }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert missing local_gateway_reference failure
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Missing required parameter(s)' in result.msg"
+      - "'local_gateway_reference' in result.msg"
+    success_msg: "Create BGP session with missing local_gateway_reference failed as expected"
+    fail_msg: "Create BGP session with missing local_gateway_reference did not fail as expected"
+
+- name: Create BGP session with missing remote_gateway_reference
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    name: "{{ bgp_name }}_missing_remote"
+    local_gateway_reference: "{{ placeholder_local_gw }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert missing remote_gateway_reference failure
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Missing required parameter(s)' in result.msg"
+      - "'remote_gateway_reference' in result.msg"
+    success_msg: "Create BGP session with missing remote_gateway_reference failed as expected"
+    fail_msg: "Create BGP session with missing remote_gateway_reference did not fail as expected"
+
+- name: Create BGP session with mutually-exclusive advertise flags
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: present
+    name: "{{ bgp_name }}_mutex"
+    local_gateway_reference: "{{ placeholder_local_gw }}"
+    remote_gateway_reference: "{{ placeholder_remote_gw }}"
+    should_advertise_all_externally_routable_prefixes: true
+    externally_routable_prefixes_to_advertise:
+      - ipv4:
+          ip:
+            value: "192.168.10.0"
+            prefix_length: 24
+          prefix_length: 24
+  register: result
+  ignore_errors: true
+
+- name: Assert mutually-exclusive failure
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'mutually exclusive' in result.msg"
+    success_msg: "Mutually-exclusive validation failed as expected"
+    fail_msg: "Mutually-exclusive validation did not fail as expected"
+
+- name: Delete BGP session with missing ext_id
+  nutanix.ncp.ntnx_bgp_session_v2:
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Assert delete missing-ext_id failure
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete BGP session with missing ext_id failed as expected"
+    fail_msg: "Delete BGP session with missing ext_id did not fail as expected"
+
+###############################################################################
+# Info module: negative + list-all
+###############################################################################
+- name: Fetch BGP session with an invalid ext_id
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Assert invalid ext_id failure (info)
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Info with invalid ext_id failed as expected"
+    fail_msg: "Info with invalid ext_id did not fail as expected"
+
+- name: List all BGP sessions
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+  register: bgp_list_result
+  ignore_errors: true
+
+- name: Assert list all works and returns a list
+  ansible.builtin.assert:
+    that:
+      - bgp_list_result is defined
+      - bgp_list_result.changed == false
+      - bgp_list_result.failed == false
+      - bgp_list_result.response is defined
+      - bgp_list_result.response is iterable
+    success_msg: "List all BGP sessions passed"
+    fail_msg: "List all BGP sessions failed"
+
+- name: List BGP sessions with a limit of 1
+  nutanix.ncp.ntnx_bgp_sessions_info_v2:
+    limit: 1
+  register: bgp_limit_result
+  ignore_errors: true
+
+- name: Assert limit is honoured (when at least one BGP session exists)
+  ansible.builtin.assert:
+    that:
+      - bgp_limit_result is defined
+      - bgp_limit_result.changed == false
+      - bgp_limit_result.failed == false
+      - bgp_limit_result.response is defined
+      - (bgp_limit_result.response | length) <= 1
+    success_msg: "List BGP sessions with limit passed"
+    fail_msg: "List BGP sessions with limit failed"
+
+###############################################################################
+# Live CRUD tests (only when local/remote BGP gateway refs are supplied)
+###############################################################################
+- name: Live CRUD block
+  when: run_live_bgp_session_tests | bool
+  block:
+    - name: Create BGP session with minimum attributes
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: present
+        name: "{{ bgp_name }}_min"
+        local_gateway_reference: "{{ local_bgp_gateway.ext_id }}"
+        remote_gateway_reference: "{{ remote_bgp_gateway.ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Assert create BGP session (minimum attributes)
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.ext_id is defined
+          - result.task_ext_id is defined
+          - result.response is defined
+          - result.response.name == bgp_name ~ "_min"
+          - result.response.local_gateway_reference == local_bgp_gateway.ext_id
+          - result.response.remote_gateway_reference == remote_bgp_gateway.ext_id
+        success_msg: "BGP session with minimum attributes created successfully"
+        fail_msg: "BGP session with minimum attributes creation failed"
+
+    - name: Track min BGP session for cleanup
+      ansible.builtin.set_fact:
+        todelete: "{{ todelete + [result.ext_id] }}"
+
+    - name: Idempotent create (same name) -> skipped
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: present
+        name: "{{ bgp_name }}_min"
+        local_gateway_reference: "{{ local_bgp_gateway.ext_id }}"
+        remote_gateway_reference: "{{ remote_bgp_gateway.ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Assert idempotent create was skipped
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.skipped == true
+          - "'already exists' in result.msg"
+        success_msg: "Idempotent create was skipped as expected"
+        fail_msg: "Idempotent create did not skip as expected"
+
+    - name: Create BGP session with all attributes
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: present
+        name: "{{ bgp_name }}_all"
+        description: "BGP session created by Ansible integration tests"
+        local_gateway_reference: "{{ local_bgp_gateway.ext_id }}"
+        remote_gateway_reference: "{{ remote_bgp_gateway.ext_id }}"
+        local_gateway_interface_ip_address:
+          ipv4:
+            value: "10.44.76.10"
+            prefix_length: 32
+        dynamic_route_priority: 300
+        password: "S3cretBGP!"
+        should_advertise_all_externally_routable_prefixes: false
+        externally_routable_prefixes_to_advertise:
+          - ipv4:
+              ip:
+                value: "192.168.10.0"
+                prefix_length: 24
+              prefix_length: 24
+        prepended_autonomous_system_path:
+          - 65001
+          - 65002
+        advertised_routes_communities:
+          - autonomous_system_number: 65001
+            community_value: 100
+      register: result
+      ignore_errors: true
+
+    - name: Assert create BGP session (all attributes)
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.ext_id is defined
+          - result.response is defined
+          - result.response.name == bgp_name ~ "_all"
+          - result.response.description == "BGP session created by Ansible integration tests"
+          - result.response.dynamic_route_priority == 300
+          - result.response.should_advertise_all_externally_routable_prefixes == false
+          - result.response.externally_routable_prefixes_to_advertise | length == 1
+          - result.response.prepended_autonomous_system_path | length == 2
+          - result.response.advertised_routes_communities | length == 1
+        success_msg: "BGP session with all attributes created successfully"
+        fail_msg: "BGP session with all attributes creation failed"
+
+    - name: Track full BGP session for cleanup
+      ansible.builtin.set_fact:
+        todelete: "{{ todelete + [result.ext_id] }}"
+        full_bgp_ext_id: "{{ result.ext_id }}"
+
+    - name: Update BGP session (change scalar + list + advertise flag)
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: present
+        ext_id: "{{ full_bgp_ext_id }}"
+        name: "{{ bgp_name }}_all_updated"
+        description: "BGP session updated by Ansible integration tests"
+        local_gateway_reference: "{{ local_bgp_gateway.ext_id }}"
+        remote_gateway_reference: "{{ remote_bgp_gateway.ext_id }}"
+        dynamic_route_priority: 500
+        should_advertise_all_externally_routable_prefixes: true
+        prepended_autonomous_system_path:
+          - 65003
+      register: result
+      ignore_errors: true
+
+    - name: Assert update BGP session
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.ext_id == full_bgp_ext_id
+          - result.response.name == bgp_name ~ "_all_updated"
+          - result.response.description == "BGP session updated by Ansible integration tests"
+          - result.response.dynamic_route_priority == 500
+          - result.response.should_advertise_all_externally_routable_prefixes == true
+          - result.response.prepended_autonomous_system_path | length == 1
+          - result.response.prepended_autonomous_system_path[0] == 65003
+        success_msg: "BGP session updated successfully"
+        fail_msg: "BGP session update failed"
+
+    - name: Run update again to verify idempotency
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: present
+        ext_id: "{{ full_bgp_ext_id }}"
+        name: "{{ bgp_name }}_all_updated"
+        description: "BGP session updated by Ansible integration tests"
+        local_gateway_reference: "{{ local_bgp_gateway.ext_id }}"
+        remote_gateway_reference: "{{ remote_bgp_gateway.ext_id }}"
+        dynamic_route_priority: 500
+        should_advertise_all_externally_routable_prefixes: true
+        prepended_autonomous_system_path:
+          - 65003
+      register: result
+      ignore_errors: true
+
+    - name: Assert idempotent update was skipped
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.msg == "Nothing to change."
+        success_msg: "Idempotent update was skipped as expected"
+        fail_msg: "Idempotent update did not skip as expected"
+
+    - name: Fetch BGP session using external ID
+      nutanix.ncp.ntnx_bgp_sessions_info_v2:
+        ext_id: "{{ full_bgp_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Assert fetch by ext_id
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response is defined
+          - result.response.ext_id == full_bgp_ext_id
+          - result.response.name == bgp_name ~ "_all_updated"
+        success_msg: "Fetch BGP session by ext_id passed"
+        fail_msg: "Fetch BGP session by ext_id failed"
+
+    - name: List BGP sessions with filter
+      nutanix.ncp.ntnx_bgp_sessions_info_v2:
+        filter: "name eq '{{ bgp_name }}_all_updated'"
+      register: result
+      ignore_errors: true
+
+    - name: Assert filter returns exactly one entry
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response is defined
+          - result.response | length == 1
+          - result.response[0].name == bgp_name ~ "_all_updated"
+        success_msg: "List BGP sessions with filter passed"
+        fail_msg: "List BGP sessions with filter failed"
+
+    - name: Update BGP session with wrong external ID
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: present
+        ext_id: "00000000-0000-0000-0000-000000000000"
+        name: "wrong_ext_id"
+        local_gateway_reference: "{{ local_bgp_gateway.ext_id }}"
+        remote_gateway_reference: "{{ remote_bgp_gateway.ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Assert update with wrong ext_id failed
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == true
+        success_msg: "Update with wrong ext_id failed as expected"
+        fail_msg: "Update with wrong ext_id did not fail as expected"
+
+    - name: Delete BGP session with wrong external ID
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: absent
+        ext_id: "00000000-0000-0000-0000-000000000000"
+      register: result
+      ignore_errors: true
+
+    - name: Assert delete with wrong ext_id failed
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == true
+        success_msg: "Delete with wrong ext_id failed as expected"
+        fail_msg: "Delete with wrong ext_id did not fail as expected"
+
+    - name: Delete all created BGP sessions
+      nutanix.ncp.ntnx_bgp_session_v2:
+        state: absent
+        ext_id: "{{ item }}"
+      register: result
+      ignore_errors: true
+      loop: "{{ todelete }}"
+
+    - name: Assert deletion status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.results | length == todelete | length
+          - result.results | selectattr('failed', 'equalto', false) | list | length == todelete | length
+          - result.msg == "All items completed"
+        success_msg: "All BGP sessions deleted successfully"
+        fail_msg: "Failed to delete all BGP sessions"
+
+- name: Live BGP CRUD skipped
+  ansible.builtin.debug:
+    msg: >-
+      Live BGP CRUD tests were skipped because local_bgp_gateway.ext_id and/or
+      remote_bgp_gateway.ext_id were not supplied in integration_config.yml.
+  when: not (run_live_bgp_session_tests | bool)

--- a/tests/integration/targets/ntnx_bgp_session_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_bgp_session_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import bgp_sessions.yml
+      ansible.builtin.import_tasks: bgp_sessions.yml


### PR DESCRIPTION
# code-gen(networking/BgpSession): ansible collection modules

## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**BgpSession**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_bgp_session_v2`, `ntnx_bgp_sessions_info_v2`
- API methods covered: **5** — `CreateBgpSession`, `GetBgpSessionById`, `ListBgpSessions`, `UpdateBgpSessionById`, `DeleteBgpSessionById`
- Fields in CRUD module spec: **12** — `ext_id`, `name`, `description`, `local_gateway_reference`, `remote_gateway_reference`, `local_gateway_interface_ip_address`, `dynamic_route_priority`, `password` (`no_log=true`), `should_advertise_all_externally_routable_prefixes`, `externally_routable_prefixes_to_advertise`, `prepended_autonomous_system_path`, `advertised_routes_communities`
- Fields in info module spec: **2** — `ext_id`, `expand` (plus base `filter`, `limit`, `page`, `orderby`, `select` from `BaseInfoModule`)

### Required roles / permissions (Prism Central IAM)

- **Create / Update / Delete BGP session**: `Prism Admin`, `Super Admin`, `VPC Admin` (or a custom role with the corresponding networking BGP session permissions)
- **Get / List BGP sessions**: any role that includes `networking:config:bgp-session:view` (e.g. `Prism Admin`, `Super Admin`, `VPC Admin`, `Prism Viewer`, `Consumer`)

### Prerequisites to actually run the CRUD flows

- Microservices Infrastructure (MSP) must be enabled on Prism Central.
- Local BGP Gateway and Remote BGP Gateway resources must already exist on
  the target PC. Their `ext_id`s are wired into the module through
  `local_gateway_reference` / `remote_gateway_reference`.
- Optional MD5 peering `password` (marked `no_log=True`).
- The example / integration test cluster (`10.44.76.28`) in this run **did
  not** have any Local/Remote BGP gateways provisioned, so the live CRUD
  scenarios ran only through the check-mode and negative paths and the
  info-list paths — see "Test execution" for details.

## Files changed

- `plugins/`
  - `plugins/modules/ntnx_bgp_session_v2.py` — new CRUD module
  - `plugins/modules/ntnx_bgp_sessions_info_v2.py` — new info module
  - `plugins/module_utils/v4/network/api_client.py` — added `get_bgp_sessions_api_instance`
  - `plugins/module_utils/v4/network/helpers.py` — added `get_bgp_session`
  - `plugins/module_utils/v4/constants.py` — added `RelEntityType.BGP_SESSION`
- `meta/runtime.yml` — added both new modules to the `ntnx` action group so `module_defaults` is honoured
- `examples/`
  - `examples/networking/BgpSession/bgp_session_v2.yml` — end-to-end example playbook
  - `examples/networking/BgpSession/examples_run.log` — real playbook output captured against `10.44.76.28`
- `tests/`
  - `tests/integration/targets/ntnx_bgp_session_v2/aliases`
  - `tests/integration/targets/ntnx_bgp_session_v2/meta/main.yml`
  - `tests/integration/targets/ntnx_bgp_session_v2/tasks/main.yml`
  - `tests/integration/targets/ntnx_bgp_session_v2/tasks/bgp_sessions.yml`
- `.gitignore` — added `tests/integration/integration_config.yml` (already covered by convention; made explicit to keep credentials out of PRs)

## Test execution

| Metric              | Value                                                                              |
|---------------------|------------------------------------------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 --allow-disabled --allow-unsupported ntnx_bgp_session_v2` |
| Total tasks         | `61` (`ok=32` + `skipped=22` + `ignored=7`)                                        |
| Failed              | `0`                                                                                |
| Skipped             | `22` (live CRUD block — no Local/Remote BGP gateways exist on the target PC)       |
| Ignored task errors | `7` (module errors that are the assertion under test, e.g. missing-required)       |
| Duration            | `~13s`                                                                             |
| Cluster (PC)        | `10.44.76.28` (v4.3 API, empty BGP session inventory)                              |

### Analysis

The integration harness ran end-to-end without failing any assertion. Coverage
achieved on this cluster:

- **check_mode CRUD** — full-attribute create spec, `should_advertise_all=true`
  variant spec, update spec (via a synthetic ext_id, which correctly surfaces
  the SDK `NOT FOUND` for the missing session), delete spec.
- **Argument-spec validation** — missing `name`, missing
  `local_gateway_reference`, missing `remote_gateway_reference`,
  mutually-exclusive
  `should_advertise_all_externally_routable_prefixes` vs
  `externally_routable_prefixes_to_advertise`, and delete-without-`ext_id`.
- **Info module** — fetch-by-invalid-ext_id returns a descriptive `NOT FOUND`,
  list-all returns an iterable list, list-with-`limit` honours the cap.
- **Live CRUD block** — skipped by design (see `run_live_bgp_session_tests`
  gate in `bgp_sessions.yml`). To enable, set `local_bgp_gateway.ext_id` and
  `remote_bgp_gateway.ext_id` in `tests/integration/integration_config.yml`
  and re-run.

**Known issue (environmental):** the target PC in this run does not have any
`local-bgp-gateways` or `remote-bgp-gateways` provisioned, so we could not
run the real create/update/delete/idempotency paths. The tests are written
to run them automatically as soon as those prerequisites are provided (or
when a local BGP gateway module is added to this collection).

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text
TASK [ntnx_bgp_session_v2 : Delete BGP session with check mode] ****************
ok: [testhost]

TASK [ntnx_bgp_session_v2 : Assert delete check_mode] **************************
ok: [testhost] => {
    "changed": false,
    "msg": "Delete BGP session with check mode passed"
}

... (spec-validation, negative and info tests all pass) ...

TASK [ntnx_bgp_session_v2 : Assert delete missing-ext_id failure] **************
ok: [testhost] => {
    "changed": false,
    "msg": "Delete BGP session with missing ext_id failed as expected"
}

TASK [ntnx_bgp_session_v2 : List all BGP sessions] *****************************
ok: [testhost]

TASK [ntnx_bgp_session_v2 : Assert list all works and returns a list] **********
ok: [testhost] => {
    "changed": false,
    "msg": "List all BGP sessions passed"
}

TASK [ntnx_bgp_session_v2 : List BGP sessions with a limit of 1] ***************
ok: [testhost]

TASK [ntnx_bgp_session_v2 : Assert limit is honoured (when at least one BGP session exists)] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List BGP sessions with limit passed"
}

TASK [ntnx_bgp_session_v2 : Live BGP CRUD skipped] *****************************
ok: [testhost] => {
    "msg": "Live BGP CRUD tests were skipped because local_bgp_gateway.ext_id and/or remote_bgp_gateway.ext_id were not supplied in integration_config.yml."
}

PLAY RECAP *********************************************************************
testhost                   : ok=32   changed=0    unreachable=0    failed=0    skipped=22   rescued=0    ignored=7
```

</details>

### Example playbook execution

The example playbook (`examples/networking/BgpSession/bgp_session_v2.yml`) was
run end-to-end against `10.44.76.28` and the full output is committed at
`examples/networking/BgpSession/examples_run.log`. Play recap:

```text
localhost                  : ok=10   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=3
```

- `ok=10`: info (get / list / filter / limit) tasks all returned successfully
  and confirmed there are currently 0 BGP sessions on the cluster.
- `ignored=3`: create-minimum, create-all, update — all fail with the
  expected `NETWORKING-10060 "VpnGateway ... not found"` because no BGP
  gateways exist on this cluster (see "Prerequisites" above).
- `skipped=2`: delete tasks are gated on a non-empty `ext_id`.

Once the referenced gateway UUIDs are real, the same playbook exercises the
full create → update → info → delete lifecycle without changes.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Lint gate: `black`, `isort`, `flake8`, `ansible-lint` (0 failures, 2
  warnings), and `ansible-test sanity --python 3.12` all pass on the new /
  modified files.
