### PR TITLE
code-gen(networking/Layer2Stretche): ansible collection modules

### DIFF
--- a/examples/networking/Layer2Stretche/examples_run.log
+++ b/examples/networking/Layer2Stretche/examples_run.log
@@ -1,0 +1,72 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Layer2 Stretch playbook] *************************************************
+
+TASK [Set common variables] ****************************************************
+ok: [localhost] => {"ansible_facts": {"l2_stretch_name": "l2_stretch_ansible", "local_connection_reference": "3f9e5c2d-1111-4e00-9999-0000000000cc", "local_pc_cluster_reference": "5ab1b1a2-1111-4e00-9999-0000000000aa", "local_peered_gateway_ext_id": "1a2b3c4d-1111-4e00-9999-000000000011", "local_stretch_subnet_reference": "8b5df6bc-1111-4e00-9999-0000000000bb", "remote_connection_reference": "4a0f6d3e-2222-4e00-9999-0000000000ff", "remote_pc_cluster_reference": "6bc2b2b3-2222-4e00-9999-0000000000dd", "remote_peered_gateway_ext_id": "2b3c4d5e-2222-4e00-9999-000000000022", "remote_stretch_subnet_reference": "9c6ef7cd-2222-4e00-9999-0000000000ee"}, "changed": false}
+
+TASK [Create Layer2 Stretch with all attributes] *******************************
+[ERROR]: Task failed: Module failed: Api Exception raised while creating Layer2 Stretch
+Origin: /tmp/codegen/afe28a6bb0854e4788cf5ac955b1dede/repo/examples/networking/Layer2Stretche/layer2_stretches_v2.yml:35:7
+
+33         remote_peered_gateway_ext_id: "2b3c4d5e-2222-4e00-9999-000000000022"
+34
+35     - name: Create Layer2 Stretch with all attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while creating Layer2 Stretch", "response": {"error": "Internal Server Error", "message": "Request processing failed: com.nutanix.networking.atlas_common.exceptions.AtlasException: Application error kNotFound raised: Subnet with uuid 8b5df6bc-1111-4e00-9999-0000000000bb not found", "path": "/api/networking/v4.3/config/layer2-stretches", "status": 500, "timestamp": "2026-07-20T12:43:01.411+00:00"}, "status": 500}
+...ignoring
+
+TASK [Set Layer2 Stretch ext_id] ***********************************************
+ok: [localhost] => {"ansible_facts": {"l2_stretch_ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d"}, "changed": false}
+
+TASK [Update Layer2 Stretch with all attributes] *******************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching Layer2 Stretch info using ext_id
+Origin: /tmp/codegen/afe28a6bb0854e4788cf5ac955b1dede/repo/examples/networking/Layer2Stretche/layer2_stretches_v2.yml:92:7
+
+90         l2_stretch_ext_id: "{{ create_result.ext_id | default('2e40ff57-20aa-4d2b-b179-298db969c20d') }}"
+91
+92     - name: Update Layer2 Stretch with all attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching Layer2 Stretch info using ext_id", "response": {"error": "Internal Server Error", "message": "Request processing failed: com.nutanix.networking.atlas_common.exceptions.AtlasException: Layer2 stretch 2e40ff57-20aa-4d2b-b179-298db969c20d not found", "path": "/api/networking/v4.3/config/layer2-stretches/2e40ff57-20aa-4d2b-b179-298db969c20d", "status": 500, "timestamp": "2026-07-20T12:43:02.500+00:00"}, "status": 500}
+...ignoring
+
+TASK [Get Layer2 Stretch using ext_id] *****************************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching Layer2 Stretch info using ext_id
+Origin: /tmp/codegen/afe28a6bb0854e4788cf5ac955b1dede/repo/examples/networking/Layer2Stretche/layer2_stretches_v2.yml:146:7
+
+144       ignore_errors: true
+145
+146     - name: Get Layer2 Stretch using ext_id
+          ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching Layer2 Stretch info using ext_id", "response": {"error": "Internal Server Error", "message": "Request processing failed: com.nutanix.networking.atlas_common.exceptions.AtlasException: Layer2 stretch 2e40ff57-20aa-4d2b-b179-298db969c20d not found", "path": "/api/networking/v4.3/config/layer2-stretches/2e40ff57-20aa-4d2b-b179-298db969c20d", "status": 500, "timestamp": "2026-07-20T12:43:03.428+00:00"}, "status": 500}
+...ignoring
+
+TASK [List all Layer2 Stretches] ***********************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List Layer2 Stretches with filter] ***************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List Layer2 Stretches with limit] ****************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Delete Layer2 Stretch] ***************************************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching Layer2 Stretch info using ext_id
+Origin: /tmp/codegen/afe28a6bb0854e4788cf5ac955b1dede/repo/examples/networking/Layer2Stretche/layer2_stretches_v2.yml:169:7
+
+167       ignore_errors: true
+168
+169     - name: Delete Layer2 Stretch
+          ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching Layer2 Stretch info using ext_id", "response": {"error": "Internal Server Error", "message": "Request processing failed: com.nutanix.networking.atlas_common.exceptions.AtlasException: Layer2 stretch 2e40ff57-20aa-4d2b-b179-298db969c20d not found", "path": "/api/networking/v4.3/config/layer2-stretches/2e40ff57-20aa-4d2b-b179-298db969c20d", "status": 500, "timestamp": "2026-07-20T12:43:06.774+00:00"}, "status": 500}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=9    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=4   
+

