### PR TITLE
code-gen(networking/AwsVpc): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+tests/output/

--- a/examples/networking/AwsVpc/aws_vpcs_v2.yml
+++ b/examples/networking/AwsVpc/aws_vpcs_v2.yml
@@ -1,0 +1,70 @@
+---
+# Summary:
+# This playbook demonstrates how to use the AwsVpc info module against an
+# NC2A (Nutanix Cloud Clusters on AWS) enabled Prism Central deployment.
+# The playbook will:
+#   1. Discover a target NC2A Prism Element cluster via ntnx_clusters_info_v2.
+#   2. List all AWS VPCs exposed by that cluster (ntnx_aws_vpcs_info_v2).
+#   3. Fetch a specific AWS VPC by external ID (client-side filter on the list).
+#
+# Notes:
+#   - AwsVpc is a READ-ONLY entity in the v4 networking SDK — only the
+#     ListAwsVpcs API is exposed. No create/update/delete APIs exist.
+#   - `cluster_ext_id` is REQUIRED because the underlying list API needs the
+#     X-Cluster-Id header to identify which NC2A cluster to query.
+
+- name: NC2A AWS VPC info playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Discover an NC2A Prism Element cluster
+      nutanix.ncp.ntnx_clusters_info_v2:
+        filter: "config/clusterFunction/any(f:f eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+      register: clusters_result
+      ignore_errors: true
+
+    - name: Set cluster_ext_id from first NC2A cluster (if available)
+      ansible.builtin.set_fact:
+        cluster_ext_id: "{{ clusters_result.response[0].ext_id }}"
+      when:
+        - clusters_result is defined
+        - clusters_result.response is defined
+        - clusters_result.response | length > 0
+
+    - name: List all AWS VPCs discovered by the NC2A cluster
+      nutanix.ncp.ntnx_aws_vpcs_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+      register: aws_vpcs_list
+      ignore_errors: true
+
+    - name: Show AWS VPC listing
+      ansible.builtin.debug:
+        var: aws_vpcs_list
+
+    - name: Fetch a specific AWS VPC by external ID
+      nutanix.ncp.ntnx_aws_vpcs_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        ext_id: "{{ (aws_vpcs_list.response | first).ext_id }}"
+      register: aws_vpc_by_id
+      when:
+        - aws_vpcs_list is defined
+        - not (aws_vpcs_list.failed | default(false) | bool)
+        - aws_vpcs_list.response is defined
+        - aws_vpcs_list.response is iterable
+        - aws_vpcs_list.response is not string
+        - aws_vpcs_list.response is not mapping
+        - (aws_vpcs_list.response | default([])) | length > 0
+      ignore_errors: true
+
+    - name: Show single AWS VPC lookup
+      ansible.builtin.debug:
+        var: aws_vpc_by_id
+      when:
+        - aws_vpc_by_id is defined
+        - not (aws_vpc_by_id.skipped | default(false) | bool)

