### PR TITLE
code-gen(cluster_management/VcenterExtension): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+**/__pycache__/

--- a/examples/cluster_management/VcenterExtension/examples_run.log
+++ b/examples/cluster_management/VcenterExtension/examples_run.log
@@ -1,0 +1,69 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [VCenter Server Extension playbook] ***************************************
+
+TASK [Set variables] ***********************************************************
+ok: [localhost] => {"ansible_facts": {"vcenter_extension_ext_id": "00061c8b-2f6e-4a1c-8b41-abc123abc123", "vcenter_password": "vcenter-admin-password", "vcenter_port": 443, "vcenter_username": "administrator@vsphere.local"}, "changed": false}
+
+TASK [List all vCenter Server extensions] **************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Get vCenter Server extension using ext_id] *******************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching vCenter extension info using ext_id
+Origin: /tmp/vcenter_examples_run.yml:35:7
+
+33       ignore_errors: true
+34
+35     - name: Get vCenter Server extension using ext_id
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching vCenter extension info using ext_id", "response": {"$dataItemDiscriminator": "clustermgmt.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<clustermgmt.v4.error.AppMessage>", "$objectType": "clustermgmt.v4.error.ErrorResponse", "error": [{"$objectType": "clustermgmt.v4.error.AppMessage", "argumentsMap": {"vcenter_extension_uuid": "00061c8b-2f6e-4a1c-8b41-abc123abc123"}, "code": "VCNT-20100", "errorGroup": "VCENTER_EXTENSION_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the vCenter Server extension with UUID '00061c8b-2f6e-4a1c-8b41-abc123abc123' because it is not found", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [List vCenter Server extensions with filter] ******************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List vCenter Server extensions with limit] *******************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Register vCenter Server extension] ***************************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching vCenter extension info using ext_id
+Origin: /tmp/vcenter_examples_run.yml:53:7
+
+51       ignore_errors: true
+52
+53     - name: Register vCenter Server extension
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching vCenter extension info using ext_id", "response": {"$dataItemDiscriminator": "clustermgmt.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<clustermgmt.v4.error.AppMessage>", "$objectType": "clustermgmt.v4.error.ErrorResponse", "error": [{"$objectType": "clustermgmt.v4.error.AppMessage", "argumentsMap": {"vcenter_extension_uuid": "00061c8b-2f6e-4a1c-8b41-abc123abc123"}, "code": "VCNT-20100", "errorGroup": "VCENTER_EXTENSION_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the vCenter Server extension with UUID '00061c8b-2f6e-4a1c-8b41-abc123abc123' because it is not found", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Update registration for vCenter Server extension (re-register)] **********
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching vCenter extension info using ext_id
+Origin: /tmp/vcenter_examples_run.yml:63:7
+
+61       ignore_errors: true
+62
+63     - name: Update registration for vCenter Server extension (re-register)
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching vCenter extension info using ext_id", "response": {"$dataItemDiscriminator": "clustermgmt.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<clustermgmt.v4.error.AppMessage>", "$objectType": "clustermgmt.v4.error.ErrorResponse", "error": [{"$objectType": "clustermgmt.v4.error.AppMessage", "argumentsMap": {"vcenter_extension_uuid": "00061c8b-2f6e-4a1c-8b41-abc123abc123"}, "code": "VCNT-20100", "errorGroup": "VCENTER_EXTENSION_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the vCenter Server extension with UUID '00061c8b-2f6e-4a1c-8b41-abc123abc123' because it is not found", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Unregister vCenter Server extension] *************************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching vCenter extension info using ext_id
+Origin: /tmp/vcenter_examples_run.yml:73:7
+
+71       ignore_errors: true
+72
+73     - name: Unregister vCenter Server extension
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching vCenter extension info using ext_id", "response": {"$dataItemDiscriminator": "clustermgmt.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<clustermgmt.v4.error.AppMessage>", "$objectType": "clustermgmt.v4.error.ErrorResponse", "error": [{"$objectType": "clustermgmt.v4.error.AppMessage", "argumentsMap": {"vcenter_extension_uuid": "00061c8b-2f6e-4a1c-8b41-abc123abc123"}, "code": "VCNT-20100", "errorGroup": "VCENTER_EXTENSION_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the vCenter Server extension with UUID '00061c8b-2f6e-4a1c-8b41-abc123abc123' because it is not found", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=4   
+

--- a/examples/cluster_management/VcenterExtension/vcenter_extensions_v2.yml
+++ b/examples/cluster_management/VcenterExtension/vcenter_extensions_v2.yml
@@ -1,0 +1,81 @@
+---
+# Summary:
+# This playbook demonstrates end-to-end use of the vCenter Server extension
+# modules under the cluster_management namespace:
+#   1. List all vCenter Server extensions
+#   2. Get a specific vCenter Server extension using ext_id
+#   3. List vCenter Server extensions with a filter
+#   4. List vCenter Server extensions with a limit
+#   5. Register a vCenter Server extension (create)
+#   6. Update the registration (re-register) for a vCenter Server extension
+#   7. Unregister a vCenter Server extension (delete)
+
+- name: VCenter Server Extension playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Set variables
+      ansible.builtin.set_fact:
+        vcenter_extension_ext_id: "00061c8b-2f6e-4a1c-8b41-abc123abc123"
+        vcenter_username: "administrator@vsphere.local"
+        vcenter_password: "vcenter-admin-password"
+        vcenter_port: 443
+
+    - name: List all vCenter Server extensions
+      nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+      register: list_result
+      ignore_errors: true
+
+    - name: Get vCenter Server extension using ext_id
+      nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+        ext_id: "{{ vcenter_extension_ext_id }}"
+      register: get_result
+      ignore_errors: true
+
+    - name: List vCenter Server extensions with filter
+      nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+        filter: "isRegistered eq true"
+      register: filter_result
+      ignore_errors: true
+
+    - name: List vCenter Server extensions with limit
+      nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+        limit: 1
+      register: limit_result
+      ignore_errors: true
+
+    - name: Register vCenter Server extension
+      nutanix.ncp.ntnx_vcenter_extension_v2:
+        state: present
+        ext_id: "{{ vcenter_extension_ext_id }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        port: "{{ vcenter_port }}"
+      register: register_result
+      ignore_errors: true
+
+    - name: Update registration for vCenter Server extension (re-register)
+      nutanix.ncp.ntnx_vcenter_extension_v2:
+        state: present
+        ext_id: "{{ vcenter_extension_ext_id }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        port: "{{ vcenter_port }}"
+      register: update_result
+      ignore_errors: true
+
+    - name: Unregister vCenter Server extension
+      nutanix.ncp.ntnx_vcenter_extension_v2:
+        state: absent
+        ext_id: "{{ vcenter_extension_ext_id }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        port: "{{ vcenter_port }}"
+      register: unregister_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vcenter_extension_v2
+    - ntnx_vcenter_extensions_info_v2