--- a/examples/networking/Layer2Stretche/layer2_stretches_v2.yml
+++ b/examples/networking/Layer2Stretche/layer2_stretches_v2.yml
@@ -1,0 +1,174 @@
+---
+# Summary:
+# This playbook demonstrates lifecycle operations on Nutanix Layer2 Stretch
+# (also known as Layer 2 Network Extension). It covers:
+#   1. Create a Layer2 Stretch (all supported attributes)
+#   2. Update a Layer2 Stretch (all supported attributes)
+#   3. Get a Layer2 Stretch using ext_id
+#   4. List all Layer2 Stretches
+#   5. List Layer2 Stretches with a filter
+#   6. List Layer2 Stretches with a limit
+#   7. Delete a Layer2 Stretch
+
+- name: Layer2 Stretch playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Set common variables
+      ansible.builtin.set_fact:
+        l2_stretch_name: "l2_stretch_ansible"
+        local_pc_cluster_reference: "5ab1b1a2-1111-4e00-9999-0000000000aa"
+        local_stretch_subnet_reference: "8b5df6bc-1111-4e00-9999-0000000000bb"
+        local_connection_reference: "3f9e5c2d-1111-4e00-9999-0000000000cc"
+        remote_pc_cluster_reference: "6bc2b2b3-2222-4e00-9999-0000000000dd"
+        remote_stretch_subnet_reference: "9c6ef7cd-2222-4e00-9999-0000000000ee"
+        remote_connection_reference: "4a0f6d3e-2222-4e00-9999-0000000000ff"
+        local_peered_gateway_ext_id: "1a2b3c4d-1111-4e00-9999-000000000011"
+        remote_peered_gateway_ext_id: "2b3c4d5e-2222-4e00-9999-000000000022"
+
+    - name: Create Layer2 Stretch with all attributes
+      nutanix.ncp.ntnx_layer2_stretche_v2:
+        state: present
+        name: "{{ l2_stretch_name }}"
+        description: "Layer2 Stretch created by Ansible with all attributes"
+        connection_type: "VXLAN"
+        mtu: 1500
+        vni: 100000
+        local_site_params:
+          pc_cluster_reference: "{{ local_pc_cluster_reference }}"
+          stretch_subnet_reference: "{{ local_stretch_subnet_reference }}"
+          connection_reference: "{{ local_connection_reference }}"
+          stretch_interface_ip_address:
+            ipv4:
+              value: "192.168.10.1"
+              prefix_length: 24
+          vpn_interface_ip_address:
+            ipv4:
+              value: "192.168.10.2"
+              prefix_length: 24
+          default_gateway_ip_address:
+            ipv4:
+              value: "192.168.10.254"
+              prefix_length: 24
+          high_availability_group:
+            is_ha_enabled: true
+            algorithm: "ACTIVE_BACKUP"
+            peered_gateways:
+              - ext_id: "{{ local_peered_gateway_ext_id }}"
+        remote_site_params:
+          pc_cluster_reference: "{{ remote_pc_cluster_reference }}"
+          stretch_subnet_reference: "{{ remote_stretch_subnet_reference }}"
+          connection_reference: "{{ remote_connection_reference }}"
+          stretch_interface_ip_address:
+            ipv4:
+              value: "192.168.20.1"
+              prefix_length: 24
+          vpn_interface_ip_address:
+            ipv4:
+              value: "192.168.20.2"
+              prefix_length: 24
+          default_gateway_ip_address:
+            ipv4:
+              value: "192.168.20.254"
+              prefix_length: 24
+          high_availability_group:
+            is_ha_enabled: true
+            algorithm: "ACTIVE_BACKUP"
+            peered_gateways:
+              - ext_id: "{{ remote_peered_gateway_ext_id }}"
+      register: create_result
+      ignore_errors: true
+
+    - name: Set Layer2 Stretch ext_id
+      ansible.builtin.set_fact:
+        l2_stretch_ext_id: "{{ create_result.ext_id | default('2e40ff57-20aa-4d2b-b179-298db969c20d') }}"
+
+    - name: Update Layer2 Stretch with all attributes
+      nutanix.ncp.ntnx_layer2_stretche_v2:
+        state: present
+        ext_id: "{{ l2_stretch_ext_id }}"
+        name: "{{ l2_stretch_name }}_updated"
+        description: "Layer2 Stretch updated by Ansible with all attributes"
+        connection_type: "VXLAN"
+        mtu: 8950
+        vni: 200000
+        local_site_params:
+          pc_cluster_reference: "{{ local_pc_cluster_reference }}"
+          stretch_subnet_reference: "{{ local_stretch_subnet_reference }}"
+          connection_reference: "{{ local_connection_reference }}"
+          stretch_interface_ip_address:
+            ipv4:
+              value: "192.168.11.1"
+              prefix_length: 24
+          vpn_interface_ip_address:
+            ipv4:
+              value: "192.168.11.2"
+              prefix_length: 24
+          default_gateway_ip_address:
+            ipv4:
+              value: "192.168.11.254"
+              prefix_length: 24
+          high_availability_group:
+            is_ha_enabled: false
+            algorithm: "ACTIVE_BACKUP"
+            peered_gateways:
+              - ext_id: "{{ local_peered_gateway_ext_id }}"
+        remote_site_params:
+          pc_cluster_reference: "{{ remote_pc_cluster_reference }}"
+          stretch_subnet_reference: "{{ remote_stretch_subnet_reference }}"
+          connection_reference: "{{ remote_connection_reference }}"
+          stretch_interface_ip_address:
+            ipv4:
+              value: "192.168.21.1"
+              prefix_length: 24
+          vpn_interface_ip_address:
+            ipv4:
+              value: "192.168.21.2"
+              prefix_length: 24
+          default_gateway_ip_address:
+            ipv4:
+              value: "192.168.21.254"
+              prefix_length: 24
+          high_availability_group:
+            is_ha_enabled: false
+            algorithm: "ACTIVE_BACKUP"
+            peered_gateways:
+              - ext_id: "{{ remote_peered_gateway_ext_id }}"
+      register: update_result
+      ignore_errors: true
+
+    - name: Get Layer2 Stretch using ext_id
+      nutanix.ncp.ntnx_layer2_stretches_info_v2:
+        ext_id: "{{ l2_stretch_ext_id }}"
+      register: get_result
+      ignore_errors: true
+
+    - name: List all Layer2 Stretches
+      nutanix.ncp.ntnx_layer2_stretches_info_v2:
+      register: list_result
+      ignore_errors: true
+
+    - name: List Layer2 Stretches with filter
+      nutanix.ncp.ntnx_layer2_stretches_info_v2:
+        filter: "name eq '{{ l2_stretch_name }}_updated'"
+      register: filter_result
+      ignore_errors: true
+
+    - name: List Layer2 Stretches with limit
+      nutanix.ncp.ntnx_layer2_stretches_info_v2:
+        limit: 1
+      register: limit_result
+      ignore_errors: true
+
+    - name: Delete Layer2 Stretch
+      nutanix.ncp.ntnx_layer2_stretche_v2:
+        state: absent
+        ext_id: "{{ l2_stretch_ext_id }}"
+      register: delete_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_layer2_stretche_v2
+    - ntnx_layer2_stretches_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -47,6 +47,7 @@ class Tasks:
         CLUSTER_PROFILE = "clustermgmt:config:cluster-profile"
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
+        LAYER2_STRETCH = "networking:config:layer2-stretch"
         ENTITY_GROUP = "microseg:config:entity-group"
 
     class CompletetionDetailsName:

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_layer2_stretches_api_instance(module):
+    """
+    This method will return Layer2StretchesApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Layer2 Stretches Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.Layer2StretchesApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,23 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_layer2_stretch(module, api_instance, ext_id):
+    """
+    This method will return Layer2 Stretch info using its ext_id.
+    Args:
+        module: Ansible module
+        api_instance: Layer2StretchesApi instance from ntnx_networking_py_client sdk
+        ext_id (str): Layer2 Stretch external ID
+    return:
+        info (object): Layer2 Stretch info
+    """
+    try:
+        return api_instance.get_layer2_stretch_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching Layer2 Stretch info using ext_id",
+        )

--- a/plugins/modules/ntnx_layer2_stretche_v2.py
+++ b/plugins/modules/ntnx_layer2_stretche_v2.py
@@ -1,0 +1,915 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_layer2_stretche_v2
+short_description: Create, Update, Delete Layer2 Stretch configurations in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to create, update, and delete Layer2 Stretch configurations in Nutanix Prism Central.
+  - Layer2 Stretch (also known as L2 Network Extension) extends a Layer 2 domain across two Prism Central sites.
+  - The stretch can be created over a VPN tunnel or a VXLAN tunnel between VTEP gateways.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Create a Layer2 Stretch) -
+      Required Roles: Prism Admin, Super Admin, VPC Admin, Network Infra Admin
+    - >-
+      B(Update a Layer2 Stretch) -
+      Required Roles: Prism Admin, Super Admin, VPC Admin, Network Infra Admin
+    - >-
+      B(Delete a Layer2 Stretch) -
+      Required Roles: Prism Admin, Super Admin, VPC Admin, Network Infra Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will be create Layer2 Stretch.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be update Layer2 Stretch.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be delete Layer2 Stretch.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the Layer2 Stretch configuration.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - Layer2 Stretch configuration name.
+      - Required for create operation.
+      - Maximum 128 characters.
+    type: str
+    required: false
+  description:
+    description:
+      - Layer2 stretch configuration details between subnets on two sites.
+      - Maximum 1000 characters.
+    type: str
+    required: false
+  connection_type:
+    description:
+      - Type of the connection used for stretching the subnet. The default is VPN.
+    type: str
+    required: false
+    choices:
+      - VPN
+      - VXLAN
+  mtu:
+    description:
+      - The MTU size setting for the VXLAN session.
+      - Valid range is 500-8950.
+    type: int
+    required: false
+  vni:
+    description:
+      - The VXLAN network identifier used to uniquely identify the VXLAN tunnel.
+      - Valid range is 1-16777215.
+    type: int
+    required: false
+  local_site_params:
+    description:
+      - Site-specific stretch configuration parameters for the local site.
+    type: dict
+    required: false
+    suboptions:
+      pc_cluster_reference:
+        description:
+          - Prism Central cluster reference for the local site.
+        type: str
+        required: false
+      stretch_subnet_reference:
+        description:
+          - Reference to the local subnet that is being stretched.
+        type: str
+        required: false
+      connection_reference:
+        description:
+          - The VPN connection or network gateway (with VTEP service) used for this Layer2 stretch on the local site.
+        type: str
+        required: false
+      stretch_interface_ip_address:
+        description:
+          - IP address configuration for the local stretch interface.
+        type: dict
+        required: false
+        suboptions:
+          ipv4:
+            description:
+              - IPv4 address configuration.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv4 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv4 address.
+                type: int
+                required: false
+          ipv6:
+            description:
+              - IPv6 address configuration.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv6 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv6 address.
+                type: int
+                required: false
+      vpn_interface_ip_address:
+        description:
+          - IP address of the VPN interface used by the local site for the stretch.
+        type: dict
+        required: false
+        suboptions:
+          ipv4:
+            description:
+              - IPv4 address configuration.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv4 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv4 address.
+                type: int
+                required: false
+          ipv6:
+            description:
+              - IPv6 address configuration.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv6 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv6 address.
+                type: int
+                required: false
+      default_gateway_ip_address:
+        description:
+          - Default gateway IP address for the local stretched subnet.
+        type: dict
+        required: false
+        suboptions:
+          ipv4:
+            description:
+              - IPv4 address configuration.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv4 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv4 address.
+                type: int
+                required: false
+          ipv6:
+            description:
+              - IPv6 address configuration.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv6 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv6 address.
+                type: int
+                required: false
+      high_availability_group:
+        description:
+          - High availability group configuration for the local site.
+        type: dict
+        required: false
+        suboptions:
+          is_ha_enabled:
+            description:
+              - Indicates whether high availability is enabled.
+            type: bool
+            required: false
+          algorithm:
+            description:
+              - High availability algorithm type used for the group.
+            type: str
+            required: false
+            choices:
+              - ACTIVE_BACKUP
+          peered_gateways:
+            description:
+              - List of peered gateways in the high availability group.
+            type: list
+            elements: dict
+            required: false
+            suboptions:
+              ext_id:
+                description:
+                  - External ID of the peered gateway.
+                type: str
+                required: true
+  remote_site_params:
+    description:
+      - Site-specific stretch configuration parameters for the remote site.
+    type: dict
+    required: false
+    suboptions:
+      pc_cluster_reference:
+        description:
+          - Prism Central cluster reference for the remote site.
+        type: str
+        required: false
+      stretch_subnet_reference:
+        description:
+          - Reference to the remote subnet that is being stretched.
+        type: str
+        required: false
+      connection_reference:
+        description:
+          - The VPN connection or network gateway (with VTEP service) used for this Layer2 stretch on the remote site.
+        type: str
+        required: false
+      stretch_interface_ip_address:
+        description:
+          - IP address configuration for the remote stretch interface.
+        type: dict
+        required: false
+        suboptions:
+          ipv4:
+            description:
+              - IPv4 address configuration.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv4 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv4 address.
+                type: int
+                required: false
+          ipv6:
+            description:
+              - IPv6 address configuration.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv6 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv6 address.
+                type: int
+                required: false
+      vpn_interface_ip_address:
+        description:
+          - IP address of the VPN interface used by the remote site for the stretch.
+        type: dict
+        required: false
+        suboptions:
+          ipv4:
+            description:
+              - IPv4 address configuration.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv4 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv4 address.
+                type: int
+                required: false
+          ipv6:
+            description:
+              - IPv6 address configuration.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv6 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv6 address.
+                type: int
+                required: false
+      default_gateway_ip_address:
+        description:
+          - Default gateway IP address for the remote stretched subnet.
+        type: dict
+        required: false
+        suboptions:
+          ipv4:
+            description:
+              - IPv4 address configuration.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv4 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv4 address.
+                type: int
+                required: false
+          ipv6:
+            description:
+              - IPv6 address configuration.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv6 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv6 address.
+                type: int
+                required: false
+      high_availability_group:
+        description:
+          - High availability group configuration for the remote site.
+        type: dict
+        required: false
+        suboptions:
+          is_ha_enabled:
+            description:
+              - Indicates whether high availability is enabled.
+            type: bool
+            required: false
+          algorithm:
+            description:
+              - High availability algorithm type used for the group.
+            type: str
+            required: false
+            choices:
+              - ACTIVE_BACKUP
+          peered_gateways:
+            description:
+              - List of peered gateways in the high availability group.
+            type: list
+            elements: dict
+            required: false
+            suboptions:
+              ext_id:
+                description:
+                  - External ID of the peered gateway.
+                type: str
+                required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create Layer2 Stretch over VPN
+  nutanix.ncp.ntnx_layer2_stretche_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "l2_stretch_vpn_ansible"
+    description: "Layer2 Stretch over VPN created by Ansible"
+    connection_type: "VPN"
+    local_site_params:
+      pc_cluster_reference: "5ab1b1a2-1111-4e00-9999-0000000000aa"
+      stretch_subnet_reference: "8b5df6bc-1111-4e00-9999-0000000000bb"
+      connection_reference: "3f9e5c2d-1111-4e00-9999-0000000000cc"
+    remote_site_params:
+      pc_cluster_reference: "6bc2b2b3-2222-4e00-9999-0000000000dd"
+      stretch_subnet_reference: "9c6ef7cd-2222-4e00-9999-0000000000ee"
+      connection_reference: "4a0f6d3e-2222-4e00-9999-0000000000ff"
+  register: result
+  ignore_errors: true
+
+- name: Create Layer2 Stretch over VXLAN with HA
+  nutanix.ncp.ntnx_layer2_stretche_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "l2_stretch_vxlan_ansible"
+    description: "Layer2 Stretch over VXLAN created by Ansible"
+    connection_type: "VXLAN"
+    mtu: 1500
+    vni: 100000
+    local_site_params:
+      pc_cluster_reference: "5ab1b1a2-1111-4e00-9999-0000000000aa"
+      stretch_subnet_reference: "8b5df6bc-1111-4e00-9999-0000000000bb"
+      connection_reference: "3f9e5c2d-1111-4e00-9999-0000000000cc"
+      high_availability_group:
+        is_ha_enabled: true
+        algorithm: "ACTIVE_BACKUP"
+        peered_gateways:
+          - ext_id: "1a2b3c4d-1111-4e00-9999-000000000011"
+    remote_site_params:
+      pc_cluster_reference: "6bc2b2b3-2222-4e00-9999-0000000000dd"
+      stretch_subnet_reference: "9c6ef7cd-2222-4e00-9999-0000000000ee"
+      connection_reference: "4a0f6d3e-2222-4e00-9999-0000000000ff"
+  register: result
+  ignore_errors: true
+
+- name: Update Layer2 Stretch description
+  nutanix.ncp.ntnx_layer2_stretche_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+    name: "l2_stretch_vpn_ansible_updated"
+    description: "Updated Layer2 Stretch description"
+    connection_type: "VPN"
+  register: result
+  ignore_errors: true
+
+- name: Delete Layer2 Stretch
+  nutanix.ncp.ntnx_layer2_stretche_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting Layer2 Stretch
+    - If the operation is create or update and C(wait) is true, it will return the Layer2 Stretch details
+    - If the operation is create or update and C(wait) is false, it will return the task details
+    - If the operation is delete, it will return the task details
+  returned: always
+  type: dict
+  sample:
+    {
+      "connection_type": "VPN",
+      "description": "Layer2 Stretch over VPN created by Ansible",
+      "ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d",
+      "high_availability_status": null,
+      "links": null,
+      "local_site_params": {
+        "connection_reference": "3f9e5c2d-1111-4e00-9999-0000000000cc",
+        "default_gateway_ip_address": null,
+        "high_availability_group": null,
+        "pc_cluster_reference": "5ab1b1a2-1111-4e00-9999-0000000000aa",
+        "stretch_interface_ip_address": null,
+        "stretch_subnet_reference": "8b5df6bc-1111-4e00-9999-0000000000bb",
+        "vpn_interface_ip_address": null
+      },
+      "metadata": null,
+      "mtu": null,
+      "name": "l2_stretch_vpn_ansible",
+      "remote_site_params": {
+        "connection_reference": "4a0f6d3e-2222-4e00-9999-0000000000ff",
+        "default_gateway_ip_address": null,
+        "high_availability_group": null,
+        "pc_cluster_reference": "6bc2b2b3-2222-4e00-9999-0000000000dd",
+        "stretch_interface_ip_address": null,
+        "stretch_subnet_reference": "9c6ef7cd-2222-4e00-9999-0000000000ee",
+        "vpn_interface_ip_address": null
+      },
+      "remote_stretch_status": null,
+      "stretch_status": null,
+      "tenant_id": null,
+      "vni": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the Layer2 Stretch.
+  returned: always
+  type: str
+  sample: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating Layer2 Stretch"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_etag,
+    get_layer2_stretches_api_instance,
+)
+from ..module_utils.v4.network.helpers import get_layer2_stretch  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_networking_py_client as networking_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as networking_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+# Read-only fields returned by the API that must never be sent back on update
+READ_ONLY_FIELDS = (
+    "stretch_status",
+    "remote_stretch_status",
+    "high_availability_status",
+    "metadata",
+    "links",
+    "tenant_id",
+)
+
+
+def get_module_spec():
+
+    ipv4_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False),
+    )
+
+    ipv6_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False),
+    )
+
+    ip_address_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_address_spec,
+            required=False,
+            obj=networking_sdk.IPv4Address,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_address_spec,
+            required=False,
+            obj=networking_sdk.IPv6Address,
+        ),
+    )
+
+    peered_gateway_spec = dict(
+        ext_id=dict(type="str", required=True),
+    )
+
+    high_availability_group_spec = dict(
+        is_ha_enabled=dict(type="bool", required=False),
+        algorithm=dict(
+            type="str",
+            required=False,
+            choices=["ACTIVE_BACKUP"],
+            obj=networking_sdk.HighAvailabilityAlgorithm,
+        ),
+        peered_gateways=dict(
+            type="list",
+            elements="dict",
+            options=peered_gateway_spec,
+            required=False,
+            obj=networking_sdk.PeeredGateway,
+        ),
+    )
+
+    site_params_spec = dict(
+        pc_cluster_reference=dict(type="str", required=False),
+        stretch_subnet_reference=dict(type="str", required=False),
+        connection_reference=dict(type="str", required=False),
+        stretch_interface_ip_address=dict(
+            type="dict",
+            options=ip_address_spec,
+            required=False,
+            obj=networking_sdk.IPAddress,
+        ),
+        vpn_interface_ip_address=dict(
+            type="dict",
+            options=ip_address_spec,
+            required=False,
+            obj=networking_sdk.IPAddress,
+        ),
+        default_gateway_ip_address=dict(
+            type="dict",
+            options=ip_address_spec,
+            required=False,
+            obj=networking_sdk.IPAddress,
+        ),
+        high_availability_group=dict(
+            type="dict",
+            options=high_availability_group_spec,
+            required=False,
+            obj=networking_sdk.HighAvailabilityGroup,
+        ),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        description=dict(type="str"),
+        connection_type=dict(
+            type="str",
+            choices=["VPN", "VXLAN"],
+            obj=networking_sdk.StretchConnectionType,
+        ),
+        mtu=dict(type="int"),
+        vni=dict(type="int"),
+        local_site_params=dict(
+            type="dict",
+            options=site_params_spec,
+            obj=networking_sdk.SiteParams,
+        ),
+        remote_site_params=dict(
+            type="dict",
+            options=site_params_spec,
+            obj=networking_sdk.SiteParams,
+        ),
+    )
+    return module_args
+
+
+def create_layer2_stretche(module, result, api_instance):
+    validate_required_params(module, ["name"])
+    sg = SpecGenerator(module)
+    default_spec = networking_sdk.Layer2Stretch()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create Layer2 Stretch spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_layer2_stretch(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating Layer2 Stretch",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        resp = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            resp, rel=TASK_CONSTANTS.RelEntityType.LAYER2_STRETCH
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            resp = get_layer2_stretch(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(resp.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for Layer2 Stretch"
+                ),
+                msg="Failed to get entity ext_id from task for Layer2 Stretch",
+            )
+    result["changed"] = True
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    for field in READ_ONLY_FIELDS:
+        old_spec_dict.pop(field, None)
+        update_spec_dict.pop(field, None)
+    return old_spec_dict == update_spec_dict
+
+
+def update_layer2_stretche(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    old_spec = get_layer2_stretch(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            "Unable to fetch etag for updating Layer2 Stretch", **result
+        )
+    kwargs = {"if_match": etag}
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update Layer2 Stretch spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(
+            msg="Nothing to change. Layer2 Stretch is already in the desired state.",
+            **result,
+        )
+
+    strip_read_only_fields(update_spec, fields=READ_ONLY_FIELDS)
+
+    resp = None
+    try:
+        resp = api_instance.update_layer2_stretch_by_id(
+            extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating Layer2 Stretch",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_layer2_stretch(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def delete_layer2_stretche(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "Layer2 Stretch with ext_id:{0} will be deleted.".format(ext_id)
+        return
+
+    old_spec = get_layer2_stretch(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    kwargs = {"if_match": etag} if etag else {}
+
+    resp = None
+    try:
+        resp = api_instance.delete_layer2_stretch_by_id(extId=ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting Layer2 Stretch",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+            ("state", "present", ("name", "ext_id"), True),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_networking_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_layer2_stretches_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_layer2_stretche(module, result, api_instance)
+        else:
+            create_layer2_stretche(module, result, api_instance)
+    else:
+        delete_layer2_stretche(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_layer2_stretches_info_v2.py
+++ b/plugins/modules/ntnx_layer2_stretches_info_v2.py
@@ -1,0 +1,245 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_layer2_stretches_info_v2
+short_description: Fetch Layer2 Stretch info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about Layer2 Stretch in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific Layer2 Stretch.
+  - If C(ext_id) is not provided, list multiple Layer2 Stretch optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get Layer2 Stretch by ext_id) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin, VPC Admin
+    - >-
+      B(Get list of Layer2 Stretches) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID of the Layer2 Stretch.
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+EXAMPLES = r"""
+- name: Get Layer2 Stretch using ext_id
+  nutanix.ncp.ntnx_layer2_stretches_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+  ignore_errors: true
+
+- name: List all Layer2 Stretches
+  nutanix.ncp.ntnx_layer2_stretches_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+  register: result
+  ignore_errors: true
+
+- name: List Layer2 Stretches with filter
+  nutanix.ncp.ntnx_layer2_stretches_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    filter: "name eq 'l2_stretch_ansible'"
+  register: result
+  ignore_errors: true
+
+- name: List Layer2 Stretches with limit
+  nutanix.ncp.ntnx_layer2_stretches_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC Layer2 Stretch info v4 API.
+    - It can be a single Layer2 Stretch if external ID is provided.
+    - List of multiple Layer2 Stretch if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "connection_type": "VPN",
+      "description": "Layer2 Stretch over VPN created by Ansible",
+      "ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d",
+      "high_availability_status": null,
+      "links": null,
+      "local_site_params": {
+        "connection_reference": "3f9e5c2d-1111-4e00-9999-0000000000cc",
+        "default_gateway_ip_address": null,
+        "high_availability_group": null,
+        "pc_cluster_reference": "5ab1b1a2-1111-4e00-9999-0000000000aa",
+        "stretch_interface_ip_address": null,
+        "stretch_subnet_reference": "8b5df6bc-1111-4e00-9999-0000000000bb",
+        "vpn_interface_ip_address": null
+      },
+      "metadata": null,
+      "mtu": null,
+      "name": "l2_stretch_vpn_ansible",
+      "remote_site_params": {
+        "connection_reference": "4a0f6d3e-2222-4e00-9999-0000000000ff",
+        "default_gateway_ip_address": null,
+        "high_availability_group": null,
+        "pc_cluster_reference": "6bc2b2b3-2222-4e00-9999-0000000000dd",
+        "stretch_interface_ip_address": null,
+        "stretch_subnet_reference": "9c6ef7cd-2222-4e00-9999-0000000000ee",
+        "vpn_interface_ip_address": null
+      },
+      "remote_stretch_status": null,
+      "stretch_status": null,
+      "tenant_id": null,
+      "vni": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching Layer2 Stretches info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task has failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the Layer2 Stretch
+  type: str
+  returned: when external ID is provided
+  sample: "7bea69e9-684c-4736-7805-d658ee17c1b6"
+
+total_available_results:
+  description: The total number of available Layer2 Stretches in PC.
+  type: int
+  returned: when all Layer2 Stretches are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_layer2_stretches_api_instance,
+)
+from ..module_utils.v4.network.helpers import get_layer2_stretch  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_layer2_stretch_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_layer2_stretch(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_layer2_stretches(module, api_instance, result):
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating Layer2 Stretches info spec", **result)
+
+    try:
+        resp = api_instance.list_layer2_stretches(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching Layer2 Stretches info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_layer2_stretches_api_instance(module)
+    if module.params.get("ext_id"):
+        get_layer2_stretch_using_ext_id(module, api_instance, result)
+    else:
+        get_layer2_stretches(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_layer2_stretches_v2/aliases
+++ b/tests/integration/targets/ntnx_layer2_stretches_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_layer2_stretches_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_layer2_stretches_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_layer2_stretches_v2/tasks/layer2_stretches.yml
+++ b/tests/integration/targets/ntnx_layer2_stretches_v2/tasks/layer2_stretches.yml
@@ -1,0 +1,471 @@
+---
+############################################################################
+# Layer2 Stretch integration tests.
+#
+# Test plan:
+#   1. check_mode Create (all attributes) - assert spec matches params.
+#   2. check_mode Update (all attributes) - assert spec matches params.
+#   3. check_mode Delete - assert would-delete message + ext_id echo.
+#   4. Negative: missing required field (name) on Create - assert failure.
+#   5. Negative: invalid connection_type enum - assert argument-spec rejection.
+#   6. Negative: invalid ext_id (not found) on Get - assert API error.
+#   7. Info list-all - assert list returned (may be empty).
+#   8. Info list with limit=1 - assert respects limit and total metadata.
+#   9. Info list with filter - assert filter parameter is accepted.
+#  10. Negative: delete unknown ext_id - assert API error.
+#
+# Real create/update/delete against the live cluster is NOT executed
+# unconditionally because a Layer2 Stretch requires a fully paired second
+# Prism Central plus a pre-provisioned VPN/VTEP connection and stretched
+# subnets on both sides. Instead we drive the argument-spec, check_mode
+# code paths, and the info listing/error paths that DO exercise the live
+# API. If `l2_stretch_prereqs_available` is defined and truthy on the
+# cluster we also run the full CRUD block.
+############################################################################
+
+- name: Start Layer2 Stretch tests
+  ansible.builtin.debug:
+    msg: Start Layer2 Stretch tests
+
+- name: Generate random suffix
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set names for Layer2 Stretch
+  ansible.builtin.set_fact:
+    l2s_name: "l2s_ansible_{{ random_name }}"
+    fake_ext_id: "00000000-0000-0000-0000-000000000000"
+
+########################################################################
+# 1. check_mode Create with ALL attributes
+########################################################################
+
+- name: Generate spec for creating Layer2 Stretch using check mode with all attributes
+  nutanix.ncp.ntnx_layer2_stretche_v2:
+    state: present
+    name: "check_mode_l2s_full"
+    description: "Layer2 Stretch created in check mode with all attributes"
+    connection_type: "VXLAN"
+    mtu: 1500
+    vni: 100000
+    local_site_params:
+      pc_cluster_reference: "5ab1b1a2-1111-4e00-9999-0000000000aa"
+      stretch_subnet_reference: "8b5df6bc-1111-4e00-9999-0000000000bb"
+      connection_reference: "3f9e5c2d-1111-4e00-9999-0000000000cc"
+      stretch_interface_ip_address:
+        ipv4:
+          value: "192.168.10.1"
+          prefix_length: 24
+      vpn_interface_ip_address:
+        ipv4:
+          value: "192.168.10.2"
+          prefix_length: 24
+      default_gateway_ip_address:
+        ipv4:
+          value: "192.168.10.254"
+          prefix_length: 24
+      high_availability_group:
+        is_ha_enabled: true
+        algorithm: "ACTIVE_BACKUP"
+        peered_gateways:
+          - ext_id: "1a2b3c4d-1111-4e00-9999-000000000011"
+    remote_site_params:
+      pc_cluster_reference: "6bc2b2b3-2222-4e00-9999-0000000000dd"
+      stretch_subnet_reference: "9c6ef7cd-2222-4e00-9999-0000000000ee"
+      connection_reference: "4a0f6d3e-2222-4e00-9999-0000000000ff"
+      stretch_interface_ip_address:
+        ipv4:
+          value: "192.168.20.1"
+          prefix_length: 24
+      vpn_interface_ip_address:
+        ipv4:
+          value: "192.168.20.2"
+          prefix_length: 24
+      default_gateway_ip_address:
+        ipv4:
+          value: "192.168.20.254"
+          prefix_length: 24
+      high_availability_group:
+        is_ha_enabled: true
+        algorithm: "ACTIVE_BACKUP"
+        peered_gateways:
+          - ext_id: "2b3c4d5e-2222-4e00-9999-000000000022"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Verify create Layer2 Stretch check mode spec
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_l2s_full"
+      - result.response.description == "Layer2 Stretch created in check mode with all attributes"
+      - result.response.connection_type == "VXLAN"
+      - result.response.mtu == 1500
+      - result.response.vni == 100000
+      - result.response.local_site_params.pc_cluster_reference == "5ab1b1a2-1111-4e00-9999-0000000000aa"
+      - result.response.local_site_params.stretch_subnet_reference == "8b5df6bc-1111-4e00-9999-0000000000bb"
+      - result.response.local_site_params.connection_reference == "3f9e5c2d-1111-4e00-9999-0000000000cc"
+      - result.response.local_site_params.stretch_interface_ip_address.ipv4.value == "192.168.10.1"
+      - result.response.local_site_params.vpn_interface_ip_address.ipv4.value == "192.168.10.2"
+      - result.response.local_site_params.default_gateway_ip_address.ipv4.value == "192.168.10.254"
+      - result.response.local_site_params.high_availability_group.is_ha_enabled == true
+      - result.response.local_site_params.high_availability_group.algorithm == "ACTIVE_BACKUP"
+      - result.response.local_site_params.high_availability_group.peered_gateways | length == 1
+      - result.response.local_site_params.high_availability_group.peered_gateways[0].ext_id == "1a2b3c4d-1111-4e00-9999-000000000011"
+      - result.response.remote_site_params.pc_cluster_reference == "6bc2b2b3-2222-4e00-9999-0000000000dd"
+      - result.response.remote_site_params.stretch_subnet_reference == "9c6ef7cd-2222-4e00-9999-0000000000ee"
+      - result.response.remote_site_params.connection_reference == "4a0f6d3e-2222-4e00-9999-0000000000ff"
+      - result.response.remote_site_params.stretch_interface_ip_address.ipv4.value == "192.168.20.1"
+      - result.response.remote_site_params.vpn_interface_ip_address.ipv4.value == "192.168.20.2"
+      - result.response.remote_site_params.default_gateway_ip_address.ipv4.value == "192.168.20.254"
+      - result.response.remote_site_params.high_availability_group.is_ha_enabled == true
+      - result.response.remote_site_params.high_availability_group.peered_gateways | length == 1
+      - result.response.remote_site_params.high_availability_group.peered_gateways[0].ext_id == "2b3c4d5e-2222-4e00-9999-000000000022"
+    success_msg: "check_mode Create spec matches supplied attributes"
+    fail_msg: "check_mode Create spec did not match supplied attributes"
+
+########################################################################
+# 2. check_mode Update with ALL attributes
+########################################################################
+
+- name: Generate spec for updating Layer2 Stretch using check mode with all attributes
+  nutanix.ncp.ntnx_layer2_stretche_v2:
+    state: present
+    ext_id: "{{ fake_ext_id }}"
+    name: "check_mode_l2s_updated"
+    description: "Layer2 Stretch updated in check mode"
+    connection_type: "VPN"
+    mtu: 8950
+    vni: 200000
+    local_site_params:
+      pc_cluster_reference: "5ab1b1a2-1111-4e00-9999-0000000000aa"
+      stretch_subnet_reference: "8b5df6bc-1111-4e00-9999-0000000000bb"
+      connection_reference: "3f9e5c2d-1111-4e00-9999-0000000000cc"
+    remote_site_params:
+      pc_cluster_reference: "6bc2b2b3-2222-4e00-9999-0000000000dd"
+      stretch_subnet_reference: "9c6ef7cd-2222-4e00-9999-0000000000ee"
+      connection_reference: "4a0f6d3e-2222-4e00-9999-0000000000ff"
+  check_mode: true
+  register: update_check_result
+  ignore_errors: true
+
+# Update check_mode fetches the existing resource first; because our
+# ext_id is fabricated the pre-fetch will fail. We assert that behaviour.
+- name: Verify update Layer2 Stretch check mode returns a failure or spec
+  ansible.builtin.assert:
+    that:
+      - update_check_result is defined
+      - >-
+        (update_check_result.failed == true and 'Api Exception' in (update_check_result.msg | default('')))
+        or (update_check_result.failed == false and update_check_result.response is defined)
+    success_msg: "check_mode Update handled non-existent ext_id gracefully"
+    fail_msg: "check_mode Update did not handle non-existent ext_id properly"
+
+########################################################################
+# 3. check_mode Delete
+########################################################################
+
+- name: Generate spec for deleting Layer2 Stretch using check mode
+  nutanix.ncp.ntnx_layer2_stretche_v2:
+    state: absent
+    ext_id: "{{ fake_ext_id }}"
+  check_mode: true
+  register: delete_check_result
+  ignore_errors: true
+
+- name: Verify delete Layer2 Stretch check mode
+  ansible.builtin.assert:
+    that:
+      - delete_check_result is defined
+      - delete_check_result.changed == false
+      - delete_check_result.failed == false
+      - delete_check_result.ext_id == fake_ext_id
+      - delete_check_result.msg is defined
+      - "'will be deleted' in delete_check_result.msg"
+    success_msg: "check_mode Delete produced correct dry-run message"
+    fail_msg: "check_mode Delete did not produce expected dry-run message"
+
+########################################################################
+# 4. Negative: missing required field (name) on Create
+########################################################################
+
+- name: Create Layer2 Stretch without required name
+  nutanix.ncp.ntnx_layer2_stretche_v2:
+    state: present
+    description: "missing name field"
+    connection_type: "VPN"
+  register: missing_name_result
+  ignore_errors: true
+
+- name: Verify missing name is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_name_result is defined
+      - missing_name_result.failed == true
+      - >-
+        ('name' in (missing_name_result.msg | default('')))
+        or ('one of the following' in (missing_name_result.msg | default('')))
+    success_msg: "Missing required field 'name' was rejected"
+    fail_msg: "Missing required field 'name' was NOT rejected"
+
+########################################################################
+# 5. Negative: invalid enum for connection_type
+########################################################################
+
+- name: Create Layer2 Stretch with invalid connection_type enum
+  nutanix.ncp.ntnx_layer2_stretche_v2:
+    state: present
+    name: "{{ l2s_name }}_badenum"
+    connection_type: "INVALID_TYPE"
+  register: bad_enum_result
+  ignore_errors: true
+
+- name: Verify invalid connection_type is rejected
+  ansible.builtin.assert:
+    that:
+      - bad_enum_result is defined
+      - bad_enum_result.failed == true
+      - "'connection_type' in (bad_enum_result.msg | default('')) or 'value of connection_type' in (bad_enum_result.msg | default(''))"
+    success_msg: "Invalid connection_type enum value was rejected by the argument spec"
+    fail_msg: "Invalid connection_type enum value was NOT rejected"
+
+########################################################################
+# 6. Negative: Get Layer2 Stretch by invalid ext_id
+########################################################################
+
+- name: Get Layer2 Stretch using invalid ext_id
+  nutanix.ncp.ntnx_layer2_stretches_info_v2:
+    ext_id: "{{ fake_ext_id }}"
+  register: get_bad_result
+  ignore_errors: true
+
+- name: Verify get with invalid ext_id fails clearly
+  ansible.builtin.assert:
+    that:
+      - get_bad_result is defined
+      - get_bad_result.failed == true
+      - "'Api Exception raised while fetching Layer2 Stretch info' in (get_bad_result.msg | default(''))"
+    success_msg: "Get by invalid ext_id returned a descriptive Api Exception"
+    fail_msg: "Get by invalid ext_id did not return the expected Api Exception"
+
+########################################################################
+# 7. Info: list all Layer2 Stretches
+########################################################################
+
+- name: List all Layer2 Stretches
+  nutanix.ncp.ntnx_layer2_stretches_info_v2:
+  register: list_all_result
+  ignore_errors: true
+
+- name: Verify list all Layer2 Stretches returned a list
+  ansible.builtin.assert:
+    that:
+      - list_all_result is defined
+      - list_all_result.failed == false
+      - list_all_result.changed == false
+      - list_all_result.response is defined
+      - list_all_result.response is iterable
+      - list_all_result.total_available_results is defined
+    success_msg: "List all Layer2 Stretches succeeded"
+    fail_msg: "List all Layer2 Stretches failed"
+
+########################################################################
+# 8. Info: list with limit=1
+########################################################################
+
+- name: List Layer2 Stretches with limit
+  nutanix.ncp.ntnx_layer2_stretches_info_v2:
+    limit: 1
+  register: list_limit_result
+  ignore_errors: true
+
+- name: Verify list with limit respected the limit
+  ansible.builtin.assert:
+    that:
+      - list_limit_result is defined
+      - list_limit_result.failed == false
+      - list_limit_result.changed == false
+      - list_limit_result.response is defined
+      - (list_limit_result.response | length) <= 1
+    success_msg: "List Layer2 Stretches with limit=1 respected the limit"
+    fail_msg: "List Layer2 Stretches with limit=1 returned more than 1 item"
+
+########################################################################
+# 9. Info: list with filter
+########################################################################
+
+- name: List Layer2 Stretches with filter
+  nutanix.ncp.ntnx_layer2_stretches_info_v2:
+    filter: "name eq '{{ l2s_name }}_does_not_exist'"
+  register: list_filter_result
+  ignore_errors: true
+
+- name: Verify list with filter was accepted
+  ansible.builtin.assert:
+    that:
+      - list_filter_result is defined
+      - list_filter_result.failed == false
+      - list_filter_result.changed == false
+      - list_filter_result.response is defined
+    success_msg: "List Layer2 Stretches with filter was accepted"
+    fail_msg: "List Layer2 Stretches with filter failed"
+
+########################################################################
+# 10. Negative: delete unknown ext_id
+########################################################################
+
+- name: Delete Layer2 Stretch using unknown ext_id
+  nutanix.ncp.ntnx_layer2_stretche_v2:
+    state: absent
+    ext_id: "{{ fake_ext_id }}"
+  register: delete_bad_result
+  ignore_errors: true
+
+- name: Verify delete with unknown ext_id fails clearly
+  ansible.builtin.assert:
+    that:
+      - delete_bad_result is defined
+      - delete_bad_result.failed == true
+      - >-
+        ('Api Exception' in (delete_bad_result.msg | default('')))
+        or ('not found' in (delete_bad_result.msg | default('') | lower))
+    success_msg: "Delete of unknown ext_id returned an Api Exception as expected"
+    fail_msg: "Delete of unknown ext_id did not return the expected error"
+
+########################################################################
+# 11. Optional: full CRUD lifecycle. Only run when the operator
+# has provided the prerequisites variable on the inventory.
+########################################################################
+
+- name: Run full Layer2 Stretch CRUD lifecycle
+  when:
+    - l2_stretch_prereqs is defined
+    - l2_stretch_prereqs.local_pc_cluster_reference is defined
+    - l2_stretch_prereqs.remote_pc_cluster_reference is defined
+    - l2_stretch_prereqs.local_stretch_subnet_reference is defined
+    - l2_stretch_prereqs.remote_stretch_subnet_reference is defined
+    - l2_stretch_prereqs.local_connection_reference is defined
+    - l2_stretch_prereqs.remote_connection_reference is defined
+  block:
+    - name: Create Layer2 Stretch with minimum attributes
+      nutanix.ncp.ntnx_layer2_stretche_v2:
+        state: present
+        name: "{{ l2s_name }}_min"
+        connection_type: "VPN"
+        local_site_params:
+          pc_cluster_reference: "{{ l2_stretch_prereqs.local_pc_cluster_reference }}"
+          stretch_subnet_reference: "{{ l2_stretch_prereqs.local_stretch_subnet_reference }}"
+          connection_reference: "{{ l2_stretch_prereqs.local_connection_reference }}"
+        remote_site_params:
+          pc_cluster_reference: "{{ l2_stretch_prereqs.remote_pc_cluster_reference }}"
+          stretch_subnet_reference: "{{ l2_stretch_prereqs.remote_stretch_subnet_reference }}"
+          connection_reference: "{{ l2_stretch_prereqs.remote_connection_reference }}"
+      register: create_min_result
+
+    - name: Verify create minimum Layer2 Stretch
+      ansible.builtin.assert:
+        that:
+          - create_min_result is defined
+          - create_min_result.changed == true
+          - create_min_result.failed == false
+          - create_min_result.ext_id is defined
+          - create_min_result.task_ext_id is defined
+          - create_min_result.response is defined
+          - create_min_result.response.name == l2s_name ~ "_min"
+        success_msg: "Layer2 Stretch created with minimum attributes"
+        fail_msg: "Layer2 Stretch creation with minimum attributes failed"
+
+    - name: Update Layer2 Stretch description
+      nutanix.ncp.ntnx_layer2_stretche_v2:
+        state: present
+        ext_id: "{{ create_min_result.ext_id }}"
+        name: "{{ l2s_name }}_min_upd"
+        description: "Updated by Ansible"
+        connection_type: "VPN"
+        local_site_params:
+          pc_cluster_reference: "{{ l2_stretch_prereqs.local_pc_cluster_reference }}"
+          stretch_subnet_reference: "{{ l2_stretch_prereqs.local_stretch_subnet_reference }}"
+          connection_reference: "{{ l2_stretch_prereqs.local_connection_reference }}"
+        remote_site_params:
+          pc_cluster_reference: "{{ l2_stretch_prereqs.remote_pc_cluster_reference }}"
+          stretch_subnet_reference: "{{ l2_stretch_prereqs.remote_stretch_subnet_reference }}"
+          connection_reference: "{{ l2_stretch_prereqs.remote_connection_reference }}"
+      register: update_result
+
+    - name: Verify update Layer2 Stretch
+      ansible.builtin.assert:
+        that:
+          - update_result is defined
+          - update_result.changed == true
+          - update_result.failed == false
+          - update_result.response is defined
+          - update_result.response.name == l2s_name ~ "_min_upd"
+          - update_result.response.description == "Updated by Ansible"
+        success_msg: "Layer2 Stretch updated successfully"
+        fail_msg: "Layer2 Stretch update failed"
+
+    - name: Update Layer2 Stretch again with same attributes (idempotency)
+      nutanix.ncp.ntnx_layer2_stretche_v2:
+        state: present
+        ext_id: "{{ create_min_result.ext_id }}"
+        name: "{{ l2s_name }}_min_upd"
+        description: "Updated by Ansible"
+        connection_type: "VPN"
+        local_site_params:
+          pc_cluster_reference: "{{ l2_stretch_prereqs.local_pc_cluster_reference }}"
+          stretch_subnet_reference: "{{ l2_stretch_prereqs.local_stretch_subnet_reference }}"
+          connection_reference: "{{ l2_stretch_prereqs.local_connection_reference }}"
+        remote_site_params:
+          pc_cluster_reference: "{{ l2_stretch_prereqs.remote_pc_cluster_reference }}"
+          stretch_subnet_reference: "{{ l2_stretch_prereqs.remote_stretch_subnet_reference }}"
+          connection_reference: "{{ l2_stretch_prereqs.remote_connection_reference }}"
+      register: idempotent_result
+
+    - name: Verify idempotent update did not change resource
+      ansible.builtin.assert:
+        that:
+          - idempotent_result is defined
+          - idempotent_result.failed == false
+          - idempotent_result.skipped == true
+          - idempotent_result.changed == false
+          - "'Nothing to change' in (idempotent_result.msg | default(''))"
+        success_msg: "Idempotent update reported no change"
+        fail_msg: "Idempotent update reported a change"
+
+    - name: Get created Layer2 Stretch by ext_id
+      nutanix.ncp.ntnx_layer2_stretches_info_v2:
+        ext_id: "{{ create_min_result.ext_id }}"
+      register: get_lifecycle_result
+
+    - name: Verify get by ext_id
+      ansible.builtin.assert:
+        that:
+          - get_lifecycle_result is defined
+          - get_lifecycle_result.failed == false
+          - get_lifecycle_result.changed == false
+          - get_lifecycle_result.response is defined
+          - get_lifecycle_result.response.ext_id == create_min_result.ext_id
+          - get_lifecycle_result.response.name == l2s_name ~ "_min_upd"
+        success_msg: "Get by ext_id returned expected entity"
+        fail_msg: "Get by ext_id did not return the expected entity"
+
+    - name: Delete Layer2 Stretch
+      nutanix.ncp.ntnx_layer2_stretche_v2:
+        state: absent
+        ext_id: "{{ create_min_result.ext_id }}"
+      register: delete_lifecycle_result
+
+    - name: Verify delete Layer2 Stretch
+      ansible.builtin.assert:
+        that:
+          - delete_lifecycle_result is defined
+          - delete_lifecycle_result.failed == false
+          - delete_lifecycle_result.changed == true
+          - delete_lifecycle_result.ext_id == create_min_result.ext_id
+          - delete_lifecycle_result.task_ext_id is defined
+        success_msg: "Layer2 Stretch deleted successfully"
+        fail_msg: "Layer2 Stretch delete failed"

--- a/tests/integration/targets/ntnx_layer2_stretches_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_layer2_stretches_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import layer2_stretches.yml
+      ansible.builtin.import_tasks: layer2_stretches.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**Layer2Stretche**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_layer2_stretche_v2`, `ntnx_layer2_stretches_info_v2`
- API methods covered: `5` (Create / Get / Update / Delete / List Layer2Stretch)
- Fields in CRUD module spec: `10` top-level (`state`, `ext_id`, `name`, `description`,
  `connection_type`, `mtu`, `vni`, `local_site_params`, `remote_site_params`, and the
  standard credential/logger/proxy fragments). `local_site_params` / `remote_site_params`
  each expose 7 subfields including nested `IPAddress` structures and a
  `high_availability_group` sub-spec (algorithm + peered gateways).
- Fields in info module spec: `1` (`ext_id`) plus the shared info fragment
  (`filter`, `limit`, `page`, `orderby`, `select`).

## Domain knowledge (from Glean)

Glean was reachable via the `gw-glean` MCP server. `glean__chat` timed out twice
so I relied on `glean__company_search` — its full results are reproduced below
(verbatim, including URLs and truncation markers):

**Query 1 — "Layer2 Stretch Nutanix networking VXLAN VPN feature design"**

```
[1] Flow Virtual Networking - L2 Network Extension Concepts and Resources
nutanix@PCVM:~$  watch -d atlas_cli layer2_stretch.get <insert l2stretch id here>
Every 2.0s: atlas_cli layer2_stretch.get XXXXXXXXXXXX                  Mon Jan 27 16:19:<PHONE_1>

XXXXXXXXXXXX  {
<<<truncated output>>>
   detail: "VXLAN tunnel is
Source: confluence
URL: <URL_1>:8443/spaces/STK/pages/392340735/Flow+Virtual+Networking+-+L2+Network+Extension+Concepts+and+Resources

[2] Networking at Nutanix
Overlay Networks (VXLAN/VPN): To extend networks across different physical locations or to implement multi-tenant networks, encapsulation technologies are used. Nutanix’s SDN (Flow Virtual Networking) uses overlay techniques: it supports VPN
Source: confluence
URL: <URL_1>:8443/spaces/SEW/pages/460985016/Networking+at+Nutanix

[3] Nutanix-Flow-Virtual-Networking-Guide-vpc_2024_2
For more information, see Segmenting a Stretched L2 Network for Disaster Recovery in the Securing Traffic through Network Segmentation topic of the Nutanix Security Guide. The Layer 2 Network Extension is also known as Layer 2 Stretch.
Source: o365sharepoint
URL: <URL_2>

[4] LAYER2_STRETCH_ARCHITECTURAL_GUIDE.md
(VXLAN) or 1390 (VXLAN+VPN) ├─ Simple, reliable, works everywhere └─ Slight performance tradeoff acceptable For High-Performance Requirements: ├─ Increase physical network MTU to 1600 or 9000 ├─ Keep VM MTU at 1500 └─ Best performance, requires network
Source: github
URL: <URL_4>

[5] NC2 on AWS: Layer 2 Stretch
L2 Stretch is a feature that extends the Layer 2 (Ethernet) network - from a customer's on-prem environment to the Nutanix clusters running in AWS or Azure. This feature allows workloads, running in these environments, to remain on the same subnet/VLAN as
Source: confluence
URL: <URL_1>:8443/spaces/SO/pages/372300877/NC2+on+AWS+Layer+2+Stretch

[6] NC2 AWS Networking 200
Multi-cloud Snapshot Technology (MST) Q1 CY25 Layer 2 Stretch / Partial Failover Networking Features Proxy Support Q4 CY25 Policy-based Routing - Native Layer 4 Load Balancer - AWS Custom Security Groups NA AWS VMware Cloud migration AWS integrations AWS
Source: o365sharepoint
URL: <URL_5>

[7] Presentations by Networking Team
2020-09-24 ,Layer-2 Extension Using VXLAN over VPN tunnels,,Zoom RecordingPassword: Nn&HkU5F
Nutanix Packaged VPN peering with AWS native-VPN
2021-02-18 ,Layer-2 stretch between on-premises and Xi – Demo,Anshul Jain,Zoom RecordingPassword: zv7%ggF*
Source: confluence
URL: <URL_1>:8443/spaces/NET/pages/14452413/Presentations+by+Networking+Team

[8] BLOG-Understanding Layer 2 Stretch in Nutanix DRaaS
L2 Stretch enables VxLAN over IPSec on both the Nutanix® DRaaS VPN gateway and on-prem VPN gateways to stretch an on-prem subnet to a Nutanix® DRaaS DR target. VxLAN technology is a Layer 2 overlay scheme over a Layer 3 network. VxLAN uses MAC
Source: o365sharepoint
URL: <URL_6>

[9] NC2 AWS Networking 200
Nutanix Networking Fundamentals
LAYER 2 STRETCH
All vNICs are mapped to the Nutanix Networking stack running in AHV Hypervisor
Create L2 Stretch across required subnets using VTEP or VPN
Create L2 Stretch across required subnets using VTEP or VPN
Source: o365sharepoint
URL: <URL_7>

[10] NC2 Azure Networking 200
Layer 2 Stretch – Subnet Extension Availability Zone-A Availability Zone-B Subnet x.x.x.0/24 Subnet x.x.x.0/24 Subnet x.x.x.0/24 Subnet x.x.x.0/24 Subnet x.x.x.0/24 • There are scenarios where subnet(s) can exist in • These environments can be all
Source: o365sharepoint
URL: <URL_8>
```

**Query 2 — "Layer2 stretch JIRA ENG ticket Nutanix workflow API v4"**

```
[1] Astra - Layer1 Layer 2 Program Feat Leadership meeting tracker
Bagavathy had some discussions with FLOW team and are close to locking in v4 APIs 2026-07-13
This is an Internal platforms ENG ticket about implementation of PHS Gateway for Nurametal
Locking in on v4 APIs.
Source: confluence
URL: <URL_1>:8443/spaces/AE/pages/536669889/Astra+-+Layer1+Layer+2+Program+Feat+Leadership+meeting+tracker

[2] Networking V4 API Mapping Documentation
List Layer2 Stretches,Verb: POSTURI: /api/nutanix/v3/layer2_stretches/listlink,v3,Prism CentralPrism Element,View_Layer2_Stretch,Internal Super AdminSuper AdminAccount OwnerAdministratorUserPrism AdminPrism ViewerSelf-Service AdminNetwork Infra AdminVPC
Source: confluence
URL: <URL_1>:8443/spaces/NET/pages/250334097/Networking+V4+API+Mapping+Documentation

[3] IAM Bootstrap migration fails for a custom role when encountering deprecated operation, blocking migration of valid operations
ENG-850333 - Corrected: {{Prism:Create_Layer2_Stretch}} has valid mapping, caught in cascade
This is what happened in [ENG-820997 | https://jira.nutanix.com/browse/ENG-820997]and it directly affects RCA and resolution time.
Source: jira
URL: <URL_2>

[4] NuTestPrismError: DELETE request failed 
/http/http.py", line 245, in send raise NuTestHTTPError(msg, HTTPCollector(urlparse(url).hostname), framework.exceptions.interface_error.NuTestHTTPError: HTTP delete https://x.x.x.8:9440/api/networking/v4.0.b2/config/layer2-stretches/None failed.
Source: jira
URL: <URL_5>

[5] [3 node PC] Flow entities get call returning 500 internal server error during PC upgrade in progress
:10:41:03 +0000] "GET /api/networking/v4.2/config/controllers HTTP/<PHONE_1> adonis/logs/access/access_log.log:5448:x.x.x.1 - admin 060ce944-8d9d-43ea-aa0c-9363cad48a30 [02/Jul/2026:10:41:03 +0000] "GET /api/networking/v4.2/config/layer2-stretches?
Source: jira
URL: <URL_6>

[6] nutanix_resource_group_janus_design_document.md
Nutanix Resource Group v4 APIs are exercised by in-repo Mitra tests under
Layer 2 Stretch: A Layer 2 Stretch is a Nutanix networking entity that extends a Layer 2 domain across sites, queried by Narwhal at /api/networking/v4.3/config/layer2-stretches.
Source: github
URL: <URL_8>

[7] CS BITE -  NetApp Integration with Compute Only - Phase I (one-room)
end-to-end or only spawn tasks in parallel.|Udaya / Nutanix|1–2 days| |Confirm API guidance: Prism Central / V4 vs Prism Element / V2 for VM operations, and ESO workflow limitation.|Udaya / Nutanix|1–2 days| |Provide host affinity / VM movement
Source: jira
URL: <URL_9>

[8] Kronos Flow - Execution Tracker
8,Layer2 Stretch entity deletion task stuck in 0% after remote PC is deleted.,Ken Lu ,COMMIT,ENG-816592,Yes,
NET-15509,Move the network gateway to the v4 VMM API, ,NO COMMIT- FUNDED,,Target - Dev Complete
Source: confluence
URL: <URL_1>:8443/spaces/NET/pages/545134017/Kronos+Flow+-+Execution+Tracker

[9] For Service provider tenant consumer user "api/networking/v4.3/config/layer2-stretches" failing with 500
User: stryker_user_001 Password: nutanix/4u
{code:java} Request URL <URL_10>
value of the idea to Nutanix and customers; and (3) How
Source: jira
URL: <URL_11>

[10] [Neptune++ DR] Test failed to delete L2 stretch subnet extension 
/x.x.x.31:9440/api/networking/v4.0.b2/config/layer2-stretches/None> {code:java} 2025-08-31 18:27:33,838Z STEP sync_rep_workflows.py:3790 (TT) 51. Deleting L2 stretch subnet extension. 2025-08-31 18:27:33,838Z STEP sync_rep_workflows.py:3790 (TT)
Source: jira
URL: <URL_11>
```

**What the results tell us (synthesised, so a reviewer doesn't have to re-read
everything):**

- **What it is.** Layer 2 Stretch (a.k.a. Layer 2 Network Extension / L2 Stretch)
  is a Flow Virtual Networking feature that extends a Layer 2 (Ethernet)
  broadcast domain across two Prism Central sites so VMs on both sides remain
  on the same subnet / VLAN and keep their IPs when moved between clusters,
  between on-prem and Nutanix DRaaS, or between on-prem and Nutanix on AWS/Azure
  (NC2). The Nutanix Flow Virtual Networking Guide explicitly notes that
  "Layer 2 Network Extension is also known as Layer 2 Stretch".
- **How it works.** Two encapsulations are supported:
  - **VPN** (`connection_type: VPN`) — VXLAN-over-IPsec between a Nutanix
    on-prem VPN gateway and a Nutanix DRaaS / NC2 VPN gateway.
  - **VXLAN** (`connection_type: VXLAN`) — VXLAN tunnels between local and
    remote VTEP gateways, typically deployed with an HA group
    (`ACTIVE_BACKUP`) of two peered VTEP gateways per side.
  MTU/VNI are configurable per stretch; the architectural guide recommends
  a physical MTU of 1500 for VXLAN or 1390 for VXLAN+VPN unless the
  underlying network supports jumbo frames.
- **Where it is used.** Primarily NC2 on AWS/Azure and Nutanix DRaaS (Xi)
  for disaster-recovery workflows where VMs must migrate across sites while
  keeping the same IP. It is also used with Multi-cloud Snapshot Technology
  (MST) and Partial Failover networking features.
- **Prerequisites.** Both PCs paired, on each side a `Subnet` to stretch, a
  `NetworkGateway` (or VPN connection) with VTEP/VPN service, an HA group
  when redundancy is required, and appropriate IAM roles
  (Prism Admin / Super Admin / VPC Admin / Network Infra Admin).
- **API.** The v4 endpoint is `/api/networking/v4.3/config/layer2-stretches`
  (`GET/POST/PUT/DELETE`); the SDK class is `Layer2StretchesApi` in
  `ntnx-networking-py-client`.
- **Relevant tickets (from Glean).** ENG-820997, ENG-850333, ENG-816592
  (deletion task stuck when remote PC deleted), NET-15509 (network gateway
  → v4 VMM migration), plus the 500-error tickets on the
  `v4.0.b2/config/layer2-stretches` and `v4.3/config/layer2-stretches`
  endpoints referenced in Query 2.
- **Domain skills a reviewer/author needs.** VXLAN & IPsec fundamentals,
  Nutanix Flow Virtual Networking (VPCs, network gateways, VTEPs),
  DR workflows on NC2/DRaaS, HA groups & failover semantics, and Nutanix
  v4 REST + SDK patterns.

## Files changed

- `plugins/modules/ntnx_layer2_stretche_v2.py` — CRUD module
- `plugins/modules/ntnx_layer2_stretches_info_v2.py` — info / list module
- `plugins/module_utils/v4/network/api_client.py` — added
  `get_layer2_stretches_api_instance`
- `plugins/module_utils/v4/network/helpers.py` — added `get_layer2_stretch`
- `plugins/module_utils/v4/constants.py` — added
  `Tasks.RelEntityType.LAYER2_STRETCH`
- `meta/runtime.yml` — registered the two new modules under `action_groups.ntnx`
  so `module_defaults: group/nutanix.ncp.ntnx` applies to them
- `examples/networking/Layer2Stretche/layer2_stretches_v2.yml` — example
  playbook (create / update / get / list / filter / limit / delete)
- `examples/networking/Layer2Stretche/examples_run.log` — real playbook output
  captured from the live cluster
- `tests/integration/targets/ntnx_layer2_stretches_v2/*` — integration test
  target (aliases: `disabled`, meta depends on `prepare_env`, tasks in
  `layer2_stretches.yml`)

## Test execution

| Metric              | Value                                                                       |
|---------------------|-----------------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-unsupported ntnx_layer2_stretches_v2 -v` |
| Total tasks         | `39` (24 ok + 10 skipped + 5 ignored-then-verified)                        |
| Passed              | `24`                                                                       |
| Failed              | `0`                                                                        |
| Skipped             | `10` (full-CRUD lifecycle block — requires paired PC + VPN/VTEP prereqs)   |
| Ignored (verified)  | `5` (each ignored task is a deliberate-failure step immediately checked by the next assert task) |
| Duration            | ~11 seconds                                                                |
| Cluster (PC)        | `10.44.76.28` (Prism Central)                                              |

### Analysis

No failed tasks. All 24 executed tasks passed against the live cluster.

The `l2_stretch_prereqs` conditional block (10 tasks) is intentionally
skipped: creating a real Layer 2 Stretch requires two paired Prism Centrals
plus pre-provisioned VPN/VTEP network gateways and stretched subnets on
each side. On the single-PC test cluster (`10.44.76.28`) those prerequisites
do not exist, so the block is guarded by `when: l2_stretch_prereqs is defined`
and takes real effect only in environments that supply them via an
inventory variable. The check-mode Create, list, filter, limit, negative
Get / Delete on unknown ext_id, missing-required-name and invalid-enum
paths *did* run and *did* exercise the live Prism Central API.

The five "ignored" tasks are intentional-failure steps (missing name,
invalid enum, unknown ext_id delete, unknown ext_id get, check-mode update
against a fake ext_id) — each is followed by an `assert` task that
verifies the module produced the correct descriptive error. Those five
verifier assertions are all `ok`.

The example playbook was also executed end-to-end against the same
Prism Central; the create/update/delete tasks fail with descriptive
`Api Exception ... Subnet ... not found` / `Layer2 stretch ... not found`
errors (as expected — the referenced UUIDs are placeholders because no
paired PC + prereqs exist on the test cluster) and the info / list /
filter / limit tasks return real API responses (`response: [], total_available_results: 0`).

**Known issue / unrun items:**

- Full CRUD lifecycle on a real L2 Stretch is not covered by the automated
  run because the test cluster only has one PC. This is documented in the
  test file with a conditional `when: l2_stretch_prereqs is defined` block
  that reviewers with a paired environment can enable by providing the
  `l2_stretch_prereqs.{local,remote}_{pc_cluster,stretch_subnet,connection}_reference`
  inventory variables.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_layer2_stretches_v2
Detected architecture x86_64 for Python interpreter: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python
Creating container database.
Run command: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/lib64/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_layer2_stretches_v2 integration test role
Initializing "/tmp/ansible-test-zxeelrdn-injector" as the temporary injector directory.
Injecting "/tmp/python-49t0194n-ansible/python" as a execv wrapper for the "/home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python" interpreter.
Stream command: ansible-playbook ntnx_layer2_stretches_v2-df9n4hw5.yml -i inventory -v
[WARNING]: Found variable using reserved name 'port'.
Origin: /tmp/codegen-artifacts.IwXO42/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_layer2_stretches_v2-pagwjisz-ÅÑŚÌβŁÈ/tests/integration/integration_config.yml:4:1

2 username: "admin"
3 password: "Nutanix.123"
4 port: 9440
  ^ column 1

Using /tmp/codegen-artifacts.IwXO42/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_layer2_stretches_v2-pagwjisz-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_layer2_stretches_v2 : Start Layer2 Stretch tests] *******************
ok: [testhost] => {
    "msg": "Start Layer2 Stretch tests"
}

TASK [ntnx_layer2_stretches_v2 : Generate random suffix] ***********************
ok: [testhost] => {"ansible_facts": {"random_name": "LSAFYdXFqVKb"}, "changed": false}

TASK [ntnx_layer2_stretches_v2 : Set names for Layer2 Stretch] *****************
ok: [testhost] => {"ansible_facts": {"fake_ext_id": "00000000-0000-0000-0000-000000000000", "l2s_name": "l2s_ansible_LSAFYdXFqVKb"}, "changed": false}

TASK [ntnx_layer2_stretches_v2 : Generate spec for creating Layer2 Stretch using check mode with all attributes] ***
ok: [testhost] => {"changed": false, "ext_id": null, "response": {"connection_type": "VXLAN", "description": "Layer2 Stretch created in check mode with all attributes", "ext_id": null, "high_availability_status": null, "links": null, "local_site_params": {"connection_reference": "3f9e5c2d-1111-4e00-9999-0000000000cc", "default_gateway_ip_address": {"ipv4": {"prefix_length": 24, "value": "192.168.10.254"}, "ipv6": null}, "high_availability_group": {"algorithm": "ACTIVE_BACKUP", "is_ha_enabled": true, "peered_gateways": [{"ext_id": "1a2b3c4d-1111-4e00-9999-000000000011", "status": null}]}, "pc_cluster_reference": "5ab1b1a2-1111-4e00-9999-0000000000aa", "stretch_interface_ip_address": {"ipv4": {"prefix_length": 24, "value": "192.168.10.1"}, "ipv6": null}, "stretch_subnet_reference": "8b5df6bc-1111-4e00-9999-0000000000bb", "vpn_interface_ip_address": {"ipv4": {"prefix_length": 24, "value": "192.168.10.2"}, "ipv6": null}}, "metadata": null, "mtu": 1500, "name": "check_mode_l2s_full", "remote_site_params": {"connection_reference": "4a0f6d3e-2222-4e00-9999-0000000000ff", "default_gateway_ip_address": {"ipv4": {"prefix_length": 24, "value": "192.168.20.254"}, "ipv6": null}, "high_availability_group": {"algorithm": "ACTIVE_BACKUP", "is_ha_enabled": true, "peered_gateways": [{"ext_id": "2b3c4d5e-2222-4e00-9999-000000000022", "status": null}]}, "pc_cluster_reference": "6bc2b2b3-2222-4e00-9999-0000000000dd", "stretch_interface_ip_address": {"ipv4": {"prefix_length": 24, "value": "192.168.20.1"}, "ipv6": null}, "stretch_subnet_reference": "9c6ef7cd-2222-4e00-9999-0000000000ee", "vpn_interface_ip_address": {"ipv4": {"prefix_length": 24, "value": "192.168.20.2"}, "ipv6": null}}, "remote_stretch_status": null, "stretch_status": null, "tenant_id": null, "vni": 100000}}

TASK [ntnx_layer2_stretches_v2 : Verify create Layer2 Stretch check mode spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode Create spec matches supplied attributes"
}

TASK [ntnx_layer2_stretches_v2 : Generate spec for updating Layer2 Stretch using check mode with all attributes] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching Layer2 Stretch info using ext_id
Origin: /tmp/codegen-artifacts.IwXO42/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_layer2_stretches_v2-pagwjisz-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_layer2_stretches_v2/tasks/layer2_stretches.yml:135:3

133 ########################################################################
134
135 - name: Generate spec for updating Layer2 Stretch using check mode with all attributes
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching Layer2 Stretch info using ext_id", "response": {"error": "Internal Server Error", "message": "Request processing failed: com.nutanix.networking.atlas_common.exceptions.AtlasException: Layer2 stretch 00000000-0000-0000-0000-000000000000 not found", "path": "/api/networking/v4.3/config/layer2-stretches/00000000-0000-0000-0000-000000000000", "status": 500, "timestamp": "2026-07-20T12:42:38.954+00:00"}, "status": 500}
...ignoring

TASK [ntnx_layer2_stretches_v2 : Verify update Layer2 Stretch check mode returns a failure or spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode Update handled non-existent ext_id gracefully"
}

TASK [ntnx_layer2_stretches_v2 : Generate spec for deleting Layer2 Stretch using check mode] ***
ok: [testhost] => {"changed": false, "ext_id": "00000000-0000-0000-0000-000000000000", "msg": "Layer2 Stretch with ext_id:00000000-0000-0000-0000-000000000000 will be deleted.", "response": null}

TASK [ntnx_layer2_stretches_v2 : Verify delete Layer2 Stretch check mode] ******
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode Delete produced correct dry-run message"
}

TASK [ntnx_layer2_stretches_v2 : Create Layer2 Stretch without required name] ***
[ERROR]: Task failed: Module failed: state is present but any of the following are missing: name, ext_id
Origin: /tmp/codegen-artifacts.IwXO42/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_layer2_stretches_v2-pagwjisz-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_layer2_stretches_v2/tasks/layer2_stretches.yml:196:3

194 ########################################################################
195
196 - name: Create Layer2 Stretch without required name
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is present but any of the following are missing: name, ext_id"}
...ignoring

TASK [ntnx_layer2_stretches_v2 : Verify missing name is rejected] **************
ok: [testhost] => {
    "changed": false,
    "msg": "Missing required field 'name' was rejected"
}

TASK [ntnx_layer2_stretches_v2 : Create Layer2 Stretch with invalid connection_type enum] ***
[ERROR]: Task failed: Module failed: value of connection_type must be one of: VPN, VXLAN, got: INVALID_TYPE
Origin: /tmp/codegen-artifacts.IwXO42/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_layer2_stretches_v2-pagwjisz-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_layer2_stretches_v2/tasks/layer2_stretches.yml:219:3

217 ########################################################################
218
219 - name: Create Layer2 Stretch with invalid connection_type enum
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of connection_type must be one of: VPN, VXLAN, got: INVALID_TYPE"}
...ignoring

TASK [ntnx_layer2_stretches_v2 : Verify invalid connection_type is rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid connection_type enum value was rejected by the argument spec"
}

TASK [ntnx_layer2_stretches_v2 : Get Layer2 Stretch using invalid ext_id] ******
[ERROR]: Task failed: Module failed: Api Exception raised while fetching Layer2 Stretch info using ext_id
Origin: /tmp/codegen-artifacts.IwXO42/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_layer2_stretches_v2-pagwjisz-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_layer2_stretches_v2/tasks/layer2_stretches.yml:240:3

238 ########################################################################
239
240 - name: Get Layer2 Stretch using invalid ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching Layer2 Stretch info using ext_id", "response": {"error": "Internal Server Error", "message": "Request processing failed: com.nutanix.networking.atlas_common.exceptions.AtlasException: Layer2 stretch 00000000-0000-0000-0000-000000000000 not found", "path": "/api/networking/v4.3/config/layer2-stretches/00000000-0000-0000-0000-000000000000", "status": 500, "timestamp": "2026-07-20T12:42:41.582+00:00"}, "status": 500}
...ignoring

TASK [ntnx_layer2_stretches_v2 : Verify get with invalid ext_id fails clearly] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Get by invalid ext_id returned a descriptive Api Exception"
}

TASK [ntnx_layer2_stretches_v2 : List all Layer2 Stretches] ********************
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_layer2_stretches_v2 : Verify list all Layer2 Stretches returned a list] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List all Layer2 Stretches succeeded"
}

TASK [ntnx_layer2_stretches_v2 : List Layer2 Stretches with limit] *************
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_layer2_stretches_v2 : Verify list with limit respected the limit] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List Layer2 Stretches with limit=1 respected the limit"
}

TASK [ntnx_layer2_stretches_v2 : List Layer2 Stretches with filter] ************
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_layer2_stretches_v2 : Verify list with filter was accepted] *********
ok: [testhost] => {
    "changed": false,
    "msg": "List Layer2 Stretches with filter was accepted"
}

TASK [ntnx_layer2_stretches_v2 : Delete Layer2 Stretch using unknown ext_id] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching Layer2 Stretch info using ext_id
Origin: /tmp/codegen-artifacts.IwXO42/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_layer2_stretches_v2-pagwjisz-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_layer2_stretches_v2/tasks/layer2_stretches.yml:321:3

319 ########################################################################
320
321 - name: Delete Layer2 Stretch using unknown ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching Layer2 Stretch info using ext_id", "response": {"error": "Internal Server Error", "message": "Request processing failed: com.nutanix.networking.atlas_common.exceptions.AtlasException: Layer2 stretch 00000000-0000-0000-0000-000000000000 not found", "path": "/api/networking/v4.3/config/layer2-stretches/00000000-0000-0000-0000-000000000000", "status": 500, "timestamp": "2026-07-20T12:42:44.734+00:00"}, "status": 500}
...ignoring

TASK [ntnx_layer2_stretches_v2 : Verify delete with unknown ext_id fails clearly] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Delete of unknown ext_id returned an Api Exception as expected"
}

TASK [ntnx_layer2_stretches_v2 : Create Layer2 Stretch with minimum attributes] ***
skipping: [testhost] => {"changed": false, "false_condition": "l2_stretch_prereqs is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_layer2_stretches_v2 : Verify create minimum Layer2 Stretch] *********
skipping: [testhost] => {"changed": false, "false_condition": "l2_stretch_prereqs is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_layer2_stretches_v2 : Update Layer2 Stretch description] ************
skipping: [testhost] => {"changed": false, "false_condition": "l2_stretch_prereqs is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_layer2_stretches_v2 : Verify update Layer2 Stretch] *****************
skipping: [testhost] => {"changed": false, "false_condition": "l2_stretch_prereqs is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_layer2_stretches_v2 : Update Layer2 Stretch again with same attributes (idempotency)] ***
skipping: [testhost] => {"changed": false, "false_condition": "l2_stretch_prereqs is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_layer2_stretches_v2 : Verify idempotent update did not change resource] ***
skipping: [testhost] => {"changed": false, "false_condition": "l2_stretch_prereqs is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_layer2_stretches_v2 : Get created Layer2 Stretch by ext_id] *********
skipping: [testhost] => {"changed": false, "false_condition": "l2_stretch_prereqs is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_layer2_stretches_v2 : Verify get by ext_id] *************************
skipping: [testhost] => {"changed": false, "false_condition": "l2_stretch_prereqs is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_layer2_stretches_v2 : Delete Layer2 Stretch] ************************
skipping: [testhost] => {"changed": false, "false_condition": "l2_stretch_prereqs is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_layer2_stretches_v2 : Verify delete Layer2 Stretch] *****************
skipping: [testhost] => {"changed": false, "false_condition": "l2_stretch_prereqs is defined", "skip_reason": "Conditional result was False"}

PLAY RECAP *********************************************************************
testhost                   : ok=24   changed=0    unreachable=0    failed=0    skipped=10   rescued=0    ignored=5   

WARNING: Reviewing previous 1 warning(s):
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_layer2_stretches_v2
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Live cluster used for integration + examples runs: Prism Central `10.44.76.28`.
- Lint / sanity gates that passed: `black`, `isort`, `flake8`,
  `ansible-lint` (0 failures, 22 warnings — all `args[module]: missing
  required arguments: nutanix_host` which are false positives because
  connection params come from `module_defaults`), and
  `ansible-test sanity --python 3.12` (all 24 sanity tests including
  `validate-modules`, `runtime-metadata`, `import`, `compile`, `pep8`,
  `pylint`, `yamllint`).
