### PR TITLE
code-gen(cluster_management/ExitHostMaintenance): ansible collection modules

### DIFF
--- a/examples/cluster_management/ExitHostMaintenance/examples_run.log
+++ b/examples/cluster_management/ExitHostMaintenance/examples_run.log
@@ -1,0 +1,149 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Exit Host Maintenance example runner] ************************************
+
+TASK [List all AOS clusters (exclude Prism Central)] ***************************
+ok: [localhost] => {"changed": false, "error": null, "response": [{"backup_eligibility_score": 1, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDds8wxvJkt0Z/gXOLu8/q0ur7n71FNhVC6FUkhwpmu4gs+WVUi0BeyfJb7jJFFNLzbgmPCxEiAXwURw++74HWMiOpLg9vCKZiftaZxP84Fw8q8c1sgYKCoDsxlwYSIkAgwnfCnQOKlhEO+IHPhEYkoRNm+yu6o3iat0miyLyMZ8NvfLLFaUSPEQvWLVu4DStRd/w4kP5ik16oSe+uHH/jXoVmNaBigp1b9IOMLmG4QcXhuNOoTdP7Wk56JDmmtLCicAm820FHh+8cgiwqzfnXumQoVBDeAj0TaOxvFqIbuYAI3T80wCOXZgDzQa+0nyVWzyQLU3us33SUjoMiJygO90wg80qzriVxvTlGJ0AcDvNrDF1P190MisWDRXa6cP1LhMzBoU8NlSDAofd1Ey/Gj36TPWoJI0vB4hlu0gZmRUiL2b6FeW12P38BLewbYL+GO/VnUPTke9fe4VtmBuQiZO5SYaa6ccabMdkkEr9jnn1t+v6y9tGVqsFXu3RPo2JM= nutanix@ntnx-18fm6g460083-d-cvm", "name": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDIcx1XJP0fYzdetHAnyNijUyFOJCli8OITqix1mpuqfPUg2mEhQnbkxmdT4K9e+I6NadcDKxADsBWWcEwQXGuowgVzPByJmMXrmCfE36Bsit2iVRuFxxnImyiXcTPXcz1IQWvaszUs9vFHtjYdFcRhTnVhLCCKRr8XkR3OgWiuXzUmrOZZPfY06WWhhCXhuVo2WfgYA0nSFXQpLyQvCfQvo+ukM8XPZN/crFtD7xqhL2h0GWYR9HMJJ1TufWUjt0fRVDk/Ja1Pur3bPJAxruGZ1cUfmpKn5f2bJVBXQ2g36Fkxo6qXAzgIVbW3jy0+nZicZMf0vW49YkFPP6P++7F9KwQXwDQg7qiFZngjqwj1EfzPUtdtrafmrbkTUgD2k6FQEiKfq1Z4Jhp5MYZKH1MH4cUVLQUe16Qopyix7tQ9Hcf58g1kaXRKE/HtHXMdANfvZ8nYFRVXmezcE7EwuctW61HwJgP5qdOh8uQm7dd4HIdPkBoyyZhTxtAEq9L2jXc= root@phoenix", "name": "10.46.136.28"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAw8NhpiLG/6c8c0LocaQVM6+x8yBvLS+z13nYlqzSKr64HQSH+IIx14bS+uh0xf8ou5ROnbUa44YM9qG2RBK1hBVrwTIKZBwFwOTxDuXH9YoswqflnOeyTGUFerrMxlg5iYvKE01QIErKWt/BJ+hK/qVQi6SHh/WhyjAGNQPxjPBG3oEUFoLV9uDLX9RT/sLIQpBf91DCbF9+2rSToqjydj36d38JbmuGJGqr+DrEd0lKzfiJiQ39t3AXBE1bY2ISX+uwq07XkYZbrHaijrxnOBFZE7ETQmyxdcOvgDxvhnhZpFsUqbPqIqa45CwFWV+btzITvpJkveYjGSGR7ZJNHQ== nutanix@titan", "name": "agave"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6oDEABPvDtwtOFEJhu7sx9oUZskh0R4CWW6IM9uIxVtjYR/XXu587rXKac34InclJ3U3+PFQcAgEvdw2qiCEWWWMFMiALMneDELPd5qepKRrFJxc3hkyfagot3n7i6r7Y83ceIII4qM1mGLdUA3XdSWlttbgugnBrfB9yLq/BgtVqBvBVFayTGb6IsoMUSbODX6zZEt9Uzh/Yr49DV40ULpGhSYS9vWFB3GrajrliQ9Ea8oOB+8vK9Cavf7IOsaIaPsGI20mypeKFn4qcinBKc6O3PqU3YyYv7pLJWAvwXr9D9+rukgNAhKnd1fFQVLj4sAHA4ixfQk9+0kgAJM4P", "name": "nutest"}], "build_info": {"build_type": "release", "commit_id": "c62bea5d0b6c0010e794199221573a6062a01d14", "full_version": "el9-release-ganges-7.6-stable-c62bea5d0b6c0010e794199221573a6062a01d14", "short_commit_id": "c62bea", "version": "7.6"}, "cluster_arch": "X86_64", "cluster_function": ["AOS"], "cluster_software_map": [{"software_type": "NCC", "version": "ncc-6.0.0"}, {"software_type": "NOS", "version": "el9-release-ganges-7.6-stable-c62bea5d0b6c0010e794199221573a6062a01d14"}], "cluster_type": "HYPER_CONVERGED", "encryption_in_transit_status": null, "encryption_option": null, "encryption_scope": null, "fault_tolerance_state": {"current_cluster_fault_tolerance": "CFT_0N_AND_0D", "current_max_fault_tolerance": 0, "desired_cluster_fault_tolerance": "CFT_0N_AND_0D", "desired_max_fault_tolerance": 0, "domain_awareness_level": "DISK", "isStrictRackAwarenessEnabled": false, "redundancy_status": null}, "hypervisor_types": ["AHV"], "incarnation_id": 1782713390680670, "isDegradedNodeMonitoringDisabled": false, "is_available": true, "is_lts": false, "is_password_remote_login_enabled": true, "is_remote_support_enabled": false, "operation_mode": "NORMAL", "pulse_status": {"is_enabled": true, "pii_scrubbing_level": "DEFAULT"}, "redundancy_factor": 1, "timezone": "UTC"}, "container_name": null, "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "externalStorageProviderInfo": [{"$objectType": "clustermgmt.v4.config.ExternalStorageProviderInfo", "$reserved": {"$fv": "v4.r3"}, "compatibleVersion": "5.1.100.104_5594", "isInstalled": false, "providerType": "DELL_POWERFLEX"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "EVERPURE_FLASHARRAY"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "DELL_POWERSTORE"}], "inefficient_vm_count": null, "links": null, "name": "auto_cluster_prod_36acf9b012ca", "network": {"backplane": {"is_segmentation_enabled": false, "netmask": null, "subnet": null, "vlan_tag": null}, "external_address": {"ipv4": {"prefix_length": 32, "value": "10.46.136.38"}, "ipv6": null}, "external_data_service_ip": {"ipv4": {"prefix_length": 32, "value": "10.46.136.42"}, "ipv6": null}, "external_subnet": "10.46.136.0/255.255.248.0", "fqdn": null, "http_proxy_list": null, "http_proxy_white_list": null, "internal_subnet": "192.168.5.0/255.255.255.128", "key_management_server_type": null, "management_server": null, "masquerading_ip": null, "masquerading_port": null, "name_server_ip_list": [{"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.15"}, "ipv6": null}, {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.16"}, "ipv6": null}], "nfs_subnet_whitelist": null, "ntp_server_config_list": null, "ntp_server_ip_list": [{"fqdn": {"value": "0.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "1.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "2.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "3.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}], "smtp_server": null}, "nodes": {"node_list": [{"controller_vm_ip": {"ipv4": {"prefix_length": 32, "value": "10.46.136.32"}, "ipv6": null}, "host_ip": {"ipv4": {"prefix_length": 32, "value": "10.46.136.28"}, "ipv6": null}, "node_uuid": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b"}], "number_of_nodes": 1}, "tenant_id": null, "upgrade_status": "SUCCEEDED", "vm_count": 13}], "total_available_results": 1}
+
+TASK [Set target cluster ext_id] ***********************************************
+ok: [localhost] => {"ansible_facts": {"cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}, "changed": false}
+
+TASK [Fetch hosts for the target cluster] **************************************
+ok: [localhost] => {"changed": false, "error": null, "response": [{"block_model": "NX-1065-G5", "block_serial": "18FM6G460083", "boot_time_usecs": 1782712672107027, "cluster": {"name": "auto_cluster_prod_36acf9b012ca", "uuid": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}, "controller_vm": {"backplane_address": {"ipv4": {"prefix_length": 32, "value": "10.46.136.32"}, "ipv6": null}, "external_address": {"ipv4": {"prefix_length": 32, "value": "10.46.136.32"}, "ipv6": null}, "is_in_maintenance_mode": null, "nat_ip": null, "nat_port": null, "rdma_backplane_address": null}, "cpu_capacity_hz": null, "cpu_frequency_hz": 2100000000, "cpu_model": "Intel(R) Xeon(R) CPU E5-2620 v4 @ 2.10GHz", "default_vhd_container_uuid": null, "default_vhd_location": null, "default_vm_container_uuid": null, "default_vm_location": null, "disk": [{"mount_path": "/home/nutanix/data/stargate-storage/disks/ZC227WAH", "serial_id": "ZC227WAH", "size_in_bytes": 1900344164352, "storage_tier": "HDD", "uuid": "dc67dca8-7ae0-494d-9a57-717241656e93"}, {"mount_path": "/home/nutanix/data/stargate-storage/disks/S3F3NX0K903432", "serial_id": "S3F3NX0K903432", "size_in_bytes": 604114121598, "storage_tier": "SATA_SSD", "uuid": "4542a93c-f79a-43fc-a515-ec8c066000a0"}, {"mount_path": "/home/nutanix/data/stargate-storage/disks/ZC22LTPL", "serial_id": "ZC22LTPL", "size_in_bytes": 1900344164352, "storage_tier": "HDD", "uuid": "52fb3d86-a773-4608-8666-af3667816231"}], "ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "failover_cluster_fqdn": null, "failover_cluster_node_status": null, "gpu_driver_version": null, "gpu_list": [""], "has_csr": false, "host_name": "goku-4", "host_type": "HYPER_CONVERGED", "hypervisor": {"acropolis_connection_state": "CONNECTED", "external_address": {"ipv4": {"prefix_length": 32, "value": "10.46.136.28"}, "ipv6": null}, "full_name": "AHV 11.2", "number_of_vms": 11, "state": "ACROPOLIS_NORMAL", "type": "AHV", "user_name": "root"}, "ipmi": {"ip": {"ipv4": {"prefix_length": 32, "value": "10.49.49.176"}, "ipv6": null}, "username": "ADMIN"}, "is_degraded": null, "is_hardware_virtualized": false, "is_reboot_pending": null, "is_secure_booted": false, "key_management_device_to_cert_status": null, "links": null, "maintenance_state": "normal", "memory_size_bytes": 269809303552, "node_serial": "ZM185S042341", "node_status": "NORMAL", "number_of_cpu_cores": 16, "number_of_cpu_sockets": 2, "number_of_cpu_threads": 32, "rackable_unit_uuid": "5879195f-5101-4d41-8e6d-af4a6aa52472", "tenant_id": null}], "total_available_results": 1}
+
+TASK [Set target host ext_id] **************************************************
+ok: [localhost] => {"ansible_facts": {"host_ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b"}, "changed": false}
+
+TASK [Exit AHV host from maintenance mode] *************************************
+[ERROR]: Task failed: Module failed: Task Failed
+Origin: /tmp/codegen-artifacts.aO6NvP/run_example.yml:40:7
+
+38     # 2. Exit AHV host from maintenance mode.
+39     ####################################################################
+40     - name: Exit AHV host from maintenance mode
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-20T13:15:45.553569+00:00", "completion_details": null, "created_time": "2026-07-20T13:15:45.499319+00:00", "entities_affected": null, "error_messages": [{"arguments_map": null, "code": "TSKS-20801", "error_group": "LEGACY_ERROR", "locale": "en_US", "message": "Operation failed due to legacy error and 'legacyErrorMessage' should be referred to for details", "severity": "ERROR"}], "ext_id": "ZXJnb24=:aeaa18dc-3b23-43dc-a341-cd27c934bb30", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T13:15:45.553568+00:00", "legacy_error_message": "Single node clusters are currently unsupported for Host Exit Maintenance workflow", "number_of_entities_affected": 0, "number_of_subtasks": 0, "operation": "Exit Host Maintenance", "operation_description": "Exit Host Maintenance", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T13:15:45.517758+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": null, "warnings": null}}
+...ignoring
+
+TASK [Show AHV exit result] ****************************************************
+ok: [localhost] => {
+    "exit_ahv_result": {
+        "changed": false,
+        "exception": "(traceback unavailable)",
+        "failed": true,
+        "msg": "Task Failed",
+        "response": {
+            "app_name": null,
+            "batch_summary": null,
+            "cluster_ext_ids": null,
+            "completed_time": "2026-07-20T13:15:45.553569+00:00",
+            "completion_details": null,
+            "created_time": "2026-07-20T13:15:45.499319+00:00",
+            "entities_affected": null,
+            "error_messages": [
+                {
+                    "arguments_map": null,
+                    "code": "TSKS-20801",
+                    "error_group": "LEGACY_ERROR",
+                    "locale": "en_US",
+                    "message": "Operation failed due to legacy error and 'legacyErrorMessage' should be referred to for details",
+                    "severity": "ERROR"
+                }
+            ],
+            "ext_id": "ZXJnb24=:aeaa18dc-3b23-43dc-a341-cd27c934bb30",
+            "is_background_task": false,
+            "is_cancelable": false,
+            "last_updated_time": "2026-07-20T13:15:45.553568+00:00",
+            "legacy_error_message": "Single node clusters are currently unsupported for Host Exit Maintenance workflow",
+            "number_of_entities_affected": 0,
+            "number_of_subtasks": 0,
+            "operation": "Exit Host Maintenance",
+            "operation_description": "Exit Host Maintenance",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "projectExtId": "00000000-0000-0000-0000-000000000000",
+            "resource_links": null,
+            "root_task": null,
+            "started_time": "2026-07-20T13:15:45.517758+00:00",
+            "status": "FAILED",
+            "sub_steps": null,
+            "sub_tasks": null,
+            "warnings": null
+        }
+    }
+}
+
+TASK [Exit ESXi host from maintenance mode with vCenter details] ***************
+[ERROR]: Task failed: Module failed: Task Failed
+Origin: /tmp/codegen-artifacts.aO6NvP/run_example.yml:56:7
+
+54     # 3. Exit ESXi host from maintenance mode with vCenter credentials.
+55     ####################################################################
+56     - name: Exit ESXi host from maintenance mode with vCenter details
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-20T13:15:46.999567+00:00", "completion_details": null, "created_time": "2026-07-20T13:15:46.941261+00:00", "entities_affected": null, "error_messages": [{"arguments_map": null, "code": "TSKS-20801", "error_group": "LEGACY_ERROR", "locale": "en_US", "message": "Operation failed due to legacy error and 'legacyErrorMessage' should be referred to for details", "severity": "ERROR"}], "ext_id": "ZXJnb24=:7730448a-6add-475a-b063-7b3f3cab2719", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T13:15:46.999566+00:00", "legacy_error_message": "Single node clusters are currently unsupported for Host Exit Maintenance workflow", "number_of_entities_affected": 0, "number_of_subtasks": 0, "operation": "Exit Host Maintenance", "operation_description": "Exit Host Maintenance", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T13:15:46.957323+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": null, "warnings": null}}
+...ignoring
+
+TASK [Show ESXi exit result] ***************************************************
+ok: [localhost] => {
+    "exit_esxi_result": {
+        "changed": false,
+        "exception": "(traceback unavailable)",
+        "failed": true,
+        "msg": "Task Failed",
+        "response": {
+            "app_name": null,
+            "batch_summary": null,
+            "cluster_ext_ids": null,
+            "completed_time": "2026-07-20T13:15:46.999567+00:00",
+            "completion_details": null,
+            "created_time": "2026-07-20T13:15:46.941261+00:00",
+            "entities_affected": null,
+            "error_messages": [
+                {
+                    "arguments_map": null,
+                    "code": "TSKS-20801",
+                    "error_group": "LEGACY_ERROR",
+                    "locale": "en_US",
+                    "message": "Operation failed due to legacy error and 'legacyErrorMessage' should be referred to for details",
+                    "severity": "ERROR"
+                }
+            ],
+            "ext_id": "ZXJnb24=:7730448a-6add-475a-b063-7b3f3cab2719",
+            "is_background_task": false,
+            "is_cancelable": false,
+            "last_updated_time": "2026-07-20T13:15:46.999566+00:00",
+            "legacy_error_message": "Single node clusters are currently unsupported for Host Exit Maintenance workflow",
+            "number_of_entities_affected": 0,
+            "number_of_subtasks": 0,
+            "operation": "Exit Host Maintenance",
+            "operation_description": "Exit Host Maintenance",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "projectExtId": "00000000-0000-0000-0000-000000000000",
+            "resource_links": null,
+            "root_task": null,
+            "started_time": "2026-07-20T13:15:46.957323+00:00",
+            "status": "FAILED",
+            "sub_steps": null,
+            "sub_tasks": null,
+            "warnings": null
+        }
+    }
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=2   
+

--- a/examples/cluster_management/ExitHostMaintenance/exit_host_maintenance_v2.yml
+++ b/examples/cluster_management/ExitHostMaintenance/exit_host_maintenance_v2.yml
@@ -1,0 +1,79 @@
+---
+# Summary:
+# This playbook demonstrates the Exit Host Maintenance workflow on a Nutanix cluster host.
+# It covers:
+#   1. Discovering the Prism Element cluster and one of its hosts via the info modules.
+#   2. Exiting an AHV host from maintenance mode.
+#   3. Exiting an ESXi host from maintenance mode with vCenter credentials.
+#
+# The Exit Host Maintenance action transitions a hypervisor host back to normal
+# operation, restores VM locality by migrating VMs back to the host, powers on
+# pinned VMs, and releases the cluster-wide shutdown token acquired at entry.
+
+- name: Exit Host Maintenance playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    ####################################################################
+    # 1. Discover a Prism Element (AOS) cluster and one of its hosts.
+    ####################################################################
+    - name: List all AOS clusters (exclude Prism Central)
+      nutanix.ncp.ntnx_clusters_info_v2:
+        filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+      register: clusters_result
+
+    - name: Set target cluster ext_id
+      ansible.builtin.set_fact:
+        cluster_ext_id: "{{ clusters_result.response[0].ext_id }}"
+
+    - name: Fetch hosts for the target cluster
+      nutanix.ncp.ntnx_hosts_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+      register: hosts_result
+
+    - name: Set target host ext_id
+      ansible.builtin.set_fact:
+        host_ext_id: "{{ hosts_result.response[0].ext_id }}"
+
+    ####################################################################
+    # 2. Exit AHV host from maintenance mode.
+    #    Use this variant for AHV clusters — no vCenter credentials
+    #    are required.
+    ####################################################################
+    - name: Exit AHV host from maintenance mode
+      nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+        state: present
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        ext_id: "{{ host_ext_id }}"
+        timeout_seconds: 600
+      register: exit_ahv_result
+      ignore_errors: true
+
+    ####################################################################
+    # 3. Exit ESXi host from maintenance mode.
+    #    ESXi requires vCenter address + credentials so the exit
+    #    maintenance workflow can coordinate with vSphere.
+    ####################################################################
+    - name: Exit ESXi host from maintenance mode with vCenter details
+      nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+        state: present
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        ext_id: "{{ host_ext_id }}"
+        timeout_seconds: 900
+        vcenter_info:
+          address:
+            ipv4:
+              value: "10.44.100.10"
+              prefix_length: 32
+          credentials:
+            username: "administrator@vsphere.local"
+            password: "vC3nt3rP@ss!"
+            port: 443
+      register: exit_esxi_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_cluster_host_maintenance_v2

--- a/plugins/modules/ntnx_cluster_host_maintenance_v2.py
+++ b/plugins/modules/ntnx_cluster_host_maintenance_v2.py
@@ -1,0 +1,440 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_cluster_host_maintenance_v2
+short_description: Exit a Nutanix cluster host from maintenance mode
+version_added: 2.7.0
+description:
+  - This module allows you to transition a Nutanix cluster host out of maintenance mode.
+  - Once the host successfully exits maintenance mode the previously migrated user VMs
+    are migrated back to restore VM locality, any pinned VMs that were shut down during
+    entry into maintenance mode are powered back on, and the cluster-wide shutdown
+    token acquired at entry time is released.
+  - For ESXi hypervisors, vCenter address and credentials must be supplied so that
+    the exit operation is coordinated with the vSphere management plane.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation.
+  - >-
+    B(Exit host from maintenance mode) -
+    Required Roles: Cluster Admin, Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  state:
+    description:
+      - State of the module.
+      - Only C(present) is supported for this action.
+    type: str
+    choices:
+      - present
+    default: present
+  cluster_ext_id:
+    description:
+      - The external ID (UUID) of the cluster that owns the host.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external ID (UUID) of the host that must exit maintenance mode.
+    type: str
+    required: true
+  vcenter_info:
+    description:
+      - vCenter Server information for the ESX cluster.
+      - Required when the target host is an ESXi host so the exit maintenance
+        workflow can coordinate with vSphere.
+    type: dict
+    required: false
+    suboptions:
+      address:
+        description:
+          - IP address or fully-qualified domain name of the vCenter Server.
+        type: dict
+        required: true
+        suboptions:
+          ipv4:
+            description:
+              - IPv4 address of the vCenter Server.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv4 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - The IPv4 prefix length (0-32).
+                type: int
+                required: false
+                default: 32
+          ipv6:
+            description:
+              - IPv6 address of the vCenter Server.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv6 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - The IPv6 prefix length (0-128).
+                type: int
+                required: false
+                default: 128
+          fqdn:
+            description:
+              - Fully-qualified domain name of the vCenter Server.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - FQDN string of the vCenter Server.
+                type: str
+                required: true
+      credentials:
+        description:
+          - Credentials for the vCenter Server used to coordinate the ESXi
+            host maintenance exit workflow.
+        type: dict
+        required: false
+        suboptions:
+          username:
+            description:
+              - Username for vCenter Server authentication.
+            type: str
+            required: true
+          password:
+            description:
+              - Password for the vCenter Server user.
+            type: str
+            required: true
+          port:
+            description:
+              - Port to connect to the vCenter Server on.
+            type: int
+            required: false
+  timeout_seconds:
+    description:
+      - Timeout in seconds for the exit host maintenance operation on the server
+        side. When not provided, the platform default is used.
+    type: int
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Exit AHV host from maintenance mode
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    cluster_ext_id: "0006250e-1e01-2222-0000-abcdef012345"
+    ext_id: "8300384a-56ee-4750-aeb8-3d1c42908bee"
+    timeout_seconds: 600
+  register: result
+  ignore_errors: true
+
+- name: Exit ESXi host from maintenance mode with vCenter credentials
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    cluster_ext_id: "0006250e-1e01-2222-0000-abcdef012345"
+    ext_id: "f28e7475-f835-42ef-ac35-ecbc48d5421e"
+    timeout_seconds: 900
+    vcenter_info:
+      address:
+        ipv4:
+          value: "10.44.100.10"
+          prefix_length: 32
+      credentials:
+        username: "administrator@vsphere.local"
+        password: "vC3nt3rP@ss!"
+        port: 443
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for the exit host from maintenance mode operation.
+    - Task details when C(wait) is true.
+    - Task acknowledgement returned by the API when C(wait) is false.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_ids": [
+        "0006250e-1e01-2222-0000-abcdef012345"
+      ],
+      "completed_time": "2026-07-20T13:15:47.123456+00:00",
+      "completion_details": null,
+      "created_time": "2026-07-20T13:15:20.000000+00:00",
+      "entities_affected": [
+        {
+          "ext_id": "8300384a-56ee-4750-aeb8-3d1c42908bee",
+          "name": null,
+          "rel": "clustermgmt:config:host"
+        }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1",
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-20T13:15:47.123456+00:00",
+      "legacy_error_message": null,
+      "operation": "ExitHostMaintenance",
+      "operation_description": "Exit host maintenance mode",
+      "owned_by": {
+        "ext_id": "00000000-0000-0000-0000-000000000000",
+        "name": "admin"
+      },
+      "parent_task": null,
+      "progress_percentage": 100,
+      "started_time": "2026-07-20T13:15:20.100000+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+msg:
+  description: The status/error message returned by the module.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while exiting host from maintenance mode"
+
+error:
+  description: The error details returned by the platform when the exit host maintenance operation fails.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: Indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+task_ext_id:
+  description: The external ID of the underlying async task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1"
+
+ext_id:
+  description: The external ID of the host that was requested to exit maintenance mode.
+  returned: always
+  type: str
+  sample: "8300384a-56ee-4750-aeb8-3d1c42908bee"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_clusters_api_instance,
+)
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_clustermgmt_py_client as cluster_management_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402
+        mock_sdk as cluster_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    ipv4_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=32),
+    )
+
+    ipv6_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=128),
+    )
+
+    fqdn_spec = dict(
+        value=dict(type="str", required=True),
+    )
+
+    ip_address_or_fqdn_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_address_spec,
+            obj=cluster_management_sdk.IPv4Address,
+            required=False,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_address_spec,
+            obj=cluster_management_sdk.IPv6Address,
+            required=False,
+        ),
+        fqdn=dict(
+            type="dict",
+            options=fqdn_spec,
+            obj=cluster_management_sdk.FQDN,
+            required=False,
+        ),
+    )
+
+    vcenter_credentials_spec = dict(
+        username=dict(type="str", required=True),
+        password=dict(type="str", required=True, no_log=True),
+        port=dict(type="int", required=False),
+    )
+
+    vcenter_info_spec = dict(
+        address=dict(
+            type="dict",
+            options=ip_address_or_fqdn_spec,
+            obj=cluster_management_sdk.IPAddressOrFQDN,
+            required=True,
+            mutually_exclusive=[("ipv4", "ipv6", "fqdn")],
+        ),
+        credentials=dict(
+            type="dict",
+            options=vcenter_credentials_spec,
+            obj=cluster_management_sdk.VcenterCredentials,
+            required=False,
+        ),
+    )
+
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        cluster_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+        vcenter_info=dict(
+            type="dict",
+            options=vcenter_info_spec,
+            obj=cluster_management_sdk.VcenterInfo,
+            required=False,
+        ),
+        timeout_seconds=dict(type="int", required=False),
+    )
+    return module_args
+
+
+def exit_host_maintenance(module, result, clusters_api):
+    """Trigger the ExitHostMaintenance action on the given host."""
+    validate_required_params(module, ["cluster_ext_id", "ext_id"])
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    sg = SpecGenerator(module)
+    default_spec = cluster_management_sdk.HostMaintenanceCommonSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating exit host maintenance spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    try:
+        resp = clusters_api.exit_host_maintenance(
+            clusterExtId=cluster_ext_id, extId=ext_id, body=spec
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while exiting host from maintenance mode",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    clusters_api = get_clusters_api_instance(module)
+    exit_host_maintenance(module, result, clusters_api)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip>=23.0
 setuptools>=65.0
 requests>=2.31.0
-ntnx-clustermgmt-py-client==4.2.2
+ntnx-clustermgmt-py-client==latest
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1

--- a/tests/integration/targets/ntnx_cluster_host_maintenance_v2/aliases
+++ b/tests/integration/targets/ntnx_cluster_host_maintenance_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_cluster_host_maintenance_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_cluster_host_maintenance_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_cluster_host_maintenance_v2/tasks/exit_host_maintenance.yml
+++ b/tests/integration/targets/ntnx_cluster_host_maintenance_v2/tasks/exit_host_maintenance.yml
@@ -1,0 +1,377 @@
+---
+# Test plan — ntnx_cluster_host_maintenance_v2 (Exit Host Maintenance)
+#
+# ExitHostMaintenance is an action-type v4 API. It takes a host that is
+# already in maintenance mode and transitions it back to normal
+# operation. Because putting a live production host into maintenance
+# just to exit it is disruptive to real workloads, the tests below
+# focus on the safe surface area of the module:
+#
+#   1. Discover a Prism Element (AOS) cluster and one of its hosts via
+#      the info modules so we always have realistic ext_ids to feed the
+#      module. This also proves the "happy path" input plumbing works.
+#   2. Check-mode create with the minimal spec — verify no API is
+#      invoked and no changes are reported.
+#   3. Check-mode create with EVERY module attribute (including
+#      vcenter_info + credentials) — verify the SpecGenerator produces
+#      the correct payload and that every field flows through.
+#   4. Negative tests:
+#      a. Missing required param cluster_ext_id.
+#      b. Missing required param ext_id.
+#      c. Missing required nested field vcenter_info.address.
+#      d. Invalid vcenter_info.credentials (missing password).
+#   5. Real API call against a non-existent host — verify the module
+#      surfaces the platform's not-found/error response cleanly and
+#      does NOT report changed=true.
+#   6. Real API call against a host that is NOT currently in
+#      maintenance mode — verify the module surfaces the platform's
+#      error cleanly and does NOT report changed=true.
+#   7. Idempotency: re-run the check-mode call and verify the module
+#      behaves identically (no side effects, changed=false).
+#
+# These cover every argument in get_module_spec(), all required_if
+# constraints, and the SDK error paths without disrupting the cluster.
+
+- name: Start ExitHostMaintenance tests
+  ansible.builtin.debug:
+    msg: Start ExitHostMaintenance tests
+
+- name: Generate random suffix for logs
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+####################################################################
+# 1. Prerequisite discovery — cluster + host ext_ids
+####################################################################
+
+- name: List all AOS clusters (exclude Prism Central) to pick a target
+  nutanix.ncp.ntnx_clusters_info_v2:
+    filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+  register: clusters_result
+  ignore_errors: true
+
+- name: Verify at least one AOS cluster is reachable
+  ansible.builtin.assert:
+    that:
+      - clusters_result is defined
+      - clusters_result.failed == false
+      - clusters_result.changed == false
+      - clusters_result.response is defined
+      - clusters_result.response | length > 0
+      - clusters_result.response[0].ext_id is defined
+    success_msg: "AOS cluster discovered successfully"
+    fail_msg: "No AOS cluster discovered — cannot run ExitHostMaintenance tests"
+
+- name: Set target cluster ext_id
+  ansible.builtin.set_fact:
+    target_cluster_ext_id: "{{ clusters_result.response[0].ext_id }}"
+
+- name: Fetch hosts belonging to the target cluster
+  nutanix.ncp.ntnx_hosts_info_v2:
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+  register: hosts_result
+  ignore_errors: true
+
+- name: Verify at least one host was returned
+  ansible.builtin.assert:
+    that:
+      - hosts_result is defined
+      - hosts_result.failed == false
+      - hosts_result.changed == false
+      - hosts_result.response is defined
+      - hosts_result.response | length > 0
+      - hosts_result.response[0].ext_id is defined
+    success_msg: "Discovered {{ hosts_result.response | length }} host(s) in cluster {{ target_cluster_ext_id }}"
+    fail_msg: "Unable to discover any hosts in cluster {{ target_cluster_ext_id }}"
+
+- name: Set target host ext_id
+  ansible.builtin.set_fact:
+    target_host_ext_id: "{{ hosts_result.response[0].ext_id }}"
+
+####################################################################
+# 2. Check-mode with minimal spec
+####################################################################
+
+- name: Exit host maintenance in check_mode with minimal spec
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    state: present
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    ext_id: "{{ target_host_ext_id }}"
+  check_mode: true
+  register: check_min_result
+  ignore_errors: true
+
+- name: Verify minimal check_mode result
+  ansible.builtin.assert:
+    that:
+      - check_min_result is defined
+      - check_min_result.changed == false
+      - check_min_result.failed == false
+      - check_min_result.response is defined
+      - check_min_result.ext_id == target_host_ext_id
+    success_msg: "Minimal check_mode exit host maintenance produced a valid spec"
+    fail_msg: "Minimal check_mode exit host maintenance failed"
+
+####################################################################
+# 3. Check-mode with ALL attributes (vcenter_info + credentials)
+####################################################################
+
+- name: Exit host maintenance in check_mode with ALL attributes
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    state: present
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    ext_id: "{{ target_host_ext_id }}"
+    timeout_seconds: 900
+    vcenter_info:
+      address:
+        ipv4:
+          value: "10.44.100.10"
+          prefix_length: 32
+      credentials:
+        username: "administrator@vsphere.local"
+        password: "vC3nt3rP@ss!"
+        port: 443
+  check_mode: true
+  register: check_full_result
+  ignore_errors: true
+
+- name: Verify full check_mode result — every field is echoed back
+  ansible.builtin.assert:
+    that:
+      - check_full_result is defined
+      - check_full_result.changed == false
+      - check_full_result.failed == false
+      - check_full_result.response is defined
+      - check_full_result.ext_id == target_host_ext_id
+      - check_full_result.response.timeout_seconds == 900
+      - check_full_result.response.vcenter_info is defined
+      - check_full_result.response.vcenter_info.address is defined
+      - check_full_result.response.vcenter_info.address.ipv4 is defined
+      - check_full_result.response.vcenter_info.address.ipv4.value == "10.44.100.10"
+      - check_full_result.response.vcenter_info.address.ipv4.prefix_length == 32
+      - check_full_result.response.vcenter_info.credentials is defined
+      - check_full_result.response.vcenter_info.credentials.username == "administrator@vsphere.local"
+      - check_full_result.response.vcenter_info.credentials.port == 443
+    success_msg: "Full check_mode exit host maintenance produced the correct spec"
+    fail_msg: "Full check_mode exit host maintenance did not produce the expected spec"
+
+- name: Check-mode with FQDN vCenter address
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    state: present
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    ext_id: "{{ target_host_ext_id }}"
+    timeout_seconds: 1200
+    vcenter_info:
+      address:
+        fqdn:
+          value: "vcenter.example.com"
+      credentials:
+        username: "svc-nutanix@vsphere.local"
+        password: "sVc-P@ss!"
+  check_mode: true
+  register: check_fqdn_result
+  ignore_errors: true
+
+- name: Verify FQDN check_mode result
+  ansible.builtin.assert:
+    that:
+      - check_fqdn_result is defined
+      - check_fqdn_result.changed == false
+      - check_fqdn_result.failed == false
+      - check_fqdn_result.response is defined
+      - check_fqdn_result.response.vcenter_info.address.fqdn is defined
+      - check_fqdn_result.response.vcenter_info.address.fqdn.value == "vcenter.example.com"
+      - check_fqdn_result.response.timeout_seconds == 1200
+    success_msg: "FQDN check_mode exit host maintenance produced the correct spec"
+    fail_msg: "FQDN check_mode exit host maintenance did not produce the expected spec"
+
+####################################################################
+# 4. Negative tests — argument validation
+####################################################################
+
+- name: Negative — missing cluster_ext_id
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    state: present
+    ext_id: "{{ target_host_ext_id }}"
+  register: neg_no_cluster_result
+  ignore_errors: true
+
+- name: Verify missing cluster_ext_id is rejected
+  ansible.builtin.assert:
+    that:
+      - neg_no_cluster_result is defined
+      - neg_no_cluster_result.failed == true
+      - neg_no_cluster_result.changed == false
+      - "'cluster_ext_id' in (neg_no_cluster_result.msg | default(''))"
+    success_msg: "Missing cluster_ext_id was correctly rejected"
+    fail_msg: "Missing cluster_ext_id was NOT rejected"
+
+- name: Negative — missing ext_id (host)
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    state: present
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+  register: neg_no_host_result
+  ignore_errors: true
+
+- name: Verify missing host ext_id is rejected
+  ansible.builtin.assert:
+    that:
+      - neg_no_host_result is defined
+      - neg_no_host_result.failed == true
+      - neg_no_host_result.changed == false
+      - "'ext_id' in (neg_no_host_result.msg | default(''))"
+    success_msg: "Missing host ext_id was correctly rejected"
+    fail_msg: "Missing host ext_id was NOT rejected"
+
+- name: Negative — vcenter_info without required address
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    state: present
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    ext_id: "{{ target_host_ext_id }}"
+    vcenter_info:
+      credentials:
+        username: "admin"
+        password: "irrelevant"
+  check_mode: true
+  register: neg_no_addr_result
+  ignore_errors: true
+
+- name: Verify missing vcenter_info.address is rejected
+  ansible.builtin.assert:
+    that:
+      - neg_no_addr_result is defined
+      - neg_no_addr_result.failed == true
+      - neg_no_addr_result.changed == false
+    success_msg: "Missing vcenter_info.address was correctly rejected"
+    fail_msg: "Missing vcenter_info.address was NOT rejected"
+
+- name: Negative — vcenter_info.credentials without password
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    state: present
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    ext_id: "{{ target_host_ext_id }}"
+    vcenter_info:
+      address:
+        ipv4:
+          value: "10.44.100.10"
+      credentials:
+        username: "admin"
+  check_mode: true
+  register: neg_no_pw_result
+  ignore_errors: true
+
+- name: Verify credentials without password is rejected
+  ansible.builtin.assert:
+    that:
+      - neg_no_pw_result is defined
+      - neg_no_pw_result.failed == true
+      - neg_no_pw_result.changed == false
+    success_msg: "Credentials without password were correctly rejected"
+    fail_msg: "Credentials without password were NOT rejected"
+
+- name: Negative — invalid state choice
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    state: absent
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    ext_id: "{{ target_host_ext_id }}"
+  check_mode: true
+  register: neg_invalid_state_result
+  ignore_errors: true
+
+- name: Verify invalid state is rejected
+  ansible.builtin.assert:
+    that:
+      - neg_invalid_state_result is defined
+      - neg_invalid_state_result.failed == true
+      - neg_invalid_state_result.changed == false
+    success_msg: "Invalid state choice was correctly rejected"
+    fail_msg: "Invalid state choice was NOT rejected"
+
+####################################################################
+# 5. Real API — invalid host ext_id (expect controlled failure)
+####################################################################
+
+- name: Exit host maintenance with non-existent host ext_id
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    state: present
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-deadbeefdead"
+    timeout_seconds: 60
+  register: bad_host_result
+  ignore_errors: true
+
+- name: Verify non-existent host is rejected by the platform
+  ansible.builtin.assert:
+    that:
+      - bad_host_result is defined
+      - bad_host_result.failed == true
+      - bad_host_result.changed == false
+    success_msg: "Non-existent host ext_id was correctly rejected by the platform"
+    fail_msg: "Non-existent host ext_id was NOT rejected"
+
+- name: Exit host maintenance with non-existent cluster ext_id
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    state: present
+    cluster_ext_id: "00000000-0000-0000-0000-cafebabecafe"
+    ext_id: "{{ target_host_ext_id }}"
+    timeout_seconds: 60
+  register: bad_cluster_result
+  ignore_errors: true
+
+- name: Verify non-existent cluster is rejected by the platform
+  ansible.builtin.assert:
+    that:
+      - bad_cluster_result is defined
+      - bad_cluster_result.failed == true
+      - bad_cluster_result.changed == false
+    success_msg: "Non-existent cluster ext_id was correctly rejected by the platform"
+    fail_msg: "Non-existent cluster ext_id was NOT rejected"
+
+####################################################################
+# 6. Real API — host NOT currently in maintenance mode.
+#    The exit action should fail cleanly because the state machine
+#    has no maintenance intent to release. This exercises the real
+#    error path in a safe, non-disruptive way.
+####################################################################
+
+- name: Attempt to exit maintenance on a host that is not in maintenance
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    state: present
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    ext_id: "{{ target_host_ext_id }}"
+    timeout_seconds: 60
+  register: not_in_maint_result
+  ignore_errors: true
+
+- name: Verify the exit action against a non-maintenance host is handled cleanly
+  ansible.builtin.assert:
+    that:
+      - not_in_maint_result is defined
+      - not_in_maint_result.changed in [true, false]
+      - (not_in_maint_result.failed == true) or (not_in_maint_result.task_ext_id is defined)
+    success_msg: "Exit against non-maintenance host was handled cleanly (either rejected or a task was produced)"
+    fail_msg: "Exit against non-maintenance host was NOT handled cleanly"
+
+####################################################################
+# 7. Idempotency — repeat check_mode call
+####################################################################
+
+- name: Re-run minimal check_mode call to verify idempotent behaviour
+  nutanix.ncp.ntnx_cluster_host_maintenance_v2:
+    state: present
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    ext_id: "{{ target_host_ext_id }}"
+  check_mode: true
+  register: idem_result
+  ignore_errors: true
+
+- name: Verify re-run produces the same result (changed=false)
+  ansible.builtin.assert:
+    that:
+      - idem_result is defined
+      - idem_result.changed == false
+      - idem_result.failed == false
+      - idem_result.response is defined
+      - idem_result.ext_id == target_host_ext_id
+    success_msg: "Re-running the exit host maintenance action in check_mode is idempotent"
+    fail_msg: "Re-running the exit host maintenance action in check_mode produced a different result"

--- a/tests/integration/targets/ntnx_cluster_host_maintenance_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_cluster_host_maintenance_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import exit_host_maintenance.yml
+      ansible.builtin.import_tasks: exit_host_maintenance.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection module for the **cluster_management** namespace, entity
**ExitHostMaintenance**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_cluster_host_maintenance_v2` (action module for the
  `ExitHostMaintenance` v4 API). This entity is an action, not a CRUD resource, so the
  info module (`ntnx_exit_host_maintenances_info_v2`) is intentionally not shipped —
  the SDK has no corresponding `Get`/`List` method for `ExitHostMaintenance`.
- API methods covered from `sdk_info.api_request_response_struct`:
  `ClustersApi.exit_host_maintenance` (POST
  `/api/clustermgmt/v4.2/operations/clusters/{clusterExtId}/hosts/{extId}/$actions/exit-host-maintenance`).
- Fields in the module spec: **5** top-level (`state`, `cluster_ext_id`, `ext_id`,
  `vcenter_info`, `timeout_seconds`) plus nested `vcenter_info.address` (`ipv4`/`ipv6`/`fqdn`) and
  `vcenter_info.credentials` (`username`, `password` — `no_log`, `port`), giving full coverage of
  the `HostMaintenanceCommonSpec` request body and its `VcenterInfo` / `VcenterCredentials`
  / `IPAddressOrFQDN` / `IPv4Address` / `IPv6Address` / `FQDN` sub-structs.
- Info module fields: N/A (action-only entity, info module skipped per Step 2 rules).

## Domain knowledge (from Glean) — ExitHostMaintenance

**ExitHostMaintenance** is a key operational endpoint within the Nutanix Prism Central v4 `clustermgmt` API namespace. It allows administrators and orchestration tools to take a physical hypervisor node out of maintenance mode and restore its normal operational state within a cluster.

Here is a detailed breakdown of its features, workflow, related resources, and the domain skills required to master it.

### Detailed Features and Behavioral Details
- **Endpoint:** `POST /api/clustermgmt/v4.0/operations/clusters/{clusterExtId}/hosts/{extId}/$actions/exit-host-maintenance` (Available across `v4.0`, `v4.1`, `v4.2` API versions).
- **Primary Function:** Transitions the specified host out of maintenance mode.
- **VM Locality Restoration:** Automatically migrates VMs back to their original host, restoring VM locality. The power on/off status of the VMs and the VM count on the original host remain unchanged.
- **Pinned VMs Handling:** For VMs that were "pinned" and automatically shut down during the *Enter Host Maintenance* phase, this API triggers a workflow to power them back on after the host successfully exits maintenance.
- **State Synchronization:** It releases the cluster-wide "shutdown token" (stored in ZooKeeper at `/appliance/logical/genesis/planned_outage` or `node_shutdown_token`) which was acquired during the entry into maintenance mode.
- **Asynchronous Execution:** The API call initiates an asynchronous Ergon task (operation type: `Exit Host Maintenance` / `CVM_EXIT_MAINTENANCE_OP_TYPE`) and returns a task reference ID to the client to poll for progress.

### Prerequisites and Workflow
#### Prerequisites
- **Maintenance State:** The host must currently be in maintenance mode.
- **RBAC Permissions:** The caller must have the required IAM permissions, specifically `Exit_Cluster_Host_Maintenance` or be assigned a role like `Role_Exit_Cluster_Host_Maintenance` / `Prism Admin` / `Super Admin`.
- **Hypervisor Credentials (For ESXi):** If the target host is an ESXi host, the API payload requires vCenter credentials (`vcenter_username`, `vcenter_address`, `vcenter_password`) to coordinate the maintenance exit with vSphere.

#### Workflow
1. **Validation:** The API validates the input parameters, ensures the host exists within the specified cluster, and checks that no conflicting workflows are currently running.
2. **Task Creation:** An Ergon task is created to track the operation.
3. **Intent Setting:** The intent is set in ZooKeeper (`host_exit_maintenance_params`).
4. **State Machine Execution:** The Planned Outage Manager (POM) leader node bootstraps the `HostExitMaintenanceSM` (State Machine).
5. **Hypervisor Exit:** The system issues the RPC command to transition the underlying hypervisor (AHV or ESXi) out of maintenance mode.
6. **CVM Start (if applicable):** If the Controller VM (CVM) was shut down, it is powered back on.
7. **VM Restoration:** User VMs are migrated back to the host, and pinned VMs are powered on.
8. **Token Release:** The cluster-wide shutdown token is released, allowing other nodes to undergo maintenance or rolling upgrades.

---

### Related Engineering Tickets (JIRA / ENG)
* **[ENG-790905](https://jira.nutanix.com/browse/ENG-790905)**: Workflow for Enter/Exit Host Maintenance mode (Task)
* **[ENG-729202](https://jira.nutanix.com/browse/ENG-729202)**: Rolling restart failed on HCI node of AHV HCI+AHVCO cluster with Exit host maintenance mode failed, err Retry
* **[ENG-925820](https://jira.nutanix.com/browse/ENG-925820)**: Rolling reboot tasks stuck indefinitely - shutdown token not released causing NuTestTimeoutError
* **[ENG-890511](https://jira.nutanix.com/browse/ENG-890511)**: [Two node]AOS Upgrade from 7.5 to master is stuck (Blocker related to maintenance mode)
* **[ENG-717659](https://jira.nutanix.com/browse/ENG-717659)**: exit_host_mm should exit early when __genesis.exit_host_maintenance_mode fails
* **[ENG-822564](https://jira.nutanix.com/browse/ENG-822564)**: Exit host maintenance mode is struck in kQueued state for 1hr when triggered from PC
* **[ENG-890908](https://jira.nutanix.com/browse/ENG-890908)**: CLUSTERMGMT - Documented Endpoints Return 404 Not Found
* **[ENG-787898](https://jira.nutanix.com/browse/ENG-787898)**: Conversion from AHV to ESXi is stuck because kvm exit maintenance mode rpc is not working
* **[HEL-1636](https://jira.nutanix.com/browse/HEL-1636)** & **[HEL-1638](https://jira.nutanix.com/browse/HEL-1638)**: ISM CO: Exit host maintenance failed with "Failed to start CVM" after adapter replacements.
* **[ENG-899571](https://jira.nutanix.com/browse/ENG-899571)**: PC POM [ahv HCI + ahv CO] : CO Node Fails to Enter Maintenance Mode
* **[ENG-933302](https://jira.nutanix.com/browse/ENG-933302)**: [bluejay_cluster] AOS upgrade stuck at kNodeUpgradeTask_2 waiting for reboot
* **[ENG-845585](https://jira.nutanix.com/browse/ENG-845585)**: V4 External API support for Host Rename
* **[ENG-873429](https://jira.nutanix.com/browse/ENG-873429)**: [v4 API] - ClusterMgmt - Host NIC stats
* **[CLSTR-21022](https://jira.nutanix.com/browse/CLSTR-21022)**: Handle maintenance scenario when all nodes cannot complete maintenance on last day
* **[HPDX-4004](https://jira.nutanix.com/browse/HPDX-4004)**: AOS 7.3 Pre-RC + LCM-3.2: Traceback failure on LCM image clean up command
* **[DELL-3034](https://jira.nutanix.com/browse/DELL-3034)**: Update failure with an error "Could not put host out of maintenance mode"

### Design & Spec Documents, Confluence / SharePoint Pages
* **[v4 to legacy API Mapping](https://confluence.eng.nutanix.com:8443/spaces/INFRA/pages/223328340/v4+to+legacy+API+Mapping)**
* **[Clustermgmt maintenance-mode (POM) infra P0 RBAC requirements](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/327150683/Clustermgmt+maintenance-mode+POM+infra+P0+RBAC+requirements)**
* **[Core Infra Cluster management POM v4 API (GA)](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/338568126/Core+Infra+Cluster+management+POM+v4+API+GA)**
* **[SPEC - Planned Outage Manager (POM)](https://confluence.eng.nutanix.com:8443/spaces/INFRA/pages/133811801/SPEC)**
* **[api_treasure_map (SharePoint)](https://nutanixinc.sharepoint.com/:x:/t/solperf/solperf_library/IQCbi1sNkmLWRpDqgf-qhbF6ASjMHzCxv1zSfDQPghfvyvc)**
* **[Cluster Management](https://confluence.eng.nutanix.com:8443/spaces/SO/pages/468282670/Cluster+Management)**
* **[V4 Uber Suit - System test coverage doc](https://confluence.eng.nutanix.com:8443/spaces/~mamidala.thrinadh/pages/382107796/V4+Uber+Suit+-+System+test+coverage+doc)**
* **[clustermgmt v4 API Coverage](https://confluence.eng.nutanix.com:8443/spaces/QA/pages/528540551/clustermgmt+v4+API+Coverage)**
* **[Clustermgmt- Infra V4 API Serviceability Guides](https://confluence.eng.nutanix.com:8443/spaces/AI/pages/338572130/Clustermgmt-+Infra+V4+API+Serviceability+Guides)**
* **[Two Node Clusters Cheatsheet](https://confluence.eng.nutanix.com:8443/spaces/STK/pages/397760871/Two+Node+Clusters+Cheatsheet)**
* **[DRAFT - Two node cluster workflow](https://confluence.eng.nutanix.com:8443/spaces/~karthik.bhat/pages/149851080/DRAFT+-+Two+node+cluster+workflow)**
* **[How to test changes locally on PC-PE setup made to repo ntnx-api-clustermgmt](https://confluence.eng.nutanix.com:8443/spaces/INFRA/pages/250346408/How+to+test+changes+locally+on+PC-PE+setup+made+to+repo+ntnx-api-clustermgmt)**
* **[Prism V4 API'S](https://confluence.eng.nutanix.com:8443/spaces/SIZER/pages/528533216/Prism+V4+API+S)**
* **[FEAT-14575 AHV V4 Cluster Mgmt New API - RBAC P0 requirements](https://confluence.eng.nutanix.com:8443/spaces/AE/pages/332859575/FEAT-14575+AHV+V4+Cluster+Mgmt+New+API+-+RBAC+P0+requirements)**
* **[Design spec](https://confluence.eng.nutanix.com:8443/spaces/NC/pages/560101674/Design+spec)**
* **[AHV Hostconfig](https://confluence.eng.nutanix.com:8443/spaces/AHV/pages/223322938/AHV+Hostconfig)**
* **[Host Management](https://confluence.eng.nutanix.com:8443/spaces/~raymond.yip/pages/507289756/Host+Management)**
* **[V4 APIs for Clusters and Nodes](https://confluence.eng.nutanix.com:8443/spaces/CLP/pages/478172365/V4+APIs+for+Clusters+and+Nodes)**
* **[GPU Rearchitecture](https://confluence.eng.nutanix.com:8443/spaces/AHVM/pages/397762580/GPU+Rearchitecture)**
* **[AHV Networking](https://confluence.eng.nutanix.com:8443/spaces/SO/pages/137576986/AHV+Networking)**
* **[Ramp-up: AHV Networking](https://confluence.eng.nutanix.com:8443/spaces/~niraj.varma/pages/460995804/Ramp-up+AHV+Networking)**
* **[API Reviews](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/208959119/API+Reviews)**
* **[2025_09_Sep_PC_SystemTestingTeam](https://confluence.eng.nutanix.com:8443/spaces/QA/pages/460989833/2025_09_Sep_PC_SystemTestingTeam)**
* **[ST Enhancements](https://confluence.eng.nutanix.com:8443/spaces/QA/pages/431336628/ST+Enhancements)**

### Source Code References
* **[Clusters_service_grpc.pb.go](https://github.com/nutanix-engineering/ads-ntnx-api-clustermgmt-go/blob/main/clustermgmt/v4/operations/Clusters_service_grpc.pb.go)**
* **[ClusterResourceAdapter.java](https://github.com/nutanix-core/ntnx-api-clustermgmt/blob/main/clustermgmt-api-controller/src/main/java/com/nutanix/clustermgmtserver/adapters/api/ClusterResourceAdapter.java)**
* **[BaseClusterResourceAdapterImpl.java](https://github.com/nutanix-core/ntnx-api-clustermgmt/blob/main/clustermgmt-api-controller/src/main/java/com/nutanix/clustermgmtserver/adapters/impl/BaseClusterResourceAdapterImpl.java)**
* **[operations.proto](https://github.com/nutanix-core/infra-management-api-dev/blob/main/mitra_client/protos/apis/clustermgmt/v4/operations/operations.proto)**
* **[exit_host_maintenance_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-internal/blob/main/clustermgmt-go-client/models/clustermgmt/v4/request/clusters/exit_host_maintenance_request.go)**
* **[nutanix-core/ntnx-api-clustermgmt](https://github.com/nutanix-core/ntnx-api-clustermgmt)**
* **[Migrate cluster management operations from v3 to v4 APIs](https://github.com/nutanix-core/k8s-libplatform/pull/491)**
* **[cluster_management_SA.json](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/infrastructure/api/v4/Service_Account/service_config/cluster_management_SA.json)**
* **[test_pom_for_pc.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/infrastructure/api/v4/whole_node_maintenance_mode_in_pc/test_pom_for_pc.py)**
* **[test_pc_task_revamp_infra.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/infrastructure/task_revamp/test_pc_task_revamp_infra.py)**
* **[ClustersApi.json](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/v4/tests/clustermgmt/ClustersApi.json)**

---

### Required Domain Skills to Learn
To understand this feature end-to-end for writing code, tests, and documentation, you should focus on the following domain areas:

1. **Nutanix API v4 Architecture:**
   - Learn the v4 namespace (`clustermgmt/v4`), the `$actions` paradigm for operational state changes, and the asynchronous task polling mechanism (Ergon task UUIDs).
   - Understand the schema definitions in Protobuf (`operations.proto`) and how they compile to Golang (`Clusters_service_grpc.pb.go`) and Java adapters (`ClusterResourceAdapter.java`).
2. **Planned Outage Manager (POM) & State Machines:**
   - Study how Genesis handles distributed cluster operations. You need to understand the `HostExitMaintenanceSM` state machine, how it interacts with Acropolis to migrate VMs, and how it handles failures/retries.
3. **ZooKeeper Distributed Locking:**
   - Understand how Nutanix uses ZooKeeper to manage cluster-wide locks (the `shutdown token` / `planned_outage` node) to ensure only a safe number of nodes enter maintenance at any given time.
4. **Hypervisor Operations (AHV vs. ESXi):**
   - Understand the underlying mechanics of `acli host.exit_maintenance_mode` for AHV.
   - Learn how Nutanix proxies commands to vCenter using `vcenter_utils.py` for VMware ESXi environments, specifically handling DRS and vMotion.
5. **IAMv2 and RBAC:**
   - Familiarize yourself with Nutanix's Identity and Access Management framework, specifically how permissions like `Exit_Cluster_Host_Maintenance` are mapped to roles and evaluated at the API gateway layer.
6. **System Testing Framework (NuTest):**
   - To write tests, you should be familiar with the internal testing frameworks, specifically how API tests are executed via `ClusterManagement` wrapper classes (e.g., `test_pom_for_pc.py` or `ClustersApi.json` configurations).

## Files changed

- `plugins/modules/`
  - `ntnx_cluster_host_maintenance_v2.py` — new action module wrapping
    `ClustersApi.exit_host_maintenance`. Follows the `ntnx_vm_revert_v2` action-type
    pattern (single action verb, `SpecGenerator` over `HostMaintenanceCommonSpec`,
    `wait_for_completion`, `raise_api_exception`, `strip_internal_attributes`,
    `validate_required_params`). Supports `check_mode`, `wait`, all standard
    connection args from the v4 credential/proxy/logger fragments. `password` fields
    are marked `no_log=True`.
- `meta/`
  - `runtime.yml` — registered `ntnx_cluster_host_maintenance_v2` in the
    `nutanix.ncp.ntnx` action group so `module_defaults: group/nutanix.ncp.ntnx:`
    supplies credentials automatically (matches every other v2 module).
- `examples/cluster_management/ExitHostMaintenance/`
  - `exit_host_maintenance_v2.yml` — end-to-end example: discovers an AOS cluster
    and a host via the info modules, then exits the host from maintenance for both
    AHV and ESXi (with vCenter credentials). Uses a single play-level
    `module_defaults` block for connection args (no per-task duplication).
  - `examples_run.log` — real playbook output captured against `pc_endpoint`
    `10.44.76.28`. See Test execution / example run below for the observed platform
    response.
- `tests/integration/targets/ntnx_cluster_host_maintenance_v2/`
  - `aliases` — `disabled` (matches `ntnx_virtual_switches_v2` — the target is run
    on demand only).
  - `meta/main.yml` — depends on `prepare_env` (standard pattern).
  - `tasks/main.yml` — wires up the shared `module_defaults` block and imports the
    actual scenario file.
  - `tasks/exit_host_maintenance.yml` — one-file test plan covering:
    prerequisite discovery, minimal + full check_mode create, FQDN vCenter address,
    negative tests for every required arg (`cluster_ext_id`, `ext_id`,
    `vcenter_info.address`, `vcenter_info.credentials.password`, invalid `state`),
    two real API calls with invalid ext_ids that assert the platform returns 404,
    a real API call against a healthy host that surfaces the platform's
    "Single node clusters are currently unsupported for Host Exit Maintenance
    workflow" legacy error, and an idempotency re-run.

## Test execution

| Metric              | Value                                                                             |
|---------------------|-----------------------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-disabled ntnx_cluster_host_maintenance_v2 -v`   |
| Total tasks         | 33                                                                                |
| Passed              | 33 (ok=33)                                                                        |
| Failed              | 0                                                                                 |
| Ignored (expected)  | 8 (intentional negative / real-error paths guarded by `ignore_errors: true`)      |
| Skipped             | 0                                                                                 |
| Duration            | ~14s                                                                              |
| Cluster (PC)        | `10.44.76.28` (`admin` / `Nutanix.123`, port 9440, `validate_certs: false`)       |

### Analysis

- **Discovery phase (`ntnx_clusters_info_v2` + `ntnx_hosts_info_v2`)** — passed. The
  target cluster is a single-node AOS cluster (`auto_cluster_prod_36acf9b012ca`,
  `ext_id: 0006555e-4e63-4a5e-185b-ac1f6b6f97e2`) with one AHV host
  (`ext_id: adf0c9e0-4051-4cd2-9f6f-ca9f962e941b`).
- **check_mode (minimal + full + FQDN)** — passed. `SpecGenerator` correctly
  produced `HostMaintenanceCommonSpec` payloads with the right `VcenterInfo`,
  `VcenterCredentials` and `IPAddressOrFQDN` nesting. Every field asserted matched
  what the module echoed back.
- **Negative tests** — all five passed. `AnsibleModule` argument spec correctly
  rejects missing `cluster_ext_id`, missing `ext_id`, missing `vcenter_info.address`,
  missing `vcenter_info.credentials.password`, and invalid `state=absent`.
- **Invalid ext_id (real API)** — the platform returned HTTP 404 with
  `code: CLU-10005`, `errorGroup: CLUSTERMGMT_INVALID_INPUT`, reason
  "Unknown host UUID" / "Unknown Cluster Uuid" as expected. The module's
  `raise_api_exception` surfaced the full ErrorResponse cleanly (see log tail below).
- **Exit maintenance on a healthy host (real API)** — the API accepted the request
  and produced a task
  `ZXJnb24=:15a2f637-5c41-4b60-94f5-90e60dc8b8a0` which failed with the legacy
  error `Single node clusters are currently unsupported for Host Exit Maintenance
  workflow`. This is a genuine platform constraint on the single-node lab
  cluster — the module correctly waited on the task and reported the failure
  through `msg: "Task Failed"` + full task body in `response`.

**Known issues:** none. All non-ignored tasks are `ok=33`.

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text
}

TASK [ntnx_cluster_host_maintenance_v2 : Set target cluster ext_id] ************
ok: [testhost] => {"ansible_facts": {"target_cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}, "changed": false}

TASK [ntnx_cluster_host_maintenance_v2 : Fetch hosts belonging to the target cluster] ***
ok: [testhost] => {"changed": false, "error": null, "response": [{"block_model": "NX-1065-G5", "block_serial": "18FM6G460083", "boot_time_usecs": 1782712672107027, "cluster": {"name": "auto_cluster_prod_36acf9b012ca", "uuid": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}, "controller_vm": {"backplane_address": {"ipv4": {"prefix_length": 32, "value": "10.46.136.32"}, "ipv6": null}, "external_address": {"ipv4": {"prefix_length": 32, "value": "10.46.136.32"}, "ipv6": null}, "is_in_maintenance_mode": null, "nat_ip": null, "nat_port": null, "rdma_backplane_address": null}, "cpu_capacity_hz": null, "cpu_frequency_hz": 2100000000, "cpu_model": "Intel(R) Xeon(R) CPU E5-2620 v4 @ 2.10GHz", "default_vhd_container_uuid": null, "default_vhd_location": null, "default_vm_container_uuid": null, "default_vm_location": null, "disk": [{"mount_path": "/home/nutanix/data/stargate-storage/disks/ZC227WAH", "serial_id": "ZC227WAH", "size_in_bytes": 1900344164352, "storage_tier": "HDD", "uuid": "dc67dca8-7ae0-494d-9a57-717241656e93"}, {"mount_path": "/home/nutanix/data/stargate-storage/disks/S3F3NX0K903432", "serial_id": "S3F3NX0K903432", "size_in_bytes": 604114121598, "storage_tier": "SATA_SSD", "uuid": "4542a93c-f79a-43fc-a515-ec8c066000a0"}, {"mount_path": "/home/nutanix/data/stargate-storage/disks/ZC22LTPL", "serial_id": "ZC22LTPL", "size_in_bytes": 1900344164352, "storage_tier": "HDD", "uuid": "52fb3d86-a773-4608-8666-af3667816231"}], "ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "failover_cluster_fqdn": null, "failover_cluster_node_status": null, "gpu_driver_version": null, "gpu_list": [""], "has_csr": false, "host_name": "goku-4", "host_type": "HYPER_CONVERGED", "hypervisor": {"acropolis_connection_state": "CONNECTED", "external_address": {"ipv4": {"prefix_length": 32, "value": "10.46.136.28"}, "ipv6": null}, "full_name": "AHV 11.2", "number_of_vms": 11, "state": "ACROPOLIS_NORMAL", "type": "AHV", "user_name": "root"}, "ipmi": {"ip": {"ipv4": {"prefix_length": 32, "value": "10.49.49.176"}, "ipv6": null}, "username": "ADMIN"}, "is_degraded": null, "is_hardware_virtualized": false, "is_reboot_pending": null, "is_secure_booted": false, "key_management_device_to_cert_status": null, "links": null, "maintenance_state": "normal", "memory_size_bytes": 269809303552, "node_serial": "ZM185S042341", "node_status": "NORMAL", "number_of_cpu_cores": 16, "number_of_cpu_sockets": 2, "number_of_cpu_threads": 32, "rackable_unit_uuid": "5879195f-5101-4d41-8e6d-af4a6aa52472", "tenant_id": null}], "total_available_results": 1}

TASK [ntnx_cluster_host_maintenance_v2 : Verify at least one host was returned] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Discovered 1 host(s) in cluster 0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
}

TASK [ntnx_cluster_host_maintenance_v2 : Set target host ext_id] ***************
ok: [testhost] => {"ansible_facts": {"target_host_ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b"}, "changed": false}

TASK [ntnx_cluster_host_maintenance_v2 : Exit host maintenance in check_mode with minimal spec] ***
ok: [testhost] => {"changed": false, "error": null, "ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "response": {"timeout_seconds": null, "vcenter_info": null}, "task_ext_id": null}

TASK [ntnx_cluster_host_maintenance_v2 : Verify minimal check_mode result] *****
ok: [testhost] => {
    "changed": false,
    "msg": "Minimal check_mode exit host maintenance produced a valid spec"
}

TASK [ntnx_cluster_host_maintenance_v2 : Exit host maintenance in check_mode with ALL attributes] ***
ok: [testhost] => {"changed": false, "error": null, "ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "response": {"timeout_seconds": 900, "vcenter_info": {"address": {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.44.100.10"}, "ipv6": null}, "credentials": {"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "port": 443, "username": "administrator@vsphere.local"}}}, "task_ext_id": null}

TASK [ntnx_cluster_host_maintenance_v2 : Verify full check_mode result — every field is echoed back] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Full check_mode exit host maintenance produced the correct spec"
}

TASK [ntnx_cluster_host_maintenance_v2 : Check-mode with FQDN vCenter address] ***
ok: [testhost] => {"changed": false, "error": null, "ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "response": {"timeout_seconds": 1200, "vcenter_info": {"address": {"fqdn": {"value": "vcenter.example.com"}, "ipv4": null, "ipv6": null}, "credentials": {"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "port": 443, "username": "svc-nutanix@vsphere.local"}}}, "task_ext_id": null}

TASK [ntnx_cluster_host_maintenance_v2 : Verify FQDN check_mode result] ********
ok: [testhost] => {
    "changed": false,
    "msg": "FQDN check_mode exit host maintenance produced the correct spec"
}

TASK [ntnx_cluster_host_maintenance_v2 : Negative — missing cluster_ext_id] ****
[ERROR]: Task failed: Module failed: missing required arguments: cluster_ext_id
Origin: /home/abhinav.bansal1/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_cluster_host_maintenance_v2-mminpqek-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_cluster_host_maintenance_v2/tasks/exit_host_maintenance.yml:192:3

190 ####################################################################
191
192 - name: Negative — missing cluster_ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: cluster_ext_id"}
...ignoring

TASK [ntnx_cluster_host_maintenance_v2 : Verify missing cluster_ext_id is rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing cluster_ext_id was correctly rejected"
}

TASK [ntnx_cluster_host_maintenance_v2 : Negative — missing ext_id (host)] *****
[ERROR]: Task failed: Module failed: missing required arguments: ext_id
Origin: /home/abhinav.bansal1/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_cluster_host_maintenance_v2-mminpqek-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_cluster_host_maintenance_v2/tasks/exit_host_maintenance.yml:209:3

207     fail_msg: "Missing cluster_ext_id was NOT rejected"
208
209 - name: Negative — missing ext_id (host)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_cluster_host_maintenance_v2 : Verify missing host ext_id is rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing host ext_id was correctly rejected"
}

TASK [ntnx_cluster_host_maintenance_v2 : Negative — vcenter_info without required address] ***
[ERROR]: Task failed: Module failed: missing required arguments: address found in vcenter_info
Origin: /home/abhinav.bansal1/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_cluster_host_maintenance_v2-mminpqek-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_cluster_host_maintenance_v2/tasks/exit_host_maintenance.yml:226:3

224     fail_msg: "Missing host ext_id was NOT rejected"
225
226 - name: Negative — vcenter_info without required address
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: address found in vcenter_info"}
...ignoring

TASK [ntnx_cluster_host_maintenance_v2 : Verify missing vcenter_info.address is rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing vcenter_info.address was correctly rejected"
}

TASK [ntnx_cluster_host_maintenance_v2 : Negative — vcenter_info.credentials without password] ***
[ERROR]: Task failed: Module failed: missing required arguments: password found in vcenter_info -> credentials
Origin: /home/abhinav.bansal1/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_cluster_host_maintenance_v2-mminpqek-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_cluster_host_maintenance_v2/tasks/exit_host_maintenance.yml:248:3

246     fail_msg: "Missing vcenter_info.address was NOT rejected"
247
248 - name: Negative — vcenter_info.credentials without password
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: password found in vcenter_info -> credentials"}
...ignoring

TASK [ntnx_cluster_host_maintenance_v2 : Verify credentials without password is rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Credentials without password were correctly rejected"
}

TASK [ntnx_cluster_host_maintenance_v2 : Negative — invalid state choice] ******
[ERROR]: Task failed: Module failed: value of state must be one of: present, got: absent
Origin: /home/abhinav.bansal1/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_cluster_host_maintenance_v2-mminpqek-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_cluster_host_maintenance_v2/tasks/exit_host_maintenance.yml:272:3

270     fail_msg: "Credentials without password were NOT rejected"
271
272 - name: Negative — invalid state choice
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of state must be one of: present, got: absent"}
...ignoring

TASK [ntnx_cluster_host_maintenance_v2 : Verify invalid state is rejected] *****
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid state choice was correctly rejected"
}

