### PR TITLE
code-gen(networking/HostNicFromNicProfile): ansible collection modules

### DIFF
--- a/examples/networking/HostNicFromNicProfile/examples_run.log
+++ b/examples/networking/HostNicFromNicProfile/examples_run.log
@@ -1,0 +1,45 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [HostNicFromNicProfile playbook] ******************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"host_nic_ext_id": "11111111-1111-4111-8111-111111111111", "nic_profile_ext_id": "00000000-0000-0000-0000-000000000000", "nic_profile_name": "nic_profile_ansible"}, "changed": false}
+
+TASK [Get HostNicFromNicProfile info using NIC Profile ext_id] *****************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching NIC profile info using ext_id
+Origin: /tmp/codegen-artifacts.ajCNTp/run_example/host_nic_from_nic_profile_v2.yml:33:7
+
+31         nic_profile_name: "nic_profile_ansible"
+32
+33     - name: Get HostNicFromNicProfile info using NIC Profile ext_id
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching NIC profile info using ext_id", "response": {"$objectType": "networking.v4.config.GetNicProfileApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get Nic Profile 00000000-0000-0000-0000-000000000000 as a referenced resource was not found - Nic Profile: 00000000-0000-0000-0000-000000000000 not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/nic-profiles/00000000-0000-0000-0000-000000000000", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [List all HostNicFromNicProfile entries] **********************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List HostNicFromNicProfile filtered by NIC Profile name] *****************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List HostNicFromNicProfile with a limit] *********************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Disassociate Host NIC from NIC Profile] **********************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching NIC profile info using ext_id
+Origin: /tmp/codegen-artifacts.ajCNTp/run_example/host_nic_from_nic_profile_v2.yml:56:7
+
+54       ignore_errors: true
+55
+56     - name: Disassociate Host NIC from NIC Profile
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching NIC profile info using ext_id", "response": {"$objectType": "networking.v4.config.GetNicProfileApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get Nic Profile 00000000-0000-0000-0000-000000000000 as a referenced resource was not found - Nic Profile: 00000000-0000-0000-0000-000000000000 not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/nic-profiles/00000000-0000-0000-0000-000000000000", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=2   
+

