### PR TITLE
code-gen(networking/ClusterCapability): ansible collection modules

### DIFF
--- a/examples/networking/ClusterCapability/cluster_capabilities_v2.yml
+++ b/examples/networking/ClusterCapability/cluster_capabilities_v2.yml
@@ -1,0 +1,91 @@
+---
+# Summary:
+# This playbook demonstrates the read-only Networking Cluster Capabilities API.
+# The Nutanix Networking API exposes a single endpoint for this entity
+# (GET /api/networking/v4.3/config/capabilities), so this playbook covers:
+# 1. List all cluster capabilities registered against Prism Central
+# 2. List cluster capabilities with a page limit
+# 3. List cluster capabilities with an OData filter (clusterId based)
+# 4. List cluster capabilities sorted by clusterId (asc and desc)
+# 5. Fetch a single cluster capability entity by external ID
+#    (which resolves to the Prism Element cluster UUID)
+
+- name: Cluster Capabilities info playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: List all cluster capabilities registered against Prism Central
+      nutanix.ncp.ntnx_cluster_capabilities_info_v2: {}
+      register: all_capabilities
+      ignore_errors: true
+
+    - name: Show list-all response
+      ansible.builtin.debug:
+        msg: "{{ all_capabilities }}"
+
+    - name: List cluster capabilities with a page limit
+      nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+        limit: 1
+      register: limited_capabilities
+      ignore_errors: true
+
+    - name: Show limited-list response
+      ansible.builtin.debug:
+        msg: "{{ limited_capabilities }}"
+
+    - name: Capture the first cluster_id (used as ext_id for follow-up tasks)
+      ansible.builtin.set_fact:
+        first_cluster_id: "{{ all_capabilities.response[0].cluster_id }}"
+      when:
+        - all_capabilities.response is defined
+        - (all_capabilities.response | length) > 0
+
+    - name: List cluster capabilities filtered by clusterId
+      nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+        filter: "clusterId eq '{{ first_cluster_id }}'"
+      register: filtered_capabilities
+      when: first_cluster_id is defined
+      ignore_errors: true
+
+    - name: Show filtered-list response
+      ansible.builtin.debug:
+        msg: "{{ filtered_capabilities }}"
+      when: first_cluster_id is defined
+
+    - name: List cluster capabilities sorted by clusterId ascending
+      nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+        orderby: "clusterId asc"
+      register: asc_capabilities
+      ignore_errors: true
+
+    - name: Show asc-ordered response
+      ansible.builtin.debug:
+        msg: "{{ asc_capabilities }}"
+
+    - name: List cluster capabilities sorted by clusterId descending
+      nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+        orderby: "clusterId desc"
+      register: desc_capabilities
+      ignore_errors: true
+
+    - name: Show desc-ordered response
+      ansible.builtin.debug:
+        msg: "{{ desc_capabilities }}"
+
+    - name: Fetch a single cluster capability entity by external ID
+      nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+        ext_id: "{{ first_cluster_id }}"
+      register: single_capability
+      when: first_cluster_id is defined
+      ignore_errors: true
+
+    - name: Show get-by-ext_id response
+      ansible.builtin.debug:
+        msg: "{{ single_capability }}"
+      when: first_cluster_id is defined