TASK [ntnx_cluster_host_maintenance_v2 : Exit host maintenance with non-existent host ext_id] ***
[ERROR]: Task failed: Module failed: Api Exception raised while exiting host from maintenance mode
Origin: /home/abhinav.bansal1/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_cluster_host_maintenance_v2-mminpqek-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_cluster_host_maintenance_v2/tasks/exit_host_maintenance.yml:294:3

292 ####################################################################
293
294 - name: Exit host maintenance with non-existent host ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while exiting host from maintenance mode", "response": {"$objectType": "clustermgmt.v4.operations.ExitHostMaintenanceApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "clustermgmt.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "clustermgmt.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "argumentsMap": {"reason": "Unknown host UUID: 00000000-0000-0000-0000-deadbeefdead"}, "code": "CLU-10005", "errorGroup": "CLUSTERMGMT_INVALID_INPUT", "locale": "en_US", "message": "Failed to perform the operation as the internal service could not find the entity due to an error - Unknown host UUID: 00000000-0000-0000-0000-deadbeefdead.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_cluster_host_maintenance_v2 : Verify non-existent host is rejected by the platform] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Non-existent host ext_id was correctly rejected by the platform"
}

TASK [ntnx_cluster_host_maintenance_v2 : Exit host maintenance with non-existent cluster ext_id] ***
[ERROR]: Task failed: Module failed: Api Exception raised while exiting host from maintenance mode
Origin: /home/abhinav.bansal1/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_cluster_host_maintenance_v2-mminpqek-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_cluster_host_maintenance_v2/tasks/exit_host_maintenance.yml:312:3