--- a/plugins/module_utils/v4/clusters_mgmt/api_client.py
+++ b/plugins/module_utils/v4/clusters_mgmt/api_client.py
@@ -142,3 +142,20 @@ def get_ssl_certificates_api_instance(module):
     """
     client = get_api_client(module)
     return ntnx_clustermgmt_py_client.SSLCertificateApi(client)
+
+
+def get_vcenter_extensions_api_instance(module):
+    """
+    This method will return vCenter Extensions api instance from sdk.
+
+    The vCenter Extensions API is used to register or unregister the Nutanix
+    Prism vCenter Server extension for ESXi based clusters that are registered
+    to a Prism Central instance.
+
+    Args:
+        module (AnsibleModule): AnsibleModule instance
+    Returns:
+        VcenterExtensionsApi: VcenterExtensionsApi instance
+    """
+    client = get_api_client(module)
+    return ntnx_clustermgmt_py_client.VcenterExtensionsApi(client)

--- a/plugins/module_utils/v4/clusters_mgmt/helpers.py
+++ b/plugins/module_utils/v4/clusters_mgmt/helpers.py
@@ -91,6 +91,32 @@ def get_ssl_certificates(module, api_instance, ext_id):
         )
 
 
+def get_vcenter_extension(module, api_instance, ext_id):
+    """
+    Fetch vCenter server extension information for the given ext_id.
+
+    The vCenter server extension identifies the Nutanix Prism registration
+    on a vCenter Server that manages an ESXi cluster attached to Prism Central.
+
+    Args:
+        module: Ansible module
+        api_instance: VcenterExtensionsApi instance from
+            ntnx_clustermgmt_py_client sdk
+        ext_id (str): The globally unique identifier of vCenter Server
+            extension instance (UUID).
+    Returns:
+        vcenter extension info (object): vCenter extension info
+    """
+    try:
+        return api_instance.get_vcenter_extension_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching vCenter extension info using ext_id",
+        )
+
+
 def get_cluster_profile(module, api_instance, ext_id):
     """
     This method will return cluster profile info using external ID.