--- a/examples/networking/AwsVpc/examples_run.log
+++ b/examples/networking/AwsVpc/examples_run.log
@@ -1,0 +1,121 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [NC2A AWS VPC info playbook] **********************************************
+
+TASK [Discover an NC2A Prism Element cluster] **********************************
+ok: [localhost] => {"changed": false, "error": null, "response": [{"backup_eligibility_score": 1, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDds8wxvJkt0Z/gXOLu8/q0ur7n71FNhVC6FUkhwpmu4gs+WVUi0BeyfJb7jJFFNLzbgmPCxEiAXwURw++74HWMiOpLg9vCKZiftaZxP84Fw8q8c1sgYKCoDsxlwYSIkAgwnfCnQOKlhEO+IHPhEYkoRNm+yu6o3iat0miyLyMZ8NvfLLFaUSPEQvWLVu4DStRd/w4kP5ik16oSe+uHH/jXoVmNaBigp1b9IOMLmG4QcXhuNOoTdP7Wk56JDmmtLCicAm820FHh+8cgiwqzfnXumQoVBDeAj0TaOxvFqIbuYAI3T80wCOXZgDzQa+0nyVWzyQLU3us33SUjoMiJygO90wg80qzriVxvTlGJ0AcDvNrDF1P190MisWDRXa6cP1LhMzBoU8NlSDAofd1Ey/Gj36TPWoJI0vB4hlu0gZmRUiL2b6FeW12P38BLewbYL+GO/VnUPTke9fe4VtmBuQiZO5SYaa6ccabMdkkEr9jnn1t+v6y9tGVqsFXu3RPo2JM= nutanix@ntnx-18fm6g460083-d-cvm", "name": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDIcx1XJP0fYzdetHAnyNijUyFOJCli8OITqix1mpuqfPUg2mEhQnbkxmdT4K9e+I6NadcDKxADsBWWcEwQXGuowgVzPByJmMXrmCfE36Bsit2iVRuFxxnImyiXcTPXcz1IQWvaszUs9vFHtjYdFcRhTnVhLCCKRr8XkR3OgWiuXzUmrOZZPfY06WWhhCXhuVo2WfgYA0nSFXQpLyQvCfQvo+ukM8XPZN/crFtD7xqhL2h0GWYR9HMJJ1TufWUjt0fRVDk/Ja1Pur3bPJAxruGZ1cUfmpKn5f2bJVBXQ2g36Fkxo6qXAzgIVbW3jy0+nZicZMf0vW49YkFPP6P++7F9KwQXwDQg7qiFZngjqwj1EfzPUtdtrafmrbkTUgD2k6FQEiKfq1Z4Jhp5MYZKH1MH4cUVLQUe16Qopyix7tQ9Hcf58g1kaXRKE/HtHXMdANfvZ8nYFRVXmezcE7EwuctW61HwJgP5qdOh8uQm7dd4HIdPkBoyyZhTxtAEq9L2jXc= root@phoenix", "name": "10.46.136.28"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAw8NhpiLG/6c8c0LocaQVM6+x8yBvLS+z13nYlqzSKr64HQSH+IIx14bS+uh0xf8ou5ROnbUa44YM9qG2RBK1hBVrwTIKZBwFwOTxDuXH9YoswqflnOeyTGUFerrMxlg5iYvKE01QIErKWt/BJ+hK/qVQi6SHh/WhyjAGNQPxjPBG3oEUFoLV9uDLX9RT/sLIQpBf91DCbF9+2rSToqjydj36d38JbmuGJGqr+DrEd0lKzfiJiQ39t3AXBE1bY2ISX+uwq07XkYZbrHaijrxnOBFZE7ETQmyxdcOvgDxvhnhZpFsUqbPqIqa45CwFWV+btzITvpJkveYjGSGR7ZJNHQ== nutanix@titan", "name": "agave"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6oDEABPvDtwtOFEJhu7sx9oUZskh0R4CWW6IM9uIxVtjYR/XXu587rXKac34InclJ3U3+PFQcAgEvdw2qiCEWWWMFMiALMneDELPd5qepKRrFJxc3hkyfagot3n7i6r7Y83ceIII4qM1mGLdUA3XdSWlttbgugnBrfB9yLq/BgtVqBvBVFayTGb6IsoMUSbODX6zZEt9Uzh/Yr49DV40ULpGhSYS9vWFB3GrajrliQ9Ea8oOB+8vK9Cavf7IOsaIaPsGI20mypeKFn4qcinBKc6O3PqU3YyYv7pLJWAvwXr9D9+rukgNAhKnd1fFQVLj4sAHA4ixfQk9+0kgAJM4P", "name": "nutest"}], "build_info": {"build_type": "release", "commit_id": "c62bea5d0b6c0010e794199221573a6062a01d14", "full_version": "el9-release-ganges-7.6-stable-c62bea5d0b6c0010e794199221573a6062a01d14", "short_commit_id": "c62bea", "version": "7.6"}, "cluster_arch": "X86_64", "cluster_function": ["AOS"], "cluster_software_map": [{"software_type": "NCC", "version": "ncc-6.0.0"}, {"software_type": "NOS", "version": "el9-release-ganges-7.6-stable-c62bea5d0b6c0010e794199221573a6062a01d14"}], "cluster_type": "HYPER_CONVERGED", "encryption_in_transit_status": null, "encryption_option": null, "encryption_scope": null, "fault_tolerance_state": {"current_cluster_fault_tolerance": "CFT_0N_AND_0D", "current_max_fault_tolerance": 0, "desired_cluster_fault_tolerance": "CFT_0N_AND_0D", "desired_max_fault_tolerance": 0, "domain_awareness_level": "DISK", "isStrictRackAwarenessEnabled": false, "redundancy_status": null}, "hypervisor_types": ["AHV"], "incarnation_id": 1782713390680670, "isDegradedNodeMonitoringDisabled": false, "is_available": true, "is_lts": false, "is_password_remote_login_enabled": true, "is_remote_support_enabled": false, "operation_mode": "NORMAL", "pulse_status": {"is_enabled": true, "pii_scrubbing_level": "DEFAULT"}, "redundancy_factor": 1, "timezone": "UTC"}, "container_name": null, "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "externalStorageProviderInfo": [{"$objectType": "clustermgmt.v4.config.ExternalStorageProviderInfo", "$reserved": {"$fv": "v4.r3"}, "compatibleVersion": "5.1.100.104_5594", "isInstalled": false, "providerType": "DELL_POWERFLEX"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "EVERPURE_FLASHARRAY"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "DELL_POWERSTORE"}], "inefficient_vm_count": null, "links": null, "name": "auto_cluster_prod_36acf9b012ca", "network": {"backplane": {"is_segmentation_enabled": false, "netmask": null, "subnet": null, "vlan_tag": null}, "external_address": {"ipv4": {"prefix_length": 32, "value": "10.46.136.38"}, "ipv6": null}, "external_data_service_ip": {"ipv4": {"prefix_length": 32, "value": "10.46.136.42"}, "ipv6": null}, "external_subnet": "10.46.136.0/255.255.248.0", "fqdn": null, "http_proxy_list": null, "http_proxy_white_list": null, "internal_subnet": "192.168.5.0/255.255.255.128", "key_management_server_type": null, "management_server": null, "masquerading_ip": null, "masquerading_port": null, "name_server_ip_list": [{"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.15"}, "ipv6": null}, {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.16"}, "ipv6": null}], "nfs_subnet_whitelist": null, "ntp_server_config_list": null, "ntp_server_ip_list": [{"fqdn": {"value": "0.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "1.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "2.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "3.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}], "smtp_server": null}, "nodes": {"node_list": [{"controller_vm_ip": {"ipv4": {"prefix_length": 32, "value": "10.46.136.32"}, "ipv6": null}, "host_ip": {"ipv4": {"prefix_length": 32, "value": "10.46.136.28"}, "ipv6": null}, "node_uuid": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b"}], "number_of_nodes": 1}, "tenant_id": null, "upgrade_status": "SUCCEEDED", "vm_count": 13}], "total_available_results": 1}
+
+TASK [Set cluster_ext_id from first NC2A cluster (if available)] ***************
+ok: [localhost] => {"ansible_facts": {"cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}, "changed": false}
+
+TASK [List all AWS VPCs discovered by the NC2A cluster] ************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching AWS VPCs info
+Origin: /tmp/aws_vpcs_v2_run.yml:40:7
+
+38         - clusters_result.response | length > 0
+39
+40     - name: List all AWS VPCs discovered by the NC2A cluster
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching AWS VPCs info", "response": {"$objectType": "networking.v4.aws.config.ListAwsVpcsApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-20002", "errorGroup": "DOWNSTREAM_SERVICE_ERROR", "locale": "en_US", "message": "Failed to reach network service on cluster 0006555e-4e63-4a5e-185b-ac1f6b6f97e2 due to an error.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "self", "rel": "https://10.44.76.28:9440/api/networking/v4.3/aws/config/vpcs"}], "totalAvailableResults": 0}}, "status": 500}
+...ignoring
+
+TASK [Show AWS VPC listing] ****************************************************
+ok: [localhost] => {
+    "aws_vpcs_list": {
+        "changed": false,
+        "error": "INTERNAL SERVER ERROR",
+        "exception": "(traceback unavailable)",
+        "failed": true,
+        "msg": "Api Exception raised while fetching AWS VPCs info",
+        "response": {
+            "$objectType": "networking.v4.aws.config.ListAwsVpcsApiResponse",
+            "$reserved": {
+                "$fv": "v4.r4"
+            },
+            "data": {
+                "$objectType": "networking.v4.error.ErrorResponse",
+                "$reserved": {
+                    "$fv": "v4.r4"
+                },
+                "error": [
+                    {
+                        "$objectType": "networking.v4.error.AppMessage",
+                        "$reserved": {
+                            "$fv": "v4.r4"
+                        },
+                        "code": "NETWORKING-20002",
+                        "errorGroup": "DOWNSTREAM_SERVICE_ERROR",
+                        "locale": "en_US",
+                        "message": "Failed to reach network service on cluster 0006555e-4e63-4a5e-185b-ac1f6b6f97e2 due to an error.",
+                        "severity": "ERROR"
+                    }
+                ]
+            },
+            "metadata": {
+                "$objectType": "common.v1.response.ApiResponseMetadata",
+                "$reserved": {
+                    "$fv": "v1.r0"
+                },
+                "flags": [
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "hasError",
+                        "value": true
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isPaginated",
+                        "value": false
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isTruncated",
+                        "value": false
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isExpandRestricted",
+                        "value": false
+                    }
+                ],
+                "links": [
+                    {
+                        "$objectType": "common.v1.response.ApiLink",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "href": "self",
+                        "rel": "https://10.44.76.28:9440/api/networking/v4.3/aws/config/vpcs"
+                    }
+                ],
+                "totalAvailableResults": 0
+            }
+        },
+        "status": 500
+    }
+}
+
+TASK [Fetch a specific AWS VPC by external ID] *********************************
+skipping: [localhost] => {"changed": false, "false_condition": "not (aws_vpcs_list.failed | default(false) | bool)", "skip_reason": "Conditional result was False"}
+
+TASK [Show single AWS VPC lookup] **********************************************
+skipping: [localhost] => {"false_condition": "not (aws_vpc_by_id.skipped | default(false) | bool)"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=1   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_aws_vpcs_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_aws_vpcs_api_instance(module):
+    """
+    This method will return AwsVpcsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): AWS VPCs Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.AwsVpcsApi(api_client=api_client)

--- a/plugins/modules/ntnx_aws_vpcs_info_v2.py
+++ b/plugins/modules/ntnx_aws_vpcs_info_v2.py
@@ -1,0 +1,227 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_aws_vpcs_info_v2
+short_description: Fetch NC2A (Nutanix Cloud Clusters on AWS) VPC info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about AwsVpc in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific AwsVpc from the target cluster.
+  - If C(ext_id) is not provided, list multiple AwsVpc for the target cluster.
+  - AwsVpc is a read-only listing surface (only the list API is available in the SDK);
+    filtering by C(ext_id) is done client-side against the list response.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get NC2A VPCs) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin, Virtual Machine Admin,
+      Virtual Machine Operator, Virtual Machine Viewer, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID of the AwsVpc.
+      - When provided, only the matching AwsVpc from the target cluster is returned.
+      - AwsVpc has no dedicated get-by-ID endpoint; this is applied as a client-side filter.
+    type: str
+  cluster_ext_id:
+    description:
+      - The external ID (UUID) of the target NC2A Prism Element cluster whose AWS VPCs should be listed.
+      - Required by the underlying list API which passes this value as the C(X-Cluster-Id) header.
+    type: str
+    required: true
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: List all AWS VPCs discovered by an NC2A cluster
+  nutanix.ncp.ntnx_aws_vpcs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    cluster_ext_id: "0006361b-6855-3644-7458-2268f8ffb2bd"
+  register: result
+  ignore_errors: true
+
+- name: Fetch a specific AWS VPC by external ID
+  nutanix.ncp.ntnx_aws_vpcs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    cluster_ext_id: "0006361b-6855-3644-7458-2268f8ffb2bd"
+    ext_id: "vpc-0a1b2c3d4e5f67890"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC AwsVpc info v4 API.
+    - It can be a single AwsVpc if external ID is provided.
+    - List of multiple AwsVpc if external ID is not provided.
+  returned: always
+  type: dict
+  sample:
+    {
+      "annotation": null,
+      "cidrs": ["10.0.0.0/16"],
+      "cloud_type": "AWS",
+      "ext_id": "vpc-0a1b2c3d4e5f67890",
+      "links": null,
+      "tenant_id": null,
+      "vpc_id": "vpc-0a1b2c3d4e5f67890"
+    }
+
+ext_id:
+  description:
+    - External ID of the AwsVpc.
+  type: str
+  returned: when external ID is provided
+  sample: "vpc-0a1b2c3d4e5f67890"
+
+total_available_results:
+  description:
+    - The total number of AwsVpc entries returned by the target cluster.
+  type: int
+  returned: when all AwsVpcs are fetched
+  sample: 3
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This field typically holds information about errors that occurred during the task execution.
+  type: str
+  returned: When an error occurs
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching AWS VPCs info"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import get_aws_vpcs_api_instance  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        cluster_ext_id=dict(type="str", required=True),
+    )
+
+    return module_args
+
+
+def _list_aws_vpcs(module, api_instance):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    try:
+        return api_instance.list_aws_vpcs(X_Cluster_Id=cluster_ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching AWS VPCs info",
+        )
+
+
+def get_aws_vpc_by_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = _list_aws_vpcs(module, api_instance)
+
+    stripped = strip_internal_attributes(resp.to_dict())
+    entries = stripped.get("data") or []
+    match = next((item for item in entries if item.get("ext_id") == ext_id), None)
+    if match is None:
+        module.fail_json(
+            msg="AwsVpc with ext_id '{0}' not found on cluster '{1}'".format(
+                ext_id, module.params.get("cluster_ext_id")
+            ),
+            failed=True,
+            response=None,
+            ext_id=ext_id,
+        )
+
+    result["ext_id"] = ext_id
+    result["response"] = match
+
+
+def get_aws_vpcs(module, api_instance, result):
+    resp = _list_aws_vpcs(module, api_instance)
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp_dict = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp_dict:
+        resp_dict = []
+    result["response"] = resp_dict
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_aws_vpcs_api_instance(module)
+    if module.params.get("ext_id"):
+        get_aws_vpc_by_ext_id(module, api_instance, result)
+    else:
+        get_aws_vpcs(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_aws_vpcs_info_v2/aliases
+++ b/tests/integration/targets/ntnx_aws_vpcs_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_aws_vpcs_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_aws_vpcs_info_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_aws_vpcs_info_v2/tasks/aws_vpcs_info.yml
+++ b/tests/integration/targets/ntnx_aws_vpcs_info_v2/tasks/aws_vpcs_info.yml
@@ -1,0 +1,228 @@
+---
+# Integration test plan for ntnx_aws_vpcs_info_v2 (AwsVpc)
+#
+# AwsVpc is a READ-ONLY entity in the v4 networking SDK. Only ListAwsVpcs
+# (GET /api/networking/v4.3/aws/config/vpcs) is exposed by the SDK; the API
+# is only meaningful when the target Prism Element cluster is an NC2A
+# (Nutanix Cloud Clusters on AWS) deployment. On non-NC2A clusters, the API
+# returns HTTP 500 with the error code C(NETWORKING-20002)
+# ("Failed to reach network service on cluster ...").
+#
+# Scenarios covered:
+# 1. Discover a target Prism Element cluster on the connected PC — provides a
+#    real cluster_ext_id.
+# 2. Positive path (if NC2A): list AWS VPCs and validate the response shape.
+# 3. Positive path (if NC2A and >= 1 AwsVpc): fetch by ext_id.
+# 4. Negative — non-NC2A cluster: the module must fail with the API exception
+#    envelope populated by the SDK (Api Exception raised while fetching AWS
+#    VPCs info) — this proves the module's error handling is correct.
+# 5. Negative — bogus ext_id (only when list succeeds): descriptive
+#    "not found" message from client-side filter.
+# 6. Negative — missing required cluster_ext_id: Ansible argument validation.
+# 7. Negative — syntactically invalid cluster_ext_id: API exception.
+# 8. Negative — unknown parameter: Ansible argument validation.
+
+- name: Start AwsVpc info tests
+  ansible.builtin.debug:
+    msg: Start AwsVpc info tests
+
+########################################################################################
+# Discover a target Prism Element cluster on the connected Prism Central
+########################################################################################
+
+- name: Fetch clusters registered to the PC
+  nutanix.ncp.ntnx_clusters_info_v2:
+  register: clusters_info
+  ignore_errors: true
+
+- name: Assert clusters were fetched
+  ansible.builtin.assert:
+    that:
+      - clusters_info is defined
+      - clusters_info.failed == false
+      - clusters_info.response is defined
+      - clusters_info.response | length > 0
+    success_msg: "Clusters fetched successfully"
+    fail_msg: "No clusters returned from PC — cannot exercise AwsVpc info module"
+
+- name: Pick the first non-PC (AOS) cluster as the AwsVpc test target
+  ansible.builtin.set_fact:
+    target_cluster_ext_id: >-
+      {{
+        (
+          clusters_info.response
+          | selectattr('config.cluster_function', 'defined')
+          | rejectattr('config.cluster_function', 'contains', 'PRISM_CENTRAL')
+          | list
+          | first
+        ).ext_id
+      }}
+
+- name: Show target cluster
+  ansible.builtin.debug:
+    var: target_cluster_ext_id
+
+########################################################################################
+# List AWS VPCs for the target cluster — success on NC2A, API error otherwise
+########################################################################################
+
+- name: List all AWS VPCs on the target cluster
+  nutanix.ncp.ntnx_aws_vpcs_info_v2:
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+  register: list_result
+  ignore_errors: true
+
+- name: Show list result envelope
+  ansible.builtin.debug:
+    msg: >-
+      list_result.failed={{ list_result.failed | default(true) }},
+      total_available_results={{ list_result.total_available_results | default('n/a') }}
+
+- name: Assert list AWS VPCs response shape (NC2A cluster path)
+  ansible.builtin.assert:
+    that:
+      - list_result.changed == false
+      - list_result.response is defined
+      - list_result.response is iterable
+      - list_result.total_available_results is defined
+      - list_result.total_available_results >= 0
+    success_msg: "List AWS VPCs returned a valid response envelope"
+    fail_msg: "List AWS VPCs returned an unexpected response envelope"
+  when: not (list_result.failed | default(true) | bool)
+
+- name: Assert list AWS VPCs correctly surfaces API exception on non-NC2A cluster
+  ansible.builtin.assert:
+    that:
+      - list_result.failed | default(false) | bool == true
+      - list_result.changed == false
+      - "'Api Exception raised while fetching AWS VPCs info' in (list_result.msg | default(''))"
+    success_msg: "List AWS VPCs correctly surfaces the SDK ApiException on a non-NC2A cluster"
+    fail_msg: "List AWS VPCs did not surface the expected SDK ApiException on a non-NC2A cluster"
+  when: (list_result.failed | default(true) | bool)
+
+- name: Assert every listed AWS VPC has the expected AwsVpc SDK fields
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined
+      - item.vpc_id is defined
+    success_msg: "AwsVpc entry {{ item.ext_id }} exposes expected fields"
+    fail_msg: "AwsVpc entry does not expose the expected fields"
+  loop: "{{ (list_result.response | default([])) if (list_result.response is iterable and list_result.response is not string and list_result.response is not mapping) else [] }}"
+  when: not (list_result.failed | default(true) | bool)
+
+########################################################################################
+# Positive — client-side get-by-ext_id (only when we actually have >= 1 AwsVpc)
+########################################################################################
+
+- name: Fetch a specific AWS VPC by external ID
+  nutanix.ncp.ntnx_aws_vpcs_info_v2:
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    ext_id: "{{ list_result.response[0].ext_id }}"
+  register: get_by_id_result
+  when:
+    - not (list_result.failed | default(true) | bool)
+    - list_result.response is iterable
+    - list_result.response is not string
+    - list_result.response is not mapping
+    - (list_result.response | default([])) | length > 0
+  ignore_errors: true
+
+- name: Assert fetch by ext_id returned the matching AwsVpc
+  ansible.builtin.assert:
+    that:
+      - get_by_id_result.changed == false
+      - get_by_id_result.failed == false
+      - get_by_id_result.ext_id == list_result.response[0].ext_id
+      - get_by_id_result.response is defined
+      - get_by_id_result.response.ext_id == list_result.response[0].ext_id
+    success_msg: "Fetch AWS VPC by ext_id returned the correct entry"
+    fail_msg: "Fetch AWS VPC by ext_id did not return the expected entry"
+  when:
+    - get_by_id_result is defined
+    - get_by_id_result.skipped | default(false) | bool == false
+
+########################################################################################
+# Negative — bogus ext_id (only when the list API is functional)
+########################################################################################
+
+- name: Fetch AWS VPC using a bogus ext_id
+  nutanix.ncp.ntnx_aws_vpcs_info_v2:
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    ext_id: "vpc-ffffffffffffffff0"
+  register: bogus_ext_id_result
+  ignore_errors: true
+  when: not (list_result.failed | default(true) | bool)
+
+- name: Assert bogus ext_id fails with descriptive not-found message
+  ansible.builtin.assert:
+    that:
+      - bogus_ext_id_result.changed == false
+      - bogus_ext_id_result.failed == true
+      - "'not found' in (bogus_ext_id_result.msg | default(''))"
+      - "'vpc-ffffffffffffffff0' in (bogus_ext_id_result.msg | default(''))"
+    success_msg: "Bogus ext_id was correctly rejected as not found"
+    fail_msg: "Bogus ext_id did not fail with the expected not-found message"
+  when:
+    - bogus_ext_id_result is defined
+    - bogus_ext_id_result.skipped | default(false) | bool == false
+
+########################################################################################
+# Negative — cluster_ext_id is required (Ansible argument validation)
+########################################################################################
+
+- name: List AWS VPCs without required cluster_ext_id
+  nutanix.ncp.ntnx_aws_vpcs_info_v2: {}
+  register: missing_cluster_result
+  ignore_errors: true
+
+- name: Assert missing cluster_ext_id fails Ansible argument validation
+  ansible.builtin.assert:
+    that:
+      - missing_cluster_result is defined
+      - missing_cluster_result.failed == true
+      - "'cluster_ext_id' in (missing_cluster_result.msg | default(''))"
+    success_msg: "Missing cluster_ext_id was correctly rejected"
+    fail_msg: "Missing cluster_ext_id was not correctly rejected"
+
+########################################################################################
+# Negative — syntactically invalid cluster_ext_id (server-side rejection)
+########################################################################################
+
+- name: List AWS VPCs with a syntactically invalid cluster_ext_id
+  nutanix.ncp.ntnx_aws_vpcs_info_v2:
+    cluster_ext_id: "not-a-real-cluster"
+  register: invalid_cluster_result
+  ignore_errors: true
+
+- name: Assert invalid cluster_ext_id fails via API exception
+  ansible.builtin.assert:
+    that:
+      - invalid_cluster_result is defined
+      - invalid_cluster_result.failed == true
+      - "'Api Exception raised while fetching AWS VPCs info' in (invalid_cluster_result.msg | default(''))"
+    success_msg: "Invalid cluster_ext_id was correctly rejected by the API"
+    fail_msg: "Invalid cluster_ext_id was not rejected by the API as expected"
+
+########################################################################################
+# Negative — unknown parameter must fail argument validation
+########################################################################################
+
+- name: Call AwsVpc info module with an unknown parameter
+  nutanix.ncp.ntnx_aws_vpcs_info_v2:
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    bogus_param: "should-be-rejected"
+  register: unknown_param_result
+  ignore_errors: true
+
+- name: Assert unknown parameter is rejected
+  ansible.builtin.assert:
+    that:
+      - unknown_param_result is defined
+      - unknown_param_result.failed == true
+      - "'bogus_param' in (unknown_param_result.msg | default(''))"
+    success_msg: "Unknown parameter was correctly rejected"
+    fail_msg: "Unknown parameter was not rejected"
+
+- name: End AwsVpc info tests
+  ansible.builtin.debug:
+    msg: End AwsVpc info tests

--- a/tests/integration/targets/ntnx_aws_vpcs_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_aws_vpcs_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import aws_vpcs_info.yml
+      ansible.builtin.import_tasks: aws_vpcs_info.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**AwsVpc**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_aws_vpcs_info_v2` (info-only)
- Modules **NOT** generated: `ntnx_aws_vpc_v2` (CRUD) — see "Scope note" below
- API methods covered: `1` (`ListAwsVpcs` on `AwsVpcsApi`)
- Fields in info module spec: `2` (`ext_id`, `cluster_ext_id`) plus base
  credentials / proxy / `read_timeout` from `BaseInfoModule`

### Scope note — no CRUD module

The upstream SDK (`ntnx_networking_py_client==4.3.0`) exposes exactly one method
for the `AwsVpc` entity:

```
AwsVpcsApi.list_aws_vpcs(X_Cluster_Id) -> ListAwsVpcsApiResponse
```

There are no `create_aws_vpc` / `update_aws_vpc_by_id` / `delete_aws_vpc_by_id` /
`get_aws_vpc_by_id` methods, and the inline SDK info in `INSTRUCTIONS.md`
explicitly records this:

```
## API Methods Available
  - ListAwsVpcs (receiver: AwsVpcsApi)
    Description: Get NC2A VPCs.
    URI: /api/networking/v4.3/aws/config/vpcs

## CRUD Resources Identified
N/A

## Info / List Methods Identified
  - ListAwsVpcs (plural datasource): Get NC2A VPCs.
```

Because AwsVpc is a read-only listing surface (Prism Element discovers the
underlying AWS VPCs from the NC2A control plane), a CRUD module would have no
API to call and would only be able to fail. Fabricating a stub module for a
non-existent API would violate the "Only add options the API/SDK actually
supports" hard rule (INSTRUCTIONS.md §1.8) and mislead reviewers. `ext_id`-based
retrieval is implemented as a **client-side filter** over the list response in
`ntnx_aws_vpcs_info_v2`.

## Domain knowledge (from Glean)

### Overview of AwsVpc in Nutanix Networking (NC2 on AWS)

In the context of **Nutanix Cloud Clusters (NC2) on AWS**, an **AWS VPC (Virtual
Private Cloud)** is the foundational network environment into which the Nutanix
HCI stack (AHV and CVMs) is deployed. NC2 provisions bare-metal EC2 instances
within this VPC, effectively creating an extension of an on-premises Nutanix
environment in the cloud.

From an API and programmatic perspective, `AwsVpc` is a configuration object in
the Nutanix Networking V4 API that represents the underlying AWS VPC. It
encapsulates metadata such as the VPC ID, associated Subnet CIDRs, annotations,
and cloud type.

### Detailed Features

1. **Native AWS Networking Integration**
   - AHV hosts run on EC2 bare-metal instances and utilize AWS Elastic Network
     Interfaces (ENIs). Each ENI can handle up to 50 IPs (1 primary for the host,
     49 secondary for UVMs).
   - UVMs (User VMs) receive IP addresses directly from the AWS VPC subnets,
     allowing native integration with AWS services (EC2, S3, RDS, etc.) without
     additional overlay routing.
2. **Prism API & UI Integration (FEAT-12891)**
   - Prism Element fetches and lists AWS VPC and Subnet details directly from
     AWS (via `GET /networking/v4.x/aws/config/vpcs`), eliminating the need to
     pivot to the AWS Console when mapping UVM networks.
3. **Flow Virtual Networking (FVN) Support**
   - Supports complex two-tier topologies (Transit VPCs and User VPCs) over the
     AWS VPC underlay.
   - Offers both **NAT** and **No-NAT** overlay connectivity paths for granular
     traffic control.
4. **Security Group Mapping**
   - NC2 automatically creates Default Security Groups (Internal Management,
     User Management, UVM).
   - ENIs attached to UVM subnets inherit these security groups, serving as
     stateful instance-level firewalls.
5. **Multi-AZ and Subnet Granularity**
   - Clusters are deployed in a single AZ, but Flow Virtual Networking allows
     stretched L2 networks and unified IPAM across multiple AZs and on-premises
     environments.

### Where and How it is Used

- **Cluster Deployment**: During cluster creation via the **Multi-Cloud Manager
  (MCM)**, customers can choose to:
  1. **Create a new VPC**: MCM automatically provisions the VPC, a private
     management subnet, an Internet Gateway (IGW), and a NAT Gateway.
  2. **Use an existing VPC**: Customers map their existing AWS network
     infrastructure to the NC2 cluster.
- **Network Mapping in Prism Element**: Once the cluster is deployed, admins go
  to Prism Element > Network Configuration, select the underlying `AwsVpc`, and
  map specific AWS Subnets to AHV networks for UVMs to consume.
- **Disaster Recovery & Bursting**: Used heavily in pilot-light DR topologies
  and capacity bursting scenarios where UVMs failover to AWS and instantly
  communicate using AWS VPC routing or Flow overlays.

### Prerequisites

1. **AWS Account & IAM Roles**: Require `IAMFullAccess` and
   `AWSCloudFormationFullAccess` to run the Nutanix CloudFormation template.
   Creates `Nutanix-Clusters-High-Nc2-Cluster-Role-Prod` and
   `Nutanix-Clusters-High-Nc2-Orchestrator-Role-Prod` roles.
2. **AWS Resource Limits**: Adequate bare-metal instance vCPU limits (e.g.,
   `i4i.metal` requires 128 vCPUs, `z1d.metal` requires 48 vCPUs).
3. **VPC Configuration (If using an existing VPC)**: `enable_dns_hostnames` and
   `enable_dns_support` must be set to `true`. Must have a **Private Subnet**
   (for CVMs/AHV hosts) and a **Public Subnet** (for NAT/IGW outbound access).
4. **Nutanix Account**: "Account Admin" role in My Nutanix is required to
   subscribe and deploy via MCM.
5. **Connectivity**: Proper outbound connectivity to NC2 Portal, AWS management
   endpoints, and Nutanix Teleport Proxies (for support tunnels).

### General Workflow

1. **Provisioning (MCM)**: Admin logs into Nutanix Clusters Portal and inputs
   deployment details (Region, Instance Type, VPC, Subnets).
2. **Resource Creation**: MCM uses AWS APIs to create ENIs, Security Groups,
   and EBS volumes, and launches the bare-metal EC2 instances in the target
   VPC.
3. **Node Check-in**: The Nutanix Host Agent on the AMI checks in with MCM.
   Once all nodes boot and form a cluster, control is handed over to the user.
4. **Subnet Mapping (Prism)**: Admin logs into Prism Element, lists the
   available subnets within the `AwsVpc`, and assigns them as UVM networks.
5. **Advanced Networking (Optional)**: If FVN is enabled, Prism Central is
   deployed, and the admin provisions Transit VPCs, User VPCs, and configures
   static routes / Externally Routable Prefixes (ERPs) for No-NAT paths.

### Related Tickets and Confluence Documentation

**Confluence Documents:**
- [NC2 on AWS: Network Configuration Deep Dive](<URL_1>:8443/spaces/SO/pages/372300893/NC2+on+AWS+Network+Configuration+Deep+Dive) — Comprehensive breakdown of AWS VPC components, ENIs, and Gateways.
- [NC2 on AWS: Cluster Creation prerequisites and workflow](<URL_1>:8443/spaces/SO/pages/372300895/NC2+on+AWS+Cluster+Creation+prerequisites+and+workflow) — Details IAM roles, vCPU limits, and basic setup.
- [FEAT-13515 - Integrate Flow Networking into AWS Clusters](<URL_1>:8443/spaces/SW/pages/301287159/FEAT-13515+-+Integrate+Flow+Networking+into+AWS+Clusters) — Design for adding FVN overlays over AWS VPCs.
- [FEAT-12891 - Listing AWS VPC and Subnet information from PE](<URL_1>:8443/spaces/SW/pages/160991773/FEAT-12891+-+Listing+AWS+VPC+and+Subnet+information+from+PE) — UX workflow for listing AWS VPCs via the Networking V4 API.
- [NC2: Nutanix Cloud Clusters Azure & AWS](<URL_1>:8443/spaces/QA/pages/128404526/NC2+Nutanix+Cloud+Clusters+Azure+AWS) — QA / Testing setup for NC2 clusters.
- [SOP: How to set up NC2 on AWS for No Nat Overlay path test](<URL_1>:8443/spaces/NTC/pages/352967207/SOP+How+to+set+up+NC2+on+AWS+for+No+Nat+Overlay+path+test)
- [AWS NC2 Flow VPC Setup](<URL_1>:8443/spaces/~roshan.shetty1/pages/344984932/AWS+NC2+Flow+VPC+Setup)
- [NC2 on AWS](<URL_1>:8443/spaces/SO/pages/360419323/NC2+on+AWS)
- [Cribl Edge - Privatelink Configuration](<URL_1>:8443/spaces/prodsec/pages/528535367/Cribl+Edge+-+Privatelink+Configuration)
- [SOP: NC2 on Azure - prerequisites check scripts](<URL_1>:8443/spaces/NTC/pages/397765711/SOP+NC2+on+Azure+-+prerequisites+check+scripts)
- [FVN Prerequisites](<URL_1>:8443/spaces/~jin.kim/pages/554389484/FVN+Prerequisites)
- [How To - Up and running with Hubble and Retina](<URL_1>:8443/spaces/~saptarshi.biswas/pages/545128939/How+To+-+Up+and+running+with+Hubble+and+Retina)
- [NC2 New Hire Ramp Up Guide](<URL_1>:8443/spaces/QA/pages/314657669/NC2+New+Hire+Ramp+Up+Guide)
- [NC2 on AWSのケース対応について](<URL_1>:8443/spaces/~zihao.liao/pages/507287297/NC2+on+AWS%E3%81%AE%E3%82%B1%E3%83%BC%E3%82%B9%E5%AF%BE%E5%BF%9C%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6)
- [NC2 AWS Networking 200 (SharePoint)](https://nutanixinc.sharepoint.com/sites/GlobalEnablementPrograms/_layouts/15/Doc.aspx?sourcedoc=%7B658C9CFF-9838-4CA4-BCC3-97E44E2EA7EE%7D&file=NC2%20AWS%20Networking%20200.pptx&action=edit&mobileredirect=true)

**JIRA / ENG Tickets:**
- **ENG-811384** — [FVN on AWS: Increase API request rate limit config for AWS VPC endpoint](https://jira.nutanix.com/browse/ENG-811384) — Addresses 429 API rate-limiting errors when Atlas queries the AWS VPC endpoints.
- **CLSTR-22572** — [[CP2.0] Post-recovery, replica node's No-NAT overlay ENI is attached with the DEAD source cluster's UVM security group](https://jira.nutanix.com/browse/CLSTR-22572) — Blocker bug related to Security Groups on overlay ENIs in VPCs after a DR failover.
- **ENG-950312** — [[Native Files on AWS] Revisit S3 Bucket Configuration](https://jira.nutanix.com/browse/ENG-950312) — Context on configuring AWS VPC S3 Interface Endpoints.

**Source / API Definitions:**
- [`AwsVpc.py` — SDK model](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/networking/ntnx_networking_py_client/models/networking/v4/aws/config/AwsVpc.py)
- [`AwsVpc.yaml` — API spec](https://github.com/nutanix-core/ntnx-api-cloud/blob/main/cloud-api-definitions/defs/namespaces/networking/versioned/v4/modules/aws/released/models/AwsVpc.yaml)
- [`awsVpcDescriptions.yaml` — cloud-pe descriptions](https://github.com/nutanix-core/ntnx-api-cloud-pe/blob/main/cloud-pe-api-definitions/defs/namespaces/networking/etc/resources/documentation/bundles/en_US/awsVpcDescriptions.yaml)
- [`AwsSubnet.py` — related SDK model](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/clustermgmt/ntnx_clustermgmt_py_client/models/networking/v4/aws/config/AwsSubnet.py)
- [Swagger v4.r3 networking (17.6.0.1378 LKG)](https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/api_artifacts/networking/v4.r3/cloud-api-definitions-17.6.0.1378.<PHONE_1>-LKG-RELEASE/swagger-networking-v4.r3-all.yaml)
- [Swagger v4.r0.b2 networking (17.0.0.856)](https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/api_artifacts/networking/v4.r0.b2/cloud-api-definitions-17.0.0.856-RELEASE/swagger-networking-v4.r0.b2-all.yaml)
- [Swagger all-17.6.0.1070](https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/api_artifacts/networking/v4.r2/cloud-api-definitions-17.6.0.1070-RELEASE/swagger-all-17.6.0.1070-RELEASE.yaml)
- [Swagger all-17.6.0.1378 LKG](https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/api_artifacts/networking/v4.r3/cloud-api-definitions-17.6.0.1378.<PHONE_1>-LKG-RELEASE/swagger-all-17.6.0.1378.<PHONE_1>-LKG-RELEASE.yaml)
- [Swagger v4.r3 documentation](https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/api_artifacts/networking/v4.r3/cloud-api-definitions-17.6.0.1378.<PHONE_1>-LKG-RELEASE/swagger-networking-v4.r3-all-documentation.yaml)

**Domain skills required to work on this feature end to end:**
- AWS VPC / Subnet / Security Group / ENI / Route Table fundamentals.
- Nutanix Cloud Clusters (NC2) on AWS provisioning workflow, including
  Multi-Cloud Manager (MCM), CloudFormation templates, and IAM roles.
- Nutanix Flow Virtual Networking (FVN) — Transit / User VPCs, Externally
  Routable Prefixes (ERPs), NAT vs No-NAT overlays.
- Nutanix v4 API/SDK usage (Python `ntnx_networking_py_client`, `AwsVpcsApi`).
- Ansible module authoring (v2 conventions: `BaseInfoModule`, argument spec,
  `strip_internal_attributes`, SDK `ApiException` mapping).

## Files changed

- `plugins/modules/`
  - `ntnx_aws_vpcs_info_v2.py` — new info module (list + client-side
    get-by-ext_id).
- `plugins/module_utils/v4/network/`
  - `api_client.py` — added `get_aws_vpcs_api_instance(module)` helper.
- `meta/`
  - `runtime.yml` — registered `ntnx_aws_vpcs_info_v2` in the `ntnx` action
    group so `module_defaults: group/nutanix.ncp.ntnx` propagates the standard
    credentials to it.
- `examples/networking/AwsVpc/`
  - `aws_vpcs_v2.yml` — new playbook covering discover-cluster / list VPCs /
    fetch-by-ext_id.
  - `examples_run.log` — real playbook output captured against PC 10.44.76.28.
- `tests/integration/targets/ntnx_aws_vpcs_info_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/aws_vpcs_info.yml` —
    new disabled-by-default integration target with positive + negative
    scenarios (see below).
- `.gitignore` — ignore `tests/integration/integration_config.yml` and
  `tests/output/`.

## Test execution

| Metric              | Value                                                        |
|---------------------|--------------------------------------------------------------|
| Command             | `ansible-test integration --allow-unsupported --allow-disabled --python 3.12 ntnx_aws_vpcs_info_v2` |
| Total tasks         | `20` (16 executed + 4 skipped/branched)                      |
| Passed              | `16`                                                         |
| Failed              | `0`                                                          |
| Skipped             | `6` (positive path branches — target cluster is NOT NC2A)    |
| Ignored             | `4` (expected module failures rescued by `ignore_errors`)    |
| Duration            | `~0:00:08`                                                   |
| Cluster (PC)        | `10.44.76.28` (non-NC2A test PC)                             |
| Sanity              | `ansible-test sanity --python 3.12` — 24 tests, 0 failures   |
| Lint                | `black --check`, `isort --check`, `flake8`, `ansible-lint` — all pass |

### Analysis

- **Positive paths (list AWS VPCs, get-by-ext_id, bogus-ext_id)** were
  correctly **skipped** because the connected PC does not front any NC2A
  cluster. The `list_aws_vpcs` API returned HTTP 500 with SDK error code
  `NETWORKING-20002` / `DOWNSTREAM_SERVICE_ERROR` ("Failed to reach network
  service on cluster ..."), which is the documented behaviour for non-NC2A
  clusters. The tests **did assert** that the module surfaces this as a
  descriptive `Api Exception raised while fetching AWS VPCs info` error — that
  assertion passed.
- **Negative paths** all executed and passed:
  - Missing `cluster_ext_id` → Ansible argument validation rejects it with the
    standard `missing required arguments: cluster_ext_id` message.
  - Invalid `cluster_ext_id` (non-UUID) → the API returns HTTP 400 with a
    schema validation error against the `X-Cluster-Id` header; the module
    surfaces this as `Api Exception raised while fetching AWS VPCs info`.
  - Unknown parameter → Ansible rejects with `Unsupported parameters for
    (nutanix.ncp.ntnx_aws_vpcs_info_v2) module: bogus_param`.
- **No CRUD tests** exist — because the SDK has no CRUD API for `AwsVpc`
  (see "Scope note" above). If/when Nutanix ships a `POST/PUT/DELETE
  /api/networking/v4.x/aws/config/vpcs/{extId}` API, a companion CRUD module
  and CRUD lifecycle tests should be added.

### Known issues

- Positive `list AWS VPCs` + `get-by-ext_id` + `bogus-ext_id` assertions could
  not be exercised because the code-gen test PC (`10.44.76.28`) does not
  register an NC2A Prism Element cluster. The test scaffolding is already in
  place to run these assertions transparently on any environment that does.

### Test logs (tail)

<details>
<summary>tail -n 100 test_logs.log</summary>

```text
TASK [ntnx_aws_vpcs_info_v2 : Fetch clusters registered to the PC] *************
ok: [testhost]

TASK [ntnx_aws_vpcs_info_v2 : Assert clusters were fetched] ********************
ok: [testhost] => { "changed": false, "msg": "Clusters fetched successfully" }

TASK [ntnx_aws_vpcs_info_v2 : Pick the first non-PC (AOS) cluster as the AwsVpc test target] ***
ok: [testhost]

TASK [ntnx_aws_vpcs_info_v2 : Show target cluster] *****************************
ok: [testhost] => { "target_cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2" }

TASK [ntnx_aws_vpcs_info_v2 : List all AWS VPCs on the target cluster] *********
fatal: [testhost]: FAILED! => {
  "changed": false,
  "error": "INTERNAL SERVER ERROR",
  "msg": "Api Exception raised while fetching AWS VPCs info",
  "response": {
    "$objectType": "networking.v4.aws.config.ListAwsVpcsApiResponse",
    "data": {
      "$objectType": "networking.v4.error.ErrorResponse",
      "error": [{
        "code": "NETWORKING-20002",
        "errorGroup": "DOWNSTREAM_SERVICE_ERROR",
        "message": "Failed to reach network service on cluster 0006555e-... due to an error.",
        "severity": "ERROR"
      }]
    },
    "metadata": {"totalAvailableResults": 0}
  },
  "status": 500
}
...ignoring

TASK [ntnx_aws_vpcs_info_v2 : Assert list AWS VPCs correctly surfaces API exception on non-NC2A cluster] ***
ok: [testhost] => { "msg": "List AWS VPCs correctly surfaces the SDK ApiException on a non-NC2A cluster" }

TASK [ntnx_aws_vpcs_info_v2 : Assert every listed AWS VPC has the expected AwsVpc SDK fields] ***
skipping: [testhost]

TASK [ntnx_aws_vpcs_info_v2 : Fetch a specific AWS VPC by external ID] *********
skipping: [testhost]

TASK [ntnx_aws_vpcs_info_v2 : Fetch AWS VPC using a bogus ext_id] **************
skipping: [testhost]

TASK [ntnx_aws_vpcs_info_v2 : List AWS VPCs without required cluster_ext_id] ***
fatal: [testhost]: FAILED! => { "msg": "missing required arguments: cluster_ext_id" }
...ignoring

TASK [ntnx_aws_vpcs_info_v2 : Assert missing cluster_ext_id fails Ansible argument validation] ***
ok: [testhost] => { "msg": "Missing cluster_ext_id was correctly rejected" }

TASK [ntnx_aws_vpcs_info_v2 : List AWS VPCs with a syntactically invalid cluster_ext_id] ***
fatal: [testhost]: FAILED! => {
  "error": "BAD REQUEST",
  "msg": "Api Exception raised while fetching AWS VPCs info",
  "response": {
    "data": {
      "$errorItemDiscriminator": "networking.v4.error.SchemaValidationError",
      "error": {
        "statusCode": 400,
        "validationErrorMessages": [{
          "location": "@header.X-Cluster-Id",
          "message": "ECMA 262 regex ... does not match input string \"not-a-real-cluster\""
        }]
      }
    }
  },
  "status": 400
}
...ignoring

TASK [ntnx_aws_vpcs_info_v2 : Assert invalid cluster_ext_id fails via API exception] ***
ok: [testhost] => { "msg": "Invalid cluster_ext_id was correctly rejected by the API" }

TASK [ntnx_aws_vpcs_info_v2 : Call AwsVpc info module with an unknown parameter] ***
fatal: [testhost]: FAILED! => {
  "msg": "Unsupported parameters for (nutanix.ncp.ntnx_aws_vpcs_info_v2) module: bogus_param. Supported parameters include: all_proxy, cluster_ext_id, ext_id, ..."
}
...ignoring

TASK [ntnx_aws_vpcs_info_v2 : Assert unknown parameter is rejected] ************
ok: [testhost] => { "msg": "Unknown parameter was correctly rejected" }

PLAY RECAP *********************************************************************
testhost                   : ok=16   changed=0    unreachable=0    failed=0    skipped=6    rescued=0    ignored=4
```

</details>

### Example execution

The example playbook `examples/networking/AwsVpc/aws_vpcs_v2.yml` was run
end-to-end against Prism Central `10.44.76.28`. Full output is captured in
`examples/networking/AwsVpc/examples_run.log`. Recap:

```
PLAY RECAP *********************************************************************
localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=1
```

The list step surfaced the same `DOWNSTREAM_SERVICE_ERROR` (non-NC2A cluster),
so the subsequent get-by-ext_id and debug steps were correctly skipped by the
`when:` conditions in the example. Response `sample:` values in the module's
`RETURN` block use synthetic AWS-shaped identifiers because no real NC2A
response was obtainable on this test cluster.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