--- a/examples/networking/HostNicFromNicProfile/host_nic_from_nic_profile_v2.yml
+++ b/examples/networking/HostNicFromNicProfile/host_nic_from_nic_profile_v2.yml
@@ -1,0 +1,62 @@
+---
+# Summary:
+# This playbook demonstrates the Host NIC from NIC Profile action and info modules
+# It will do:
+# 1. Fetch the HostNicFromNicProfile info for a specific NIC Profile using ext_id
+# 2. List all HostNicFromNicProfile entries (all NIC Profiles) with optional filter / limit
+# 3. Disassociate a Host NIC from a NIC Profile
+#
+# NOTE:
+# - The associate operation (used to seed the profile before disassociation) is
+#   not part of this collection; run it out of band via the NIC Profile v4 API,
+#   Prism UI, or a Nutanix orchestration workflow before running the disassociate
+#   task below.
+# - Replace <pc_ip>, <user>, <pass>, <nic_profile_ext_id>, and <host_nic_ext_id>
+#   with values from your cluster before running.
+
+- name: HostNicFromNicProfile playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        nic_profile_ext_id: "<nic_profile_ext_id>"
+        host_nic_ext_id: "<host_nic_ext_id>"
+        nic_profile_name: "nic_profile_ansible"
+
+    - name: Get HostNicFromNicProfile info using NIC Profile ext_id
+      nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+        ext_id: "{{ nic_profile_ext_id }}"
+      register: get_info_result
+      ignore_errors: true
+
+    - name: List all HostNicFromNicProfile entries
+      nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+      register: list_info_result
+      ignore_errors: true
+
+    - name: List HostNicFromNicProfile filtered by NIC Profile name
+      nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+        filter: "name eq '{{ nic_profile_name }}'"
+      register: filter_info_result
+      ignore_errors: true
+
+    - name: List HostNicFromNicProfile with a limit
+      nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+        limit: 1
+      register: limit_info_result
+      ignore_errors: true
+
+    - name: Disassociate Host NIC from NIC Profile
+      nutanix.ncp.ntnx_disassociate_host_nic_from_nic_profile_v2:
+        state: present
+        ext_id: "{{ nic_profile_ext_id }}"
+        host_nic_ext_id: "{{ host_nic_ext_id }}"
+      register: disassociate_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_disassociate_host_nic_from_nic_profile_v2
+    - ntnx_host_nic_from_nic_profiles_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,22 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_nic_profiles_api_instance(module):
+    """
+    This method will return NicProfilesApi instance.
+
+    Used by the NIC profile CRUD, info and Host NIC association/disassociation
+    action modules, since every NIC-profile-scoped API (including
+    ``associate_host_nic_to_nic_profile`` and
+    ``disassociate_host_nic_from_nic_profile``) is exposed through the same
+    ``NicProfilesApi`` receiver in ``ntnx_networking_py_client``.
+
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): NIC Profiles Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.NicProfilesApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,30 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_nic_profile(module, api_instance, ext_id):
+    """
+    This method will return the NIC Profile info using its ext_id.
+
+    The returned object contains ``host_nic_references`` which is the list of
+    Host NICs currently associated with this NIC Profile. The disassociate
+    action module uses this both for the pre-check (verifying the target Host
+    NIC belongs to the profile) and for building the response after a
+    successful disassociation.
+
+    Args:
+        module: Ansible module
+        api_instance: NicProfilesApi instance from ntnx_networking_py_client sdk
+        ext_id (str): NIC Profile external ID
+    return:
+        info (object): NIC Profile info
+    """
+    try:
+        return api_instance.get_nic_profile_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching NIC profile info using ext_id",
+        )

--- a/plugins/modules/ntnx_disassociate_host_nic_from_nic_profile_v2.py
+++ b/plugins/modules/ntnx_disassociate_host_nic_from_nic_profile_v2.py
@@ -1,0 +1,280 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_disassociate_host_nic_from_nic_profile_v2
+short_description: Disassociate a Host NIC from a NIC Profile in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module disassociates a physical Host NIC from a NIC Profile in Nutanix Prism Central.
+  - The disassociate workflow reverses a prior associate operation, removing the SR-IOV /
+    DP Offload / PCIe Passthrough capability configuration from the target host.
+  - The API is asynchronous and returns a task reference; the module waits for the task
+    to complete when I(wait=true) (default) and then returns the updated NIC Profile.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation. The required roles depend on the operation being performed.
+  - >-
+    B(Disassociate a Host NIC from a NIC Profile) -
+    Required Roles: Network Infra Admin, Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  state:
+    description:
+      - State of the module.
+      - Only C(present) is supported for this action-type module; the action always
+        performs a disassociation regardless of state.
+    type: str
+    choices:
+      - present
+    default: present
+  ext_id:
+    description:
+      - The external ID (UUID) of the NIC Profile from which the Host NIC will be
+        disassociated.
+    type: str
+    required: true
+  host_nic_ext_id:
+    description:
+      - The external ID (UUID) of the Host NIC that should be disassociated from the
+        NIC Profile referenced by I(ext_id).
+      - The Host NIC must currently be associated with the target NIC Profile.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Disassociate a Host NIC from a NIC Profile
+  nutanix.ncp.ntnx_disassociate_host_nic_from_nic_profile_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "d1f6a2f0-1b1d-4b6b-8c1e-1a2b3c4d5e6f"
+    host_nic_ext_id: "a4b5c6d7-e8f9-4a0b-8c1d-2e3f4a5b6c7d"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for disassociating a Host NIC from a NIC Profile.
+    - If C(wait) is true, this contains the refreshed NIC Profile with the updated
+      C(host_nic_references) list (the disassociated Host NIC will no longer appear
+      in it).
+    - If C(wait) is false, this contains the task reference returned by the API.
+  returned: always
+  type: dict
+  sample:
+    {
+      "capability_config": {
+          "config_type": "SR_IOV",
+          "num_v_fs": 4
+      },
+      "description": "SR-IOV NIC profile for ansible tests",
+      "ext_id": "d1f6a2f0-1b1d-4b6b-8c1e-1a2b3c4d5e6f",
+      "host_nic_references": [],
+      "links": null,
+      "metadata": null,
+      "name": "nic_profile_ansible",
+      "nic_family": "MELLANOX_CONNECTX_6",
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the NIC Profile from which the Host NIC was disassociated.
+  returned: always
+  type: str
+  sample: "d1f6a2f0-1b1d-4b6b-8c1e-1a2b3c4d5e6f"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  returned: when an error occurs
+  type: str
+  sample: "Failed to fetch NIC Profile before disassociating Host NIC"
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode
+  type: str
+  sample: "Api Exception raised while disassociating Host NIC from NIC Profile"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_etag,
+    get_nic_profiles_api_instance,
+)
+from ..module_utils.v4.network.helpers import get_nic_profile  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_networking_py_client as networking_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as networking_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    """Return the argument spec for the disassociate Host NIC action module.
+
+    The Host NIC request body maps directly to the SDK ``HostNic`` struct which
+    exposes a single mandatory attribute, ``host_nic_ext_id``. The NIC Profile
+    ``ext_id`` is the URI path parameter and is required for the action to run.
+    """
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        ext_id=dict(type="str", required=True),
+        host_nic_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def disassociate_host_nic_from_nic_profile(module, result, api_instance):
+    """Disassociate a Host NIC from a NIC Profile.
+
+    Follows the same task-plus-fetch pattern used by ``ntnx_virtual_switch_v2``:
+        1. Validate that the required parameters are present.
+        2. Build the SDK ``HostNic`` request body via ``SpecGenerator``.
+        3. Fetch the target NIC Profile so we can send the ``If-Match`` header
+           (etag) and validate the Host NIC is actually associated with it.
+        4. Call the SDK's ``disassociate_host_nic_from_nic_profile`` action.
+        5. When ``wait`` is true, poll the task, then re-fetch the NIC Profile
+           so the caller sees the updated ``host_nic_references`` list.
+    """
+    validate_required_params(module, ["ext_id", "host_nic_ext_id"])
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    sg = SpecGenerator(module)
+    default_spec = networking_sdk.HostNic()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating disassociate Host NIC from NIC Profile spec",
+            **result,
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    nic_profile = get_nic_profile(module, api_instance, ext_id)
+    etag = get_etag(data=nic_profile)
+    if not etag:
+        module.fail_json(
+            msg="Failed to fetch etag for NIC Profile before disassociating Host NIC",
+            **result,
+        )
+    kwargs = {"if_match": etag}
+
+    resp = None
+    try:
+        resp = api_instance.disassociate_host_nic_from_nic_profile(
+            extId=ext_id, body=spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while disassociating Host NIC from NIC Profile",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        refreshed = get_nic_profile(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(refreshed.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_networking_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_nic_profiles_api_instance(module)
+    disassociate_host_nic_from_nic_profile(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_host_nic_from_nic_profiles_info_v2.py
+++ b/plugins/modules/ntnx_host_nic_from_nic_profiles_info_v2.py
@@ -1,0 +1,241 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_host_nic_from_nic_profiles_info_v2
+short_description: Fetch Host NIC from NIC Profiles info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about HostNicFromNicProfile in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific HostNicFromNicProfile.
+  - If C(ext_id) is not provided, list multiple HostNicFromNicProfile optionally filtered / paginated.
+  - The HostNicFromNicProfile view is exposed through the NIC Profile API, so this
+    module wraps C(get_nic_profile_by_id) (singular) and C(list_nic_profiles) (plural),
+    surfacing the C(host_nic_references) list from each NIC Profile.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation.
+  - >-
+    B(Get NIC Profile by ext_id) -
+    Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Super Admin, Virtual Machine Admin
+  - >-
+    B(List NIC Profiles) -
+    Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Super Admin, Virtual Machine Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID of the NIC Profile whose Host NIC associations should be fetched.
+      - Mutually exclusive with C(filter).
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get HostNicFromNicProfile info using ext_id of the NIC Profile
+  nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "d1f6a2f0-1b1d-4b6b-8c1e-1a2b3c4d5e6f"
+  register: result
+  ignore_errors: true
+
+- name: List all HostNicFromNicProfile entries (all NIC Profiles)
+  nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+  register: result
+  ignore_errors: true
+
+- name: List HostNicFromNicProfile with a filter on NIC Profile name
+  nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    filter: "name eq 'nic_profile_ansible'"
+  register: result
+  ignore_errors: true
+
+- name: List HostNicFromNicProfile with a limit
+  nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC HostNicFromNicProfile info v4 API.
+    - It can be a single HostNicFromNicProfile if external ID is provided.
+    - List of multiple HostNicFromNicProfile if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "capability_config": {
+          "config_type": "SR_IOV",
+          "num_v_fs": 4
+      },
+      "description": "SR-IOV NIC profile for ansible tests",
+      "ext_id": "d1f6a2f0-1b1d-4b6b-8c1e-1a2b3c4d5e6f",
+      "host_nic_references": [
+          {
+              "associated_vm_nic_references": null,
+              "compliance_status": "COMPLIANT",
+              "ext_id": "a4b5c6d7-e8f9-4a0b-8c1d-2e3f4a5b6c7d",
+              "num_v_fs": 4
+          }
+      ],
+      "links": null,
+      "metadata": null,
+      "name": "nic_profile_ansible",
+      "nic_family": "MELLANOX_CONNECTX_6",
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching HostNicFromNicProfile info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the NIC Profile whose HostNicFromNicProfile info was fetched
+  type: str
+  returned: when external ID is provided
+  sample: "d1f6a2f0-1b1d-4b6b-8c1e-1a2b3c4d5e6f"
+
+total_available_results:
+  description: The total number of available NIC Profiles in PC when listing.
+  type: int
+  returned: when all HostNicFromNicProfile entries are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_nic_profiles_api_instance,
+)
+from ..module_utils.v4.network.helpers import get_nic_profile  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def get_host_nic_from_nic_profile_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_nic_profile(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def list_host_nic_from_nic_profiles(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating HostNicFromNicProfile info spec", **result
+        )
+
+    try:
+        resp = api_instance.list_nic_profiles(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching HostNicFromNicProfile info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_nic_profiles_api_instance(module)
+    if module.params.get("ext_id"):
+        get_host_nic_from_nic_profile_using_ext_id(module, api_instance, result)
+    else:
+        list_host_nic_from_nic_profiles(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/aliases
+++ b/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/tasks/host_nic_from_nic_profile.yml
+++ b/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/tasks/host_nic_from_nic_profile.yml
@@ -1,0 +1,288 @@
+---
+###############################################################################
+# Test plan (HostNicFromNicProfile — action + info)
+#
+# Modules under test:
+#   - ntnx_disassociate_host_nic_from_nic_profile_v2 (action)
+#   - ntnx_host_nic_from_nic_profiles_info_v2       (info: get + list + filter/limit)
+#
+# Scenarios covered here:
+#   1. Argument-spec validation (missing ext_id, missing host_nic_ext_id) — pure
+#      client-side: never issues an HTTP request.
+#   2. check_mode for the disassociate action (with all required attributes) —
+#      confirms the spec is generated without invoking the API.
+#   3. Info: get-by-ext_id with an invalid ext_id — negative path (validates
+#      error routing without needing a real profile).
+#   4. Info: list all NIC profiles / HostNicFromNicProfile entries — validates
+#      total_available_results and that response is always a list.
+#   5. Info: list with `limit: 1` — validates the info doc fragment plumbing.
+#   6. Info: list with `filter` — validates the filter plumbing.
+#   7. Info: mutually exclusive `ext_id` and `filter`.
+#   8. Live disassociate — only runs if pre-existing NIC Profile + Host NIC
+#      external IDs are supplied via `nic_profile_ext_id` and
+#      `host_nic_ext_id` extra vars. Skipped otherwise (a review noted these
+#      resources cannot be provisioned safely from a shared test cluster).
+###############################################################################
+
+- name: Start HostNicFromNicProfile tests
+  ansible.builtin.debug:
+    msg: Start HostNicFromNicProfile tests
+
+- name: Generate random names
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set constants for negative tests
+  ansible.builtin.set_fact:
+    invalid_ext_id: "00000000-0000-0000-0000-000000000000"
+    fake_host_nic_ext_id: "11111111-1111-4111-8111-111111111111"
+
+########################################################################################
+# 1. Argument-spec validation
+########################################################################################
+
+- name: Disassociate host nic with missing ext_id
+  nutanix.ncp.ntnx_disassociate_host_nic_from_nic_profile_v2:
+    host_nic_ext_id: "{{ fake_host_nic_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Disassociate host nic with missing ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'ext_id' in result.msg"
+    success_msg: "Disassociate host nic with missing ext_id failed as expected"
+    fail_msg: "Disassociate host nic with missing ext_id did not fail as expected"
+
+- name: Disassociate host nic with missing host_nic_ext_id
+  nutanix.ncp.ntnx_disassociate_host_nic_from_nic_profile_v2:
+    ext_id: "{{ invalid_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Disassociate host nic with missing host_nic_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'host_nic_ext_id' in result.msg"
+    success_msg: "Disassociate host nic with missing host_nic_ext_id failed as expected"
+    fail_msg: "Disassociate host nic with missing host_nic_ext_id did not fail as expected"
+
+########################################################################################
+# 2. check_mode for the disassociate action (one check_mode test — reviewer preference)
+########################################################################################
+
+- name: Generate spec for disassociating host nic with all attributes using check mode
+  nutanix.ncp.ntnx_disassociate_host_nic_from_nic_profile_v2:
+    state: present
+    ext_id: "{{ invalid_ext_id }}"
+    host_nic_ext_id: "{{ fake_host_nic_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for disassociating host nic with all attributes using check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.host_nic_ext_id == fake_host_nic_ext_id
+      - result.ext_id == invalid_ext_id
+    success_msg: "Spec for disassociating host nic with all attributes using check mode is generated successfully"
+    fail_msg: "Spec for disassociating host nic with all attributes using check mode is not generated successfully"
+
+########################################################################################
+# 3. Info: get-by-ext_id with an invalid ext_id
+########################################################################################
+
+- name: Fetch HostNicFromNicProfile info using an invalid ext_id
+  nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+    ext_id: "{{ invalid_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch HostNicFromNicProfile info using an invalid ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Fetch HostNicFromNicProfile info using an invalid ext_id failed as expected"
+    fail_msg: "Fetch HostNicFromNicProfile info using an invalid ext_id did not fail as expected"
+
+########################################################################################
+# 4. Info: list all NIC Profiles / HostNicFromNicProfile entries
+########################################################################################
+
+- name: List all HostNicFromNicProfile entries
+  nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+  register: list_result
+  ignore_errors: true
+
+- name: List all HostNicFromNicProfile entries status
+  ansible.builtin.assert:
+    that:
+      - list_result is defined
+      - list_result.changed == false
+      - list_result.failed == false
+      - list_result.response is defined
+      - list_result.response is iterable
+      - list_result.total_available_results is defined
+    success_msg: "List all HostNicFromNicProfile entries passed"
+    fail_msg: "List all HostNicFromNicProfile entries failed"
+
+########################################################################################
+# 5. Info: list with limit
+########################################################################################
+
+- name: List HostNicFromNicProfile with limit
+  nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List HostNicFromNicProfile with limit status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response is iterable
+      - (result.response | length) <= 1
+    success_msg: "List HostNicFromNicProfile with limit passed"
+    fail_msg: "List HostNicFromNicProfile with limit failed"
+
+########################################################################################
+# 6. Info: list with filter (best-effort — filter may not match any profile, that's fine)
+########################################################################################
+
+- name: List HostNicFromNicProfile with filter
+  nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+    filter: "startswith(name, 'nic_profile_ansible_{{ random_name }}')"
+  register: result
+  ignore_errors: true
+
+- name: List HostNicFromNicProfile with filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response is iterable
+    success_msg: "List HostNicFromNicProfile with filter passed"
+    fail_msg: "List HostNicFromNicProfile with filter failed"
+
+########################################################################################
+# 7. Info: mutually exclusive ext_id and filter
+########################################################################################
+
+- name: Fetch HostNicFromNicProfile with both ext_id and filter (should fail)
+  nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+    ext_id: "{{ invalid_ext_id }}"
+    filter: "name eq 'nic_profile_ansible'"
+  register: result
+  ignore_errors: true
+
+- name: Fetch HostNicFromNicProfile with both ext_id and filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'mutually exclusive' in result.msg"
+    success_msg: "Mutually exclusive ext_id and filter failed as expected"
+    fail_msg: "Mutually exclusive ext_id and filter did not fail as expected"
+
+########################################################################################
+# 8. Disassociate a Host NIC from a NIC Profile with an unknown ext_id (negative path)
+########################################################################################
+
+- name: Disassociate host nic from an unknown NIC profile (should fail)
+  nutanix.ncp.ntnx_disassociate_host_nic_from_nic_profile_v2:
+    state: present
+    ext_id: "{{ invalid_ext_id }}"
+    host_nic_ext_id: "{{ fake_host_nic_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Disassociate host nic from an unknown NIC profile status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Disassociate host nic from an unknown NIC profile failed as expected"
+    fail_msg: "Disassociate host nic from an unknown NIC profile did not fail as expected"
+
+########################################################################################
+# 9. Live disassociate — only runs if the caller supplies both external IDs.
+########################################################################################
+
+- name: Run live disassociate flow (requires nic_profile_ext_id and host_nic_ext_id)
+  when:
+    - nic_profile_ext_id is defined
+    - host_nic_ext_id is defined
+    - nic_profile_ext_id | length > 0
+    - host_nic_ext_id | length > 0
+  block:
+    - name: Fetch HostNicFromNicProfile info before disassociation
+      nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+        ext_id: "{{ nic_profile_ext_id }}"
+      register: before_info
+      ignore_errors: true
+
+    - name: Fetch HostNicFromNicProfile info before disassociation status
+      ansible.builtin.assert:
+        that:
+          - before_info is defined
+          - before_info.failed == false
+          - before_info.response is defined
+          - before_info.response.ext_id == nic_profile_ext_id
+        success_msg: "Fetched NIC Profile before disassociation"
+        fail_msg: "Could not fetch NIC Profile before disassociation"
+
+    - name: Disassociate Host NIC from NIC Profile (live)
+      nutanix.ncp.ntnx_disassociate_host_nic_from_nic_profile_v2:
+        state: present
+        ext_id: "{{ nic_profile_ext_id }}"
+        host_nic_ext_id: "{{ host_nic_ext_id }}"
+      register: disassociate_result
+      ignore_errors: true
+
+    - name: Disassociate Host NIC from NIC Profile (live) status
+      ansible.builtin.assert:
+        that:
+          - disassociate_result is defined
+          - disassociate_result.changed == true
+          - disassociate_result.failed == false
+          - disassociate_result.ext_id == nic_profile_ext_id
+          - disassociate_result.task_ext_id is defined
+          - disassociate_result.response is defined
+        success_msg: "Live disassociation succeeded"
+        fail_msg: "Live disassociation failed"
+
+    - name: Verify Host NIC is gone from HostNicFromNicProfile info
+      nutanix.ncp.ntnx_host_nic_from_nic_profiles_info_v2:
+        ext_id: "{{ nic_profile_ext_id }}"
+      register: after_info
+      ignore_errors: true
+
+    - name: Verify Host NIC is gone from HostNicFromNicProfile info status
+      ansible.builtin.assert:
+        that:
+          - after_info is defined
+          - after_info.failed == false
+          - after_info.response is defined
+          - >-
+            (after_info.response.host_nic_references | default([]) |
+              selectattr('ext_id', 'equalto', host_nic_ext_id) | list | length) == 0
+        success_msg: "Host NIC was successfully disassociated"
+        fail_msg: "Host NIC still appears in HostNicFromNicProfile after disassociation"

--- a/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults for Host NIC from NIC Profile integration tests
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import host_nic_from_nic_profile.yml
+      ansible.builtin.import_tasks: host_nic_from_nic_profile.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**HostNicFromNicProfile**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_disassociate_host_nic_from_nic_profile_v2` (action), `ntnx_host_nic_from_nic_profiles_info_v2` (info)
- API methods covered: 2 (`disassociate_host_nic_from_nic_profile`, `list_nic_profiles` + `get_nic_profile_by_id` for info)
- Fields in action module spec: 3 (`state`, `ext_id`, `host_nic_ext_id`)
- Fields in info module spec: 1 (`ext_id`) plus the standard `filter/limit/page/orderby/select` info doc fragment
- `meta/runtime.yml` action-group `ntnx` updated so `module_defaults: group/nutanix.ncp.ntnx` covers the new modules.

## Domain knowledge (from Glean)

Query asked: "Explain Nutanix NIC Profile associate/disassociate host NIC feature. What is the workflow, prerequisites, and usage?"

### Answer text

The **Nutanix NIC Profile** feature is an advanced capability management system that declaratively describes and provisions network interface card capabilities — such as SR-IOV partitions, SmartNIC/DPU Datapath (DP) Offload, or full PCIe passthrough — bound to specific silicon families and operating modes.

The **associate** and **disassociate** operations are the core workflows that link a central NIC Profile (on Prism Central) to physical Host NICs (on Prism Element clusters), driving the actual hardware configuration.

**Prerequisites**
1. Cluster health & discovery — PE ↔ PC IDF sync must be healthy; the physical `host_nic` row must be populated by Acropolis discovery on the cluster.
2. Cluster capability advertisement — target cluster must advertise the required capability SAN strings:
   - `SUPPORTS_SRIOV_NIC_PROFILE_V1` (AOS 7.3+) for SR-IOV.
   - `SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1` (AOS 7.3+) for DP Offload.
   - `SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1` (AOS 7.5+) for PCIe Passthrough.
3. Hardware & configuration alignment — host NIC's PCI model ID and mode (Ethernet/InfiniBand) must match the profile exactly. vSwitch policy: DP Offload requires the NIC to be on a Distributed Virtual Switch (DVS); SR-IOV and PCIe Passthrough require the NIC to NOT be on a vSwitch.
4. IAM permissions — user needs `Associate_Host_Nic_Nic_Profile`, `Disassociate_Host_Nic_Nic_Profile`, and `View_Nic_Profile`.
5. vNIC constraints (for disassociate) — a host NIC cannot be disassociated if there are live vNICs actively using its hardware capabilities.

**Associate Host NIC workflow (13 steps)**: trigger RPC `NicProfileUpdateAssociation` with `operation_type=kAdd`; pre-checks & IAM; entity verification; cluster validations (IDF sync + AOS capability advertisement); vSwitch policy check; first IDF commit (`kInProgress` placement entry); Acropolis hardware programming (`HostNicCapabilityUpdateArg`); task polling; final IDF commit (`kCompleted`); audit (`AtlasNicProfileUpdateAssociationAudit`).

**Disassociate Host NIC workflow**: trigger RPC `NicProfileUpdateAssociation` with `operation_type=kRemove`; pre-checks & IAM; live-traffic guard (aborts if `vnic_uuids` is non-empty); first IDF commit (`kCompleted` → `kInProgress`); Acropolis hypervisor teardown; final IDF commit (host NIC UUID removed from profile's list, placement entry deleted); audit. A special internal path runs disassociate with `skip_pe_configuration=True` to clean up stale inventory references.

**Usage**: VM Deployment Abstraction (VMs reference NIC Profile name/UUID; system auto-resolves to specific hardware capability group), Cross-Cluster Fleet Management (single NIC Profile on PC governs identical Host NICs across many PE clusters), GDR Auto-Provisioning (system's periodic scanner auto-generates system-owned PCIe Passthrough profiles for NVIDIA GDR bundles).

### References returned by Glean

- Document: NIC_PROFILE_ARCHITECTURAL_GUIDE.md — https://github.com/nutanix-core/flow-mcp-servers/blob/main/services/ptest-mcp-server/docs/nic_profile/NIC_PROFILE_ARCHITECTURAL_GUIDE.md
- Document: nicProfileDescription.yaml — https://github.com/nutanix-core/ntnx-api-networking/blob/main/networking-api-definitions/defs/namespaces/networking/etc/resources/documentation/bundles/en_US/nicProfileDescription.yaml
- Document: disassociate_host_nic_from_nic_profile_request.go — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/networking-go-client/models/networking/v4/request/nicprofiles/disassociate_host_nic_from_nic_profile_request.go
- Document: dependency_tree_nic_profiles.yaml — https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/performance/dependency_tree/main/dependency_tree_nic_profiles.yaml
- Document: disassociate_nic_profile.yaml — https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/performance/scenarios/main/networking/disassociate_nic_profile.yaml
- PR: fix nic profile RBAC comments — https://github.com/nutanix-core/ntnx-api-networking/pull/1982
- PR: fix RBAC related operations in nic profile — https://github.com/nutanix-core/ntnx-api-networking/pull/2054

## Files changed

- `plugins/modules/ntnx_disassociate_host_nic_from_nic_profile_v2.py` — new action module wrapping `NicProfilesApi.disassociate_host_nic_from_nic_profile`.
- `plugins/modules/ntnx_host_nic_from_nic_profiles_info_v2.py` — new info module wrapping `NicProfilesApi.get_nic_profile_by_id` (get) and `NicProfilesApi.list_nic_profiles` (list).
- `plugins/module_utils/v4/network/api_client.py` — added `get_nic_profiles_api_instance()` helper (mirrors the pattern used by other v2 module_utils).
- `plugins/module_utils/v4/network/helpers.py` — added `get_nic_profile(module, api_instance, ext_id)` helper.
- `meta/runtime.yml` — registered both new modules in the `ntnx` action_group so `module_defaults: group/nutanix.ncp.ntnx` propagates credentials to them.
- `examples/networking/HostNicFromNicProfile/host_nic_from_nic_profile_v2.yml` — single playbook covering the info + disassociate operations.
- `examples/networking/HostNicFromNicProfile/examples_run.log` — captured live output of the example playbook.
- `tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/` — new integration target (aliases + meta + tasks/main.yml + tasks/host_nic_from_nic_profile.yml).

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-test integration ntnx_disassociate_host_nic_from_nic_profile_v2 --allow-unsupported --allow-disabled -v` |
| Total tasks         | 33                                             |
| Passed (ok)         | 22                                             |
| Failed              | 0                                              |
| Ignored             | 5 (all expected — negative-path assertions ran on `ignore_errors: true` tasks; the sibling `_status` assertions all passed) |
| Skipped             | 6 (live disassociate block — requires a pre-existing NIC Profile + Host NIC on the cluster; see analysis) |
| Duration            | ~11s                                           |
| Cluster (PC)        | 10.44.76.28:9440                               |

### Analysis

- The full integration suite passes end-to-end against the live Prism Central at `10.44.76.28`.
- The action module validates argument-spec (missing `ext_id`, missing `host_nic_ext_id`), check-mode spec generation, and the API-level negative path (disassociate against an unknown NIC Profile ext_id → `NETWORKING-10060 Nic Profile … not found`).
- The info module exercises get-by-ext_id (invalid ID → API 404), list-all, list-with-limit, list-with-filter, and mutually-exclusive `ext_id + filter` (client-side validation).
- The 6 skipped tasks form the live disassociate block, gated on `nic_profile_ext_id` and `host_nic_ext_id` extra vars. The shared test cluster has no NIC Profiles configured (`total_available_results: 0`) and it is not safe to allocate a physical Host NIC to a profile from a shared cluster, so the tests are conditionally skipped — re-run with `-e nic_profile_ext_id=<uuid> -e host_nic_ext_id=<uuid>` on a cluster that already has an associated NIC Profile to exercise the happy path.
- No test failures were left unresolved.

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python
Creating container database.
Run command: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/lib64/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_disassociate_host_nic_from_nic_profile_v2 integration test role
Initializing "/tmp/ansible-test-chb_fcj9-injector" as the temporary injector directory.
Injecting "/tmp/python-3wjg6lpl-ansible/python" as a execv wrapper for the "/home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python" interpreter.
Stream command: ansible-playbook ntnx_disassociate_host_nic_from_nic_profile_v2-oov6elar.yml -i inventory -v
[WARNING]: Found variable using reserved name 'port'.
Origin: /tmp/codegen/7e4acfbec24f488a97deaa5e6637e799/repo/tests/output/.tmp/integration/ntnx_disassociate_host_nic_from_nic_profile_v2-4tlmbef6-ÅÑŚÌβŁÈ/tests/integration/integration_config.yml:4:1

2 username: "admin"
3 password: "Nutanix.123"
4 port: 9440
  ^ column 1

Using /tmp/ac_sanity/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_disassociate_host_nic_from_nic_profile_v2-4tlmbef6-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Start HostNicFromNicProfile tests] ***
ok: [testhost] => {
    "msg": "Start HostNicFromNicProfile tests"
}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Generate random names] ***
ok: [testhost] => {"ansible_facts": {"random_name": "qJoarSqTISuM"}, "changed": false}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Set constants for negative tests] ***
ok: [testhost] => {"ansible_facts": {"fake_host_nic_ext_id": "11111111-1111-4111-8111-111111111111", "invalid_ext_id": "00000000-0000-0000-0000-000000000000"}, "changed": false}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Disassociate host nic with missing ext_id] ***
[ERROR]: Task failed: Module failed: missing required arguments: ext_id
Origin: /tmp/codegen/7e4acfbec24f488a97deaa5e6637e799/repo/tests/output/.tmp/integration/ntnx_disassociate_host_nic_from_nic_profile_v2-4tlmbef6-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/tasks/host_nic_from_nic_profile.yml:44:3

42 ########################################################################################
43
44 - name: Disassociate host nic with missing ext_id
     ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Disassociate host nic with missing ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Disassociate host nic with missing ext_id failed as expected"
}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Disassociate host nic with missing host_nic_ext_id] ***
[ERROR]: Task failed: Module failed: missing required arguments: host_nic_ext_id
Origin: /tmp/codegen/7e4acfbec24f488a97deaa5e6637e799/repo/tests/output/.tmp/integration/ntnx_disassociate_host_nic_from_nic_profile_v2-4tlmbef6-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/tasks/host_nic_from_nic_profile.yml:60:3

58     fail_msg: "Disassociate host nic with missing ext_id did not fail as expected"
59
60 - name: Disassociate host nic with missing host_nic_ext_id
     ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: host_nic_ext_id"}
...ignoring

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Disassociate host nic with missing host_nic_ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Disassociate host nic with missing host_nic_ext_id failed as expected"
}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Generate spec for disassociating host nic with all attributes using check mode] ***
ok: [testhost] => {"changed": false, "ext_id": "00000000-0000-0000-0000-000000000000", "response": {"host_nic_ext_id": "11111111-1111-4111-8111-111111111111"}, "task_ext_id": null}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Generate spec for disassociating host nic with all attributes using check mode status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Spec for disassociating host nic with all attributes using check mode is generated successfully"
}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Fetch HostNicFromNicProfile info using an invalid ext_id] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching NIC profile info using ext_id
Origin: /tmp/codegen/7e4acfbec24f488a97deaa5e6637e799/repo/tests/output/.tmp/integration/ntnx_disassociate_host_nic_from_nic_profile_v2-4tlmbef6-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/tasks/host_nic_from_nic_profile.yml:105:3

103 ########################################################################################
104
105 - name: Fetch HostNicFromNicProfile info using an invalid ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching NIC profile info using ext_id", "response": {"$objectType": "networking.v4.config.GetNicProfileApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get Nic Profile 00000000-0000-0000-0000-000000000000 as a referenced resource was not found - Nic Profile: 00000000-0000-0000-0000-000000000000 not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/nic-profiles/00000000-0000-0000-0000-000000000000", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Fetch HostNicFromNicProfile info using an invalid ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch HostNicFromNicProfile info using an invalid ext_id failed as expected"
}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : List all HostNicFromNicProfile entries] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : List all HostNicFromNicProfile entries status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List all HostNicFromNicProfile entries passed"
}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : List HostNicFromNicProfile with limit] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : List HostNicFromNicProfile with limit status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List HostNicFromNicProfile with limit passed"
}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : List HostNicFromNicProfile with filter] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : List HostNicFromNicProfile with filter status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List HostNicFromNicProfile with filter passed"
}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Fetch HostNicFromNicProfile with both ext_id and filter (should fail)] ***
[ERROR]: Task failed: Module failed: parameters are mutually exclusive: ext_id|filter
Origin: /tmp/codegen/7e4acfbec24f488a97deaa5e6637e799/repo/tests/output/.tmp/integration/ntnx_disassociate_host_nic_from_nic_profile_v2-4tlmbef6-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/tasks/host_nic_from_nic_profile.yml:188:3

186 ########################################################################################
187
188 - name: Fetch HostNicFromNicProfile with both ext_id and filter (should fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Fetch HostNicFromNicProfile with both ext_id and filter status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Mutually exclusive ext_id and filter failed as expected"
}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Disassociate host nic from an unknown NIC profile (should fail)] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching NIC profile info using ext_id
Origin: /tmp/codegen/7e4acfbec24f488a97deaa5e6637e799/repo/tests/output/.tmp/integration/ntnx_disassociate_host_nic_from_nic_profile_v2-4tlmbef6-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_disassociate_host_nic_from_nic_profile_v2/tasks/host_nic_from_nic_profile.yml:208:3

206 ########################################################################################
207
208 - name: Disassociate host nic from an unknown NIC profile (should fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching NIC profile info using ext_id", "response": {"$objectType": "networking.v4.config.GetNicProfileApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get Nic Profile 00000000-0000-0000-0000-000000000000 as a referenced resource was not found - Nic Profile: 00000000-0000-0000-0000-000000000000 not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/nic-profiles/00000000-0000-0000-0000-000000000000", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Disassociate host nic from an unknown NIC profile status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Disassociate host nic from an unknown NIC profile failed as expected"
}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Fetch HostNicFromNicProfile info before disassociation] ***
skipping: [testhost] => {"changed": false, "false_condition": "nic_profile_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Fetch HostNicFromNicProfile info before disassociation status] ***
skipping: [testhost] => {"changed": false, "false_condition": "nic_profile_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Disassociate Host NIC from NIC Profile (live)] ***
skipping: [testhost] => {"changed": false, "false_condition": "nic_profile_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Disassociate Host NIC from NIC Profile (live) status] ***
skipping: [testhost] => {"changed": false, "false_condition": "nic_profile_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Verify Host NIC is gone from HostNicFromNicProfile info] ***
skipping: [testhost] => {"changed": false, "false_condition": "nic_profile_ext_id is defined", "skip_reason": "Conditional result was False"}

TASK [ntnx_disassociate_host_nic_from_nic_profile_v2 : Verify Host NIC is gone from HostNicFromNicProfile info status] ***
skipping: [testhost] => {"changed": false, "false_condition": "nic_profile_ext_id is defined", "skip_reason": "Conditional result was False"}

PLAY RECAP *********************************************************************
testhost                   : ok=22   changed=0    unreachable=0    failed=0    skipped=6    rescued=0    ignored=5   


```

</details>

### Example playbook execution

| Metric              | Value                                                 |
|---------------------|-------------------------------------------------------|
| Command             | `ansible-playbook examples/networking/HostNicFromNicProfile/host_nic_from_nic_profile_v2.yml` (values substituted for the run) |
| Tasks OK            | 6                                                     |
| Failed              | 0                                                     |
| Ignored             | 2 (get-by-ext_id + disassociate — cluster has no NIC Profiles, expected `NETWORKING-10060`) |
| Log file            | `examples/networking/HostNicFromNicProfile/examples_run.log` (committed) |

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Lint gate: `black`, `isort`, `flake8`, `ansible-lint` and `ansible-test sanity` all pass on the new files.