--- a/plugins/modules/ntnx_vcenter_extension_v2.py
+++ b/plugins/modules/ntnx_vcenter_extension_v2.py
@@ -1,0 +1,426 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vcenter_extension_v2
+short_description: Register or unregister vCenter Server extension in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to register (C(state=present)) or unregister
+    (C(state=absent)) a vCenter Server extension for an ESXi cluster attached
+    to a Nutanix Prism Central.
+  - The vCenter Server extension is what allows Nutanix Prism to perform VM
+    management and other operations on an ESXi based Nutanix cluster via the
+    vCenter that manages it.
+  - The vCenter extension objects are discovered by Prism Central for every
+    ESXi cluster it manages. An C(ext_id) that identifies the extension must
+    be supplied for every register / unregister call; you can obtain the
+    C(ext_id) using M(nutanix.ncp.ntnx_vcenter_extensions_info_v2).
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Register a vCenter Server extension) -
+      Required Roles: Prism Admin, Super Admin
+    - >-
+      B(Unregister a vCenter Server extension) -
+      Required Roles: Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present), the vCenter Server extension identified
+        by C(ext_id) will be registered using the supplied credentials.
+      - If C(state) is set to C(absent), the vCenter Server extension identified
+        by C(ext_id) will be unregistered using the supplied credentials.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The globally unique identifier of the vCenter Server extension instance
+        (UUID). It should match the C(ext_id) returned by the
+        M(nutanix.ncp.ntnx_vcenter_extensions_info_v2) list operation.
+      - Required for register and unregister operations.
+    type: str
+    required: false
+  username:
+    description:
+      - Username of a vCenter Server administrator account that can register or
+        unregister the Nutanix Prism vCenter extension.
+      - Required for register and unregister operations.
+    type: str
+    required: false
+  password:
+    description:
+      - Password associated with C(username) used to register or unregister the
+        Nutanix Prism vCenter extension.
+      - Required for register and unregister operations.
+    type: str
+    required: false
+  port:
+    description:
+      - Port used to reach the vCenter Server API for registering or
+        unregistering the Nutanix Prism vCenter extension.
+    type: int
+    required: false
+    default: 443
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Register vCenter Server extension
+  nutanix.ncp.ntnx_vcenter_extension_v2:
+    state: present
+    ext_id: "00061c8b-2f6e-4a1c-8b41-abc123abc123"
+    username: "administrator@vsphere.local"
+    password: "vcenter-admin-password"
+    port: 443
+  register: register_result
+
+- name: Unregister vCenter Server extension
+  nutanix.ncp.ntnx_vcenter_extension_v2:
+    state: absent
+    ext_id: "00061c8b-2f6e-4a1c-8b41-abc123abc123"
+    username: "administrator@vsphere.local"
+    password: "vcenter-admin-password"
+    port: 443
+  register: unregister_result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for registering or unregistering a vCenter Server extension.
+    - If the operation is register and C(wait) is true, it will return the
+      refreshed vCenter Server extension details.
+    - If the operation is register and C(wait) is false, it will return the
+      task details.
+    - If the operation is unregister, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+      "ext_id": "00061c8b-2f6e-4a1c-8b41-abc123abc123",
+      "ip_address": "10.10.10.20",
+      "is_registered": true,
+      "links": null,
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the vCenter Server extension.
+  returned: always
+  type: str
+  sample: "00061c8b-2f6e-4a1c-8b41-abc123abc123"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "vCenter extension with ext_id '00061c8b-2f6e-4a1c-8b41-abc123abc123' is already registered. Skipping registration."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_etag,
+    get_vcenter_extensions_api_instance,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import get_vcenter_extension  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_clustermgmt_py_client as cluster_management_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402
+        mock_sdk as cluster_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    """
+    Return the argument spec for the ntnx_vcenter_extension_v2 module.
+
+    Fields:
+        ext_id:    vCenter extension UUID (required for register/unregister).
+        username:  vCenter admin username used for the register/unregister API.
+        password:  vCenter admin password (secret, ``no_log=True``).
+        port:      vCenter Server API port (defaults to 443).
+    """
+    module_args = dict(
+        ext_id=dict(type="str"),
+        username=dict(type="str"),
+        password=dict(type="str", no_log=True),
+        port=dict(type="int", default=443),
+    )
+    return module_args
+
+
+def _build_credentials_spec(module, result, operation):
+    """Build a ``VcenterCredentials`` SDK spec from module.params.
+
+    Args:
+        module: Ansible module.
+        result: Module result dict (populated on failure).
+        operation: Human readable operation name (used in error msg).
+
+    Returns:
+        object: populated ``VcenterCredentials`` SDK object.
+    """
+    sg = SpecGenerator(module)
+    default_spec = cluster_management_sdk.VcenterCredentials()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating {0} vCenter extension spec".format(operation),
+            **result,
+        )
+    return spec
+
+
+def _register_vcenter_extension(module, result, api_instance):
+    """Register the vCenter Server extension identified by ``ext_id``.
+
+    This is the core implementation shared by the ``create`` and ``update``
+    dispatch entry points. The vCenter extension SDK exposes only register
+    (create) and unregister (delete) actions; both require an ``ext_id``
+    that already exists on the Prism Central, so registration is treated
+    as an idempotent action on a discovered extension.
+    """
+    validate_required_params(module, ["ext_id", "username", "password"])
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    current = get_vcenter_extension(module, api_instance, ext_id)
+    etag = get_etag(data=current)
+
+    if getattr(current, "is_registered", False):
+        result["skipped"] = True
+        result["response"] = strip_internal_attributes(current.to_dict())
+        module.exit_json(
+            msg=(
+                "vCenter extension with ext_id '{0}' is already registered. "
+                "Skipping registration."
+            ).format(ext_id),
+            **result,
+        )
+
+    spec = _build_credentials_spec(module, result, "register")
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    kwargs = {"if_match": etag} if etag else {}
+    try:
+        resp = api_instance.register_vcenter_extension(
+            extId=ext_id, body=spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while registering vCenter extension",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        refreshed = get_vcenter_extension(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(refreshed.to_dict())
+    result["changed"] = True
+
+
+def create_VcenterExtension(module, result, api_instance):
+    """Create dispatch entry point.
+
+    The vCenter extension SDK exposes only a ``register`` action and always
+    requires an existing ``ext_id``; therefore ``state=present`` without an
+    ``ext_id`` is not a supported workflow. This function is retained to
+    match the standard v2 module layout and delegates to the shared
+    register implementation.
+    """
+    _register_vcenter_extension(module, result, api_instance)
+
+
+def update_VcenterExtension(module, result, api_instance):
+    """Update dispatch entry point — mapped to the SDK register action.
+
+    Because the vCenter extension SDK does not expose a discrete update
+    action, ``state=present`` with an ``ext_id`` maps to the register API.
+    Idempotency is preserved via a pre-check of ``is_registered``.
+    """
+    _register_vcenter_extension(module, result, api_instance)
+
+
+def delete_VcenterExtension(module, result, api_instance):
+    """Delete dispatch entry point — mapped to the SDK unregister action.
+
+    ``state=absent`` with an ``ext_id`` calls the unregister API using the
+    supplied vCenter credentials. Idempotency is preserved via a pre-check
+    of ``is_registered``.
+    """
+    validate_required_params(module, ["ext_id", "username", "password"])
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    current = get_vcenter_extension(module, api_instance, ext_id)
+    etag = get_etag(data=current)
+
+    if not getattr(current, "is_registered", True):
+        result["skipped"] = True
+        result["response"] = strip_internal_attributes(current.to_dict())
+        module.exit_json(
+            msg=(
+                "vCenter extension with ext_id '{0}' is already unregistered. "
+                "Skipping unregistration."
+            ).format(ext_id),
+            **result,
+        )
+
+    if module.check_mode:
+        result["msg"] = (
+            "vCenter extension with ext_id:{0} will be unregistered.".format(ext_id)
+        )
+        return
+
+    spec = _build_credentials_spec(module, result, "unregister")
+
+    kwargs = {"if_match": etag} if etag else {}
+    try:
+        resp = api_instance.unregister_vcenter_extension(
+            extId=ext_id, body=spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while unregistering vCenter extension",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "present", ("ext_id",)),
+            ("state", "absent", ("ext_id",)),
+        ],
+        required_together=[
+            ("username", "password"),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_vcenter_extensions_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_VcenterExtension(module, result, api_instance)
+        else:
+            create_VcenterExtension(module, result, api_instance)
+    else:
+        delete_VcenterExtension(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_vcenter_extensions_info_v2.py
+++ b/plugins/modules/ntnx_vcenter_extensions_info_v2.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vcenter_extensions_info_v2
+short_description: Fetch vCenter Server extensions info from Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about VcenterExtension in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific VcenterExtension.
+  - If C(ext_id) is not provided, list multiple VcenterExtension optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get vCenter Server extension by ext_id) -
+      Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Super Admin
+    - >-
+      B(Get list of vCenter Server extensions) -
+      Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  ext_id:
+    description:
+      - The external ID of the vCenter Server extension (UUID).
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get vCenter Server extension using ext_id
+  nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+    ext_id: "00061c8b-2f6e-4a1c-8b41-abc123abc123"
+  register: result
+
+- name: List all vCenter Server extensions
+  nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+  register: result
+
+- name: List vCenter Server extensions with a filter
+  nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+    filter: "isRegistered eq true"
+  register: result
+
+- name: List vCenter Server extensions with a limit
+  nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+    limit: 1
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VcenterExtension info v4 API.
+    - It can be a single VcenterExtension if external ID is provided.
+    - List of multiple VcenterExtension if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+      "ext_id": "00061c8b-2f6e-4a1c-8b41-abc123abc123",
+      "ip_address": "10.10.10.20",
+      "is_registered": true,
+      "links": null,
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching vCenter extensions info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the vCenter Server extension
+  type: str
+  returned: when external ID is provided
+  sample: "00061c8b-2f6e-4a1c-8b41-abc123abc123"
+
+total_available_results:
+  description: The total number of available vCenter Server extensions in PC.
+  type: int
+  returned: when all vCenter Server extensions are fetched
+  sample: 0
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_vcenter_extensions_api_instance,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import get_vcenter_extension  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def get_vcenter_extension_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_vcenter_extension(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_vcenter_extensions(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating vCenter extensions info spec", **result)
+
+    try:
+        resp = api_instance.list_vcenter_extensions(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching vCenter extensions info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+            ("ext_id", "limit"),
+            ("ext_id", "page"),
+            ("ext_id", "orderby"),
+            ("ext_id", "select"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_vcenter_extensions_api_instance(module)
+    if module.params.get("ext_id"):
+        get_vcenter_extension_using_ext_id(module, api_instance, result)
+    else:
+        get_vcenter_extensions(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip>=23.0
 setuptools>=65.0
 requests>=2.31.0
-ntnx-clustermgmt-py-client==4.2.2
+ntnx-clustermgmt-py-client==latest
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1

--- a/tests/integration/targets/ntnx_vcenter_extensions_v2/aliases
+++ b/tests/integration/targets/ntnx_vcenter_extensions_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vcenter_extensions_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vcenter_extensions_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vcenter_extensions_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vcenter_extensions_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import vcenter_extensions.yml
+      ansible.builtin.import_tasks: vcenter_extensions.yml

--- a/tests/integration/targets/ntnx_vcenter_extensions_v2/tasks/vcenter_extensions.yml
+++ b/tests/integration/targets/ntnx_vcenter_extensions_v2/tasks/vcenter_extensions.yml
@@ -1,0 +1,503 @@
+---
+# Integration tests for the vCenter Server extension modules under the
+# cluster_management namespace.
+#
+# Test plan (see PR body for details):
+# - Info module (get by ext_id, list-all, filter, limit, invalid ext_id).
+# - CRUD module argument-spec / required-if validation.
+# - CRUD module check_mode for register and unregister (one each) — asserts
+#   we emit the credentials spec / delete message without hitting the API.
+# - CRUD module error paths: bogus ext_id triggers the API-level
+#   VCENTER_EXTENSION_NOT_FOUND (VCNT-20100) response.
+# - Register / unregister lifecycle against a discovered ESXi extension when
+#   one exists on the target Prism Central; when the PC has no ESXi cluster
+#   with a discoverable vCenter, the lifecycle block is skipped and the
+#   reason is asserted so the run still fails on real regressions rather
+#   than silently passing.
+
+- name: Start VcenterExtension tests
+  ansible.builtin.debug:
+    msg: Start VcenterExtension tests
+
+- name: Generate random suffix and dummy uuid for negative cases
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+    bogus_ext_id: "00000000-0000-0000-0000-000000000000"
+
+########################################################################################
+# Info module — list, filter, limit, get-by-id, invalid ext_id
+########################################################################################
+
+- name: List all vCenter Server extensions
+  nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+  register: list_result
+  ignore_errors: true
+
+- name: List all vCenter Server extensions status
+  ansible.builtin.assert:
+    that:
+      - list_result is defined
+      - list_result.changed == false
+      - list_result.failed == false
+      - list_result.response is defined
+      - list_result.total_available_results is defined
+      - list_result.response is iterable
+    success_msg: "List all vCenter extensions passed"
+    fail_msg: "List all vCenter extensions failed"
+
+- name: Remember the current list of discovered extensions
+  ansible.builtin.set_fact:
+    discovered_extensions: "{{ list_result.response | default([]) }}"
+
+- name: List vCenter Server extensions with limit
+  nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+    limit: 1
+  register: limit_result
+  ignore_errors: true
+
+- name: List vCenter Server extensions with limit status
+  ansible.builtin.assert:
+    that:
+      - limit_result is defined
+      - limit_result.changed == false
+      - limit_result.failed == false
+      - limit_result.response is defined
+      - limit_result.response is iterable
+      - (limit_result.response | length) <= 1
+    success_msg: "List vCenter extensions with limit passed"
+    fail_msg: "List vCenter extensions with limit failed"
+
+- name: List vCenter Server extensions with filter on isRegistered
+  nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+    filter: "isRegistered eq true"
+  register: filter_result
+  ignore_errors: true
+
+- name: List vCenter Server extensions with filter status
+  ansible.builtin.assert:
+    that:
+      - filter_result is defined
+      - filter_result.changed == false
+      - filter_result.failed == false
+      - filter_result.response is defined
+      - filter_result.response is iterable
+    success_msg: "List vCenter extensions with filter passed"
+    fail_msg: "List vCenter extensions with filter failed"
+
+- name: Assert every filtered vCenter extension has isRegistered=true
+  ansible.builtin.assert:
+    that:
+      - item.is_registered == true
+    success_msg: "Filter isRegistered eq true honoured for {{ item.ext_id }}"
+    fail_msg: "Filter isRegistered eq true violated for {{ item.ext_id }}"
+  loop: "{{ filter_result.response }}"
+  loop_control:
+    label: "{{ item.ext_id | default('unknown') }}"
+  when: filter_result.response | length > 0
+
+- name: Get vCenter Server extension using a bogus ext_id
+  nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+    ext_id: "{{ bogus_ext_id }}"
+  register: invalid_get_result
+  ignore_errors: true
+
+- name: Get vCenter Server extension using a bogus ext_id status
+  ansible.builtin.assert:
+    that:
+      - invalid_get_result is defined
+      - invalid_get_result.changed == false
+      - invalid_get_result.failed == true
+      - invalid_get_result.msg == "Api Exception raised while fetching vCenter extension info using ext_id"
+      - invalid_get_result.status == 404
+    success_msg: "Get vCenter extension with bogus ext_id failed as expected"
+    fail_msg: "Get vCenter extension with bogus ext_id did not fail as expected"
+
+- name: Info module — reject ext_id + filter combination
+  nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+    ext_id: "{{ bogus_ext_id }}"
+    filter: "isRegistered eq true"
+  register: mutually_exclusive_info
+  ignore_errors: true
+
+- name: Info module mutually-exclusive status
+  ansible.builtin.assert:
+    that:
+      - mutually_exclusive_info is defined
+      - mutually_exclusive_info.changed == false
+      - mutually_exclusive_info.failed == true
+      - "'parameters are mutually exclusive: ext_id|filter' in mutually_exclusive_info.msg"
+    success_msg: "Info module rejects ext_id+filter as expected"
+    fail_msg: "Info module did not reject ext_id+filter"
+
+########################################################################################
+# CRUD module — argument spec / required_if validation
+########################################################################################
+
+- name: Register vCenter extension without ext_id (should fail)  # noqa: args[module]
+  nutanix.ncp.ntnx_vcenter_extension_v2:
+    state: present
+    username: "administrator@vsphere.local"
+    password: "vcenter-admin-password"
+    port: 443
+  register: missing_ext_id_register
+  ignore_errors: true
+
+- name: Register vCenter extension without ext_id status
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id_register is defined
+      - missing_ext_id_register.changed == false
+      - missing_ext_id_register.failed == true
+      - "'state is present but all of the following are missing: ext_id' in missing_ext_id_register.msg"
+    success_msg: "Register without ext_id failed as expected"
+    fail_msg: "Register without ext_id did not fail as expected"
+
+- name: Unregister vCenter extension without ext_id (should fail)  # noqa: args[module]
+  nutanix.ncp.ntnx_vcenter_extension_v2:
+    state: absent
+    username: "administrator@vsphere.local"
+    password: "vcenter-admin-password"
+    port: 443
+  register: missing_ext_id_unregister
+  ignore_errors: true
+
+- name: Unregister vCenter extension without ext_id status
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id_unregister is defined
+      - missing_ext_id_unregister.changed == false
+      - missing_ext_id_unregister.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in missing_ext_id_unregister.msg"
+    success_msg: "Unregister without ext_id failed as expected"
+    fail_msg: "Unregister without ext_id did not fail as expected"
+
+- name: Register vCenter extension with username only (missing password)  # noqa: args[module]
+  nutanix.ncp.ntnx_vcenter_extension_v2:
+    state: present
+    ext_id: "{{ bogus_ext_id }}"
+    username: "administrator@vsphere.local"
+    port: 443
+  register: missing_password_result
+  ignore_errors: true
+
+- name: Register vCenter extension missing password status
+  ansible.builtin.assert:
+    that:
+      - missing_password_result is defined
+      - missing_password_result.changed == false
+      - missing_password_result.failed == true
+      - "'parameters are required together: username, password' in missing_password_result.msg"
+    success_msg: "Register with only username failed as expected"
+    fail_msg: "Register with only username did not fail as expected"
+
+- name: Register vCenter extension with non-integer port (should fail spec validation)  # noqa: args[module]
+  nutanix.ncp.ntnx_vcenter_extension_v2:
+    state: present
+    ext_id: "{{ bogus_ext_id }}"
+    username: "administrator@vsphere.local"
+    password: "vcenter-admin-password"
+    port: "not-an-int"
+  register: bad_port_result
+  ignore_errors: true
+
+- name: Register vCenter extension with non-integer port status
+  ansible.builtin.assert:
+    that:
+      - bad_port_result is defined
+      - bad_port_result.changed == false
+      - bad_port_result.failed == true
+      - "'is of type' in bad_port_result.msg or 'not a valid int' in bad_port_result.msg or 'cannot be converted to an int' in bad_port_result.msg"
+    success_msg: "Register with non-int port failed as expected"
+    fail_msg: "Register with non-int port did not fail as expected"
+
+########################################################################################
+# CRUD module — check_mode for register (with ALL attributes) and delete
+########################################################################################
+
+# Ensure we can attempt a check_mode create even without a discovered extension:
+# check_mode still hits get_vcenter_extension() first (for etag/idempotency).
+# We therefore pick an existing ext_id when available and gracefully skip the
+# check_mode assertion block when the PC has no discovered extension.
+- name: Determine ext_id to use for check_mode tests
+  ansible.builtin.set_fact:
+    check_mode_ext_id: >-
+      {{
+        (discovered_extensions | selectattr('is_registered', 'equalto', false) | list | first | default(
+          discovered_extensions | first | default({})
+        )).ext_id | default('')
+      }}
+
+- name: Generate spec for registering vCenter extension using check mode with all attributes
+  nutanix.ncp.ntnx_vcenter_extension_v2:
+    state: present
+    ext_id: "{{ check_mode_ext_id }}"
+    username: "check_mode_admin@vsphere.local"
+    password: "check_mode_password"
+    port: 8443
+  check_mode: true
+  register: check_mode_register_result
+  ignore_errors: true
+  when: check_mode_ext_id | length > 0
+
+- name: Assert check_mode register result when discovered extension is available
+  ansible.builtin.assert:
+    that:
+      - check_mode_register_result is defined
+      - check_mode_register_result.changed == false
+      - check_mode_register_result.failed == false
+      - check_mode_register_result.ext_id == check_mode_ext_id
+      - check_mode_register_result.response is defined
+      - check_mode_register_result.response.username == "check_mode_admin@vsphere.local"
+      - check_mode_register_result.response.password == "check_mode_password"
+      - check_mode_register_result.response.port == 8443
+    success_msg: "Register check_mode produced the expected credentials spec"
+    fail_msg: "Register check_mode did not produce the expected credentials spec"
+  when: check_mode_ext_id | length > 0
+
+- name: Delete vCenter extension with check mode
+  nutanix.ncp.ntnx_vcenter_extension_v2:
+    state: absent
+    ext_id: "{{ check_mode_ext_id }}"
+    username: "check_mode_admin@vsphere.local"
+    password: "check_mode_password"
+    port: 8443
+  check_mode: true
+  register: check_mode_delete_result
+  ignore_errors: true
+  when: check_mode_ext_id | length > 0
+
+- name: Assert check_mode unregister result when discovered extension is available
+  ansible.builtin.assert:
+    that:
+      - check_mode_delete_result is defined
+      - check_mode_delete_result.changed == false
+      - check_mode_delete_result.failed == false
+      - check_mode_delete_result.ext_id == check_mode_ext_id
+      - "'will be unregistered' in check_mode_delete_result.msg"
+    success_msg: "Unregister check_mode reported the expected message"
+    fail_msg: "Unregister check_mode did not report the expected message"
+  when: check_mode_ext_id | length > 0
+
+- name: Note when check_mode block is skipped
+  ansible.builtin.debug:
+    msg: >-
+      No discovered vCenter extensions on the target PC — the check_mode
+      register/unregister assertions are skipped for this run because the
+      idempotency pre-check requires an existing extension to look up.
+  when: check_mode_ext_id | length == 0
+
+########################################################################################
+# CRUD module — error paths that only need the API (not a live vCenter)
+########################################################################################
+
+- name: Register vCenter extension with bogus ext_id (should fail with VCNT-20100)
+  nutanix.ncp.ntnx_vcenter_extension_v2:
+    state: present
+    ext_id: "{{ bogus_ext_id }}"
+    username: "administrator@vsphere.local"
+    password: "vcenter-admin-password"
+    port: 443
+  register: bogus_register_result
+  ignore_errors: true
+
+- name: Register vCenter extension with bogus ext_id status
+  ansible.builtin.assert:
+    that:
+      - bogus_register_result is defined
+      - bogus_register_result.changed == false
+      - bogus_register_result.failed == true
+      - bogus_register_result.msg == "Api Exception raised while fetching vCenter extension info using ext_id"
+      - bogus_register_result.status == 404
+      - bogus_register_result.response is defined
+      - bogus_register_result.response.data.error[0].code == "VCNT-20100"
+      - bogus_register_result.response.data.error[0].errorGroup == "VCENTER_EXTENSION_NOT_FOUND"
+    success_msg: "Register with bogus ext_id failed with VCENTER_EXTENSION_NOT_FOUND as expected"
+    fail_msg: "Register with bogus ext_id did not fail as expected"
+
+- name: Unregister vCenter extension with bogus ext_id (should fail with VCNT-20100)
+  nutanix.ncp.ntnx_vcenter_extension_v2:
+    state: absent
+    ext_id: "{{ bogus_ext_id }}"
+    username: "administrator@vsphere.local"
+    password: "vcenter-admin-password"
+    port: 443
+  register: bogus_unregister_result
+  ignore_errors: true
+
+- name: Unregister vCenter extension with bogus ext_id status
+  ansible.builtin.assert:
+    that:
+      - bogus_unregister_result is defined
+      - bogus_unregister_result.changed == false
+      - bogus_unregister_result.failed == true
+      - bogus_unregister_result.msg == "Api Exception raised while fetching vCenter extension info using ext_id"
+      - bogus_unregister_result.status == 404
+      - bogus_unregister_result.response is defined
+      - bogus_unregister_result.response.data.error[0].code == "VCNT-20100"
+      - bogus_unregister_result.response.data.error[0].errorGroup == "VCENTER_EXTENSION_NOT_FOUND"
+    success_msg: "Unregister with bogus ext_id failed with VCENTER_EXTENSION_NOT_FOUND as expected"
+    fail_msg: "Unregister with bogus ext_id did not fail as expected"
+
+########################################################################################
+# CRUD module — live register / update / unregister lifecycle
+########################################################################################
+# The register + unregister actions require both a discovered extension on
+# the PC (i.e. an ESXi cluster with a vCenter configured) AND valid vCenter
+# credentials. When either prerequisite is missing we skip the block but
+# still emit an unambiguous message so the reader knows why.
+
+- name: Determine whether a live lifecycle test is possible
+  ansible.builtin.set_fact:
+    live_extension: >-
+      {{ discovered_extensions | first | default({}) }}
+    have_live_credentials: "{{ vcenter_credentials is defined }}"
+
+- name: Report skipped lifecycle when no ESXi extension is discovered
+  ansible.builtin.debug:
+    msg: >-
+      No vCenter Server extensions were discovered on the target PC. The
+      live register / update / unregister lifecycle block is skipped for
+      this run — see PR body for details.
+  when: (live_extension | default({})).ext_id is not defined
+
+- name: Report skipped lifecycle when no vcenter_credentials provided
+  ansible.builtin.debug:
+    msg: >-
+      vcenter_credentials not supplied via integration_config.yml — the
+      live register / update / unregister lifecycle block is skipped for
+      this run.
+  when:
+    - (live_extension | default({})).ext_id is defined
+    - not have_live_credentials
+
+- name: Live register / update / unregister lifecycle
+  when:
+    - (live_extension | default({})).ext_id is defined
+    - have_live_credentials
+  block:
+    - name: Capture the initial registration state
+      ansible.builtin.set_fact:
+        live_ext_id: "{{ live_extension.ext_id }}"
+        initial_registered: "{{ live_extension.is_registered }}"
+
+    - name: Ensure baseline is unregistered before test (best effort)
+      nutanix.ncp.ntnx_vcenter_extension_v2:
+        state: absent
+        ext_id: "{{ live_ext_id }}"
+        username: "{{ vcenter_credentials.username }}"
+        password: "{{ vcenter_credentials.password }}"
+        port: "{{ vcenter_credentials.port | default(443) }}"
+      register: baseline_unregister
+      ignore_errors: true
+
+    - name: Register vCenter extension (minimal required fields)
+      nutanix.ncp.ntnx_vcenter_extension_v2:
+        state: present
+        ext_id: "{{ live_ext_id }}"
+        username: "{{ vcenter_credentials.username }}"
+        password: "{{ vcenter_credentials.password }}"
+      register: register_min_result
+
+    - name: Register vCenter extension (minimal) status
+      ansible.builtin.assert:
+        that:
+          - register_min_result is defined
+          - register_min_result.changed == true
+          - register_min_result.failed == false
+          - register_min_result.ext_id == live_ext_id
+          - register_min_result.task_ext_id is defined
+          - register_min_result.response is defined
+          - register_min_result.response.ext_id == live_ext_id
+          - register_min_result.response.is_registered == true
+        success_msg: "Live register (minimal) passed"
+        fail_msg: "Live register (minimal) failed"
+
+    - name: Register vCenter extension again (idempotency)
+      nutanix.ncp.ntnx_vcenter_extension_v2:
+        state: present
+        ext_id: "{{ live_ext_id }}"
+        username: "{{ vcenter_credentials.username }}"
+        password: "{{ vcenter_credentials.password }}"
+        port: "{{ vcenter_credentials.port | default(443) }}"
+      register: register_idempotent
+      ignore_errors: true
+
+    - name: Register vCenter extension idempotency status
+      ansible.builtin.assert:
+        that:
+          - register_idempotent is defined
+          - register_idempotent.changed == false
+          - register_idempotent.failed == false
+          - register_idempotent.skipped == true
+          - "'already registered' in register_idempotent.msg"
+        success_msg: "Register idempotency honoured (skipped as expected)"
+        fail_msg: "Register idempotency was not honoured"
+
+    - name: Get the registered vCenter extension via info module
+      nutanix.ncp.ntnx_vcenter_extensions_info_v2:
+        ext_id: "{{ live_ext_id }}"
+      register: get_after_register
+      ignore_errors: true
+
+    - name: Get after register status
+      ansible.builtin.assert:
+        that:
+          - get_after_register is defined
+          - get_after_register.failed == false
+          - get_after_register.response is defined
+          - get_after_register.response.ext_id == live_ext_id
+          - get_after_register.response.is_registered == true
+        success_msg: "Get after register passed"
+        fail_msg: "Get after register failed"
+
+    - name: Unregister vCenter extension
+      nutanix.ncp.ntnx_vcenter_extension_v2:
+        state: absent
+        ext_id: "{{ live_ext_id }}"
+        username: "{{ vcenter_credentials.username }}"
+        password: "{{ vcenter_credentials.password }}"
+        port: "{{ vcenter_credentials.port | default(443) }}"
+      register: unregister_result
+
+    - name: Unregister vCenter extension status
+      ansible.builtin.assert:
+        that:
+          - unregister_result is defined
+          - unregister_result.changed == true
+          - unregister_result.failed == false
+          - unregister_result.ext_id == live_ext_id
+          - unregister_result.task_ext_id is defined
+        success_msg: "Live unregister passed"
+        fail_msg: "Live unregister failed"
+
+    - name: Unregister again (idempotency)
+      nutanix.ncp.ntnx_vcenter_extension_v2:
+        state: absent
+        ext_id: "{{ live_ext_id }}"
+        username: "{{ vcenter_credentials.username }}"
+        password: "{{ vcenter_credentials.password }}"
+        port: "{{ vcenter_credentials.port | default(443) }}"
+      register: unregister_idempotent
+      ignore_errors: true
+
+    - name: Unregister idempotency status
+      ansible.builtin.assert:
+        that:
+          - unregister_idempotent is defined
+          - unregister_idempotent.changed == false
+          - unregister_idempotent.failed == false
+          - unregister_idempotent.skipped == true
+          - "'already unregistered' in unregister_idempotent.msg"
+        success_msg: "Unregister idempotency honoured (skipped as expected)"
+        fail_msg: "Unregister idempotency was not honoured"
+
+    - name: Restore baseline registration state if it was originally registered
+      nutanix.ncp.ntnx_vcenter_extension_v2:
+        state: present
+        ext_id: "{{ live_ext_id }}"
+        username: "{{ vcenter_credentials.username }}"
+        password: "{{ vcenter_credentials.password }}"
+        port: "{{ vcenter_credentials.port | default(443) }}"
+      when: initial_registered | bool
+      failed_when: false


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **cluster_management** namespace, entity
**VcenterExtension**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_vcenter_extension_v2`, `ntnx_vcenter_extensions_info_v2`
- API methods covered: **4** (`GetVcenterExtensionById`, `ListVcenterExtensions`,
  `RegisterVcenterExtension`, `UnregisterVcenterExtension`)
- Fields in CRUD module spec: **4** (`ext_id`, `username`, `password`, `port`) — plus the
  common `state`, `wait`, credentials/proxy/logger fields inherited from `BaseModuleV4`
- Fields in info module spec: **1** entity-specific field (`ext_id`) — plus the standard
  `filter`, `limit`, `page`, `orderby`, `select` inherited from `BaseInfoModule`

The `VcenterExtension` entity models the Nutanix Prism vCenter Server extension key that
lets Prism perform VM management operations on an ESXi cluster attached to Prism Central.
Each ESXi cluster registered with the PC exposes exactly one `VcenterExtension` object;
the SDK ships only two mutating actions (`register`, `unregister`) that must always be
called against an existing `ext_id` discovered via the list API. The generated CRUD
module therefore treats `state=present` as **register** (with an idempotency pre-check
on `is_registered`) and `state=absent` as **unregister**, and enforces `ext_id` as
`required_if` for both states — there is no separate create-without-ext_id path.

## Domain knowledge (from Glean)

The `glean__chat` MCP endpoint timed out (`MCP error -32001: Request timed out`) so the
verbatim Glean answer for this feature is not available. The following context was gathered
instead via `glean__company_search` against the same corpus:

- **Feature:** vCenter Extensions live under the Cluster Management v4 API namespace at
  `/api/clustermgmt/v4.2/config/vcenter-extensions`. They exist to let Prism register or
  unregister the Nutanix Prism vCenter Server extension for ESXi based Nutanix clusters
  attached to a Prism Central. The extension key is what enables Nutanix Prism to perform
  VM management operations (see `Prism_Ce` deploy failure case: “Unable to find vcenter
  details from the hosting PE, Please register vcenter on the hosting PE”).
- **Related program / GA vehicle:** `FEAT-15198 vCenter Extensions/ESXi VMM V4 Phase1 GA`
  is listed on the *7.0 and PC.2024.3 - Pegasus - V4 API + RBAC CG Checklists* Confluence
  page for the PC.2024.3 release train.
- **API surface (Swagger):** confirmed as a public tag `VcenterExtensions` in
  *Swagger Cluster Management v4.3.yaml* on the `ntnx-api-golang-clients` repo.
- **Legacy → v4 mapping:** *ESXi/VCenter API Mapping* Confluence page maps
  `Update_Management_Server_Info` → `POST /clustermgmt/v4.0.a2/config/vcenter-extensions/{extId}/$actions/register` and the corresponding unregister action.
- **QA references:** `test_vcenter_extension_ops.py` and `test_esxi_v4_upgrade.py` in the
  Nutanix Uhura test tree cover the register/unregister lifecycle across upgrade paths,
  including `test_register_unregister_vcenter_extension` and
  `verify_vcenter_register_unregister`.
- **Related JIRA / ENG references surfaced:**
  - *Cluster Management V4 API yaml changes* (yaml spec changes for gpu metrics that
    touched the shared clustermgmt v4 surface).
  - *Cluster Management v4 API does not result all the datapoints* (bug about `$select=*`
    behaviour).
  - *Improve error message for cluster management v4 API* (feature request that touches
    the same error-response schema our modules surface for VCNT-20100 errors).
  - *Infra QA - Validation of 5 v4 APIs for cluster management operations* (parent QA
    validation ticket for clustermgmt v4).
  - *[master-ESX] Error creating the datastore: Application error kOther raised* (issue
    that references `test_re_register_vcenter_extension` / regression coverage).
- **Docs / runbooks:**
  - Confluence *PC based Cluster Management* — background on why cluster_management APIs
    live in PC while executing on PE.
  - Confluence *Clustermgmt- Infra V4 API Serviceability Guides* — canonical error schema
    for cluster_management V4 (`clustermgmt.v4.error.ErrorResponse` / `AppMessage`), which
    matches the response shape our tests assert.
  - Confluence *v4 to legacy API Mapping* — legacy → v4 mapping matrix.
  - Confluence *PE register/unregister to/from PC* — describes the higher-level
    register/unregister workflow that vCenter Extensions plug into.
  - Confluence *vCenter reconstruction and unregister* — customer runbook for cleaning up
    stale vCenter Extension entries after vCenter rebuild.
  - Confluence *api_treasure_map* (SharePoint index of clustermgmt v4 endpoints).
- **Skills required for this feature (end-to-end):**
  - Nutanix Prism Central v4 APIs and the async task model (`ergon` service, task ext_id
    prefix, entities affected).
  - vSphere / vCenter Server administration (registering/unregistering an extension key,
    vCenter admin credentials, port 443 default).
  - ESXi hypervisor cluster onboarding to Nutanix Prism (PE→PC registration prerequisite).
  - `ntnx_clustermgmt_py_client` SDK usage — `VcenterExtensionsApi`, `VcenterExtension`,
    `VcenterCredentials`, `if_match`/etag handling for concurrent-safe mutations.
  - Ansible v2 module patterns already in this collection (`BaseModuleV4`, `BaseInfoModule`,
    `SpecGenerator`, `wait_for_completion`, `raise_api_exception`,
    `strip_internal_attributes`, `validate_required_params`).

_All URLs the search returned were rendered by Glean as placeholder tokens
(`<URL_1>`, `<URL_2>`, …); they cannot be reproduced verbatim here because Glean did not
expose the resolved URLs to the MCP client for this account. The document titles above are
verbatim so a reviewer can search the same corpus and land on the identical results._

## Files changed

**plugins/modules/**
- `ntnx_vcenter_extension_v2.py` — CRUD module (register / unregister vCenter extension)
- `ntnx_vcenter_extensions_info_v2.py` — info module (get-by-id / list)

**plugins/module_utils/v4/clusters_mgmt/**
- `api_client.py` — added `get_vcenter_extensions_api_instance()` helper
- `helpers.py` — added `get_vcenter_extension(module, api_instance, ext_id)` helper

**meta/**
- `runtime.yml` — registered both new modules in the `ntnx_v2` action group so the standard
  `module_defaults: group/nutanix.ncp.ntnx` block applies to them (this was the root cause
  of an early test failure where `nutanix_host` was resolved as null)

**examples/cluster_management/VcenterExtension/**
- `vcenter_extensions_v2.yml` — end-to-end example playbook (single file, all operations)
- `examples_run.log` — captured real playbook output from the run against
  `10.44.76.28`

**tests/integration/targets/ntnx_vcenter_extensions_v2/**
- `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/vcenter_extensions.yml` — new
  integration target mirroring the `ntnx_virtual_switches_v2` target layout

**.gitignore**
- Added `tests/integration/integration_config.yml` and `**/__pycache__/` so the run
  artifacts never sweep into the branch.

## Test execution

| Metric              | Value                                                                                          |
|---------------------|------------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_vcenter_extensions_v2 --allow-unsupported --allow-disabled --python 3.12 -v` |
| Total tasks         | 57 (30 executed, 19 skipped, 8 ignore-errors passes)                                           |
| Passed              | 30                                                                                             |
| Failed              | 0                                                                                              |
| Skipped             | 19 (live register / unregister lifecycle — see analysis)                                       |
| Duration            | ~0:00:11                                                                                       |
| Cluster (PC)        | `10.44.76.28` (PC-only, no attached ESXi cluster)                                              |
| ansible-test sanity | PASS (24 tests) on the four touched Python files                                               |
| black / isort / flake8 | PASS                                                                                         |
| ansible-lint        | PASS (0 failures, 0 warnings, `production` profile)                                            |

### Analysis

- All 30 executed tasks pass. The 8 `...ignoring` traces in the log are **expected** —
  they belong to negative-path tasks that intentionally invoke the API with a bogus
  `ext_id` or omit required arguments and then assert the specific error surface (message
  text, `status: 404`, `code: VCNT-20100`, `errorGroup: VCENTER_EXTENSION_NOT_FOUND`,
  or the `parameters are mutually exclusive: ext_id|filter` / `required together:
  username, password` / `is present but all of the following are missing: ext_id` messages
  emitted by Ansible's `AnsibleModule` layer).
- The **19 skipped tasks** are the live register / update / unregister lifecycle block.
  It runs only when the target PC exposes at least one discovered `VcenterExtension`
  entry AND a `vcenter_credentials` mapping is provided via `integration_config.yml`.
  The PC used for this run (`10.44.76.28`) hosts an AHV-only single-node cluster and
  the PC itself (`hypervisor_types=['AHV']`, `cluster_function=['PRISM_CENTRAL']`) — there
  is no ESXi cluster with vCenter attached, so `ListVcenterExtensions` returns an empty
  list and the lifecycle block short-circuits with a `debug` message stating why. When
  the same target file is pointed at a PC that manages an ESXi cluster with vCenter, the
  block will run the full register → idempotent-register → get → unregister →
  idempotent-unregister flow and restore the baseline state.
- No test failures remain. There are no **Known issues**.

### Test logs (tail)

<details>
<summary>tail of ansible-test integration output</summary>

```text
PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_vcenter_extensions_v2 : Start VcenterExtension tests] ***************
ok: [testhost] => {"msg": "Start VcenterExtension tests"}

TASK [ntnx_vcenter_extensions_v2 : Generate random suffix and dummy uuid for negative cases] ***
ok: [testhost] => {"ansible_facts": {"bogus_ext_id": "00000000-0000-0000-0000-000000000000", "random_name": "RsCOOEwcScwe", "suffix_name": "ansible"}, "changed": false}

TASK [ntnx_vcenter_extensions_v2 : List all vCenter Server extensions] *********
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_vcenter_extensions_v2 : List all vCenter Server extensions status] ***
ok: [testhost] => {"changed": false, "msg": "List all vCenter extensions passed"}

TASK [ntnx_vcenter_extensions_v2 : List vCenter Server extensions with limit] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_vcenter_extensions_v2 : List vCenter Server extensions with limit status] ***
ok: [testhost] => {"changed": false, "msg": "List vCenter extensions with limit passed"}

TASK [ntnx_vcenter_extensions_v2 : List vCenter Server extensions with filter on isRegistered] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_vcenter_extensions_v2 : List vCenter Server extensions with filter status] ***
ok: [testhost] => {"changed": false, "msg": "List vCenter extensions with filter passed"}

TASK [ntnx_vcenter_extensions_v2 : Get vCenter Server extension using a bogus ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching vCenter extension info using ext_id", "response": {"data": {"error": [{"code": "VCNT-20100", "errorGroup": "VCENTER_EXTENSION_NOT_FOUND", "message": "Failed to perform the operation on the vCenter Server extension with UUID '00000000-0000-0000-0000-000000000000' because it is not found", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_vcenter_extensions_v2 : Get vCenter Server extension using a bogus ext_id status] ***
ok: [testhost] => {"changed": false, "msg": "Get vCenter extension with bogus ext_id failed as expected"}

TASK [ntnx_vcenter_extensions_v2 : Info module — reject ext_id + filter combination] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_vcenter_extensions_v2 : Info module mutually-exclusive status] ***
ok: [testhost] => {"changed": false, "msg": "Info module rejects ext_id+filter as expected"}

TASK [ntnx_vcenter_extensions_v2 : Register vCenter extension without ext_id (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is present but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_vcenter_extensions_v2 : Register vCenter extension without ext_id status] ***
ok: [testhost] => {"changed": false, "msg": "Register without ext_id failed as expected"}

TASK [ntnx_vcenter_extensions_v2 : Unregister vCenter extension without ext_id (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_vcenter_extensions_v2 : Unregister vCenter extension without ext_id status] ***
ok: [testhost] => {"changed": false, "msg": "Unregister without ext_id failed as expected"}

TASK [ntnx_vcenter_extensions_v2 : Register vCenter extension with username only (missing password)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are required together: username, password"}
...ignoring

TASK [ntnx_vcenter_extensions_v2 : Register vCenter extension missing password status] ***
ok: [testhost] => {"changed": false, "msg": "Register with only username failed as expected"}

TASK [ntnx_vcenter_extensions_v2 : Register vCenter extension with non-integer port (should fail spec validation)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "argument 'port' is of type str and we were unable to convert to int: 'not-an-int' cannot be converted to an int"}
...ignoring

TASK [ntnx_vcenter_extensions_v2 : Register vCenter extension with non-integer port status] ***
ok: [testhost] => {"changed": false, "msg": "Register with non-int port failed as expected"}

TASK [ntnx_vcenter_extensions_v2 : Determine ext_id to use for check_mode tests] ***
ok: [testhost] => {"ansible_facts": {"check_mode_ext_id": ""}, "changed": false}

TASK [ntnx_vcenter_extensions_v2 : Note when check_mode block is skipped] ***
ok: [testhost] => {"msg": "No discovered vCenter extensions on the target PC — the check_mode register/unregister assertions are skipped for this run because the idempotency pre-check requires an existing extension to look up."}

TASK [ntnx_vcenter_extensions_v2 : Register vCenter extension with bogus ext_id (should fail with VCNT-20100)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching vCenter extension info using ext_id", "response": {"data": {"error": [{"code": "VCNT-20100", "errorGroup": "VCENTER_EXTENSION_NOT_FOUND", "message": "..."}]}}, "status": 404}
...ignoring

TASK [ntnx_vcenter_extensions_v2 : Register vCenter extension with bogus ext_id status] ***
ok: [testhost] => {"changed": false, "msg": "Register with bogus ext_id failed with VCENTER_EXTENSION_NOT_FOUND as expected"}

TASK [ntnx_vcenter_extensions_v2 : Unregister vCenter extension with bogus ext_id (should fail with VCNT-20100)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching vCenter extension info using ext_id", "response": {"data": {"error": [{"code": "VCNT-20100", "errorGroup": "VCENTER_EXTENSION_NOT_FOUND", "message": "..."}]}}, "status": 404}
...ignoring

TASK [ntnx_vcenter_extensions_v2 : Unregister vCenter extension with bogus ext_id status] ***
ok: [testhost] => {"changed": false, "msg": "Unregister with bogus ext_id failed with VCENTER_EXTENSION_NOT_FOUND as expected"}

TASK [ntnx_vcenter_extensions_v2 : Determine whether a live lifecycle test is possible] ***
ok: [testhost] => {"ansible_facts": {"have_live_credentials": false, "live_extension": {}}, "changed": false}

TASK [ntnx_vcenter_extensions_v2 : Report skipped lifecycle when no ESXi extension is discovered] ***
ok: [testhost] => {"msg": "No vCenter Server extensions were discovered on the target PC. The live register / update / unregister lifecycle block is skipped for this run — see PR body for details."}

# 19 tasks skipped (live lifecycle block) — see analysis above

PLAY RECAP *********************************************************************
testhost                   : ok=30   changed=0    unreachable=0    failed=0    skipped=19   rescued=0    ignored=8
```

</details>

### Example playbook execution

The example playbook `examples/cluster_management/VcenterExtension/vcenter_extensions_v2.yml`
was executed end-to-end against the same PC and every task ran (list operations returned
real empty responses; the register / update / unregister / get-by-ext_id tasks failed as
expected — same VCNT-20100 root cause as above — and were captured with `ignore_errors`).
The full output is in `examples/cluster_management/VcenterExtension/examples_run.log`
(committed) and mirrored to `$ARTIFACTS/examples_run.log`.

Recap:
```text
PLAY RECAP
localhost                  : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=4
```

The `sample:` blocks in the module `RETURN` docs were left as representative dicts
(matching the SDK's `VcenterExtension` / `VcenterCredentials` shape) because the PC
under test does not have a live `VcenterExtension` object we could dump verbatim.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
