### PR TITLE
code-gen(networking/IpfixExporter): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/networking/IpfixExporter/ipfix_exporter_v2.yml
+++ b/examples/networking/IpfixExporter/ipfix_exporter_v2.yml
@@ -1,0 +1,95 @@
+---
+# Summary:
+# This playbook demonstrates end-to-end usage of the IPFIX Exporter v4 API modules:
+# 1. Create an IPFIX exporter (with all supported fields)
+# 2. Get the IPFIX exporter by external ID
+# 3. List IPFIX exporters (all / filtered / limited)
+# 4. Update the IPFIX exporter (with all supported fields)
+# 5. Delete the IPFIX exporter
+
+- name: IPFIX Exporter v4 playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') | default('10.44.76.28', True) }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') | default('admin', True) }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') | default('Nutanix.123', True) }}"
+      validate_certs: false
+  tasks:
+    - name: Set common variables for this playbook
+      ansible.builtin.set_fact:
+        ipfix_exporter_name: "ipfix_exporter_ansible_example"
+        collector_ip: "10.44.10.20"
+        collector_port: 4739
+        pe_cluster_uuid: "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+
+    - name: Create IPFIX exporter (all fields)
+      nutanix.ncp.ntnx_ipfix_exporter_v2:
+        state: present
+        name: "{{ ipfix_exporter_name }}"
+        description: "IPFIX exporter created by Ansible example playbook"
+        collector_ip: "{{ collector_ip }}"
+        collector_port: "{{ collector_port }}"
+        protocol: "TCP"
+        export_rate_limit_per_node_bps: 1000000
+        export_scopes:
+          - uuid: "{{ pe_cluster_uuid }}"
+            scope_type: "PE"
+            ip_family: "V4"
+      register: create_result
+      ignore_errors: true
+
+    - name: Save the created IPFIX exporter external ID (if create succeeded)
+      ansible.builtin.set_fact:
+        ipfix_ext_id: "{{ create_result.ext_id | default('') }}"
+
+    - name: List all IPFIX exporters
+      nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+      register: list_all_result
+      ignore_errors: true
+
+    - name: List IPFIX exporters with filter
+      nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+        filter: "name eq '{{ ipfix_exporter_name }}'"
+      register: list_filter_result
+      ignore_errors: true
+
+    - name: List IPFIX exporters with limit
+      nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+        limit: 1
+      register: list_limit_result
+      ignore_errors: true
+
+    - name: Get IPFIX exporter using ext_id (only if create succeeded)
+      nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+        ext_id: "{{ ipfix_ext_id }}"
+      register: get_result
+      when: ipfix_ext_id | length > 0
+      ignore_errors: true
+
+    - name: Update IPFIX exporter (all fields) (only if create succeeded)
+      nutanix.ncp.ntnx_ipfix_exporter_v2:
+        state: present
+        ext_id: "{{ ipfix_ext_id }}"
+        name: "{{ ipfix_exporter_name }}_updated"
+        description: "IPFIX exporter updated by Ansible example playbook"
+        collector_ip: "10.44.10.30"
+        collector_port: 4740
+        protocol: "UDP"
+        export_rate_limit_per_node_bps: 2000000
+        export_scopes:
+          - uuid: "{{ pe_cluster_uuid }}"
+            scope_type: "PE"
+            ip_family: "BOTH"
+      register: update_result
+      when: ipfix_ext_id | length > 0
+      ignore_errors: true
+
+    - name: Delete IPFIX exporter (only if create succeeded)
+      nutanix.ncp.ntnx_ipfix_exporter_v2:
+        state: absent
+        ext_id: "{{ ipfix_ext_id }}"
+      register: delete_result
+      when: ipfix_ext_id | length > 0
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_ipfix_exporter_v2
+    - ntnx_ipfix_exporters_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,7 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        IPFIX_EXPORTER = "networking:config:ipfix-exporter"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_ipfix_exporters_api_instance(module):
+    """
+    This method will return IPFIXExportersApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): IPFIX Exporters Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.IPFIXExportersApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,23 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_ipfix_exporter(module, api_instance, ext_id):
+    """
+    This method will return IPFIX exporter info using its ext_id.
+    Args:
+        module: Ansible module
+        api_instance: IPFIXExportersApi instance from ntnx_networking_py_client sdk
+        ext_id (str): IPFIX exporter external ID
+    return:
+        info (object): IPFIX exporter info
+    """
+    try:
+        return api_instance.get_ipfix_exporter_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching IPFIX exporter info using ext_id",
+        )

--- a/plugins/modules/ntnx_ipfix_exporter_v2.py
+++ b/plugins/modules/ntnx_ipfix_exporter_v2.py
@@ -1,0 +1,558 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_ipfix_exporter_v2
+short_description: Create, Update, Delete IPFIX Exporter in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to create, update, and delete IPFIX Exporters in Nutanix Prism Central.
+  - An IPFIX Exporter exports IP Flow Information Export (IPFIX) records
+    from AHV hosts to an external collector for network traffic visibility
+    and security analytics.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Create an IPFIX Exporter) -
+      Required Roles: Prism Admin, Super Admin
+    - >-
+      B(Delete an IPFIX Exporter) -
+      Required Roles: Prism Admin, Super Admin
+    - >-
+      B(Update an IPFIX Exporter) -
+      Required Roles: Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will be create IPFIX exporter.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be update IPFIX exporter.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be delete IPFIX exporter.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID (UUID) of the IPFIX exporter.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - Name of the IPFIX Exporter.
+      - Required for create operation.
+      - Maximum 128 characters.
+    type: str
+    required: false
+  description:
+    description:
+      - User provided description for the IPFIX Exporter.
+    type: str
+    required: false
+  collector_ip:
+    description:
+      - IP address of the external IPFIX collector to which flow records are exported.
+      - Required for create operation.
+    type: str
+    required: false
+  collector_port:
+    description:
+      - UDP/TCP port on the external IPFIX collector to which flow records are exported.
+      - Required for create operation.
+    type: int
+    required: false
+  protocol:
+    description:
+      - Transport protocol used to send IPFIX flow records to the collector.
+      - Required for create operation.
+    type: str
+    required: false
+    choices:
+      - TCP
+      - UDP
+      - TLS_TCP
+  export_rate_limit_per_node_bps:
+    description:
+      - Maximum export rate limit per node in bits per second.
+      - Used to cap the outgoing IPFIX traffic per AHV node to avoid overwhelming the collector.
+    type: int
+    required: false
+  export_scopes:
+    description:
+      - List of scopes (Prism Central or Prism Element clusters) whose flow records
+        should be exported by this IPFIX exporter.
+      - Required for create operation.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      uuid:
+        description:
+          - UUID of the Prism Central (PC) or Prism Element (PE) cluster.
+        type: str
+        required: true
+      scope_type:
+        description:
+          - Whether the referenced UUID belongs to a PC or a PE cluster.
+        type: str
+        required: false
+        choices:
+          - PC
+          - PE
+      ip_family:
+        description:
+          - IP address family for which flow records should be exported.
+        type: str
+        required: false
+        choices:
+          - V4
+          - V6
+          - BOTH
+  metadata:
+    description:
+      - Metadata associated with the IPFIX exporter.
+    type: dict
+    required: false
+    suboptions:
+      owner_reference_id:
+        description:
+          - A globally unique identifier that represents the owner of this resource.
+        type: str
+        required: false
+      owner_user_name:
+        description:
+          - The userName of the owner of this resource.
+        type: str
+        required: false
+      project_reference_id:
+        description:
+          - A globally unique identifier that represents the project this resource belongs to.
+        type: str
+        required: false
+      project_name:
+        description:
+          - The name of the project this resource belongs to.
+        type: str
+        required: false
+      category_ids:
+        description:
+          - A list of globally unique identifiers that represent all the
+            categories the resource is associated with.
+        type: list
+        elements: str
+        required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create IPFIX exporter with all attributes
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    state: present
+    name: "ipfix_exporter_ansible_full"
+    description: "IPFIX exporter created by Ansible"
+    collector_ip: "10.44.10.20"
+    collector_port: 4739
+    protocol: "TCP"
+    export_rate_limit_per_node_bps: 1000000
+    export_scopes:
+      - uuid: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+        scope_type: "PE"
+        ip_family: "V4"
+  register: result
+
+- name: Update IPFIX exporter
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    state: present
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+    name: "ipfix_exporter_ansible_updated"
+    description: "Updated IPFIX exporter description"
+    collector_ip: "10.44.10.30"
+    collector_port: 4739
+    protocol: "TCP"
+    export_rate_limit_per_node_bps: 2000000
+    export_scopes:
+      - uuid: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+        scope_type: "PE"
+        ip_family: "BOTH"
+  register: result
+
+- name: Delete IPFIX exporter
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    state: absent
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting IPFIX exporter.
+    - If the operation is create or update and C(wait) is true, it will return the IPFIX exporter details.
+    - If the operation is create or update and C(wait) is false, it will return the task details.
+    - If the operation is delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "collector_ip": "10.44.10.20",
+      "collector_port": 4739,
+      "description": "IPFIX exporter created by Ansible example playbook",
+      "export_rate_limit_per_node_bps": 1000000,
+      "export_scopes": [
+          {
+              "ip_family": "V4",
+              "scope_type": "PE",
+              "uuid": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+          }
+      ],
+      "ext_id": "db5429c8-f3a1-4cff-9d51-208a0fb175be",
+      "links": null,
+      "metadata": {
+          "category_ids": null,
+          "owner_reference_id": "00000000-0000-0000-0000-000000000000",
+          "owner_user_name": "admin",
+          "project_name": "_internal",
+          "project_reference_id": "00000000-0000-0000-0000-000000000000"
+      },
+      "name": "ipfix_exporter_ansible_example",
+      "protocol": "TCP",
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task associated with this operation.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:3b7a0e2a-e515-4fdd-ad01-1fe13aef79bc"
+
+ext_id:
+  description:
+    - The external ID of the IPFIX exporter.
+  returned: always
+  type: str
+  sample: "db5429c8-f3a1-4cff-9d51-208a0fb175be"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description:
+    - This indicates the message if any message occurred.
+    - Populated on error, on idempotent runs, and on delete check_mode.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating IPFIX exporter"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_etag,
+    get_ipfix_exporters_api_instance,
+)
+from ..module_utils.v4.network.helpers import get_ipfix_exporter  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_networking_py_client as networking_sdk  # noqa: E402
+except ImportError:
+    from ..module_utils.v4.sdk_mock import mock_sdk as networking_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    export_scope_spec = dict(
+        uuid=dict(type="str", required=True),
+        scope_type=dict(
+            type="str",
+            required=False,
+            choices=["PC", "PE"],
+            obj=networking_sdk.ScopeType,
+        ),
+        ip_family=dict(
+            type="str",
+            required=False,
+            choices=["V4", "V6", "BOTH"],
+            obj=networking_sdk.IpFamily,
+        ),
+    )
+
+    metadata_spec = dict(
+        owner_reference_id=dict(type="str", required=False),
+        owner_user_name=dict(type="str", required=False),
+        project_reference_id=dict(type="str", required=False),
+        project_name=dict(type="str", required=False),
+        category_ids=dict(type="list", elements="str", required=False),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        description=dict(type="str"),
+        collector_ip=dict(type="str"),
+        collector_port=dict(type="int"),
+        protocol=dict(
+            type="str",
+            choices=["TCP", "UDP", "TLS_TCP"],
+            obj=networking_sdk.ExporterProtocol,
+        ),
+        export_rate_limit_per_node_bps=dict(type="int"),
+        export_scopes=dict(
+            type="list",
+            elements="dict",
+            options=export_scope_spec,
+            obj=networking_sdk.ExportScope,
+        ),
+        metadata=dict(
+            type="dict",
+            options=metadata_spec,
+            obj=networking_sdk.Metadata,
+        ),
+    )
+    return module_args
+
+
+def create_IpfixExporter(module, result, api_instance):
+    validate_required_params(
+        module,
+        ["name", "collector_ip", "collector_port", "protocol", "export_scopes"],
+    )
+
+    sg = SpecGenerator(module)
+    default_spec = networking_sdk.IPFIXExporter()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create IPFIX exporter spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_ipfix_exporter(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating IPFIX exporter",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task_status, rel=TASK_CONSTANTS.RelEntityType.IPFIX_EXPORTER
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            resp = get_ipfix_exporter(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(resp.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for IPFIX Exporter"
+                ),
+                msg="Failed to get entity ext_id from task for IPFIX Exporter",
+            )
+    result["changed"] = True
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    return old_spec_dict == update_spec_dict
+
+
+def update_IpfixExporter(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    old_spec = get_ipfix_exporter(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for updating IPFIX exporter", **result
+        )
+    kwargs = {"if_match": etag}
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update IPFIX exporter spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    resp = None
+    try:
+        resp = api_instance.update_ipfix_exporter_by_id(
+            extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating IPFIX exporter",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_ipfix_exporter(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def delete_IpfixExporter(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "IPFIX exporter with ext_id:{0} will be deleted.".format(ext_id)
+        return
+
+    current_spec = get_ipfix_exporter(module, api_instance, ext_id)
+    etag = get_etag(data=current_spec)
+    kwargs = {}
+    if etag:
+        kwargs["if_match"] = etag
+
+    resp = None
+    try:
+        resp = api_instance.delete_ipfix_exporter_by_id(extId=ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting IPFIX exporter",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, raise_error=True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+            ("state", "present", ("name", "ext_id"), True),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_networking_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_ipfix_exporters_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_IpfixExporter(module, result, api_instance)
+        else:
+            create_IpfixExporter(module, result, api_instance)
+    else:
+        delete_IpfixExporter(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_ipfix_exporters_info_v2.py
+++ b/plugins/modules/ntnx_ipfix_exporters_info_v2.py
@@ -1,0 +1,216 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_ipfix_exporters_info_v2
+short_description: Fetch IPFIX Exporter info from Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about IpfixExporter in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific IpfixExporter.
+  - If C(ext_id) is not provided, list multiple IpfixExporter optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get IPFIX exporter by ext_id) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin
+    - >-
+      B(Get list of IPFIX exporters) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID (UUID) of the IPFIX exporter.
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+EXAMPLES = r"""
+- name: Get IPFIX exporter using ext_id
+  nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+
+- name: List all IPFIX exporters
+  nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+  register: result
+
+- name: List IPFIX exporters with filter
+  nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+    filter: "name eq 'ipfix_exporter_ansible'"
+  register: result
+
+- name: List IPFIX exporters with limit
+  nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+    limit: 1
+  register: result
+"""
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC IpfixExporter info v4 API.
+    - It can be a single IpfixExporter if external ID is provided.
+    - List of multiple IpfixExporter if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "collector_ip": "10.44.10.20",
+      "collector_port": 4739,
+      "description": "IPFIX exporter created by Ansible example playbook",
+      "export_rate_limit_per_node_bps": 1000000,
+      "export_scopes": [
+          {
+              "ip_family": "V4",
+              "scope_type": "PE",
+              "uuid": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+          }
+      ],
+      "ext_id": "db5429c8-f3a1-4cff-9d51-208a0fb175be",
+      "links": null,
+      "metadata": {
+          "category_ids": null,
+          "owner_reference_id": "00000000-0000-0000-0000-000000000000",
+          "owner_user_name": "admin",
+          "project_name": "_internal",
+          "project_reference_id": "00000000-0000-0000-0000-000000000000"
+      },
+      "name": "ipfix_exporter_ansible_example",
+      "protocol": "TCP",
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching IPFIX exporter info using ext_id"
+
+error:
+  description:
+    - This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the IPFIX exporter.
+  type: str
+  returned: when external ID is provided
+  sample: "7bea69e9-684c-4736-7805-d658ee17c1b6"
+
+total_available_results:
+  description: The total number of available IPFIX exporters in PC.
+  type: int
+  returned: when all IPFIX exporters are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_ipfix_exporters_api_instance,
+)
+from ..module_utils.v4.network.helpers import get_ipfix_exporter  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_ipfix_exporter_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_ipfix_exporter(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_ipfix_exporters(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating IPFIX exporters info spec", **result)
+
+    try:
+        resp = api_instance.list_ipfix_exporters(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching IPFIX exporters info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_ipfix_exporters_api_instance(module)
+    if module.params.get("ext_id"):
+        get_ipfix_exporter_using_ext_id(module, api_instance, result)
+    else:
+        get_ipfix_exporters(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_ipfix_exporter_v2/aliases
+++ b/tests/integration/targets/ntnx_ipfix_exporter_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_ipfix_exporter_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_ipfix_exporter_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_ipfix_exporter_v2/tasks/ipfix_exporters.yml
+++ b/tests/integration/targets/ntnx_ipfix_exporter_v2/tasks/ipfix_exporters.yml
@@ -1,0 +1,676 @@
+---
+###############################################################################
+# IPFIX Exporter v2 integration tests
+#
+# Test plan:
+#   * Check-mode spec generation for Create / Update / Delete (one each).
+#   * Create an IPFIX exporter with the minimum required fields.
+#   * Create an IPFIX exporter with ALL supported fields, including
+#     export_scopes (PE + V4 + BOTH ip_family) and metadata.
+#   * Fetch created exporter by ext_id and by name-filter.
+#   * List all IPFIX exporters, verify pagination limit works.
+#   * Update the full-attribute exporter (scalar name/description/rate limit
+#     change + change protocol to a DIFFERENT valid enum value).
+#   * Idempotency: running the same update again returns changed=false and
+#     "Nothing to change.".
+#   * Negative:
+#       - Create without required fields (name, collector_ip, collector_port,
+#         protocol) — module must fail with a descriptive message.
+#       - Invalid enum for `protocol` — spec validation must reject it.
+#       - Invalid scope_type enum — spec validation must reject it.
+#       - Update / Delete / Get with a non-existent ext_id — API error.
+#       - Delete without ext_id — Ansible required_if must reject it.
+#       - Info module rejects ext_id + filter (mutually exclusive).
+#   * Delete cleanup: delete every created exporter, then verify the list.
+###############################################################################
+
+- name: Start IPFIX Exporter tests
+  ansible.builtin.debug:
+    msg: Start IPFIX Exporter tests
+
+- name: Generate random suffix for resource names
+  ansible.builtin.set_fact:
+    random_suffix: "{{ query('community.general.random_string', numbers=false, special=false, length=10)[0] }}"
+    todelete: []
+
+- name: Build entity names and unique collector coordinates (avoids IP+port+protocol clashes)
+  ansible.builtin.set_fact:
+    ipfix_min_name: "ipfix_min_{{ random_suffix }}"
+    ipfix_full_name: "ipfix_full_{{ random_suffix }}"
+    ipfix_updated_name: "ipfix_updated_{{ random_suffix }}"
+    collector_min_ip: "10.44.{{ 20 + (100 | random(seed=random_suffix)) % 100 }}.10"
+    collector_full_ip: "10.44.{{ 20 + (100 | random(seed=random_suffix + 'full')) % 100 }}.11"
+    collector_update_ip: "10.44.{{ 20 + (100 | random(seed=random_suffix + 'update')) % 100 }}.12"
+    collector_min_port: "{{ 30000 + (30000 | random(seed=random_suffix)) }}"
+    collector_full_port: "{{ 30000 + (30000 | random(seed=random_suffix + 'full')) }}"
+    collector_update_port: "{{ 30000 + (30000 | random(seed=random_suffix + 'update')) }}"
+
+########################################################################################
+# Fetch a PE cluster ext_id to reference in export_scopes
+########################################################################################
+
+- name: Fetch clusters
+  nutanix.ncp.ntnx_clusters_info_v2:
+  register: clusters_result
+  ignore_errors: true
+
+- name: Assert clusters were fetched
+  ansible.builtin.assert:
+    that:
+      - clusters_result is defined
+      - clusters_result.failed == false
+      - clusters_result.response is defined
+      - clusters_result.response | length > 0
+    success_msg: "Clusters info fetched successfully"
+    fail_msg: "Failed to fetch clusters info"
+
+- name: Pick a PE cluster ext_id (fallback to first cluster)
+  ansible.builtin.set_fact:
+    pe_cluster_ext_id: >-
+      {{
+        (clusters_result.response | selectattr('config.cluster_function', 'defined')
+                                    | selectattr('config.cluster_function', 'contains', 'AOS')
+                                    | map(attribute='ext_id') | list
+         + clusters_result.response | map(attribute='ext_id') | list)
+         | first
+      }}
+
+- name: Show the PE cluster ext_id in use
+  ansible.builtin.debug:
+    msg: "Using PE cluster ext_id: {{ pe_cluster_ext_id }}"
+
+########################################################################################
+# Pre-clean stale IPFIX exporters left over from previous test runs so IP+port+protocol
+# uniqueness constraints from the API do not conflict with fresh entities we are about
+# to create.
+########################################################################################
+
+- name: List existing IPFIX exporters to detect stale test artifacts
+  nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+  register: preexisting
+  ignore_errors: true
+
+- name: Compute list of stale ext_ids to prune (only test-created names)
+  ansible.builtin.set_fact:
+    stale_ext_ids: >-
+      {{
+        (preexisting.response | default([]))
+        | selectattr('name', 'defined')
+        | selectattr('name', 'match', '^(ipfix_min_|ipfix_full_|ipfix_updated_|check_mode_).*')
+        | map(attribute='ext_id') | list
+      }}
+
+- name: Delete stale IPFIX exporters from previous runs (best-effort)
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  loop: "{{ stale_ext_ids }}"
+  register: prune_result
+  retries: 3
+  delay: 10
+  until: prune_result is not failed
+  ignore_errors: true
+
+########################################################################################
+# Check-mode tests (exactly one for each of Create/Update/Delete)
+########################################################################################
+
+- name: Generate spec for creating IPFIX exporter using check mode with all attributes
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    name: "check_mode_ipfix_full"
+    description: "IPFIX exporter created in check mode with all attributes"
+    collector_ip: "10.44.10.20"
+    collector_port: 4739
+    protocol: "TCP"
+    export_rate_limit_per_node_bps: 1000000
+    export_scopes:
+      - uuid: "{{ pe_cluster_ext_id }}"
+        scope_type: "PE"
+        ip_family: "V4"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert Create IPFIX exporter check-mode spec
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_ipfix_full"
+      - result.response.description == "IPFIX exporter created in check mode with all attributes"
+      - result.response.collector_ip == "10.44.10.20"
+      - result.response.collector_port == 4739
+      - result.response.protocol == "TCP"
+      - result.response.export_rate_limit_per_node_bps == 1000000
+      - result.response.export_scopes | length == 1
+      - result.response.export_scopes[0].uuid == pe_cluster_ext_id
+      - result.response.export_scopes[0].scope_type == "PE"
+      - result.response.export_scopes[0].ip_family == "V4"
+    success_msg: "IPFIX exporter create check-mode spec generated successfully"
+    fail_msg: "IPFIX exporter create check-mode spec generation failed"
+
+########################################################################################
+# Create Tests
+########################################################################################
+
+- name: Create IPFIX exporter with minimum required attributes
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    name: "{{ ipfix_min_name }}"
+    collector_ip: "{{ collector_min_ip }}"
+    collector_port: "{{ collector_min_port }}"
+    protocol: "UDP"
+    export_scopes:
+      - uuid: "{{ pe_cluster_ext_id }}"
+        scope_type: "PE"
+  register: result
+  ignore_errors: true
+
+- name: Assert Create IPFIX exporter with minimum required attributes
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.name == ipfix_min_name
+      - result.response.collector_ip == collector_min_ip
+      - result.response.collector_port == (collector_min_port | int)
+      - result.response.protocol == "UDP"
+      - result.response.export_scopes | length == 1
+      - result.response.export_scopes[0].uuid == pe_cluster_ext_id
+      - result.response.export_scopes[0].scope_type == "PE"
+    success_msg: "Minimum IPFIX exporter created successfully"
+    fail_msg: "Minimum IPFIX exporter creation failed"
+
+- name: Track minimum exporter for cleanup
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+    ipfix_min_ext_id: "{{ result.ext_id }}"
+
+- name: Create IPFIX exporter with all attributes
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    name: "{{ ipfix_full_name }}"
+    description: "IPFIX exporter created by Ansible integration tests"
+    collector_ip: "{{ collector_full_ip }}"
+    collector_port: "{{ collector_full_port }}"
+    protocol: "TCP"
+    export_rate_limit_per_node_bps: 1500000
+    export_scopes:
+      - uuid: "{{ pe_cluster_ext_id }}"
+        scope_type: "PE"
+        ip_family: "V4"
+  register: result
+  ignore_errors: true
+
+- name: Assert Create IPFIX exporter with all attributes
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.name == ipfix_full_name
+      - result.response.description == "IPFIX exporter created by Ansible integration tests"
+      - result.response.collector_ip == collector_full_ip
+      - result.response.collector_port == (collector_full_port | int)
+      - result.response.protocol == "TCP"
+      - result.response.export_rate_limit_per_node_bps == 1500000
+      - result.response.export_scopes | length == 1
+      - result.response.export_scopes[0].uuid == pe_cluster_ext_id
+      - result.response.export_scopes[0].scope_type == "PE"
+      - result.response.export_scopes[0].ip_family == "V4"
+    success_msg: "Full IPFIX exporter created successfully"
+    fail_msg: "Full IPFIX exporter creation failed"
+
+- name: Track full exporter for cleanup
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+    ipfix_full_ext_id: "{{ result.ext_id }}"
+
+########################################################################################
+# Negative Create Tests
+########################################################################################
+
+- name: Create IPFIX exporter with missing required fields (name)
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    collector_ip: "10.44.13.20"
+    collector_port: 4739
+    protocol: "UDP"
+  register: result
+  ignore_errors: true
+
+- name: Assert Create IPFIX exporter with missing name fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - 'result.msg == "state is present but any of the following are missing: name, ext_id"'
+    success_msg: "Create IPFIX exporter with missing name failed as expected"
+    fail_msg: "Create IPFIX exporter with missing name did not fail as expected"
+
+- name: Create IPFIX exporter with missing collector_ip
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    name: "missing_collector_ip"
+    collector_port: 4739
+    protocol: "UDP"
+  register: result
+  ignore_errors: true
+
+- name: Assert Create IPFIX exporter with missing collector_ip fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Missing required parameter(s): collector_ip' in result.msg"
+    success_msg: "Create IPFIX exporter with missing collector_ip failed as expected"
+    fail_msg: "Create IPFIX exporter with missing collector_ip did not fail as expected"
+
+- name: Create IPFIX exporter with missing collector_port
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    name: "missing_collector_port"
+    collector_ip: "10.44.13.20"
+    protocol: "UDP"
+  register: result
+  ignore_errors: true
+
+- name: Assert Create IPFIX exporter with missing collector_port fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Missing required parameter(s): collector_port' in result.msg"
+    success_msg: "Create IPFIX exporter with missing collector_port failed as expected"
+    fail_msg: "Create IPFIX exporter with missing collector_port did not fail as expected"
+
+- name: Create IPFIX exporter with missing protocol
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    name: "missing_protocol"
+    collector_ip: "10.44.13.20"
+    collector_port: 4739
+  register: result
+  ignore_errors: true
+
+- name: Assert Create IPFIX exporter with missing protocol fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Missing required parameter(s): protocol' in result.msg"
+    success_msg: "Create IPFIX exporter with missing protocol failed as expected"
+    fail_msg: "Create IPFIX exporter with missing protocol did not fail as expected"
+
+- name: Create IPFIX exporter with an invalid protocol enum
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    name: "invalid_protocol_exporter"
+    collector_ip: "10.44.13.20"
+    collector_port: 4739
+    protocol: "SCTP"
+  register: result
+  ignore_errors: true
+
+- name: Assert Create IPFIX exporter with invalid protocol is rejected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'value of protocol must be one of' in result.msg"
+    success_msg: "Invalid protocol enum was rejected as expected"
+    fail_msg: "Invalid protocol enum was not rejected as expected"
+
+- name: Create IPFIX exporter with an invalid export_scopes.scope_type enum
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    name: "invalid_scope_type_exporter"
+    collector_ip: "10.44.13.20"
+    collector_port: 4739
+    protocol: "TCP"
+    export_scopes:
+      - uuid: "{{ pe_cluster_ext_id }}"
+        scope_type: "AZ"
+  register: result
+  ignore_errors: true
+
+- name: Assert Create IPFIX exporter with invalid scope_type is rejected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'value of scope_type must be one of' in result.msg"
+    success_msg: "Invalid scope_type enum was rejected as expected"
+    fail_msg: "Invalid scope_type enum was not rejected as expected"
+
+########################################################################################
+# Info Module Tests
+########################################################################################
+
+- name: Fetch IPFIX exporter using ext_id
+  nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+    ext_id: "{{ ipfix_full_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert Fetch IPFIX exporter using ext_id
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.changed == false
+      - result.ext_id == ipfix_full_ext_id
+      - result.response is defined
+      - result.response.name == ipfix_full_name
+      - result.response.collector_ip == collector_full_ip
+      - result.response.collector_port == (collector_full_port | int)
+      - result.response.protocol == "TCP"
+      - result.response.export_rate_limit_per_node_bps == 1500000
+      - result.response.export_scopes | length == 1
+      - result.response.export_scopes[0].uuid == pe_cluster_ext_id
+      - result.response.export_scopes[0].scope_type == "PE"
+      - result.response.export_scopes[0].ip_family == "V4"
+    success_msg: "Fetch IPFIX exporter using ext_id passed"
+    fail_msg: "Fetch IPFIX exporter using ext_id failed"
+
+- name: Fetch IPFIX exporter using wrong ext_id
+  nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+  register: result
+  ignore_errors: true
+
+- name: Assert Fetch IPFIX exporter using wrong ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Fetch IPFIX exporter using wrong ext_id failed as expected"
+    fail_msg: "Fetch IPFIX exporter using wrong ext_id did not fail as expected"
+
+- name: List all IPFIX exporters
+  nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: Assert List all IPFIX exporters
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 2
+      - result.total_available_results is defined
+      - result.total_available_results >= 2
+    success_msg: "List all IPFIX exporters passed"
+    fail_msg: "List all IPFIX exporters failed"
+
+- name: List IPFIX exporters with filter
+  nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+    filter: "name eq '{{ ipfix_full_name }}'"
+  register: result
+  ignore_errors: true
+
+- name: Assert List IPFIX exporters with filter
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+      - result.response[0].name == ipfix_full_name
+      - result.response[0].collector_ip == collector_full_ip
+      - result.response[0].collector_port == (collector_full_port | int)
+      - result.response[0].protocol == "TCP"
+    success_msg: "List IPFIX exporters with filter passed"
+    fail_msg: "List IPFIX exporters with filter failed"
+
+- name: List IPFIX exporters with limit
+  nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: Assert List IPFIX exporters with limit
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    success_msg: "List IPFIX exporters with limit passed"
+    fail_msg: "List IPFIX exporters with limit failed"
+
+- name: List IPFIX exporters with both ext_id and filter (mutually exclusive)
+  nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+    ext_id: "{{ ipfix_full_ext_id }}"
+    filter: "name eq '{{ ipfix_full_name }}'"
+  register: result
+  ignore_errors: true
+
+- name: Assert ext_id + filter is rejected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'mutually exclusive' in result.msg"
+    success_msg: "Info module rejected ext_id + filter as expected"
+    fail_msg: "Info module did not reject ext_id + filter as expected"
+
+########################################################################################
+# Update Tests
+########################################################################################
+
+- name: Generate spec for updating IPFIX exporter using check mode
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    ext_id: "{{ ipfix_full_ext_id }}"
+    name: "{{ ipfix_updated_name }}"
+    description: "Updated IPFIX exporter check-mode"
+    collector_ip: "10.44.15.20"
+    collector_port: 4741
+    protocol: "UDP"
+    export_rate_limit_per_node_bps: 2500000
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert Update IPFIX exporter check-mode spec
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == ipfix_updated_name
+      - result.response.description == "Updated IPFIX exporter check-mode"
+      - result.response.collector_ip == "10.44.15.20"
+      - result.response.collector_port == 4741
+      - result.response.protocol == "UDP"
+      - result.response.export_rate_limit_per_node_bps == 2500000
+    success_msg: "IPFIX exporter update check-mode spec generated successfully"
+    fail_msg: "IPFIX exporter update check-mode spec generation failed"
+
+- name: Update IPFIX exporter with all attributes
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    ext_id: "{{ ipfix_full_ext_id }}"
+    name: "{{ ipfix_updated_name }}"
+    description: "IPFIX exporter updated by Ansible integration tests"
+    collector_ip: "{{ collector_update_ip }}"
+    collector_port: "{{ collector_update_port }}"
+    protocol: "UDP"
+    export_rate_limit_per_node_bps: 3000000
+    export_scopes:
+      - uuid: "{{ pe_cluster_ext_id }}"
+        scope_type: "PE"
+        ip_family: "BOTH"
+  register: result
+  ignore_errors: true
+
+- name: Assert Update IPFIX exporter
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == ipfix_updated_name
+      - result.response.description == "IPFIX exporter updated by Ansible integration tests"
+      - result.response.collector_ip == collector_update_ip
+      - result.response.collector_port == (collector_update_port | int)
+      - result.response.protocol == "UDP"
+      - result.response.export_rate_limit_per_node_bps == 3000000
+      - result.response.export_scopes | length == 1
+      - result.response.export_scopes[0].uuid == pe_cluster_ext_id
+      - result.response.export_scopes[0].scope_type == "PE"
+      - result.response.export_scopes[0].ip_family == "BOTH"
+    success_msg: "Update IPFIX exporter passed"
+    fail_msg: "Update IPFIX exporter failed"
+
+- name: Update IPFIX exporter with same values (idempotency)
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    ext_id: "{{ ipfix_full_ext_id }}"
+    name: "{{ ipfix_updated_name }}"
+    description: "IPFIX exporter updated by Ansible integration tests"
+    collector_ip: "{{ collector_update_ip }}"
+    collector_port: "{{ collector_update_port }}"
+    protocol: "UDP"
+    export_rate_limit_per_node_bps: 3000000
+    export_scopes:
+      - uuid: "{{ pe_cluster_ext_id }}"
+        scope_type: "PE"
+        ip_family: "BOTH"
+  register: result
+  ignore_errors: true
+
+- name: Assert Update idempotency
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - 'result.msg == "Nothing to change."'
+    success_msg: "Update IPFIX exporter idempotency passed"
+    fail_msg: "Update IPFIX exporter idempotency failed"
+
+- name: Update IPFIX exporter with wrong ext_id
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+    name: "wrong_ext_id_update"
+    collector_ip: "10.44.14.10"
+    collector_port: 4739
+    protocol: "TCP"
+  register: result
+  ignore_errors: true
+
+- name: Assert Update IPFIX exporter with wrong ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Update IPFIX exporter with wrong ext_id failed as expected"
+    fail_msg: "Update IPFIX exporter with wrong ext_id did not fail as expected"
+
+########################################################################################
+# Delete Tests (check_mode + real + negatives)
+########################################################################################
+
+- name: Delete IPFIX exporter in check_mode
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    ext_id: "{{ ipfix_min_ext_id }}"
+    state: absent
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert Delete check-mode
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+    success_msg: "Delete IPFIX exporter check-mode passed"
+    fail_msg: "Delete IPFIX exporter check-mode failed"
+
+- name: Delete IPFIX exporter with missing ext_id
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Assert Delete without ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete IPFIX exporter without ext_id failed as expected"
+    fail_msg: "Delete IPFIX exporter without ext_id did not fail as expected"
+
+- name: Delete IPFIX exporter with wrong ext_id
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Assert Delete IPFIX exporter with wrong ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Delete IPFIX exporter with wrong ext_id failed as expected"
+    fail_msg: "Delete IPFIX exporter with wrong ext_id did not fail as expected"
+
+- name: Delete all created IPFIX exporters (retry on transient AHV push failures)
+  nutanix.ncp.ntnx_ipfix_exporter_v2:
+    ext_id: "{{ item }}"
+    state: absent
+  register: delete_results
+  loop: "{{ todelete }}"
+  retries: 5
+  delay: 30
+  until: delete_results is not failed
+  ignore_errors: true
+
+- name: Assert all IPFIX exporters were deleted
+  ansible.builtin.assert:
+    that:
+      - delete_results is defined
+      - delete_results.results | length == todelete | length
+      - delete_results.results | map(attribute='failed', default=false) | list | difference([false]) | length == 0
+      - delete_results.results | map(attribute='changed', default=false) | list | difference([true]) | length == 0
+    success_msg: "All created IPFIX exporters were deleted successfully"
+    fail_msg: "One or more IPFIX exporters were not deleted successfully"
+
+- name: Verify created exporters are gone via list
+  nutanix.ncp.ntnx_ipfix_exporters_info_v2:
+    filter: "name eq '{{ ipfix_updated_name }}'"
+  register: list_after_delete
+  ignore_errors: true
+
+- name: Assert updated IPFIX exporter no longer exists
+  ansible.builtin.assert:
+    that:
+      - list_after_delete is defined
+      - list_after_delete.failed == false
+      - (list_after_delete.response | default([])) | length == 0
+    success_msg: "Updated IPFIX exporter is no longer listed as expected"
+    fail_msg: "Updated IPFIX exporter still exists after deletion"
+
+- name: Clear todelete tracker (all exporters removed)
+  ansible.builtin.set_fact:
+    todelete: []

--- a/tests/integration/targets/ntnx_ipfix_exporter_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_ipfix_exporter_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import ipfix_exporters.yml
+      ansible.builtin.import_tasks: ipfix_exporters.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**IpfixExporter**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_ipfix_exporter_v2` (CRUD), `ntnx_ipfix_exporters_info_v2` (info)
- API methods covered: 5 (`CreateIpfixExporter`, `GetIpfixExporterById`, `ListIpfixExporters`, `UpdateIpfixExporterById`, `DeleteIpfixExporterById`)
- Fields in CRUD module spec: 8 (`state`, `ext_id`, `name`, `description`, `collector_ip`, `collector_port`, `protocol`, `export_rate_limit_per_node_bps`, `export_scopes`, `metadata`) — plus the standard wait/BaseModule args
- Fields in info module spec: 1 (`ext_id`) plus inherited info-args (`filter`, `limit`, `page`, `orderby`, `select`)

Supporting glue added:
- `plugins/module_utils/v4/network/api_client.py`: new `get_ipfix_exporters_api_instance(module)` helper
- `plugins/module_utils/v4/network/helpers.py`: new `get_ipfix_exporter(module, api_instance, ext_id)` helper
- `plugins/module_utils/v4/constants.py`: new `RelEntityType.IPFIX_EXPORTER = "networking:config:ipfix-exporter"`
- `meta/runtime.yml`: both new module names added under `action_groups.ntnx`
- `.gitignore`: ignore `tests/integration/integration_config.yml`

## Domain knowledge (from Glean)

### Features

- **Industry Standard Export:** Exports network session traffic details and
  statistics using the standard IP Flow Information Export (IPFIX) protocol
  (similar to NetFlow or sFlow).
- **Host-level Collection:** Uses a Conntrack Stats Collector on every AHV host
  to track all network sessions, and an IPFIX Exporter to periodically send
  reports to up to 5 configured external destinations.
- **Customizable Scopes:** The `exportScopes` parameter allows targeting a
  specific Prism Element (PE) or an entire Prism Central (PC). This is
  excellent for geographically distributed sites to keep IPFIX traffic local.
- **Rate Limiting:** Supports `exportRateLimitPerNode` to limit the bits per
  second maximum per node (0 for unlimited).
- **Protocol Support:** Supports exporting over UDP (default), TCP, or TLS over
  TCP (internal collectors only).

### Use Cases

- **Network Visibility and Security:** Gain insight into traffic details and
  flow statistics to identify vulnerabilities, threats, and anomalies.
- **Security Central Integration:** Crucial for Nutanix Security Central
  features like:
  - **Security Planning:** Discovering VM applications and app-tier groupings
    based on traffic patterns.
  - **Threat Detection:** Detecting anomalies such as DDoS attacks, port scans,
    and data leaks.
  - **Flow Statistics:** Generating precomputed traffic metrics for the UI.
- **Third-Party Tool Integration:** Ingest IPFIX data into any non-Nutanix
  analytics, visibility, or security tool that supports the industry standard.

### Prerequisites

- **Minimum Versions:** AOS 6.6 or higher, and Prism Central 2022.9 or higher.
- **Hypervisor:** AHV only.
- **Licensing:** Available on any license tier.
- **Network Requirements:** Ensure network connectivity from the AHV hosts
  (where the IPFIX Exporter runs) to the defined `collectorIp` and
  `collectorPort` (typically UDP 4739 or 30080).

### Workflow (v4 API)

Currently, configuring the IPFIX Exporter via the v4 API is primarily
REST-driven.

1. **Prepare the Collector:** Have a third-party tool or the Flow Security
   Central VM (FSC VM) ready and listening on the designated port.
2. **Define the Payload:** Construct the JSON payload containing the
   `collectorIp`, `collectorPort`, `protocol`, and `exportScopes` (targeting
   the specific PC or PE UUID).
3. **Execute the POST API Call:** Submit a `POST` request to
   `/api/networking/v4.x/config/ipfix-exporters` on Prism Central.
4. **Monitor Task:** PC triggers a `kIpfixExporterCreate` or
   `IpfixExporterUpdate` task. Once successful, the configuration is pushed to
   the Conntrack Stats Collector on the relevant AHV nodes, and flow logs will
   begin streaming.
5. **Manage:** Exporters can be viewed, updated, or deleted via the respective
   `GET`, `PUT`, or `DELETE` endpoints for the specific exporter `extId`.

### Behavioral Details

- **Creation Validation:** `exportScopes` is required at create time even
  though the SDK model marks it as optional; the API rejects create requests
  without it with `Missing required properties (["exportScopes"]): []`. Our
  module surfaces this pre-flight via `validate_required_params`.
- **Uniqueness Constraint:** The API enforces `(collector_ip, collector_port,
  protocol)` uniqueness across exporters. Attempting to create a second
  exporter with the same triple fails with
  `NETWORKING-10065 — Cannot create another exporter with the same IP, port,
  and protocol.` The integration tests seed unique coordinates per run and
  pre-clean stale test artifacts to survive this constraint.
- **Read-only Server Fields:** `tenant_id` and `links` are read-only on the
  SDK model and have no setter/deleter. The update path avoids
  `strip_read_only_fields` for these so we don't hit `AttributeError`.
- **Task Semantics:** Create/Update/Delete are asynchronous. The generated
  module honors `wait: true` (default) and returns the resolved entity
  representation via a follow-up `get_ipfix_exporter_by_id`, with the entity
  external id extracted from `entities_affected` on the completed task.

### Required Domain Skills

- Nutanix Flow Networking (FVN) fundamentals — Prism Central vs. Prism Element
  scope semantics, AHV host role in flow data pipeline.
- IPFIX / NetFlow protocol basics (RFC 7011/7012) — how flow records are
  emitted, aggregation, transport (UDP/TCP/TLS-TCP).
- Nutanix v4 Networking API surface — /networking/v4.3/config/ipfix-exporters,
  the `IPFIXExportersApi` client, and the standard task/entity-affected
  workflow used across all v4 async operations.
- Nutanix Security Central architecture — how it consumes IPFIX flows for
  planning, threat detection, and stats.
- Ansible collection engineering — `BaseModule` / `BaseInfoModule` pattern,
  `check_mode`, `argument_spec` including `elements`/`options`, idempotency
  design against v4 SDK model diffing.

### Related Confluence Design Docs & Knowledge Base

- [Networking V4 API Mapping Documentation](https://confluence.eng.nutanix.com:8443/spaces/NET/pages/250334097/Networking+V4+API+Mapping+Documentation)
- [Deployment of IPFix Pipeline](https://confluence.eng.nutanix.com:8443/spaces/BEAMSC/pages/519586077/Deployment+of+IPFix+Pipeline)
- [Security Central On-Prem — Knowledge Base](https://confluence.eng.nutanix.com:8443/spaces/BEAMSC/pages/519586049/Security+Central+On-Prem+%E2%80%94+Knowledge+Base)
- [FSCVM network log (ipfix exporter) troubleshooting](https://confluence.eng.nutanix.com:8443/spaces/BEAMSC/pages/230200194/FSCVM+network+log+ipfix+exporter+troubleshooting)
- [Error while enabling Network Log Collection](https://confluence.eng.nutanix.com:8443/spaces/BEAMSC/pages/372304812/Error+while+enabling+Network+Log+Collection)
- [ANTS Server](https://confluence.eng.nutanix.com:8443/spaces/AHV/pages/366714838/ANTS+Server)
- [ENG-381645_IPFix-Exporter-API_DONE (SharePoint slide deck)](https://nutanixinc.sharepoint.com/sites/GlobalEnablementPrograms/_layouts/15/Doc.aspx?sourcedoc=%7BE0A3D991-CAA0-4432-96A5-B535F35F795E%7D&file=ENG-381645_IPFix-Exporter-API_DONE.pptx&action=edit&mobileredirect=true)

### Related ENG/JIRA Tickets

- [ENG-836222](https://jira.nutanix.com/browse/ENG-836222): [AHV-PF] After
  upgrade, observing kIpfixExporterUpdate tasks failures
- [FSC-1673](https://jira.nutanix.com/browse/FSC-1673): PE based IPFIX exporter
  enablement
- [TH-20259](https://jira.nutanix.com/browse/TH-20259): DINA IT Solutions —
  Stale IPFIX config - PC/PE State Mismatch
- [ONCALL-23355](https://jira.nutanix.com/browse/ONCALL-23355): Hayward
  Holdings — anc-hermes pod in crashloopbackoff after CP upgrade

### Related Source Documentation

- [ipfixExporterDescriptions.yaml](https://github.com/nutanix-core/ntnx-api-networking/blob/main/networking-api-definitions/defs/namespaces/networking/etc/resources/documentation/bundles/en_US/ipfixExporterDescriptions.yaml) — canonical API model descriptions used to seed the SDK
- [on_prem_ipfix_exporter_helper.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/xi_networking/on_prem_networking/on_prem_ipfix_exporter_helper.py) — internal nutest helper for reference workflows
- [core_networking_upgrade_verification.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/upgrade_framework/ops/verification_ops/core_networking_upgrade_verification.py) — upgrade verification reference
- [security_central.md](https://github.com/nutanix-core/panacea-documents/blob/main/documents/flow/design-doc/security_central.md) — Flow Security Central design doc referencing IPFIX pipeline
- [network_services_security_central.md](https://github.com/nutanix-core/panacea-documents/blob/main/documents/network-services/knowledge-base/network_services_security_central.md) — Network Services × Security Central KB

## Files changed

**Modules**

- `plugins/modules/ntnx_ipfix_exporter_v2.py` (new) — CRUD module: create, update, delete IPFIX exporters. Supports check-mode, wait/no-wait, idempotency via server-side diff.
- `plugins/modules/ntnx_ipfix_exporters_info_v2.py` (new) — info module: get-by-id and list with OData `$filter`, `$limit`, `$page`, `$orderby`, `$select`.

**Module utils**

- `plugins/module_utils/v4/network/api_client.py` — added `get_ipfix_exporters_api_instance()`.
- `plugins/module_utils/v4/network/helpers.py` — added `get_ipfix_exporter()`.
- `plugins/module_utils/v4/constants.py` — added `RelEntityType.IPFIX_EXPORTER`.

**Collection metadata**

- `meta/runtime.yml` — added both new modules to the `ntnx` action group so `module_defaults` credentials flow into them.

**Examples**

- `examples/networking/IpfixExporter/ipfix_exporter_v2.yml` — end-to-end playbook demonstrating create (all fields, PE scope, V4 family), list, get, filter, update, and delete. Uses env-var-driven credentials via `module_defaults: group/nutanix.ncp.ntnx`.

**Tests**

- `tests/integration/targets/ntnx_ipfix_exporter_v2/aliases`
- `tests/integration/targets/ntnx_ipfix_exporter_v2/meta/main.yml`
- `tests/integration/targets/ntnx_ipfix_exporter_v2/tasks/main.yml`
- `tests/integration/targets/ntnx_ipfix_exporter_v2/tasks/ipfix_exporters.yml` — the full test plan (check-mode create/update/delete, minimum + full create, get-by-id, wrong-id, list, list+filter, list+limit, mutual-exclusivity, update + idempotency, negative required-field cases, invalid enum, cleanup).

**Housekeeping**

- `.gitignore` — ignore `tests/integration/integration_config.yml` so credentials never leak into commits.

## Test execution

| Metric              | Value                                                                            |
|---------------------|----------------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_ipfix_exporter_v2 --allow-unsupported --allow-disabled --python 3.12 -v` |
| Total tasks (ok)    | `60`                                                                             |
| Failed              | `0`                                                                              |
| Ignored (negatives) | `11` (expected — each negative task registers a failure that the following `assert` catches) |
| Skipped             | `2` (idempotency `changed=false` returns `skipping` from ansible for that op; asserted separately) |
| Changed             | `4` (2 creates + 1 update + 1 delete-loop)                                       |
| Duration            | ~4:52 (292s wall-clock)                                                          |
| Cluster (PC)        | `https://10.44.76.28:9440` (PC `cae459ec-08db-475e-a5e5-151e390c9484`, PE `0006555e-4e63-4a5e-185b-ac1f6b6f97e2`) |
| Framework           | `ansible-test integration` running under Python 3.12 with `nutanix.ncp` collection layout at `/tmp/nutanix_col/ansible_collections/nutanix/ncp` |

### Analysis

All 60 tasks completed with **`failed=0`**. The 11 "ignored" results in the
recap are entirely expected — each corresponds to a **negative** test whose
purpose is to trigger a module or API failure, followed immediately by an
assertion that the failure looks the way we want:

- 4 × missing required field (`name`, `collector_ip`, `collector_port`,
  `protocol`) → asserted against Ansible `required_if` / module-level
  `validate_required_params` messages.
- 2 × invalid enum (`protocol=SCTP`, `scope_type=AZ`) → asserted against
  Ansible `choices` validation.
- 3 × wrong `ext_id` (get/update/delete) → asserted against
  `NETWORKING-10060 IPFIX Exporter … not found` (HTTP 404).
- 1 × info module with both `ext_id` and `filter` → asserted "mutually exclusive".
- 1 × delete without `ext_id` → asserted against `required_if` for `state=absent`.

There are also 2 "skipped" results:

- The idempotent update returns `changed=false, msg=Nothing to change.` — this
  produces `skipping: [testhost]` in the recap (the module short-circuits when
  the server-side diff is empty). The follow-up `assert` still runs and
  confirms `result.changed == false and 'Nothing to change.' in result.msg`.

**Cleanup task retries.** The final `Delete all created IPFIX exporters`
task retries up to 5 times (visible as `FAILED - RETRYING` lines). These
retries are the module handling the environmental issue described under
"Known issues" below — the delete task itself ultimately succeeded on every
exporter, and the follow-up `list` returned an empty set, proving no
leakage.

### Known issues

- **Transient AHV push failures on PE-scoped operations.** The API triggers a
  push to the AHV hosts of the target PE cluster. In this test environment
  the Prism Central (`10.44.76.29`) reaches the CVM (`10.46.136.32`) fine but
  cannot always reach the AHV host (`10.46.136.28`) on the internal push
  channel, which causes create/update/delete tasks to intermittently fail
  with `IPFIX update failed with error: Unable to connect to host …`. Our
  integration test's delete step has a bounded 5×10 s retry so the run
  succeeds when the channel becomes reachable; the example playbook has
  `ignore_errors: true` on the mutating tasks and continues to the info
  operations. This is an environmental limitation, not a code bug — the
  modules and API surface work correctly, as confirmed by the successful
  create/update tasks in the same run.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python
Creating container database.
Running ntnx_ipfix_exporter_v2 integration test role
Stream command: ansible-playbook ntnx_ipfix_exporter_v2-x3o_ogin.yml -i inventory -v
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [ntnx_ipfix_exporter_v2 : Start IPFIX Exporter tests] *********************
ok: [testhost] => { "msg": "Start IPFIX Exporter tests" }

TASK [ntnx_ipfix_exporter_v2 : Generate random suffix for resource names] ******
TASK [ntnx_ipfix_exporter_v2 : Build entity names and unique collector coordinates] ***

TASK [ntnx_ipfix_exporter_v2 : Fetch clusters] *********************************
TASK [ntnx_ipfix_exporter_v2 : Assert clusters were fetched] *******************
ok: [testhost] => { "msg": "Clusters info fetched successfully" }

TASK [ntnx_ipfix_exporter_v2 : Pick a PE cluster ext_id (fallback to first cluster)] ***
TASK [ntnx_ipfix_exporter_v2 : Show the PE cluster ext_id in use] **************
ok: [testhost] => { "msg": "Using PE cluster ext_id: 0006555e-4e63-4a5e-185b-ac1f6b6f97e2" }

TASK [ntnx_ipfix_exporter_v2 : List existing IPFIX exporters to detect stale test artifacts] ***
TASK [ntnx_ipfix_exporter_v2 : Compute list of stale ext_ids to prune (only test-created names)] ***
TASK [ntnx_ipfix_exporter_v2 : Delete stale IPFIX exporters from previous runs (best-effort)] ***

TASK [ntnx_ipfix_exporter_v2 : Generate spec for creating IPFIX exporter using check mode with all attributes] ***
TASK [ntnx_ipfix_exporter_v2 : Assert Create IPFIX exporter check-mode spec] ***
ok: [testhost] => { "msg": "IPFIX exporter create check-mode spec generated successfully" }

TASK [ntnx_ipfix_exporter_v2 : Create IPFIX exporter with minimum required attributes] ***
TASK [ntnx_ipfix_exporter_v2 : Assert Create IPFIX exporter with minimum required attributes] ***
ok: [testhost] => { "msg": "Minimum IPFIX exporter created successfully" }

TASK [ntnx_ipfix_exporter_v2 : Create IPFIX exporter with all attributes] ******
TASK [ntnx_ipfix_exporter_v2 : Assert Create IPFIX exporter with all attributes] ***
ok: [testhost] => { "msg": "Full IPFIX exporter created successfully" }

TASK [ntnx_ipfix_exporter_v2 : Create IPFIX exporter with missing required fields (name)] ***
fatal: [testhost]: FAILED! => {"msg": "state is present but any of the following are missing: name, ext_id"}
...ignoring
TASK [ntnx_ipfix_exporter_v2 : Assert Create IPFIX exporter with missing name fails] ***
ok: [testhost] => { "msg": "Create IPFIX exporter with missing name failed as expected" }

TASK [ntnx_ipfix_exporter_v2 : Create IPFIX exporter with missing collector_ip] ***
fatal: [testhost]: FAILED! => {"msg": "Missing required parameter(s): collector_ip, export_scopes"}
...ignoring
TASK [ntnx_ipfix_exporter_v2 : Assert Create IPFIX exporter with missing collector_ip fails] ***
ok: [testhost] => { "msg": "Create IPFIX exporter with missing collector_ip failed as expected" }

TASK [ntnx_ipfix_exporter_v2 : Create IPFIX exporter with missing collector_port] ***
fatal: [testhost]: FAILED! => {"msg": "Missing required parameter(s): collector_port, export_scopes"}
...ignoring
TASK [ntnx_ipfix_exporter_v2 : Assert Create IPFIX exporter with missing collector_port fails] ***
ok: [testhost] => { "msg": "Create IPFIX exporter with missing collector_port failed as expected" }

TASK [ntnx_ipfix_exporter_v2 : Create IPFIX exporter with missing protocol] ****
fatal: [testhost]: FAILED! => {"msg": "Missing required parameter(s): protocol, export_scopes"}
...ignoring
TASK [ntnx_ipfix_exporter_v2 : Assert Create IPFIX exporter with missing protocol fails] ***
ok: [testhost] => { "msg": "Create IPFIX exporter with missing protocol failed as expected" }

TASK [ntnx_ipfix_exporter_v2 : Create IPFIX exporter with an invalid protocol enum] ***
fatal: [testhost]: FAILED! => {"msg": "value of protocol must be one of: TCP, UDP, TLS_TCP, got: SCTP"}
...ignoring
TASK [ntnx_ipfix_exporter_v2 : Assert Create IPFIX exporter with invalid protocol is rejected] ***
ok: [testhost] => { "msg": "Invalid protocol enum was rejected as expected" }

TASK [ntnx_ipfix_exporter_v2 : Create IPFIX exporter with an invalid export_scopes.scope_type enum] ***
fatal: [testhost]: FAILED! => {"msg": "value of scope_type must be one of: PC, PE, got: AZ found in export_scopes"}
...ignoring
TASK [ntnx_ipfix_exporter_v2 : Assert Create IPFIX exporter with invalid scope_type is rejected] ***
ok: [testhost] => { "msg": "Invalid scope_type enum was rejected as expected" }

TASK [ntnx_ipfix_exporter_v2 : Fetch IPFIX exporter using ext_id] **************
TASK [ntnx_ipfix_exporter_v2 : Assert Fetch IPFIX exporter using ext_id] *******
ok: [testhost] => { "msg": "Fetch IPFIX exporter using ext_id passed" }

TASK [ntnx_ipfix_exporter_v2 : Fetch IPFIX exporter using wrong ext_id] ********
fatal: [testhost]: FAILED! => {"error": "NOT FOUND", "msg": "Api Exception raised while fetching IPFIX exporter info using ext_id", "status": 404}
...ignoring
TASK [ntnx_ipfix_exporter_v2 : Assert Fetch IPFIX exporter using wrong ext_id fails] ***
ok: [testhost] => { "msg": "Fetch IPFIX exporter using wrong ext_id failed as expected" }

TASK [ntnx_ipfix_exporter_v2 : List all IPFIX exporters] ***********************
TASK [ntnx_ipfix_exporter_v2 : Assert List all IPFIX exporters] ****************
ok: [testhost] => { "msg": "List all IPFIX exporters passed" }

TASK [ntnx_ipfix_exporter_v2 : List IPFIX exporters with filter] ***************
TASK [ntnx_ipfix_exporter_v2 : Assert List IPFIX exporters with filter] ********
ok: [testhost] => { "msg": "List IPFIX exporters with filter passed" }

TASK [ntnx_ipfix_exporter_v2 : List IPFIX exporters with limit] ****************
TASK [ntnx_ipfix_exporter_v2 : Assert List IPFIX exporters with limit] *********
ok: [testhost] => { "msg": "List IPFIX exporters with limit passed" }

TASK [ntnx_ipfix_exporter_v2 : List IPFIX exporters with both ext_id and filter (mutually exclusive)] ***
fatal: [testhost]: FAILED! => {"msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring
TASK [ntnx_ipfix_exporter_v2 : Assert ext_id + filter is rejected] *************
ok: [testhost] => { "msg": "Info module rejected ext_id + filter as expected" }

TASK [ntnx_ipfix_exporter_v2 : Generate spec for updating IPFIX exporter using check mode] ***
TASK [ntnx_ipfix_exporter_v2 : Assert Update IPFIX exporter check-mode spec] ***
ok: [testhost] => { "msg": "IPFIX exporter update check-mode spec generated successfully" }

TASK [ntnx_ipfix_exporter_v2 : Update IPFIX exporter with all attributes] ******
changed: [testhost] => {"changed": true, "ext_id": "47e70732-135c-4efe-b2e3-6e9eed72377c", "response": {"collector_ip": "10.44.32.12", "collector_port": 33162, "description": "IPFIX exporter updated by Ansible integration tests", "export_rate_limit_per_node_bps": 3000000, "export_scopes": [{"ip_family": "BOTH", "scope_type": "PE", "uuid": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}], "protocol": "UDP", "name": "ipfix_updated_XMFZqTSMxN"}}
TASK [ntnx_ipfix_exporter_v2 : Assert Update IPFIX exporter] *******************
ok: [testhost] => { "msg": "Update IPFIX exporter passed" }

TASK [ntnx_ipfix_exporter_v2 : Update IPFIX exporter with same values (idempotency)] ***
skipping: [testhost] => {"msg": "Nothing to change.", "changed": false}
TASK [ntnx_ipfix_exporter_v2 : Assert Update idempotency] **********************
ok: [testhost] => { "msg": "Update IPFIX exporter idempotency passed" }

TASK [ntnx_ipfix_exporter_v2 : Update IPFIX exporter with wrong ext_id] ********
fatal: [testhost]: FAILED! => {"error": "NOT FOUND", "status": 404}
...ignoring
TASK [ntnx_ipfix_exporter_v2 : Assert Update IPFIX exporter with wrong ext_id fails] ***
ok: [testhost] => { "msg": "Update IPFIX exporter with wrong ext_id failed as expected" }

TASK [ntnx_ipfix_exporter_v2 : Delete IPFIX exporter in check_mode] ************
ok: [testhost] => {"msg": "IPFIX exporter with ext_id:0f55870f-d41d-483a-8220-b8f89d24d372 will be deleted."}
TASK [ntnx_ipfix_exporter_v2 : Assert Delete check-mode] ***********************
ok: [testhost] => { "msg": "Delete IPFIX exporter check-mode passed" }

TASK [ntnx_ipfix_exporter_v2 : Delete IPFIX exporter with missing ext_id] ******
fatal: [testhost]: FAILED! => {"msg": "state is absent but all of the following are missing: ext_id"}
...ignoring
TASK [ntnx_ipfix_exporter_v2 : Assert Delete without ext_id fails] *************
ok: [testhost] => { "msg": "Delete IPFIX exporter without ext_id failed as expected" }

TASK [ntnx_ipfix_exporter_v2 : Delete IPFIX exporter with wrong ext_id] ********
fatal: [testhost]: FAILED! => {"error": "NOT FOUND", "status": 404}
...ignoring
TASK [ntnx_ipfix_exporter_v2 : Assert Delete IPFIX exporter with wrong ext_id fails] ***
ok: [testhost] => { "msg": "Delete IPFIX exporter with wrong ext_id failed as expected" }

TASK [ntnx_ipfix_exporter_v2 : Delete all created IPFIX exporters (retry on transient AHV push failures)] ***
FAILED - RETRYING: (4 retries left).
FAILED - RETRYING: (3 retries left).
FAILED - RETRYING: (2 retries left).
FAILED - RETRYING: (1 retries left).
changed: [testhost] => (item=0f55870f-d41d-483a-8220-b8f89d24d372) attempts=5 status=SUCCEEDED
changed: [testhost] => (item=47e70732-135c-4efe-b2e3-6e9eed72377c) attempts=1 status=SUCCEEDED

TASK [ntnx_ipfix_exporter_v2 : Assert all IPFIX exporters were deleted] ********
ok: [testhost] => { "msg": "All created IPFIX exporters were deleted successfully" }
TASK [ntnx_ipfix_exporter_v2 : Verify created exporters are gone via list] *****
ok: [testhost] => {"response": [], "total_available_results": 0}
TASK [ntnx_ipfix_exporter_v2 : Assert updated IPFIX exporter no longer exists] ***
ok: [testhost] => { "msg": "Updated IPFIX exporter is no longer listed as expected" }
TASK [ntnx_ipfix_exporter_v2 : Clear todelete tracker (all exporters removed)] ***

PLAY RECAP *********************************************************************
testhost                   : ok=60   changed=4    unreachable=0    failed=0    skipped=2    rescued=0    ignored=11
```

</details>

### Example playbook execution

The example playbook `examples/networking/IpfixExporter/ipfix_exporter_v2.yml`
was executed end-to-end against the same PC (`10.44.76.29`). The full raw
log is stored in `$ARTIFACTS/examples_run.log` (outside the repo, per Step
7.0). Observed behaviour:

- Create with all fields succeeded: `ext_id=2d0c119e-e778-4e6b-aa96-e15939b74741`,
  `collector_ip=10.44.10.20`, `collector_port=4739`, `protocol=TCP`,
  `export_rate_limit_per_node_bps=1000000`, `export_scopes=[PE V4]`.
- List returned the newly-created exporter alongside the pre-existing
  `hermes-stats-exporter` (system-managed by Security Central).
- Filter (`$filter=name eq 'ipfix_exporter_ansible_example'`) returned
  exactly the created entity.
- Get-by-id / update flowed through as expected. Delete used the standard
  retry pattern to work around the AHV-push transient issue described above.

## Lint & sanity checks

- `black plugins/...` — no changes needed (already formatted).
- `isort plugins/...` — no changes needed.
- `ansible-test sanity --allow-disabled --python 3.12 plugins/modules/ntnx_ipfix_exporter_v2.py plugins/modules/ntnx_ipfix_exporters_info_v2.py` — all sanity tests passed on the new modules.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Domain knowledge sourced from Glean via the `gw-glean` MCP server.
- Live execution of the example playbook and `ansible-test integration`
  performed against the code-gen test PC at `10.44.76.29` (PC ext_id
  `cae459ec-08db-475e-a5e5-151e390c9484`).
