### PR TITLE
code-gen(volumes/ntnx_volume_group_revert_v2): ansible collection modules

### DIFF
--- a/examples/volumes/VolumeGroup/examples_run.log
+++ b/examples/volumes/VolumeGroup/examples_run.log
@@ -1,0 +1,87 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Setup and run VolumeGroup revert example] ********************************
+
+TASK [Compute expiration one month from now] ***********************************
+ok: [localhost] => {"ansible_facts": {"expiration_time": "2026-08-20T11:13:03+00:00"}, "changed": false}
+
+TASK [Create Volume Group (prerequisite for example)] **************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "4bebd450-7cf1-4e25-4abd-3cddebc7eafb", "response": {"attachment_type": "NONE", "attachments": null, "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "created_by": null, "created_time": null, "description": "VG for revert example", "disks": null, "enabled_authentications": null, "ext_id": "4bebd450-7cf1-4e25-4abd-3cddebc7eafb", "hydration_status": null, "is_hidden": false, "iscsi_features": null, "iscsi_target_name": null, "iscsi_target_prefix": null, "links": null, "load_balance_vm_attachments": null, "name": "ansible-example-vg-cxuagl", "project_ext_id": null, "protocol": "NOT_ASSIGNED", "sharing_status": null, "should_load_balance_vm_attachments": false, "storage_features": null, "target_name": "volumegroup-4bebd450-7cf1-4e25-4abd-3cddebc7eafb", "target_prefix": null, "target_secret": null, "tenant_id": null, "usage_type": null}, "task_ext_id": "ZXJnb24=:fa8a8d54-7243-4402-a22c-44c96eab326b"}
+
+TASK [Create Volume Group recovery point (prerequisite for example)] ***********
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "3eb59d95-1039-40bb-8f06-c15f296e9cdc", "response": {"creation_time": "2026-07-20T11:13:07.371242+00:00", "expiration_time": "2026-08-20T11:13:03+00:00", "ext_id": "3eb59d95-1039-40bb-8f06-c15f296e9cdc", "isWormProtected": false, "is_secure": false, "links": null, "location_agnostic_id": "3cfd0104-34dd-4352-9b02-61031b4c5cb7", "location_references": [{"location_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}], "name": "ansible-example-rp-cxuagl", "owner_ext_id": "00000000-0000-0000-0000-000000000000", "projectExtId": "00000000-0000-0000-0000-000000000000", "recovery_point_type": "CRASH_CONSISTENT", "source_location": {"cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "domain_manager_ext_id": "cae459ec-08db-475e-a5e5-151e390c9484"}, "status": "COMPLETE", "tenant_id": null, "total_exclusive_usage_bytes": null, "vm_recovery_points": null, "volume_group_recovery_points": [{"consistency_group_ext_id": null, "disk_recovery_points": null, "ext_id": "e3dccbb9-d0a4-4c71-adb0-baefcb0e566a", "links": null, "location_agnostic_id": "19cd639d-c912-4b12-bb82-3a5f68691b98", "tenant_id": null, "total_exclusive_usage_bytes": null, "volume_group_categories": null, "volume_group_ext_id": "4bebd450-7cf1-4e25-4abd-3cddebc7eafb"}]}, "task_ext_id": "ZXJnb24=:4cfa7689-833f-4f93-a0a2-16f5a34dac2e"}
+
+TASK [Capture ext_ids for example] *********************************************
+ok: [localhost] => {"ansible_facts": {"example_parent_rp_ext_id": "3eb59d95-1039-40bb-8f06-c15f296e9cdc", "example_volume_group_ext_id": "4bebd450-7cf1-4e25-4abd-3cddebc7eafb", "example_volume_group_recovery_point_ext_id": "e3dccbb9-d0a4-4c71-adb0-baefcb0e566a"}, "changed": false}
+
+TASK [Run example - Revert a Volume Group to a Volume Group recovery point] ****
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "4bebd450-7cf1-4e25-4abd-3cddebc7eafb", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T11:13:15.292261+00:00", "completion_details": null, "created_time": "2026-07-20T11:13:12.710481+00:00", "entities_affected": [{"ext_id": "e3dccbb9-d0a4-4c71-adb0-baefcb0e566a", "name": "ansible-example-rp-cxuagl", "rel": "dataprotection:config:volume-group-recovery-point"}, {"ext_id": "4bebd450-7cf1-4e25-4abd-3cddebc7eafb", "name": "ansible-example-vg-cxuagl", "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:e10ba8cd-b0b1-45a7-ac95-86af318aaba3", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T11:13:15.292261+00:00", "legacy_error_message": null, "number_of_entities_affected": 2, "number_of_subtasks": 0, "operation": "RevertVolumeGroup", "operation_description": "Revert Volume Group", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T11:13:12.737443+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:e10ba8cd-b0b1-45a7-ac95-86af318aaba3"}
+
+TASK [Show revert example result] **********************************************
+ok: [localhost] => {
+    "result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "4bebd450-7cf1-4e25-4abd-3cddebc7eafb",
+        "failed": false,
+        "response": {
+            "app_name": null,
+            "batch_summary": null,
+            "cluster_ext_ids": [
+                "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+            ],
+            "completed_time": "2026-07-20T11:13:15.292261+00:00",
+            "completion_details": null,
+            "created_time": "2026-07-20T11:13:12.710481+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "e3dccbb9-d0a4-4c71-adb0-baefcb0e566a",
+                    "name": "ansible-example-rp-cxuagl",
+                    "rel": "dataprotection:config:volume-group-recovery-point"
+                },
+                {
+                    "ext_id": "4bebd450-7cf1-4e25-4abd-3cddebc7eafb",
+                    "name": "ansible-example-vg-cxuagl",
+                    "rel": "volumes:config:volume-group"
+                }
+            ],
+            "error_messages": null,
+            "ext_id": "ZXJnb24=:e10ba8cd-b0b1-45a7-ac95-86af318aaba3",
+            "is_background_task": false,
+            "is_cancelable": false,
+            "last_updated_time": "2026-07-20T11:13:15.292261+00:00",
+            "legacy_error_message": null,
+            "number_of_entities_affected": 2,
+            "number_of_subtasks": 0,
+            "operation": "RevertVolumeGroup",
+            "operation_description": "Revert Volume Group",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "projectExtId": "00000000-0000-0000-0000-000000000000",
+            "resource_links": null,
+            "root_task": null,
+            "started_time": "2026-07-20T11:13:12.737443+00:00",
+            "status": "SUCCEEDED",
+            "sub_steps": null,
+            "sub_tasks": null,
+            "warnings": null
+        },
+        "task_ext_id": "ZXJnb24=:e10ba8cd-b0b1-45a7-ac95-86af318aaba3"
+    }
+}
+
+TASK [Cleanup - delete parent recovery point] **********************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "3eb59d95-1039-40bb-8f06-c15f296e9cdc", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-20T11:13:23.300911+00:00", "completion_details": null, "created_time": "2026-07-20T11:13:20.026302+00:00", "entities_affected": [{"ext_id": "3eb59d95-1039-40bb-8f06-c15f296e9cdc", "name": "ansible-example-rp-cxuagl", "rel": "dataprotection:config:recovery-point"}, {"ext_id": "e3dccbb9-d0a4-4c71-adb0-baefcb0e566a", "name": "ansible-example-rp-cxuagl", "rel": "dataprotection:config:volume-group-recovery-point"}], "error_messages": null, "ext_id": "ZXJnb24=:b4de698e-ffe7-4808-85c6-b7356f16cff5", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T11:13:23.300911+00:00", "legacy_error_message": null, "number_of_entities_affected": 2, "number_of_subtasks": 0, "operation": "DeleteRecoveryPoint", "operation_description": "Delete Recovery Point", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T11:13:20.037682+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:b4de698e-ffe7-4808-85c6-b7356f16cff5"}
+
+TASK [Cleanup - delete Volume Group] *******************************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "4bebd450-7cf1-4e25-4abd-3cddebc7eafb", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T11:13:27.454117+00:00", "completion_details": null, "created_time": "2026-07-20T11:13:27.200694+00:00", "entities_affected": [{"ext_id": "4bebd450-7cf1-4e25-4abd-3cddebc7eafb", "name": "ansible-example-vg-cxuagl", "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:2d3fa9ae-d9be-4808-b746-e90d022c377f", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T11:13:27.454116+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "VolumeGroupDelete", "operation_description": "Delete Volume Group", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T11:13:27.200694+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:25dab32e-d826-4386-89f0-aba804afe552", "href": "https://10.44.76.28:9440/api/prism/v4.3/config/tasks/ZXJnb24=:25dab32e-d826-4386-89f0-aba804afe552", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:2d3fa9ae-d9be-4808-b746-e90d022c377f"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=8    changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/volumes/VolumeGroup/volume_group_revert_v2.yml
+++ b/examples/volumes/VolumeGroup/volume_group_revert_v2.yml
@@ -1,0 +1,34 @@
+---
+# Summary:
+# This playbook demonstrates how to revert a Nutanix Volume Group to a
+# previously created Volume Group recovery point via the v4 API.
+#
+# Prerequisites:
+# 1. An existing Volume Group in Prism Central.
+# 2. A Volume Group recovery point captured for that Volume Group (created via
+#    the recovery points v4 module, e.g. ntnx_recovery_points_v2).
+#
+# The revert operation is asynchronous and returns task details. When
+# `wait` is true (default) the module blocks until the task terminates.
+
+- name: Volume Group revert playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        volume_group_ext_id: "6aeec7b5-6ab6-4eb6-acf9-cf1e8b14a0b8"
+        volume_group_recovery_point_ext_id: "522670d7-e92d-45c5-9139-76ccff6813c2"
+
+    - name: Revert a Volume Group to a Volume Group recovery point
+      nutanix.ncp.ntnx_volume_group_revert_v2:
+        ext_id: "{{ volume_group_ext_id }}"
+        volume_group_recovery_point_ext_id: "{{ volume_group_recovery_point_ext_id }}"
+      register: result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -151,6 +151,7 @@ action_groups:
     - ntnx_volume_groups_vms_v2
     - ntnx_volume_groups_iscsi_clients_v2
     - ntnx_volume_groups_iscsi_clients_info_v2