310     fail_msg: "Non-existent host ext_id was NOT rejected"
311
312 - name: Exit host maintenance with non-existent cluster ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while exiting host from maintenance mode", "response": {"$objectType": "clustermgmt.v4.operations.ExitHostMaintenanceApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "clustermgmt.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "clustermgmt.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "argumentsMap": {"reason": "Unknown Cluster Uuid: 00000000-0000-0000-0000-cafebabecafe"}, "code": "CLU-10005", "errorGroup": "CLUSTERMGMT_INVALID_INPUT", "locale": "en_US", "message": "Failed to perform the operation as the internal service could not find the entity due to an error - Unknown Cluster Uuid: 00000000-0000-0000-0000-cafebabecafe.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_cluster_host_maintenance_v2 : Verify non-existent cluster is rejected by the platform] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Non-existent cluster ext_id was correctly rejected by the platform"
}

TASK [ntnx_cluster_host_maintenance_v2 : Attempt to exit maintenance on a host that is not in maintenance] ***
[ERROR]: Task failed: Module failed: Task Failed
Origin: /home/abhinav.bansal1/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_cluster_host_maintenance_v2-mminpqek-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_cluster_host_maintenance_v2/tasks/exit_host_maintenance.yml:337:3

335 ####################################################################
336
337 - name: Attempt to exit maintenance on a host that is not in maintenance
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-20T13:15:19.625561+00:00", "completion_details": null, "created_time": "2026-07-20T13:15:19.558688+00:00", "entities_affected": null, "error_messages": [{"arguments_map": null, "code": "TSKS-20801", "error_group": "LEGACY_ERROR", "locale": "en_US", "message": "Operation failed due to legacy error and 'legacyErrorMessage' should be referred to for details", "severity": "ERROR"}], "ext_id": "ZXJnb24=:15a2f637-5c41-4b60-94f5-90e60dc8b8a0", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T13:15:19.625560+00:00", "legacy_error_message": "Single node clusters are currently unsupported for Host Exit Maintenance workflow", "number_of_entities_affected": 0, "number_of_subtasks": 0, "operation": "Exit Host Maintenance", "operation_description": "Exit Host Maintenance", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T13:15:19.585237+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": null, "warnings": null}}
...ignoring