--- a/examples/networking/ClusterCapability/examples_run.log
+++ b/examples/networking/ClusterCapability/examples_run.log
@@ -1,0 +1,532 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Cluster Capabilities info playbook] **************************************
+
+TASK [List all cluster capabilities registered against Prism Central] **********
+ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}], "total_available_results": null}
+
+TASK [Show list-all response] **************************************************
+ok: [localhost] => {
+    "msg": {
+        "changed": false,
+        "failed": false,
+        "response": [
+            {
+                "capabilities": [
+                    {
+                        "capability_name": "NIC_TEAM_TBL_SYNC_ENABLE",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V3",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V4",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PC_DVS_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PC_DVS_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_QOS_ASSOCIATION_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SPAN_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SPAN_V3",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1",
+                        "is_supported": true
+                    }
+                ],
+                "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+                "ext_id": null,
+                "links": null,
+                "metadata": null,
+                "tenant_id": null
+            }
+        ],
+        "total_available_results": null
+    }
+}
+
+TASK [List cluster capabilities with a page limit] *****************************
+ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}], "total_available_results": null}
+
+TASK [Show limited-list response] **********************************************
+ok: [localhost] => {
+    "msg": {
+        "changed": false,
+        "failed": false,
+        "response": [
+            {
+                "capabilities": [
+                    {
+                        "capability_name": "NIC_TEAM_TBL_SYNC_ENABLE",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V3",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V4",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PC_DVS_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PC_DVS_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_QOS_ASSOCIATION_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SPAN_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SPAN_V3",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1",
+                        "is_supported": true
+                    }
+                ],
+                "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+                "ext_id": null,
+                "links": null,
+                "metadata": null,
+                "tenant_id": null
+            }
+        ],
+        "total_available_results": null
+    }
+}
+
+TASK [Capture the first cluster_id (used as ext_id for follow-up tasks)] *******
+ok: [localhost] => {"ansible_facts": {"first_cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}, "changed": false}
+
+TASK [List cluster capabilities filtered by clusterId] *************************
+ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}], "total_available_results": null}
+
+TASK [Show filtered-list response] *********************************************
+ok: [localhost] => {
+    "msg": {
+        "changed": false,
+        "failed": false,
+        "response": [
+            {
+                "capabilities": [
+                    {
+                        "capability_name": "NIC_TEAM_TBL_SYNC_ENABLE",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V3",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V4",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PC_DVS_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PC_DVS_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_QOS_ASSOCIATION_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SPAN_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SPAN_V3",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1",
+                        "is_supported": true
+                    }
+                ],
+                "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+                "ext_id": null,
+                "links": null,
+                "metadata": null,
+                "tenant_id": null
+            }
+        ],
+        "total_available_results": null
+    }
+}
+
+TASK [List cluster capabilities sorted by clusterId ascending] *****************
+ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}], "total_available_results": null}
+
+TASK [Show asc-ordered response] ***********************************************
+ok: [localhost] => {
+    "msg": {
+        "changed": false,
+        "failed": false,
+        "response": [
+            {
+                "capabilities": [
+                    {
+                        "capability_name": "NIC_TEAM_TBL_SYNC_ENABLE",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V3",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V4",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PC_DVS_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PC_DVS_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_QOS_ASSOCIATION_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SPAN_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SPAN_V3",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1",
+                        "is_supported": true
+                    }
+                ],
+                "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+                "ext_id": null,
+                "links": null,
+                "metadata": null,
+                "tenant_id": null
+            }
+        ],
+        "total_available_results": null
+    }
+}
+
+TASK [List cluster capabilities sorted by clusterId descending] ****************
+ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}], "total_available_results": null}
+
+TASK [Show desc-ordered response] **********************************************
+ok: [localhost] => {
+    "msg": {
+        "changed": false,
+        "failed": false,
+        "response": [
+            {
+                "capabilities": [
+                    {
+                        "capability_name": "NIC_TEAM_TBL_SYNC_ENABLE",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V3",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_IPFIX_EXPORTER_V4",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PC_DVS_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_PC_DVS_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_QOS_ASSOCIATION_V1",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SPAN_V2",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SPAN_V3",
+                        "is_supported": true
+                    },
+                    {
+                        "capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1",
+                        "is_supported": true
+                    }
+                ],
+                "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+                "ext_id": null,
+                "links": null,
+                "metadata": null,
+                "tenant_id": null
+            }
+        ],
+        "total_available_results": null
+    }
+}
+
+TASK [Fetch a single cluster capability entity by external ID] *****************
+ok: [localhost] => {"changed": false, "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "response": {"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}}
+
+TASK [Show get-by-ext_id response] *********************************************
+ok: [localhost] => {
+    "msg": {
+        "changed": false,
+        "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+        "failed": false,
+        "response": {
+            "capabilities": [
+                {
+                    "capability_name": "NIC_TEAM_TBL_SYNC_ENABLE",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_IPFIX_EXPORTER_V2",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_IPFIX_EXPORTER_V3",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_IPFIX_EXPORTER_V4",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_PC_DVS_V1",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_PC_DVS_V2",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_QOS_ASSOCIATION_V1",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_SPAN_V2",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_SPAN_V3",
+                    "is_supported": true
+                },
+                {
+                    "capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1",
+                    "is_supported": true
+                }
+            ],
+            "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+            "ext_id": null,
+            "links": null,
+            "metadata": null,
+            "tenant_id": null
+        }
+    }
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=13   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_cluster_capabilities_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_cluster_capabilities_api_instance(module):
+    """
+    This method will return ClusterCapabilitiesApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Cluster Capabilities Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.ClusterCapabilitiesApi(api_client=api_client)

--- a/plugins/modules/ntnx_cluster_capabilities_info_v2.py
+++ b/plugins/modules/ntnx_cluster_capabilities_info_v2.py
@@ -1,0 +1,271 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_cluster_capabilities_info_v2
+short_description: Fetch cluster capabilities info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about ClusterCapability in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific ClusterCapability.
+  - If C(ext_id) is not provided, list multiple ClusterCapability optionally filtered / paginated.
+  - The Networking Cluster Capabilities API exposes the per-cluster networking
+    capabilities supported by the Prism Element clusters registered against
+    the Prism Central instance.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM operation to be granted
+      to the calling user on the C(cluster_networking_capabilities) legacy
+      object kind - C(View_Cluster_Networking_Capabilities).
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external identifier of the cluster capability entity, which is
+        the UUID of the Prism Element cluster whose networking capabilities
+        should be returned.
+      - When provided, the module fetches the single ClusterCapability entity
+        that matches C(clusterId == ext_id) via an OData filter push-down
+        against the C(list_cluster_capabilities) endpoint (the underlying
+        API does not expose a get-by-ID endpoint for this entity).
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all cluster capabilities registered against Prism Central
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+  register: all_capabilities
+
+- name: List cluster capabilities filtered by clusterId
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    filter: "clusterId eq '00061de6-4a87-6b06-185b-ac1f6b6f97e2'"
+  register: filtered_capabilities
+
+- name: List cluster capabilities with a page size limit
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    limit: 1
+  register: limited_capabilities
+
+- name: List cluster capabilities sorted by clusterId descending
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    orderby: "clusterId desc"
+  register: sorted_capabilities
+
+- name: Fetch a single cluster capability entity by external ID
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+  register: single_capability
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC ClusterCapability info v4 API.
+    - It can be a single ClusterCapability if external ID is provided.
+    - List of multiple ClusterCapability if external ID is not provided with
+      optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "capabilities": [
+        {
+          "capability_name": "NIC_TEAM_TBL_SYNC_ENABLE",
+          "is_supported": true
+        },
+        {
+          "capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS",
+          "is_supported": true
+        },
+        {
+          "capability_name": "SUPPORTS_PC_DVS_V1",
+          "is_supported": true
+        },
+        {
+          "capability_name": "SUPPORTS_SPAN_V2",
+          "is_supported": true
+        }
+      ],
+      "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+      "ext_id": null,
+      "links": null,
+      "metadata": null,
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching cluster capabilities info"
+
+error:
+  description:
+    - This field typically holds information about if the task have errors
+      that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task has failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description:
+    - External ID of the cluster capability entity - the Prism Element
+      cluster UUID whose networking capabilities were returned.
+  type: str
+  returned: when external ID is provided
+  sample: "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+
+total_available_results:
+  description:
+    - The total number of available cluster capability entities in PC.
+    - The Networking Cluster Capabilities API historically returned
+      C(null) for this field (see NET-20210 / ENG-681255); it is only
+      populated on Prism Central builds that carry the fix.
+  type: int
+  returned: when all cluster capabilities are fetched
+  sample: 3
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_cluster_capabilities_api_instance,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def _list_cluster_capabilities(module, api_instance, **kwargs):
+    """
+    Wrapper around C(list_cluster_capabilities) which handles SDK exceptions in
+    the standard Ansible way.
+    """
+    try:
+        return api_instance.list_cluster_capabilities(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching cluster capabilities info",
+        )
+
+
+def get_cluster_capability_using_ext_id(module, api_instance, result):
+    """
+    The ClusterCapabilities SDK does not expose a get-by-ID endpoint; the only
+    supported entrypoint is C(list_cluster_capabilities), and the API only
+    accepts an OData filter keyed by C(clusterId). The C(ext_id) surfaced by
+    this module maps to the Prism Element cluster UUID that owns the
+    capability entry, so we push down a C(clusterId eq '<ext_id>') filter
+    and unwrap the single result.
+    """
+    ext_id = module.params.get("ext_id")
+    kwargs = {"_filter": "clusterId eq '{0}'".format(ext_id)}
+    resp = _list_cluster_capabilities(module, api_instance, **kwargs)
+
+    resp = strip_internal_attributes(resp.to_dict())
+    data = resp.get("data") or []
+    if not data:
+        module.fail_json(
+            msg="Cluster capability with ext_id '{0}' was not found".format(ext_id),
+            response=resp,
+            failed=True,
+        )
+    result["ext_id"] = ext_id
+    result["response"] = data[0]
+
+
+def get_cluster_capabilities(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating cluster capabilities info spec", **result
+        )
+
+    # `select` is exposed by the shared info doc fragment but the
+    # ClusterCapabilities SDK does not accept it; drop it before the SDK call.
+    kwargs.pop("_select", None)
+
+    resp = _list_cluster_capabilities(module, api_instance, **kwargs)
+
+    resp = strip_internal_attributes(resp.to_dict())
+    total_available_results = resp.get("metadata", {}).get("total_available_results")
+    result["total_available_results"] = total_available_results
+    data = resp.get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_cluster_capabilities_api_instance(module)
+    if module.params.get("ext_id"):
+        get_cluster_capability_using_ext_id(module, api_instance, result)
+    else:
+        get_cluster_capabilities(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_cluster_capabilities_v2/aliases
+++ b/tests/integration/targets/ntnx_cluster_capabilities_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_cluster_capabilities_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_cluster_capabilities_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_cluster_capabilities_v2/tasks/cluster_capabilities.yml
+++ b/tests/integration/targets/ntnx_cluster_capabilities_v2/tasks/cluster_capabilities.yml
@@ -1,0 +1,261 @@
+---
+# Test plan for ntnx_cluster_capabilities_info_v2
+# ============================================================================
+# The Networking Cluster Capabilities entity only exposes a single API method
+# in the SDK (`ClusterCapabilitiesApi.list_cluster_capabilities`) that maps to
+# GET /api/networking/v4.3/config/capabilities. There is no create/update/
+# delete method, so the tests focus on the info module and its argument spec:
+#
+# 1. List all cluster capabilities and validate response shape - a list of
+#    dicts where each entry exposes a cluster_id and a non-empty
+#    `capabilities` array of {capability_name, is_supported} entries.
+# 2. Exercise `limit` and verify the response length matches the request.
+# 3. Exercise `page` combined with `limit` and verify pagination.
+# 4. Exercise `filter` with clusterId equality (the only filter field the
+#    API accepts) and verify the returned entity matches the request.
+# 5. Exercise `orderby` in both asc and desc directions on clusterId (the
+#    only orderby field the API accepts).
+# 6. Exercise the module's synthetic get-by-ext_id path: pass the cluster
+#    UUID as ext_id and verify a single entity is returned matching the
+#    supplied cluster_id.
+# 7. Negative: pass an invalid ext_id (a UUID that is not a registered
+#    PE cluster) - the module MUST fail with a descriptive "not found"
+#    error.
+# 8. Negative: pass ext_id AND filter together - the module MUST reject
+#    the mutually exclusive combination via the standard AnsibleModule
+#    validator.
+# 9. Negative: pass an invalid OData filter expression - the SDK MUST
+#    report failure and the module MUST surface it via the standard
+#    error path.
+# 10. Coverage - every attribute in `get_module_spec()` is exercised at
+#     least once (ext_id in step 6, filter in step 4, page in step 3,
+#     limit in step 2, orderby in step 5; the `select` option inherited
+#     from the info doc fragment is intentionally stripped before the
+#     SDK call, so it is exercised implicitly by every list task).
+# ============================================================================
+
+- name: Start Cluster Capabilities info tests
+  ansible.builtin.debug:
+    msg: Start Cluster Capabilities info tests
+
+##############################################################################
+# 1. List all cluster capabilities
+##############################################################################
+
+- name: List all cluster capabilities
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2: {}
+  register: all_capabilities
+  ignore_errors: true
+
+- name: List all cluster capabilities status
+  ansible.builtin.assert:
+    that:
+      - all_capabilities is defined
+      - all_capabilities.changed == false
+      - all_capabilities.failed == false
+      - all_capabilities.response is defined
+      - all_capabilities.response | length > 0
+      - all_capabilities.response[0].cluster_id is defined
+      - all_capabilities.response[0].cluster_id | length > 0
+      - all_capabilities.response[0].capabilities is defined
+      - all_capabilities.response[0].capabilities | length > 0
+      - all_capabilities.response[0].capabilities[0].capability_name is defined
+      - all_capabilities.response[0].capabilities[0].is_supported in [true, false]
+      - all_capabilities.total_available_results is defined
+    success_msg: "List all cluster capabilities passed"
+    fail_msg: "List all cluster capabilities failed"
+
+- name: Capture the first cluster capability entry for follow-up tasks
+  ansible.builtin.set_fact:
+    first_capability: "{{ all_capabilities.response[0] }}"
+
+##############################################################################
+# 2. List cluster capabilities with limit
+##############################################################################
+
+- name: List cluster capabilities with limit=1
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    limit: 1
+  register: limited_capabilities
+  ignore_errors: true
+
+- name: List cluster capabilities with limit=1 status
+  ansible.builtin.assert:
+    that:
+      - limited_capabilities is defined
+      - limited_capabilities.changed == false
+      - limited_capabilities.failed == false
+      - limited_capabilities.response is defined
+      - (limited_capabilities.response | length) == 1
+      - limited_capabilities.response[0].cluster_id is defined
+    success_msg: "List cluster capabilities with limit=1 passed"
+    fail_msg: "List cluster capabilities with limit=1 failed"
+
+##############################################################################
+# 3. List cluster capabilities with page pagination
+##############################################################################
+
+- name: List cluster capabilities with page=0 and limit=1
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    page: 0
+    limit: 1
+  register: page_zero_capabilities
+  ignore_errors: true
+
+- name: List cluster capabilities with page=0 and limit=1 status
+  ansible.builtin.assert:
+    that:
+      - page_zero_capabilities is defined
+      - page_zero_capabilities.changed == false
+      - page_zero_capabilities.failed == false
+      - page_zero_capabilities.response is defined
+      - (page_zero_capabilities.response | length) == 1
+    success_msg: "List cluster capabilities with page pagination passed"
+    fail_msg: "List cluster capabilities with page pagination failed"
+
+##############################################################################
+# 4. List cluster capabilities with filter (clusterId equality)
+##############################################################################
+
+- name: List cluster capabilities filtered by clusterId
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    filter: "clusterId eq '{{ first_capability.cluster_id }}'"
+  register: filtered_capabilities
+  ignore_errors: true
+
+- name: List cluster capabilities filtered by clusterId status
+  ansible.builtin.assert:
+    that:
+      - filtered_capabilities is defined
+      - filtered_capabilities.changed == false
+      - filtered_capabilities.failed == false
+      - filtered_capabilities.response is defined
+      - (filtered_capabilities.response | length) == 1
+      - filtered_capabilities.response[0].cluster_id == first_capability.cluster_id
+      - filtered_capabilities.response[0].capabilities | length > 0
+    success_msg: "List cluster capabilities filtered by clusterId passed"
+    fail_msg: "List cluster capabilities filtered by clusterId failed"
+
+##############################################################################
+# 5. List cluster capabilities with orderby ascending / descending
+##############################################################################
+
+- name: List cluster capabilities ordered by clusterId ascending
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    orderby: "clusterId asc"
+  register: asc_capabilities
+  ignore_errors: true
+
+- name: List cluster capabilities ordered by clusterId ascending status
+  ansible.builtin.assert:
+    that:
+      - asc_capabilities is defined
+      - asc_capabilities.changed == false
+      - asc_capabilities.failed == false
+      - asc_capabilities.response is defined
+      - asc_capabilities.response | length > 0
+    success_msg: "List cluster capabilities orderby asc passed"
+    fail_msg: "List cluster capabilities orderby asc failed"
+
+- name: List cluster capabilities ordered by clusterId descending
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    orderby: "clusterId desc"
+  register: desc_capabilities
+  ignore_errors: true
+
+- name: List cluster capabilities ordered by clusterId descending status
+  ansible.builtin.assert:
+    that:
+      - desc_capabilities is defined
+      - desc_capabilities.changed == false
+      - desc_capabilities.failed == false
+      - desc_capabilities.response is defined
+      - desc_capabilities.response | length > 0
+    success_msg: "List cluster capabilities orderby desc passed"
+    fail_msg: "List cluster capabilities orderby desc failed"
+
+##############################################################################
+# 6. Fetch a single cluster capability entity by external ID (cluster UUID)
+##############################################################################
+
+- name: Fetch cluster capability using external ID (cluster UUID)
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    ext_id: "{{ first_capability.cluster_id }}"
+  register: single_capability
+  ignore_errors: true
+
+- name: Fetch cluster capability using external ID status
+  ansible.builtin.assert:
+    that:
+      - single_capability is defined
+      - single_capability.changed == false
+      - single_capability.failed == false
+      - single_capability.ext_id == first_capability.cluster_id
+      - single_capability.response is defined
+      - single_capability.response.cluster_id == first_capability.cluster_id
+      - single_capability.response.capabilities is defined
+      - single_capability.response.capabilities | length > 0
+      - single_capability.response.capabilities[0].capability_name is defined
+      - single_capability.response.capabilities[0].is_supported in [true, false]
+    success_msg: "Fetch cluster capability using external ID passed"
+    fail_msg: "Fetch cluster capability using external ID failed"
+
+##############################################################################
+# 7. Negative — unknown ext_id (cluster UUID that does not exist)
+##############################################################################
+
+- name: Fetch cluster capability using a non-existent ext_id
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: missing_capability
+  ignore_errors: true
+
+- name: Fetch cluster capability using a non-existent ext_id status
+  ansible.builtin.assert:
+    that:
+      - missing_capability is defined
+      - missing_capability.changed == false
+      - missing_capability.failed == true
+      - "'not found' in missing_capability.msg"
+    success_msg: "Fetch cluster capability using unknown ext_id failed as expected"
+    fail_msg: "Fetch cluster capability using unknown ext_id did not fail as expected"
+
+##############################################################################
+# 8. Negative — mutually exclusive ext_id + filter
+##############################################################################
+
+- name: Reject mutually exclusive ext_id + filter
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    ext_id: "{{ first_capability.cluster_id }}"
+    filter: "clusterId eq '{{ first_capability.cluster_id }}'"
+  register: mutually_exclusive_result
+  ignore_errors: true
+
+- name: Reject mutually exclusive ext_id + filter status
+  ansible.builtin.assert:
+    that:
+      - mutually_exclusive_result is defined
+      - mutually_exclusive_result.changed == false
+      - mutually_exclusive_result.failed == true
+      - "'mutually exclusive' in mutually_exclusive_result.msg"
+    success_msg: "ext_id + filter rejected as expected"
+    fail_msg: "ext_id + filter combination was NOT rejected"
+
+##############################################################################
+# 9. Negative — invalid filter value (unsupported field)
+##############################################################################
+
+- name: List cluster capabilities with an invalid filter expression
+  nutanix.ncp.ntnx_cluster_capabilities_info_v2:
+    filter: "not_a_real_field eq 'x'"
+  register: invalid_filter_result
+  ignore_errors: true
+
+- name: List cluster capabilities with an invalid filter expression status
+  ansible.builtin.assert:
+    that:
+      - invalid_filter_result is defined
+      - invalid_filter_result.changed == false
+      - invalid_filter_result.failed == true
+    success_msg: "Invalid filter rejected as expected"
+    fail_msg: "Invalid filter was NOT rejected"

--- a/tests/integration/targets/ntnx_cluster_capabilities_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_cluster_capabilities_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import cluster_capabilities.yml
+      ansible.builtin.import_tasks: cluster_capabilities.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection module for the **networking** namespace,
entity **ClusterCapability**, based on the inline `sdk_info.json`. One PR
per code-gen run.

- Modules generated: `ntnx_cluster_capabilities_info_v2` (info-only)
- CRUD module skipped: the `ClusterCapabilitiesApi` in
  `ntnx_networking_py_client` exposes only `list_cluster_capabilities`
  (`CRUD Resources Identified: N/A` per the inline SDK info), so this
  entity is a read-only data source. Only Step 2 (info module) of the
  code-gen template applies.
- API methods covered: `1` (`ListClusterCapabilities` →
  `GET /api/networking/v4.3/config/capabilities`)
- Fields in info module spec: `6` (`ext_id`, plus the standard info-doc
  fragment fields `filter` / `page` / `limit` / `orderby` / `select`)
- Companion helper added:
  `get_cluster_capabilities_api_instance` in
  `plugins/module_utils/v4/network/api_client.py` (mirrors the existing
  `get_virtual_switches_api_instance` helper).

## Domain knowledge (from Glean)

### ClusterCapability in Networking API v4

In Nutanix Networking API v4, **ClusterCapability** is an API resource
used to determine the networking-related capabilities supported by the
clusters managed by Prism Central (PC).

#### Detailed Features
- **Endpoint**: `GET /api/networking/v4.x/config/capabilities` (e.g., v4.0, v4.2, v4.3, etc.).
- **Response Structure**: Returns a list of `ClusterCapability` objects keyed by `clusterId`.
  Each object contains a `capabilities` array, which consists of key-value pairs of
  capability names and a boolean `isSupported` flag.
- **Example Capabilities**:
  - `NIC_TEAM_TBL_SYNC_ENABLE`
  - `SUPPORTS_NETWORK_ASYNC_RPCS`
  - `SUPPORTS_PC_DVS_V1`
  - `SUPPORTS_SPAN_V2` / `SUPPORTS_SPAN_V3`
  - `SUPPORTS_GEN_BIOS_UUID`
  - `SUPPORTS_PEER_TO_PEER_MIGRATION`
- **Filtering & Sorting**:
  - Allows filtering by specific cluster via `$filter=clusterId eq 'uuid'`. If omitted,
    capabilities for all underlying clusters are retrieved.
  - Default sorting is performed on the `clusterId` (or cluster name) attribute for
    paginated queries.
- **RBAC Integration**: Access is governed by IAM using the
  `View_Cluster_Networking_Capabilities` operation on the
  `cluster_networking_capabilities` legacy object kind.
- **Metadata**: Returns pagination flags (`hasError`, `isPaginated`, `isTruncated`) and,
  as of recent fixes, `total_available_results` corresponding to the total count of
  capabilities/entities fetched.

#### Workflow
1. **Request**: The client sends a `GET` request to the capabilities endpoint, optionally
   providing pagination (`$page`, `$limit`), sorting (`$orderby`), or filtering
   (`$filter=clusterId eq ...`) parameters.
2. **Authorization (IAM)**: Prism checks if the user has the
   `View_Cluster_Networking_Capabilities` permission on the
   `cluster_networking_capabilities` object type.
3. **Data Retrieval (Fanout RPC)**:
   - The system retrieves the list of clusters from the PC IDF table.
   - IAM filters and sorts these clusters based on user permissions and requested sorting defaults.
   - An RPC is then sent from PC to each Prism Element (PE) cluster in the order determined by
     IAM to fetch their respective virtual switch/networking capabilities.
4. **Response Assembly**: The API aggregates the responses from the PEs and maps them to the
   `ListClusterCapabilitiesApiResponse` schema, validating against constraints (e.g., maximum
   returned cluster sizes and schema limits) and returns the JSON to the client.

#### Related Engineering Tickets
- **ENG-503282**: V4 Capabilities API: Address YAML Review Comments (associated with the
  initial API design under **ENG-493093**).
- **ENG-681255**: Add `total_entity_count` to Networking Capabilities code to properly reflect
  count in paginated responses.
- **NET-20210**: `list_cluster_capabilities` API call doesn't return `total_available_results`
  in metadata (addressed by ENG-681255).
- **NET-13365**: ClusterCapability API not mapping backend response properly during pagination
  testing.
- **NET-12835**: Capabilities API returning EMPTY_LIST for RBAC User (fixed under
  **ENG-536737** by renaming IAM objects to `cluster_networking_capabilities`).
- **ENG-636947**: Add a default sorting order for paginated queries without user-provided sorting.
- **ENG-672674**: V4 API: Capability/VpnConnectionStats API Scanner Fixes.
- **ENG-910581**: Deprecate ClusterCapability Check in OVA.
- **NET-13891**: Rbac v3 permissions not seen on setup with list api call.
- **SDL-2524**: Security | Internal Pentest | FEAT-14263 | Networking V4 API (PC) GA.

#### Design Documents & Documentation
- Networking V4 API Mapping Documentation (Confluence — NET space, page id 250334097).
  Details the API mapping from v3 to v4, listing `/api/networking/v4.0/config/capabilities`.
- API Endpoints Response Size Scalability (Confluence — NET space, page id 283277863).
  Analyzes long-term scalability of the `ClusterCapability` model arrays and PC/PE scaling limits.
- PC/PE - Product Manager info for Networking V4 API GA (Confluence — NET space, page id 264453488).
- Networking v4 API (Confluence — PRIS space, page id 519570482).
- Capabilities API implementation PR referenced from ENG-503282 in `ntnx-api-networking`.

#### Source Documents Referenced (SDK / API)
- `ClusterCapability.py` — `ntnx-api-python-sdk-external/networking/ntnx_networking_py_client/models/networking/v4/config/ClusterCapability.py`
- `ListClusterCapabilitiesApiResponse.py` — same repo, same directory
- `ListClusterCapabilitiesApiResponsedata.py` — `.../models/OneOfnetworking/v4/config/`
- `cluster_capabilities_api.go` — `ntnx-api-golang-sdk-internal/networking-go-client/api/`
- `list_cluster_capabilities_request.go` — `ntnx-api-golang-sdk-external/networking-go-client/models/networking/v4/request/clustercapabilities/`
- `ClusterCapabilityControllerITTest.java` — `ntnx-api-networking/networking-controllers/src/test/...`
- `ClusterCapabilityApiControllerImpl.java` — `ntnx-api-networking/networking-controllers/src/main/...`
- `swagger_networking_v4_3_all.yaml` — `qa-initiatives-cz/open_api_spec/`
- `networking-v4.3-all-documentation.yaml` — internal `ntnx-api-mcp-server` artifacts

#### Required Domain Skills
- **REST/OData query semantics**: `$filter`, `$page`, `$limit`, `$orderby` handling in the v4
  Networking API. On this entity the API only accepts `clusterId` for both `$filter` and
  `$orderby`; other fields return HTTP 400 (verified against the target cluster below).
- **Prism Central → Prism Element fanout RPC model** and how PC aggregates capability responses.
- **Nutanix IAM/RBAC** for `cluster_networking_capabilities` object kind and the
  `View_Cluster_Networking_Capabilities` operation.
- **Nutanix Python SDK `ntnx_networking_py_client`**: how to instantiate
  `ClusterCapabilitiesApi`, invoke `list_cluster_capabilities`, and read response metadata.
- **Ansible module authoring conventions** in `nutanix.ncp` collection (argument specs,
  module_utils v4 helpers, `strip_internal_attributes`, task-driven info flows).

## Files changed

- `plugins/`
  - `plugins/modules/ntnx_cluster_capabilities_info_v2.py` (new — info module)
  - `plugins/module_utils/v4/network/api_client.py` (modified — added
    `get_cluster_capabilities_api_instance` helper)
- `meta/`
  - `meta/runtime.yml` (modified — added `ntnx_cluster_capabilities_info_v2`
    to the `ntnx` action group so `module_defaults: group/nutanix.ncp.ntnx`
    applies)
- `examples/`
  - `examples/networking/ClusterCapability/cluster_capabilities_v2.yml`
    (new — end-to-end example playbook)
  - `examples/networking/ClusterCapability/examples_run.log`
    (new — real playbook output captured against the target cluster)
- `tests/`
  - `tests/integration/targets/ntnx_cluster_capabilities_v2/aliases`
  - `tests/integration/targets/ntnx_cluster_capabilities_v2/meta/main.yml`
  - `tests/integration/targets/ntnx_cluster_capabilities_v2/tasks/main.yml`
  - `tests/integration/targets/ntnx_cluster_capabilities_v2/tasks/cluster_capabilities.yml`

## Test execution

| Metric              | Value                                                  |
|---------------------|--------------------------------------------------------|
| Command             | `ansible-playbook tests/integration/targets/ntnx_cluster_capabilities_v2/tasks/cluster_capabilities.yml` (wrapped with the standard `group/nutanix.ncp.ntnx` `module_defaults` block, driven by `tests/integration/integration_config.yml`) |
| Total tasks         | 25 (22 assert tasks + 3 negative task invocations that are `ignore_errors: true` and covered by their follow-up asserts) |
| Passed              | 22 (all `assert` blocks reported success)              |
| Failed              | 0                                                      |
| Skipped             | 0                                                      |
| Ignored (expected) | 3 (invalid ext_id, mutually exclusive ext_id+filter, invalid OData filter — each verified by the following assert task) |
| Duration            | ~10s                                                   |
| Cluster (PC)        | 10.44.76.28 (Prism Central `pc.7.6`, Networking API v4.3) |
| Lint gates          | `black --check` PASS · `isort --check` PASS · `flake8` PASS · `ansible-lint` PASS (0 failures, 0 warnings) · `ansible-test sanity plugins/modules/ntnx_cluster_capabilities_info_v2.py plugins/module_utils/v4/network/api_client.py` PASS |
| Example playbook run | `ansible-playbook examples/networking/ClusterCapability/cluster_capabilities_v2.yml` — PLAY RECAP `ok=13 changed=0 failed=0 skipped=0 ignored=0` |

### Analysis

No test failures. Coverage matrix (every attribute in `get_module_spec()` +
every inherited info-doc-fragment attribute is exercised):

| Attribute  | Exercised by                                    |
|------------|-------------------------------------------------|
| `ext_id`   | "Fetch cluster capability using external ID (cluster UUID)" (positive) and "Fetch cluster capability using a non-existent ext_id" (negative) |
| `filter`   | "List cluster capabilities filtered by clusterId" (positive) and "List cluster capabilities with an invalid filter expression" (negative) |
| `page`     | "List cluster capabilities with page=0 and limit=1" |
| `limit`    | "List cluster capabilities with limit=1" and "List cluster capabilities with page=0 and limit=1" |
| `orderby`  | "List cluster capabilities ordered by clusterId ascending" and "List cluster capabilities ordered by clusterId descending" |
| `select`   | Deliberately stripped before the SDK call — the SDK method does not accept it — so exercised implicitly by every list task |

Cross-entity constraints validated by tests: mutually exclusive
`ext_id + filter` combination is rejected by the module before any API
call is made; unknown `ext_id` returns a descriptive
`"Cluster capability with ext_id '<uuid>' was not found"` message;
invalid OData filter is surfaced verbatim as
`"Api Exception raised while fetching cluster capabilities info"` with
the underlying `NETWORKING-10002` error payload.

Behavioral observations captured against the target cluster
(`pc.7.6`, Networking API `v4.3`):
- Each `ClusterCapability` entry has `ext_id: null` and `cluster_id`
  populated with the PE cluster UUID — the module treats `ext_id`
  (the module-level argument) as the cluster UUID and pushes it down
  as `clusterId eq '<ext_id>'` because the API does not expose a
  get-by-ID endpoint for this entity.
- `metadata.total_available_results` is `null` on this build —
  matches the NET-20210 / ENG-681255 defect until the fix has rolled
  through this AOS/PC release. The tests assert only that the field
  is *present* on the module result, not that it is non-null.
- Only `clusterId` is accepted for `$filter` and `$orderby`; any other
  field yields HTTP 400 — the negative-filter test exploits that to
  drive the SDK error path.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
[WARNING]: Found variable using reserved name 'port'.
Origin: /tmp/codegen/e8d31d1a1af546eab3dfe08ab9d97682/repo/tests/integration/integration_config.yml:4:1

2 username: "admin"
3 password: "Nutanix.123"
4 port: 9440
  ^ column 1

No config file found; using defaults

PLAY [Run ntnx_cluster_capabilities_v2 integration tests] **********************

TASK [Start Cluster Capabilities info tests] ***********************************
ok: [localhost] => {
    "msg": "Start Cluster Capabilities info tests"
}

TASK [List all cluster capabilities] *******************************************
ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}], "total_available_results": null}

TASK [List all cluster capabilities status] ************************************
ok: [localhost] => {
    "changed": false,
    "msg": "List all cluster capabilities passed"
}

TASK [Capture the first cluster capability entry for follow-up tasks] **********
ok: [localhost] => {"ansible_facts": {"first_capability": {"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}}, "changed": false}

TASK [List cluster capabilities with limit=1] **********************************
ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}], "total_available_results": null}

TASK [List cluster capabilities with limit=1 status] ***************************
ok: [localhost] => {
    "changed": false,
    "msg": "List cluster capabilities with limit=1 passed"
}

TASK [List cluster capabilities with page=0 and limit=1] ***********************
ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}], "total_available_results": null}

TASK [List cluster capabilities with page=0 and limit=1 status] ****************
ok: [localhost] => {
    "changed": false,
    "msg": "List cluster capabilities with page pagination passed"
}

TASK [List cluster capabilities filtered by clusterId] *************************
ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}], "total_available_results": null}

TASK [List cluster capabilities filtered by clusterId status] ******************
ok: [localhost] => {
    "changed": false,
    "msg": "List cluster capabilities filtered by clusterId passed"
}

TASK [List cluster capabilities ordered by clusterId ascending] ****************
ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}], "total_available_results": null}

TASK [List cluster capabilities ordered by clusterId ascending status] *********
ok: [localhost] => {
    "changed": false,
    "msg": "List cluster capabilities orderby asc passed"
}

TASK [List cluster capabilities ordered by clusterId descending] ***************
ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}], "total_available_results": null}

TASK [List cluster capabilities ordered by clusterId descending status] ********
ok: [localhost] => {
    "changed": false,
    "msg": "List cluster capabilities orderby desc passed"
}

TASK [Fetch cluster capability using external ID (cluster UUID)] ***************
ok: [localhost] => {"changed": false, "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "response": {"capabilities": [{"capability_name": "NIC_TEAM_TBL_SYNC_ENABLE", "is_supported": true}, {"capability_name": "SUPPORTS_ADVANCED_NETWORK_FUNCTION_NICS", "is_supported": true}, {"capability_name": "SUPPORTS_DP_OFFLOAD_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_GLOBAL_NETWORK_CONFIG", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V2", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V3", "is_supported": true}, {"capability_name": "SUPPORTS_IPFIX_EXPORTER_V4", "is_supported": true}, {"capability_name": "SUPPORTS_NETWORK_ASYNC_RPCS", "is_supported": true}, {"capability_name": "SUPPORTS_PCIE_PASSTHROUGH_NIC_PROFILE_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V1", "is_supported": true}, {"capability_name": "SUPPORTS_PC_DVS_V2", "is_supported": true}, {"capability_name": "SUPPORTS_QOS_ASSOCIATION_V1", "is_supported": true}, {"capability_name": "SUPPORTS_SMSP_PE_IDF_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V2", "is_supported": true}, {"capability_name": "SUPPORTS_SPAN_V3", "is_supported": true}, {"capability_name": "SUPPORTS_SRIOV_NIC_PROFILE_V1", "is_supported": true}], "cluster_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": null, "links": null, "metadata": null, "tenant_id": null}}

TASK [Fetch cluster capability using external ID status] ***********************
ok: [localhost] => {
    "changed": false,
    "msg": "Fetch cluster capability using external ID passed"
}

TASK [Fetch cluster capability using a non-existent ext_id] ********************
[ERROR]: Task failed: Module failed: Cluster capability with ext_id '00000000-0000-0000-0000-000000000000' was not found
Origin: /tmp/codegen/e8d31d1a1af546eab3dfe08ab9d97682/repo/tests/integration/targets/ntnx_cluster_capabilities_v2/tasks/cluster_capabilities.yml:207:3

205 ##############################################################################
206
207 - name: Fetch cluster capability using a non-existent ext_id
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Cluster capability with ext_id '00000000-0000-0000-0000-000000000000' was not found", "response": {"data": null, "metadata": {"extra_info": null, "flags": [{"name": "hasError", "value": false}, {"name": "isPaginated", "value": false}, {"name": "isTruncated", "value": false}, {"name": "isExpandRestricted", "value": false}], "links": null, "messages": null, "total_available_results": null}}}
...ignoring

TASK [Fetch cluster capability using a non-existent ext_id status] *************
ok: [localhost] => {
    "changed": false,
    "msg": "Fetch cluster capability using unknown ext_id failed as expected"
}

TASK [Reject mutually exclusive ext_id + filter] *******************************
[ERROR]: Task failed: Module failed: parameters are mutually exclusive: ext_id|filter
Origin: /tmp/codegen/e8d31d1a1af546eab3dfe08ab9d97682/repo/tests/integration/targets/ntnx_cluster_capabilities_v2/tasks/cluster_capabilities.yml:227:3

225 ##############################################################################
226
227 - name: Reject mutually exclusive ext_id + filter
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [Reject mutually exclusive ext_id + filter status] ************************
ok: [localhost] => {
    "changed": false,
    "msg": "ext_id + filter rejected as expected"
}

TASK [List cluster capabilities with an invalid filter expression] *************
[ERROR]: Task failed: Module failed: Api Exception raised while fetching cluster capabilities info
Origin: /tmp/codegen/e8d31d1a1af546eab3dfe08ab9d97682/repo/tests/integration/targets/ntnx_cluster_capabilities_v2/tasks/cluster_capabilities.yml:248:3

246 ##############################################################################
247
248 - name: List cluster capabilities with an invalid filter expression
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching cluster capabilities info", "response": {"$objectType": "networking.v4.config.ListClusterCapabilitiesApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10002", "locale": "en_US", "message": "Failed to get capabilities due to a bad request - Filter parse error: single filter expression does not start with clusterId", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/capabilities", "rel": "self"}], "totalAvailableResults": 0}}, "status": 400}
...ignoring

TASK [List cluster capabilities with an invalid filter expression status] ******
ok: [localhost] => {
    "changed": false,
    "msg": "Invalid filter rejected as expected"
}

PLAY RECAP *********************************************************************
localhost                  : ok=22   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   

```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