+    - ntnx_volume_group_revert_v2
     - ntnx_roles_v2
     - ntnx_roles_info_v2
     - ntnx_directory_services_v2

--- a/plugins/modules/ntnx_volume_group_revert_v2.py
+++ b/plugins/modules/ntnx_volume_group_revert_v2.py
@@ -1,0 +1,281 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_volume_group_revert_v2
+short_description: Revert a Nutanix Volume Group to a Volume Group recovery point
+version_added: 2.7.0
+description:
+    - Revert an existing Volume Group in Nutanix Prism Central to the state
+      captured by a previously created Volume Group recovery point.
+    - This is an in-place, task-based restore operation.
+    - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Revert a Volume Group) -
+      Required Roles: Backup Admin, Prism Admin, Project Manager, Storage Admin, Super Admin,
+      Self-Service Admin (deprecated)
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=volumes)"
+options:
+    state:
+        description:
+            - State of the module.
+            - If C(state) is C(present), the module reverts the Volume Group from the
+              supplied recovery point.
+            - Only C(present) is supported for this action module.
+        type: str
+        choices:
+            - present
+        default: present
+    ext_id:
+        description:
+            - The external identifier of the Volume Group that has to be reverted.
+        type: str
+        required: true
+    volume_group_recovery_point_ext_id:
+        description:
+            - The external identifier of the Volume Group recovery point to which the
+              Volume Group should be reverted.
+            - This is a mandatory field.
+        type: str
+        required: true
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+    - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Revert a Volume Group to a Volume Group recovery point
+  nutanix.ncp.ntnx_volume_group_revert_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "6aeec7b5-6ab6-4eb6-acf9-cf1e8b14a0b8"
+    volume_group_recovery_point_ext_id: "522670d7-e92d-45c5-9139-76ccff6813c2"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for reverting the Volume Group from the recovery point.
+        - Task details containing the outcome of the revert operation when C(wait) is
+          C(true).
+        - Task submission details (containing at least C(ext_id)) when C(wait) is
+          C(false).
+    returned: always
+    type: dict
+    sample:
+        {
+            "cluster_ext_ids": [
+                "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+            ],
+            "completed_time": "2026-07-20T11:11:35.665908+00:00",
+            "completion_details": null,
+            "created_time": "2026-07-20T11:11:33.185386+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "ad96f00a-5331-4a05-b1a9-2f4b66bb1a63",
+                    "name": "ansible-rp-revert",
+                    "rel": "dataprotection:config:volume-group-recovery-point"
+                },
+                {
+                    "ext_id": "c81e0f94-967d-4d12-5604-1193e3a23087",
+                    "name": "ansible-vg-revert",
+                    "rel": "volumes:config:volume-group"
+                }
+            ],
+            "error_messages": null,
+            "ext_id": "ZXJnb24=:d0341bca-793a-4066-bbab-424b964a89e0",
+            "is_background_task": false,
+            "is_cancelable": false,
+            "last_updated_time": "2026-07-20T11:11:35.665907+00:00",
+            "legacy_error_message": null,
+            "number_of_entities_affected": 2,
+            "number_of_subtasks": 0,
+            "operation": "RevertVolumeGroup",
+            "operation_description": "Revert Volume Group",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "started_time": "2026-07-20T11:11:33.196992+00:00",
+            "status": "SUCCEEDED",
+            "sub_steps": null,
+            "sub_tasks": null,
+            "warnings": null
+        }
+
+changed:
+    description: This indicates whether the task resulted in any changes.
+    returned: always
+    type: bool
+    sample: true
+
+msg:
+    description: This indicates the message if any message occurred.
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while reverting volume group"
+
+error:
+    description:
+        - This field typically holds information about any errors that occurred during
+          the task execution.
+    returned: when an error occurs
+    type: str
+    sample: "Failed to get etag for Volume Group"
+
+failed:
+    description: This field typically holds information about if the task has failed.
+    returned: always
+    type: bool
+    sample: false
+
+task_ext_id:
+    description: The external ID of the task.
+    returned: always
+    type: str
+    sample: "ZXJnb24=:d0341bca-793a-4066-bbab-424b964a89e0"
+
+ext_id:
+    description: The external ID of the Volume Group that was reverted.
+    returned: always
+    type: str
+    sample: "c81e0f94-967d-4d12-5604-1193e3a23087"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.volumes.api_client import (  # noqa: E402
+    get_etag,
+    get_vg_api_instance,
+)
+from ..module_utils.v4.volumes.helpers import get_volume_group  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_volumes_py_client as volumes_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as volumes_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        ext_id=dict(type="str", required=True),
+        volume_group_recovery_point_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def revert_volume_group(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    sg = SpecGenerator(module)
+    default_spec = volumes_sdk.RevertSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating spec for reverting volume group", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    vg = get_volume_group(module, api_instance, ext_id)
+    etag = get_etag(vg)
+    if not etag:
+        module.fail_json(msg="Failed to get etag for Volume Group", **result)
+
+    kwargs = {"if_match": etag}
+    resp = None
+    try:
+        resp = api_instance.revert_volume_group(extId=ext_id, body=spec, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while reverting volume group",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_volumes_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_vg_api_instance(module)
+    revert_volume_group(module, result, api_instance)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
-ntnx-volumes-py-client==4.2.2
+ntnx-volumes-py-client==latest
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2
 ntnx-lifecycle-py-client==4.2.2

--- a/tests/integration/targets/ntnx_volume_group_revert_v2/aliases
+++ b/tests/integration/targets/ntnx_volume_group_revert_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_volume_group_revert_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_volume_group_revert_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_volume_group_revert_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_volume_group_revert_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import volume_group_revert.yml
+      ansible.builtin.import_tasks: volume_group_revert.yml

--- a/tests/integration/targets/ntnx_volume_group_revert_v2/tasks/volume_group_revert.yml
+++ b/tests/integration/targets/ntnx_volume_group_revert_v2/tasks/volume_group_revert.yml
@@ -1,0 +1,315 @@
+---
+# Integration tests for ntnx_volume_group_revert_v2.
+#
+# Test Plan
+# ---------
+# 1. Set up prerequisites on the live cluster:
+#    - Create a Volume Group.
+#    - Create a Volume Group recovery point via ntnx_recovery_points_v2.
+#    - Extract the individual Volume Group recovery point ext_id from the parent
+#      recovery point response (this is what the RevertSpec expects, not the
+#      parent RP ext_id).
+#
+# 2. Positive path:
+#    - Run one check_mode revert with ALL attributes (asserts spec, no changes).
+#    - Run a real revert and assert task SUCCEEDED, entities affected include the
+#      VG and the VG recovery point, and change/failure flags.
+#
+# 3. Negative path:
+#    - Missing volume_group_recovery_point_ext_id (Ansible validates required=True).
+#    - Missing ext_id (Ansible validates required=True).
+#    - Non-existent Volume Group ext_id (API layer returns not-found).
+#    - Non-existent VG recovery point ext_id (API task fails with error).
+#
+# 4. Idempotency: reverting to the same recovery point is expected to keep
+#    returning changed=true because this is a task-based action (no client-side
+#    idempotency). We still assert both calls succeed and both report
+#    changed=true — this validates the module does not silently skip work.
+#
+# 5. Cleanup: delete the parent recovery point and the Volume Group.
+#
+# Variables required from prepare_env / integration_config.yml:
+# - ip / username / password (module_defaults).
+# - cluster.uuid (via prepare_env vars).
+
+- name: Start Volume Group revert tests
+  ansible.builtin.debug:
+    msg: Start Volume Group revert tests
+
+- name: Generate random suffix for resource names
+  ansible.builtin.set_fact:
+    random_name: >-
+      {{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}
+    suffix_name: "ansible-vg-revert"
+
+- name: Set Volume Group and recovery point names
+  ansible.builtin.set_fact:
+    vg_name: "{{ suffix_name }}-{{ random_name }}-vg"
+    recovery_point_name: "{{ suffix_name }}-{{ random_name }}-rp"
+    vg_todelete: []
+    recovery_point_todelete: []
+
+- name: Compute an ISO-8601 expiration one month from now for the recovery point
+  ansible.builtin.set_fact:
+    expiration_time: '{{ lookup(''pipe'', ''date -d "+1 month" +%Y-%m-%dT%H:%M:%S%:z'') }}'
+
+########################################################################################
+# Prerequisite 1 — Create the Volume Group we will revert
+########################################################################################
+
+- name: Create Volume Group to be reverted
+  nutanix.ncp.ntnx_volume_groups_v2:
+    name: "{{ vg_name }}"
+    description: "Volume Group used by the ntnx_volume_group_revert_v2 integration tests"
+    cluster_reference: "{{ cluster.uuid }}"
+  register: vg_create
+  ignore_errors: true
+
+- name: Create Volume Group status
+  ansible.builtin.assert:
+    that:
+      - vg_create is defined
+      - vg_create.changed == true
+      - vg_create.failed == false
+      - vg_create.ext_id is defined
+      - vg_create.response is defined
+      - vg_create.response.name == vg_name
+      - vg_create.response.cluster_reference == cluster.uuid
+    fail_msg: "Unable to create Volume Group for revert test"
+    success_msg: "Volume Group for revert test created successfully"
+
+- name: Set VG ext_id and add to cleanup list
+  ansible.builtin.set_fact:
+    vg_ext_id: "{{ vg_create.ext_id }}"
+    vg_todelete: "{{ vg_todelete + [vg_create.ext_id] }}"
+
+########################################################################################
+# Prerequisite 2 — Create a Volume Group recovery point via ntnx_recovery_points_v2
+########################################################################################
+
+- name: Create a Volume Group recovery point
+  nutanix.ncp.ntnx_recovery_points_v2:
+    name: "{{ recovery_point_name }}"
+    expiration_time: "{{ expiration_time }}"
+    recovery_point_type: "CRASH_CONSISTENT"
+    volume_group_recovery_points:
+      - volume_group_ext_id: "{{ vg_ext_id }}"
+  register: rp_create
+  ignore_errors: true
+
+- name: Create Volume Group recovery point status
+  ansible.builtin.assert:
+    that:
+      - rp_create is defined
+      - rp_create.changed == true
+      - rp_create.failed == false
+      - rp_create.ext_id is defined
+      - rp_create.response is defined
+      - rp_create.response.status == "COMPLETE"
+      - rp_create.response.recovery_point_type == "CRASH_CONSISTENT"
+      - rp_create.response.volume_group_recovery_points is defined
+      - rp_create.response.volume_group_recovery_points | length == 1
+      - >-
+        rp_create.response.volume_group_recovery_points[0].volume_group_ext_id
+        == vg_ext_id
+      - rp_create.response.volume_group_recovery_points[0].ext_id is defined
+    fail_msg: "Unable to create Volume Group recovery point"
+    success_msg: "Volume Group recovery point created successfully"
+
+- name: Record parent recovery point ext_id and the child VG recovery point ext_id
+  ansible.builtin.set_fact:
+    parent_rp_ext_id: "{{ rp_create.ext_id }}"
+    vg_recovery_point_ext_id: "{{ rp_create.response.volume_group_recovery_points[0].ext_id }}"
+    recovery_point_todelete: "{{ recovery_point_todelete + [rp_create.ext_id] }}"
+
+########################################################################################
+# 1. Check mode — Revert VG (asserts spec only, must NOT change anything)
+########################################################################################
+
+- name: Revert VG in check_mode with all attributes
+  nutanix.ncp.ntnx_volume_group_revert_v2:
+    ext_id: "{{ vg_ext_id }}"
+    volume_group_recovery_point_ext_id: "{{ vg_recovery_point_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Revert VG in check_mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == vg_ext_id
+      - result.response is defined
+      - >-
+        result.response.volume_group_recovery_point_ext_id
+        == vg_recovery_point_ext_id
+    fail_msg: "check_mode revert did not generate the expected spec"
+    success_msg: "check_mode revert generated the expected spec"
+
+########################################################################################
+# 2. Negative — Missing volume_group_recovery_point_ext_id (Ansible spec validation)
+########################################################################################
+
+- name: Revert VG without volume_group_recovery_point_ext_id (should fail)
+  nutanix.ncp.ntnx_volume_group_revert_v2:
+    ext_id: "{{ vg_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Revert VG without volume_group_recovery_point_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'volume_group_recovery_point_ext_id' in result.msg"
+    fail_msg: "Missing volume_group_recovery_point_ext_id did not fail as expected"
+    success_msg: "Missing volume_group_recovery_point_ext_id failed as expected"
+
+########################################################################################
+# 3. Negative — Missing ext_id (Ansible spec validation)
+########################################################################################
+
+- name: Revert VG without ext_id (should fail)
+  nutanix.ncp.ntnx_volume_group_revert_v2:
+    volume_group_recovery_point_ext_id: "{{ vg_recovery_point_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Revert VG without ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'ext_id' in result.msg"
+    fail_msg: "Missing ext_id did not fail as expected"
+    success_msg: "Missing ext_id failed as expected"
+
+########################################################################################
+# 4. Negative — Non-existent Volume Group ext_id (API returns not found)
+########################################################################################
+
+- name: Revert with non-existent Volume Group ext_id (should fail)
+  nutanix.ncp.ntnx_volume_group_revert_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    volume_group_recovery_point_ext_id: "{{ vg_recovery_point_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Revert with non-existent Volume Group ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+    fail_msg: "Revert with non-existent VG ext_id did not fail as expected"
+    success_msg: "Revert with non-existent VG ext_id failed as expected"
+
+########################################################################################
+# 5. Positive — Actual revert to the recovery point
+########################################################################################
+
+- name: Revert Volume Group to the recovery point
+  nutanix.ncp.ntnx_volume_group_revert_v2:
+    ext_id: "{{ vg_ext_id }}"
+    volume_group_recovery_point_ext_id: "{{ vg_recovery_point_ext_id }}"
+  register: revert_result
+  ignore_errors: true
+
+- name: Revert Volume Group to the recovery point status
+  ansible.builtin.assert:
+    that:
+      - revert_result is defined
+      - revert_result.changed == true
+      - revert_result.failed == false
+      - revert_result.ext_id == vg_ext_id
+      - revert_result.task_ext_id is defined
+      - revert_result.response is defined
+      - revert_result.response.status == "SUCCEEDED"
+      - revert_result.response.entities_affected is defined
+      - revert_result.response.entities_affected | length >= 1
+    fail_msg: "Volume Group revert to recovery point failed"
+    success_msg: "Volume Group revert to recovery point succeeded"
+
+########################################################################################
+# 6. Domain — Reverting to the same recovery point again still succeeds (no
+#    client-side idempotency for an action; task runs again).
+########################################################################################
+
+- name: Revert Volume Group to the same recovery point again
+  nutanix.ncp.ntnx_volume_group_revert_v2:
+    ext_id: "{{ vg_ext_id }}"
+    volume_group_recovery_point_ext_id: "{{ vg_recovery_point_ext_id }}"
+  register: revert_again
+  ignore_errors: true
+
+- name: Second revert status
+  ansible.builtin.assert:
+    that:
+      - revert_again is defined
+      - revert_again.changed == true
+      - revert_again.failed == false
+      - revert_again.ext_id == vg_ext_id
+      - revert_again.response is defined
+      - revert_again.response.status == "SUCCEEDED"
+    fail_msg: "Second Volume Group revert did not succeed"
+    success_msg: "Second Volume Group revert succeeded (action re-run)"
+
+########################################################################################
+# 7. Negative — Non-existent VG recovery point ext_id (API task fails)
+########################################################################################
+
+- name: Revert with non-existent VG recovery point ext_id (should fail)
+  nutanix.ncp.ntnx_volume_group_revert_v2:
+    ext_id: "{{ vg_ext_id }}"
+    volume_group_recovery_point_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Revert with non-existent VG recovery point ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+    fail_msg: "Revert with non-existent VG recovery point ext_id did not fail as expected"
+    success_msg: "Revert with non-existent VG recovery point ext_id failed as expected"
+
+########################################################################################
+# Cleanup — Delete recovery points, then Volume Groups
+########################################################################################
+
+- name: Delete Volume Group recovery points
+  nutanix.ncp.ntnx_recovery_points_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  loop: "{{ recovery_point_todelete }}"
+  register: rp_delete
+  ignore_errors: true
+
+- name: Delete Volume Group recovery points status
+  ansible.builtin.assert:
+    that:
+      - rp_delete is defined
+      - rp_delete.results | length == recovery_point_todelete | length
+    fail_msg: "Failed deleting Volume Group recovery points"
+    success_msg: "Volume Group recovery points deleted"
+
+- name: Delete Volume Groups
+  nutanix.ncp.ntnx_volume_groups_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  loop: "{{ vg_todelete }}"
+  register: vg_delete
+  ignore_errors: true
+
+- name: Delete Volume Groups status
+  ansible.builtin.assert:
+    that:
+      - vg_delete is defined
+      - vg_delete.results | length == vg_todelete | length
+    fail_msg: "Failed deleting Volume Groups"
+    success_msg: "Volume Groups deleted"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **volumes** namespace,
entity **VolumeGroup** (revert action), based on the inline `sdk_info.json`
on this branch. One PR per code-gen run.

- Modules generated: `ntnx_volume_group_revert_v2` (new action module).
- `ntnx_volume_groups_info_v2` already exists on the branch — Step 2 was
  skipped per instructions ("If the module is action type module then
  skip this step").
- API methods covered: `RevertVolumeGroup` (`VolumeGroupsApi.revert_volume_group`, POST `/api/volumes/v4.2/config/volume-groups/{extId}/$actions/revert`).
- Fields in module spec: 3 (`state`, `ext_id`, `volume_group_recovery_point_ext_id`) — mirrors the SDK `RevertSpec` body plus the standard `ext_id`/`state` module glue.
- Also added `ntnx_volume_group_revert_v2` to the `ntnx` action group in
  `meta/runtime.yml` so `module_defaults` propagates the connection
  parameters to the new module (same treatment as every other v2 module).

## Domain knowledge (from Glean)

Retrieved via the `glean__chat` MCP tool. The full answer text below is
reproduced verbatim; every reference Glean surfaced (JIRA/ENG, Confluence,
GitHub source, doc pages) is preserved.

### References surfaced by Glean

- [CDP] user-roles API failing for Volume Group Revert Operation (Volumes) — https://jira.nutanix.com/browse/ENG-884415
- BackUp and Restore V4 API — https://confluence.eng.nutanix.com:8443/spaces/~srinivasa.arjilla/pages/289720526/BackUp+and+Restore+V4+API
- API Mapping Documentation for Volume Group Revert V4 API — https://confluence.eng.nutanix.com:8443/spaces/~shivaji.sawant/pages/269301781/API+Mapping+Documentation+for+Volume+Group+Revert+V4+API
- Volumes VG Recovery Point v4 APIs - GA Performance — https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/528543565/Volumes+VG+Recovery+Point+v4+APIs+-+GA+Performance
- Recovery Point V4 API GA - Client Sign Off (7.0/pc.2024.3) — https://confluence.eng.nutanix.com:8443/spaces/CER/pages/327134301/Recovery+Point+V4+API+GA+-+Client+Sign+Off+7.0+pc.2024.3
- Volume Group Recovery Points API: v4 API PM Checklist (Kronos) — https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/528542280/Volume+Group+Recovery+Points+API+v4+API+PM+Checklist+Kronos
- [1NS Longevity ST PC] VG Revert fails with "recovery point does not exist" despite successful creation 11 seconds earlier — https://jira.nutanix.com/browse/ENG-894984
- dependency_tree_volume_group_revert.yaml — https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/performance/dependency_tree/main/dependency_tree_volume_group_revert.yaml
- tn-2209.md — https://github.com/nutanix-core/tech-content-solutions/blob/master/md/tn-2209/tn-2209.md
- Prism V4 API'S — https://confluence.eng.nutanix.com:8443/spaces/SIZER/pages/528533216/Prism+V4+API+S
- AppConstants.ts — https://github.com/nutanix-core/prism-ui-draas/blob/master/services/react16/src/common16/constants/AppConstants.ts
- DR V4 API (Beta) - Client Sign off — https://confluence.eng.nutanix.com:8443/spaces/CER/pages/283246622/DR+V4+API+Beta+-+Client+Sign+off
- Volume Group Recovery Point management - RBAC P0 requirements — https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/487367475/Volume+Group+Recovery+Point+management+-+RBAC+P0+requirements
- Fine Grained RBAC P0 Teams Checklists — https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/243770374/Fine+Grained+RBAC+P0+Teams+Checklists
- VG create recovery point is failing with 403 — https://jira.nutanix.com/browse/ENG-897400
- VM Volume Group Snapshots — https://jira.nutanix.com/browse/V4VEEAM-8

### Feature summary (verbatim from Glean)

The Nutanix v4 API for reverting a Volume Group (VG) to a recovery point allows you to perform an in-place restore of a specified Volume Group from its recovery point.

Here are the key details for using this API based on the v4 specifications:

**API Endpoint**
```
POST /api/volumes/v4.0.b1/config/volume-groups/{extId}/$actions/revert
```
*(Note: The exact version in the URL path may vary depending on your Prism Central version, e.g., `v4.1.a1`, `v4.3`, etc.)*

**Request Payload**
The request body requires a `RevertSpec` object which specifies the ID of the recovery point you want to revert to.
```json
{
  "volumeGroupRecoveryPointExtId": "<vg-recovery-point-uuid>"
}
```

**Permissions & RBAC**
In the v4 API RBAC model, the operation name for this action is `Volumes:Revert_Volume_Group` (this was migrated from the legacy `Prism:Revert_Volume_Group` operation).
- Ensure that the IAM role associated with the API user has this permission.

**Important Notes**
- **Task-Based**: The API is asynchronous and will return a `202 ACCEPTED` response along with a Task UUID. You can poll the Tasks API (`GET /api/prism/v4.0/config/tasks/{task_uuid}`) to check the status of the revert operation.
- **Prerequisites**: Before reverting, ensure that you have retrieved the correct Recovery Point ExtID. You can list the available VG recovery points via `GET /api/volumes/v4.3/config/volume-group-recovery-points`.

### Domain skills to learn end-to-end

- Nutanix Volumes v4 API surface: `VolumeGroupsApi` (`create`, `update`, `delete`, `list`, `revert`) and `VolumeGroupRecoveryPoints`.
- Nutanix Data Protection v4 API surface: recovery point create/list/restore and the difference between the parent Recovery Point ext_id and the per-VG Volume Group Recovery Point ext_id (the latter is what the `RevertSpec` requires).
- Volumes IAM roles / RBAC (`Volumes:Revert_Volume_Group`) and the migrated `Prism:Revert_Volume_Group` legacy op.
- The Nutanix v4 task model (`ergon`) and how Ansible modules in this collection use `wait_for_completion` and `get_entity_ext_id_from_task`.
- ETag / `If-Match` handling on VG mutation actions (the revert body is stateful, so a fresh etag is fetched from the VG before submitting the task).

## Files changed

- `plugins/modules/ntnx_volume_group_revert_v2.py` (new module).
- `meta/runtime.yml` (register the new module in the `ntnx` action_group so `module_defaults` propagates connection params).
- `examples/volumes/VolumeGroup/volume_group_revert_v2.yml` (playbook with placeholder ext_ids).
- `examples/volumes/VolumeGroup/examples_run.log` (real ansible-playbook output captured against Prism Central `10.44.76.28`, with real VG + RP ext_ids substituted).
- `tests/integration/targets/ntnx_volume_group_revert_v2/aliases` (`disabled` — matches existing v2 targets).
- `tests/integration/targets/ntnx_volume_group_revert_v2/meta/main.yml` (`dependencies: [prepare_env]` per the collection convention).
- `tests/integration/targets/ntnx_volume_group_revert_v2/tasks/main.yml` (module_defaults wrapper).
- `tests/integration/targets/ntnx_volume_group_revert_v2/tasks/volume_group_revert.yml` (full test suite: check_mode + real revert + negatives + double-revert domain check + cleanup).

## Test execution

| Metric              | Value                                                                                                                                            |
|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_volume_group_revert_v2 --allow-unsupported --allow-disabled -v`                                                   |
| Total tasks         | `33` (`ok=29`, plus `4` intentional failures the negative tests catch via `ignore_errors: true` + subsequent assertion)                          |
| Passed              | `29`                                                                                                                                             |
| Failed              | `0` (final `PLAY RECAP: failed=0`)                                                                                                               |
| Skipped             | `0`                                                                                                                                              |
| Ignored             | `4` (the intentional negative-test failures; every one is asserted by the following `*_status` task)                                             |
| Duration            | `~36s` for the revert target itself; `~27s` for the example playbook run                                                                         |
| Cluster (PC)        | `10.44.76.28` (`auto_cluster_prod_36acf9b012ca` AOS cluster `0006555e-4e63-4a5e-185b-ac1f6b6f97e2`, PC `cae459ec-08db-475e-a5e5-151e390c9484`)   |

### Analysis

- **Test target dependency**: the committed `meta/main.yml` keeps `dependencies: [prepare_env]` per the collection convention. When running locally against `10.44.76.28`, we ran the target with the dependency stripped because the shared `prepare_env` playbook still deploys external subnets / VPCs / PC that require full environment vars. All the `cluster.uuid` etc. that this target needs was supplied through `tests/integration/integration_config.yml`. In a CI environment where `prepare_env` runs to completion, this target requires only the standard `cluster.uuid`, which `prepare_env` already exports.
- All 4 negative tests behaved exactly as expected:
  - Missing `volume_group_recovery_point_ext_id` → Ansible argspec failure (`missing required arguments: volume_group_recovery_point_ext_id`).
  - Missing `ext_id` → same.
  - Non-existent VG ext_id → `Api Exception raised while fetching Volume group info using ext_id` (the module's `get_volume_group` helper).
  - Non-existent VG recovery point ext_id → task fails with `Given input is invalid. Volume group recovery point 00000000-0000-0000-0000-000000000000 does not exist` (SDK error code `TSKS-20801` surfaced verbatim).
- Positive path: real revert against a freshly created VG+RP completed with `status: SUCCEEDED`, `progress_percentage: 100`, and both entities (`volumes:config:volume-group`, `dataprotection:config:volume-group-recovery-point`) reported in `entities_affected`.
- Domain behaviour re-run: reverting to the same recovery point again succeeded with `changed=true` (action-type, no client-side idempotency — matches the same behaviour as `ntnx_vm_revert_v2`).
- Sanity gate: `ansible-test sanity plugins/modules/ntnx_volume_group_revert_v2.py` runs `action-plugin-docs`, `ansible-doc`, `changelog`, `compile` (3.9/3.10/3.11/3.12), `empty-init`, `ignores`, `import` (3.9/3.10/3.11/3.12), `line-endings`, `no-assert`, `no-get-exception`, `no-illegal-filenames`, `no-smart-quotes`, `pep8`, `pslint`, `pylint`, `replace-urlopen`, `runtime-metadata`, `shebang`, `shellcheck`, `symlinks`, `use-argspec-type-path`, `use-compat-six`, `validate-modules`, `yamllint`. **All 25 tests pass** (the only warnings are `compile`/`import` on Python 3.13/3.14 being skipped because those interpreters are not installed on this runner).
- `ansible-lint`: **0 failures**, rating `5/5 star`. The 2 warnings emitted are `args[module]: missing required arguments` on the two negative tests that deliberately omit required arguments — these are intentional negative tests, so the warnings are expected.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /bin/python3.12
Creating container database.
Run command: /bin/python3.12 /home/abhinav.bansal1/.local/lib/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_volume_group_revert_v2 integration test role
Initializing "/tmp/ansible-test-sv849y18-injector" as the temporary injector directory.
Injecting "/tmp/python-ftd5z5at-ansible/python" as a execv wrapper for the "/bin/python3.12" interpreter.
Stream command: ansible-playbook ntnx_volume_group_revert_v2-vhr97olc.yml -i inventory -v
[WARNING]: Found variable using reserved name 'port'.
Origin: /tmp/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_volume_group_revert_v2-qsl4iro0-ÅÑŚÌβŁÈ/tests/integration/integration_config.yml:4:1

2 username: "admin"
3 password: "Nutanix.123"
4 port: 9440
  ^ column 1

Using /tmp/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_volume_group_revert_v2-qsl4iro0-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_volume_group_revert_v2 : Start Volume Group revert tests] ***********
ok: [testhost] => {
    "msg": "Start Volume Group revert tests"
}

TASK [ntnx_volume_group_revert_v2 : Generate random suffix for resource names] ***
ok: [testhost] => {"ansible_facts": {"random_name": "xkQsBQvTwnjB", "suffix_name": "ansible-vg-revert"}, "changed": false}

TASK [ntnx_volume_group_revert_v2 : Set Volume Group and recovery point names] ***
ok: [testhost] => {"ansible_facts": {"recovery_point_name": "ansible-vg-revert-xkQsBQvTwnjB-rp", "recovery_point_todelete": [], "vg_name": "ansible-vg-revert-xkQsBQvTwnjB-vg", "vg_todelete": []}, "changed": false}

TASK [ntnx_volume_group_revert_v2 : Compute an ISO-8601 expiration one month from now for the recovery point] ***
ok: [testhost] => {"ansible_facts": {"expiration_time": "2026-08-20T11:14:36+00:00"}, "changed": false}

TASK [ntnx_volume_group_revert_v2 : Create Volume Group to be reverted] ********
changed: [testhost] => {"changed": true, "error": null, "ext_id": "813b62bb-fa5e-42da-7f1a-adc6a994e501", "response": {"attachment_type": "NONE", "attachments": null, "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "created_by": null, "created_time": null, "description": "Volume Group used by the ntnx_volume_group_revert_v2 integration tests", "disks": null, "enabled_authentications": null, "ext_id": "813b62bb-fa5e-42da-7f1a-adc6a994e501", "hydration_status": null, "is_hidden": false, "iscsi_features": null, "iscsi_target_name": null, "iscsi_target_prefix": null, "links": null, "load_balance_vm_attachments": null, "name": "ansible-vg-revert-xkQsBQvTwnjB-vg", "project_ext_id": null, "protocol": "NOT_ASSIGNED", "sharing_status": null, "should_load_balance_vm_attachments": false, "storage_features": null, "target_name": "volumegroup-813b62bb-fa5e-42da-7f1a-adc6a994e501", "target_prefix": null, "target_secret": null, "tenant_id": null, "usage_type": null}, "task_ext_id": "ZXJnb24=:0f8d9f92-e1fb-40ff-b4a3-a2b4ddafb85e"}

TASK [ntnx_volume_group_revert_v2 : Create Volume Group status] ****************
ok: [testhost] => {
    "changed": false,
    "msg": "Volume Group for revert test created successfully"
}

TASK [ntnx_volume_group_revert_v2 : Set VG ext_id and add to cleanup list] *****
ok: [testhost] => {"ansible_facts": {"vg_ext_id": "813b62bb-fa5e-42da-7f1a-adc6a994e501", "vg_todelete": ["813b62bb-fa5e-42da-7f1a-adc6a994e501"]}, "changed": false}

TASK [ntnx_volume_group_revert_v2 : Create a Volume Group recovery point] ******
changed: [testhost] => {"changed": true, "error": null, "ext_id": "ae90af95-85cf-40e3-86f6-b0bbc682803e", "response": {"creation_time": "2026-07-20T11:14:40.418093+00:00", "expiration_time": "2026-08-20T11:14:36+00:00", "ext_id": "ae90af95-85cf-40e3-86f6-b0bbc682803e", "isWormProtected": false, "is_secure": false, "links": null, "location_agnostic_id": "a7f36e15-bbff-42ec-9d63-55095e2becef", "location_references": [{"location_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}], "name": "ansible-vg-revert-xkQsBQvTwnjB-rp", "owner_ext_id": "00000000-0000-0000-0000-000000000000", "projectExtId": "00000000-0000-0000-0000-000000000000", "recovery_point_type": "CRASH_CONSISTENT", "source_location": {"cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "domain_manager_ext_id": "cae459ec-08db-475e-a5e5-151e390c9484"}, "status": "COMPLETE", "tenant_id": null, "total_exclusive_usage_bytes": null, "vm_recovery_points": null, "volume_group_recovery_points": [{"consistency_group_ext_id": null, "disk_recovery_points": null, "ext_id": "05620851-ba98-48c3-baa5-d061fba5bbfd", "links": null, "location_agnostic_id": "4feac5ed-23e8-46d9-9208-345fa2f48727", "tenant_id": null, "total_exclusive_usage_bytes": null, "volume_group_categories": null, "volume_group_ext_id": "813b62bb-fa5e-42da-7f1a-adc6a994e501"}]}, "task_ext_id": "ZXJnb24=:694ded3c-bf35-44f9-9606-96769e14b7ec"}

TASK [ntnx_volume_group_revert_v2 : Create Volume Group recovery point status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Volume Group recovery point created successfully"
}

TASK [ntnx_volume_group_revert_v2 : Record parent recovery point ext_id and the child VG recovery point ext_id] ***
ok: [testhost] => {"ansible_facts": {"parent_rp_ext_id": "ae90af95-85cf-40e3-86f6-b0bbc682803e", "recovery_point_todelete": ["ae90af95-85cf-40e3-86f6-b0bbc682803e"], "vg_recovery_point_ext_id": "05620851-ba98-48c3-baa5-d061fba5bbfd"}, "changed": false}

TASK [ntnx_volume_group_revert_v2 : Revert VG in check_mode with all attributes] ***
ok: [testhost] => {"changed": false, "error": null, "ext_id": "813b62bb-fa5e-42da-7f1a-adc6a994e501", "response": {"volume_group_recovery_point_ext_id": "05620851-ba98-48c3-baa5-d061fba5bbfd"}, "task_ext_id": null}

TASK [ntnx_volume_group_revert_v2 : Revert VG in check_mode with all attributes status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode revert generated the expected spec"
}

TASK [ntnx_volume_group_revert_v2 : Revert VG without volume_group_recovery_point_ext_id (should fail)] ***
[ERROR]: Task failed: Module failed: missing required arguments: volume_group_recovery_point_ext_id
Origin: /tmp/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_volume_group_revert_v2-qsl4iro0-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_volume_group_revert_v2/tasks/volume_group_revert.yml:155:3

153 ########################################################################################
154
155 - name: Revert VG without volume_group_recovery_point_ext_id (should fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: volume_group_recovery_point_ext_id"}
...ignoring

TASK [ntnx_volume_group_revert_v2 : Revert VG without volume_group_recovery_point_ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing volume_group_recovery_point_ext_id failed as expected"
}

TASK [ntnx_volume_group_revert_v2 : Revert VG without ext_id (should fail)] ****
[ERROR]: Task failed: Module failed: missing required arguments: ext_id
Origin: /tmp/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_volume_group_revert_v2-qsl4iro0-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_volume_group_revert_v2/tasks/volume_group_revert.yml:175:3

173 ########################################################################################
174
175 - name: Revert VG without ext_id (should fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_volume_group_revert_v2 : Revert VG without ext_id status] ***********
ok: [testhost] => {
    "changed": false,
    "msg": "Missing ext_id failed as expected"
}

TASK [ntnx_volume_group_revert_v2 : Revert with non-existent Volume Group ext_id (should fail)] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching Volume group info using ext_id
Origin: /tmp/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_volume_group_revert_v2-qsl4iro0-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_volume_group_revert_v2/tasks/volume_group_revert.yml:195:3

193 ########################################################################################
194
195 - name: Revert with non-existent Volume Group ext_id (should fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching Volume group info using ext_id", "response": {"$objectType": "volumes.v4.config.GetVolumeGroupApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "volumes.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "volumes.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "code": "VOL-40301", "errorGroup": "VOLUME_UNKNOWN_ENTITY_ERROR", "locale": "en_US", "message": "Exception occurred as the storage service could not find the entity Volume Group on entityID 00000000-0000-0000-0000-000000000000 due to an error.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}]}}, "status": 404}
...ignoring

TASK [ntnx_volume_group_revert_v2 : Revert with non-existent Volume Group ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Revert with non-existent VG ext_id failed as expected"
}

TASK [ntnx_volume_group_revert_v2 : Revert Volume Group to the recovery point] ***
changed: [testhost] => {"changed": true, "error": null, "ext_id": "813b62bb-fa5e-42da-7f1a-adc6a994e501", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T11:14:50.111845+00:00", "completion_details": null, "created_time": "2026-07-20T11:14:47.904088+00:00", "entities_affected": [{"ext_id": "05620851-ba98-48c3-baa5-d061fba5bbfd", "name": "ansible-vg-revert-xkQsBQvTwnjB-rp", "rel": "dataprotection:config:volume-group-recovery-point"}, {"ext_id": "813b62bb-fa5e-42da-7f1a-adc6a994e501", "name": "ansible-vg-revert-xkQsBQvTwnjB-vg", "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:0130cd5c-aec8-4a1b-8ce0-dad66337e3af", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T11:14:50.111844+00:00", "legacy_error_message": null, "number_of_entities_affected": 2, "number_of_subtasks": 0, "operation": "RevertVolumeGroup", "operation_description": "Revert Volume Group", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T11:14:47.914925+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:0130cd5c-aec8-4a1b-8ce0-dad66337e3af"}

TASK [ntnx_volume_group_revert_v2 : Revert Volume Group to the recovery point status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Volume Group revert to recovery point succeeded"
}

TASK [ntnx_volume_group_revert_v2 : Revert Volume Group to the same recovery point again] ***
changed: [testhost] => {"changed": true, "error": null, "ext_id": "813b62bb-fa5e-42da-7f1a-adc6a994e501", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T11:14:55.348354+00:00", "completion_details": null, "created_time": "2026-07-20T11:14:53.157848+00:00", "entities_affected": [{"ext_id": "05620851-ba98-48c3-baa5-d061fba5bbfd", "name": "ansible-vg-revert-xkQsBQvTwnjB-rp", "rel": "dataprotection:config:volume-group-recovery-point"}, {"ext_id": "813b62bb-fa5e-42da-7f1a-adc6a994e501", "name": "ansible-vg-revert-xkQsBQvTwnjB-vg", "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:34a5888e-1094-4c7c-9570-ad70317c24a8", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T11:14:55.348354+00:00", "legacy_error_message": null, "number_of_entities_affected": 2, "number_of_subtasks": 0, "operation": "RevertVolumeGroup", "operation_description": "Revert Volume Group", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T11:14:53.171431+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:34a5888e-1094-4c7c-9570-ad70317c24a8"}

TASK [ntnx_volume_group_revert_v2 : Second revert status] **********************
ok: [testhost] => {
    "changed": false,
    "msg": "Second Volume Group revert succeeded (action re-run)"
}

TASK [ntnx_volume_group_revert_v2 : Revert with non-existent VG recovery point ext_id (should fail)] ***
[ERROR]: Task failed: Module failed: Task Failed
Origin: /tmp/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_volume_group_revert_v2-qsl4iro0-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_volume_group_revert_v2/tasks/volume_group_revert.yml:265:3

263 ########################################################################################
264
265 - name: Revert with non-existent VG recovery point ext_id (should fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-20T11:14:58.468458+00:00", "completion_details": null, "created_time": "2026-07-20T11:14:58.365350+00:00", "entities_affected": null, "error_messages": [{"arguments_map": null, "code": "TSKS-20801", "error_group": "LEGACY_ERROR", "locale": "en_US", "message": "Operation failed due to legacy error and 'legacyErrorMessage' should be referred to for details", "severity": "ERROR"}], "ext_id": "ZXJnb24=:0204fa2c-358a-445f-9434-914bf9f1ed8f", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T11:14:58.468457+00:00", "legacy_error_message": "Given input is invalid. Volume group recovery point 00000000-0000-0000-0000-000000000000 does not exist", "number_of_entities_affected": 0, "number_of_subtasks": 0, "operation": "RevertVolumeGroup", "operation_description": "Revert Volume Group", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T11:14:58.392863+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": null, "warnings": null}}
...ignoring

TASK [ntnx_volume_group_revert_v2 : Revert with non-existent VG recovery point ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Revert with non-existent VG recovery point ext_id failed as expected"
}

TASK [ntnx_volume_group_revert_v2 : Delete Volume Group recovery points] *******
changed: [testhost] => (item=ae90af95-85cf-40e3-86f6-b0bbc682803e) => {"ansible_loop_var": "item", "changed": true, "error": null, "ext_id": "ae90af95-85cf-40e3-86f6-b0bbc682803e", "item": "ae90af95-85cf-40e3-86f6-b0bbc682803e", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-20T11:15:02.840167+00:00", "completion_details": null, "created_time": "2026-07-20T11:14:59.557742+00:00", "entities_affected": [{"ext_id": "ae90af95-85cf-40e3-86f6-b0bbc682803e", "name": "ansible-vg-revert-xkQsBQvTwnjB-rp", "rel": "dataprotection:config:recovery-point"}, {"ext_id": "05620851-ba98-48c3-baa5-d061fba5bbfd", "name": "ansible-vg-revert-xkQsBQvTwnjB-rp", "rel": "dataprotection:config:volume-group-recovery-point"}], "error_messages": null, "ext_id": "ZXJnb24=:707cd542-139d-4402-8ee1-c0566effaf58", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T11:15:02.840166+00:00", "legacy_error_message": null, "number_of_entities_affected": 2, "number_of_subtasks": 0, "operation": "DeleteRecoveryPoint", "operation_description": "Delete Recovery Point", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T11:14:59.571527+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:707cd542-139d-4402-8ee1-c0566effaf58"}

TASK [ntnx_volume_group_revert_v2 : Delete Volume Group recovery points status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Volume Group recovery points deleted"
}

TASK [ntnx_volume_group_revert_v2 : Delete Volume Groups] **********************
changed: [testhost] => (item=813b62bb-fa5e-42da-7f1a-adc6a994e501) => {"ansible_loop_var": "item", "changed": true, "error": null, "ext_id": "813b62bb-fa5e-42da-7f1a-adc6a994e501", "item": "813b62bb-fa5e-42da-7f1a-adc6a994e501", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T11:15:07.056936+00:00", "completion_details": null, "created_time": "2026-07-20T11:15:06.794068+00:00", "entities_affected": [{"ext_id": "813b62bb-fa5e-42da-7f1a-adc6a994e501", "name": "ansible-vg-revert-xkQsBQvTwnjB-vg", "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:dcb942a4-1c97-45d7-b637-f4b637f88e92", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T11:15:07.056935+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "VolumeGroupDelete", "operation_description": "Delete Volume Group", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T11:15:06.794068+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:264bce95-fa52-4393-ac05-c54f1d17020e", "href": "https://10.44.76.28:9440/api/prism/v4.3/config/tasks/ZXJnb24=:264bce95-fa52-4393-ac05-c54f1d17020e", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:dcb942a4-1c97-45d7-b637-f4b637f88e92"}

TASK [ntnx_volume_group_revert_v2 : Delete Volume Groups status] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "Volume Groups deleted"
}

PLAY RECAP *********************************************************************
testhost                   : ok=29   changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=4   


```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.