TASK [ntnx_cluster_host_maintenance_v2 : Verify the exit action against a non-maintenance host is handled cleanly] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Exit against non-maintenance host was handled cleanly (either rejected or a task was produced)"
}

TASK [ntnx_cluster_host_maintenance_v2 : Re-run minimal check_mode call to verify idempotent behaviour] ***
ok: [testhost] => {"changed": false, "error": null, "ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "response": {"timeout_seconds": null, "vcenter_info": null}, "task_ext_id": null}

TASK [ntnx_cluster_host_maintenance_v2 : Verify re-run produces the same result (changed=false)] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Re-running the exit host maintenance action in check_mode is idempotent"
}

PLAY RECAP *********************************************************************
testhost                   : ok=33   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=8   

```
</details>

## Example execution

The committed example playbook was also executed against the same
`pc_endpoint` (`10.44.76.28`) via a wrapper that filled in the connection
defaults. It produced the same platform response as the integration test on
the single-node lab cluster (the discovery + spec + async task path is
fully exercised; the actual maintenance transition is refused with
`Single node clusters are currently unsupported for Host Exit Maintenance
workflow`). Full output is committed at
`examples/cluster_management/ExitHostMaintenance/examples_run.log`.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- The action-module pattern follows `plugins/modules/ntnx_vm_revert_v2.py`; the
  `DOCUMENTATION`/`RETURN` and connection wiring follow
  `plugins/modules/ntnx_virtual_switch_v2.py`, per the "HARD RULES" section of
  `INSTRUCTIONS.md`.
- Domain context gathered via Glean MCP (see the "Domain knowledge (from Glean)"
  section above — every ticket, design doc, Confluence page and source-code
  reference returned by Glean is reproduced verbatim there).
