### PR TITLE
DiskLEDState Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/cluster_management/DiskLEDState/disk_led_state.yml
+++ b/examples/cluster_management/DiskLEDState/disk_led_state.yml
@@ -1,0 +1,36 @@
+# Summary:
+# This playbook demonstrates how to control the physical LED of a Disk on a
+# Nutanix cluster via the Cluster Management v4 API. Turning the LED on lets a
+# datacenter operator visually locate a drive (for example, while replacing a
+# failed disk); turning it off is the standard follow-up once maintenance is
+# complete. The `ntnx_disk_led_state_v2` module is action-only — it always
+# submits a task and returns the task response, so use `nutanix.ncp.ntnx_disks_info_v2`
+# (or the platform inventory) to discover a valid disk `ext_id` first.
+
+- name: Disk LED state management playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Set disk ext_id used by the play
+      ansible.builtin.set_fact:
+        disk_ext_id: "5a2b0e5c-4a2b-4c9b-8d5a-2f0e0e3b9a11"
+
+    - name: Turn ON the LED for the target disk (locate the drive)
+      nutanix.ncp.ntnx_disk_led_state_v2:
+        ext_id: "{{ disk_ext_id }}"
+        is_engaged: true
+      register: led_on_result
+      ignore_errors: true
+
+    - name: Turn OFF the LED for the target disk (after maintenance)
+      nutanix.ncp.ntnx_disk_led_state_v2:
+        ext_id: "{{ disk_ext_id }}"
+        is_engaged: false
+      register: led_off_result
+      ignore_errors: true

--- a/examples/cluster_management/DiskLEDState/examples_run.log
+++ b/examples/cluster_management/DiskLEDState/examples_run.log
@@ -1,0 +1,18 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Disk LED state management playbook] **************************************
+
+TASK [Set disk ext_id used by the play] ****************************************
+ok: [localhost] => {"ansible_facts": {"disk_ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0"}, "changed": false}
+
+TASK [Turn ON the LED for the target disk (locate the drive)] ******************
+changed: [localhost] => {"changed": true, "ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T13:14:44.070871+00:00", "completion_details": null, "created_time": "2026-07-20T13:14:43.918054+00:00", "entities_affected": [{"ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "name": null, "rel": "clustermgmt:config:disks"}], "error_messages": null, "ext_id": "ZXJnb24=:75a28b33-dfcd-4a52-6e32-b2faf70eb417", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T13:14:44.070870+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kUpdateLed", "operation_description": "Update Disk Led state", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T13:14:43.933314+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:75a28b33-dfcd-4a52-6e32-b2faf70eb417"}
+
+TASK [Turn OFF the LED for the target disk (after maintenance)] ****************
+changed: [localhost] => {"changed": true, "ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T13:14:47.525797+00:00", "completion_details": null, "created_time": "2026-07-20T13:14:47.359890+00:00", "entities_affected": [{"ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "name": null, "rel": "clustermgmt:config:disks"}], "error_messages": null, "ext_id": "ZXJnb24=:e744c010-84da-4c92-799d-7f9735f0a081", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T13:14:47.525796+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kUpdateLed", "operation_description": "Update Disk Led state", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T13:14:47.378585+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:e744c010-84da-4c92-799d-7f9735f0a081"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_disk_led_state_v2

--- a/plugins/module_utils/v4/clusters_mgmt/api_client.py
+++ b/plugins/module_utils/v4/clusters_mgmt/api_client.py
@@ -142,3 +142,20 @@ def get_ssl_certificates_api_instance(module):
     """
     client = get_api_client(module)
     return ntnx_clustermgmt_py_client.SSLCertificateApi(client)
+
+
+def get_disks_api_instance(module):
+    """
+    This method will return disks api instance from sdk.
+
+    The DisksApi exposes the cluster-scoped Disk endpoints under
+    ``/api/clustermgmt/v4.x/config/disks`` — including the
+    ``$actions/update-led-state`` action used to identify a physical disk
+    via its chassis LED.
+    Args:
+        module (AnsibleModule): AnsibleModule instance
+    Returns:
+        DisksApi: DisksApi instance
+    """
+    client = get_api_client(module)
+    return ntnx_clustermgmt_py_client.DisksApi(client)

--- a/plugins/module_utils/v4/clusters_mgmt/helpers.py
+++ b/plugins/module_utils/v4/clusters_mgmt/helpers.py
@@ -91,6 +91,29 @@ def get_ssl_certificates(module, api_instance, ext_id):
         )
 
 
+def get_disk(module, api_instance, ext_id):
+    """
+    This method will return disk info using external ID.
+
+    Used by disk-related modules (e.g. the ``update-led-state`` action) to
+    fetch the current Disk representation from the cluster management v4 API.
+    Args:
+        module: Ansible module
+        api_instance: DisksApi instance from sdk
+        ext_id (str): disk external ID
+    return:
+        disk info (object): disk info
+    """
+    try:
+        return api_instance.get_disk_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching disk info using ext_id",
+        )
+
+
 def get_cluster_profile(module, api_instance, ext_id):
     """
     This method will return cluster profile info using external ID.

--- a/plugins/modules/ntnx_disk_led_state_v2.py
+++ b/plugins/modules/ntnx_disk_led_state_v2.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_disk_led_state_v2
+short_description: Update the LED state of a physical Disk in a Nutanix cluster
+version_added: 2.7.0
+description:
+  - This module allows you to update (turn on / turn off) the physical LED of a Disk
+    in a Nutanix cluster.
+  - The action is used to visually locate a specific drive in a chassis — typically
+    while replacing a failed disk or performing hardware maintenance in the datacenter.
+  - The operation is asynchronous — an ergon task is returned by the API and, when
+    C(wait) is true (default), the module polls until the task completes.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation.
+  - >-
+    B(Update Disk LED state) -
+    Required Roles: Prism Admin, Super Admin, Cluster Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  state:
+    description:
+      - State of the module.
+      - Only C(present) is supported — this is an action-only module.
+    type: str
+    choices:
+      - present
+    default: present
+  ext_id:
+    description:
+      - The external identifier (UUID) of the Disk whose LED state must be updated.
+    type: str
+    required: true
+  is_engaged:
+    description:
+      - Indicates the target LED status of the Disk.
+      - C(true) turns the LED on (engaged / locate mode) so the drive can be
+        visually identified.
+      - C(false) turns the LED off (disengaged).
+    type: bool
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Turn ON the LED of a disk to locate it in the chassis
+  nutanix.ncp.ntnx_disk_led_state_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "5a2b0e5c-4a2b-4c9b-8d5a-2f0e0e3b9a11"
+    is_engaged: true
+  register: result
+  ignore_errors: true
+
+- name: Turn OFF the LED of a disk after maintenance
+  nutanix.ncp.ntnx_disk_led_state_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "5a2b0e5c-4a2b-4c9b-8d5a-2f0e0e3b9a11"
+    is_engaged: false
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for updating the LED state of a Disk.
+    - Task details (final task object) if C(wait) is true.
+    - Initial task submission response if C(wait) is false.
+  returned: always
+  type: dict
+  sample:
+    {
+      "app_name": null,
+      "batch_summary": null,
+      "cluster_ext_ids": [
+        "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+      ],
+      "completed_time": "2026-07-20T13:14:44.070871+00:00",
+      "completion_details": null,
+      "created_time": "2026-07-20T13:14:43.918054+00:00",
+      "entities_affected": [
+        {
+          "ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0",
+          "name": null,
+          "rel": "clustermgmt:config:disks"
+        }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:75a28b33-dfcd-4a52-6e32-b2faf70eb417",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-20T13:14:44.070870+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 1,
+      "number_of_subtasks": 0,
+      "operation": "kUpdateLed",
+      "operation_description": "Update Disk Led state",
+      "owned_by": {
+        "ext_id": "00000000-0000-0000-0000-000000000000",
+        "name": "admin"
+      },
+      "parent_task": null,
+      "progress_percentage": 100,
+      "projectExtId": "00000000-0000-0000-0000-000000000000",
+      "resource_links": null,
+      "root_task": null,
+      "started_time": "2026-07-20T13:14:43.933314+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while updating disk LED state"
+
+error:
+  description:
+    - This field typically holds information about if the task have errors that
+      occurred during the task execution.
+  returned: when an error occurs
+  type: str
+  sample: "Failed to get etag for Disk"
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+task_ext_id:
+  description: The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:75a28b33-dfcd-4a52-6e32-b2faf70eb417"
+
+ext_id:
+  description: The external ID of the Disk whose LED state was updated.
+  returned: always
+  type: str
+  sample: "4542a93c-f79a-43fc-a515-ec8c066000a0"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_disks_api_instance,
+)
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_clustermgmt_py_client as cluster_management_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402
+        mock_sdk as cluster_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        ext_id=dict(type="str", required=True),
+        is_engaged=dict(type="bool", required=True),
+    )
+    return module_args
+
+
+def update_disk_led_state(module, disks_api, result):
+    """Trigger the Disk LED state update action.
+
+    This is an action-only operation (no CRUD idempotency): the API always
+    submits a task, and the caller is expected to poll via C(wait).
+
+    The Cluster Management v4 ``$actions/update-led-state`` endpoint is a
+    plain POST that does not require an ``If-Match`` header, so this
+    module intentionally does NOT perform a preflight
+    ``get_disk_by_id`` — invalid ``ext_id`` values fall through to the
+    action call and surface as a descriptive API error.
+    """
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    sg = SpecGenerator(module)
+    default_spec = cluster_management_sdk.LEDStateUpdationSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating disk LED state update spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = disks_api.update_disk_led_state(extId=ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating disk LED state",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    disks_api = get_disks_api_instance(module)
+    update_disk_led_state(module, disks_api, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip>=23.0
 setuptools>=65.0
 requests>=2.31.0
-ntnx-clustermgmt-py-client==4.2.2
+ntnx-clustermgmt-py-client==latest
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1

--- a/tests/integration/targets/ntnx_disk_led_state_v2/aliases
+++ b/tests/integration/targets/ntnx_disk_led_state_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_disk_led_state_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_disk_led_state_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_disk_led_state_v2/tasks/disk_led_state.yml
+++ b/tests/integration/targets/ntnx_disk_led_state_v2/tasks/disk_led_state.yml
@@ -1,0 +1,255 @@
+---
+# Test plan for ntnx_disk_led_state_v2
+# ------------------------------------
+# The module is action-only: it POSTs to the Cluster Management v4
+# ``/config/disks/{extId}/$actions/update-led-state`` endpoint. The API
+# submits a task, so tests focus on:
+#   * argument-spec validation (required fields, choice constraints)
+#   * check_mode behaviour (no API call, spec echoed back)
+#   * the happy-path locate/unlocate flow against a real disk on the cluster
+#   * wait=false path (task_ext_id returned, response is the task submission)
+#   * negative path with an invalid ext_id
+#
+# The target is marked ``disabled`` (like every other v2 integration
+# target). It is executed on-demand during code-gen; do not enable it in
+# the default sanity gate.
+
+- name: Start Disk LED State tests
+  ansible.builtin.debug:
+    msg: Start Disk LED State tests
+
+########################################################################
+# Discover a disk on the live cluster via the raw v4 REST API. We use
+# ``ansible.builtin.uri`` so this test target does not require the
+# (still to be generated) ``ntnx_disks_info_v2`` module.
+########################################################################
+
+- name: List disks on the cluster (raw v4 REST call)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default(9440) }}/api/clustermgmt/v4.2/config/disks?$limit=1"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    return_content: true
+    status_code: 200
+    headers:
+      Accept: application/json
+  register: disks_list_response
+  ignore_errors: true
+
+- name: Verify at least one disk was returned
+  ansible.builtin.assert:
+    that:
+      - disks_list_response is defined
+      - disks_list_response.failed == false
+      - disks_list_response.json is defined
+      - disks_list_response.json.data is defined
+      - disks_list_response.json.data | length > 0
+    fail_msg: "No disks were returned from the cluster — cannot exercise disk LED tests"
+    success_msg: "Fetched at least one disk from the cluster"
+
+- name: Capture a disk ext_id for the tests
+  ansible.builtin.set_fact:
+    disk_ext_id: "{{ disks_list_response.json.data[0].extId }}"
+
+- name: Show the captured disk ext_id
+  ansible.builtin.debug:
+    var: disk_ext_id
+
+########################################################################
+# check_mode: turning the LED on must build a valid spec, must not
+# trigger a real API call, and must not report ``changed``.
+########################################################################
+
+- name: Check_mode turn LED ON — spec is built without calling API
+  nutanix.ncp.ntnx_disk_led_state_v2:
+    ext_id: "{{ disk_ext_id }}"
+    is_engaged: true
+  check_mode: true
+  register: cm_on
+  ignore_errors: true
+
+- name: Verify check_mode LED ON
+  ansible.builtin.assert:
+    that:
+      - cm_on.changed == false
+      - cm_on.failed == false
+      - cm_on.ext_id == disk_ext_id
+      - cm_on.response is defined
+      - cm_on.response.is_engaged == true
+      - cm_on.task_ext_id is none
+    fail_msg: "check_mode LED-ON did not produce the expected spec-only response"
+    success_msg: "check_mode LED-ON produced the expected spec-only response"
+
+- name: Check_mode turn LED OFF — spec is built without calling API
+  nutanix.ncp.ntnx_disk_led_state_v2:
+    ext_id: "{{ disk_ext_id }}"
+    is_engaged: false
+  check_mode: true
+  register: cm_off
+  ignore_errors: true
+
+- name: Verify check_mode LED OFF
+  ansible.builtin.assert:
+    that:
+      - cm_off.changed == false
+      - cm_off.failed == false
+      - cm_off.ext_id == disk_ext_id
+      - cm_off.response is defined
+      - cm_off.response.is_engaged == false
+      - cm_off.task_ext_id is none
+    fail_msg: "check_mode LED-OFF did not produce the expected spec-only response"
+    success_msg: "check_mode LED-OFF produced the expected spec-only response"
+
+########################################################################
+# Happy path: locate the drive (turn LED on), then unlocate it (turn LED
+# off). Both must return ``changed=true`` and produce a SUCCEEDED task
+# with the disk in ``entities_affected``.
+########################################################################
+
+- name: Turn LED ON for the disk (locate)
+  nutanix.ncp.ntnx_disk_led_state_v2:
+    ext_id: "{{ disk_ext_id }}"
+    is_engaged: true
+  register: led_on
+  ignore_errors: true
+
+- name: Verify LED ON task succeeded
+  ansible.builtin.assert:
+    that:
+      - led_on.changed == true
+      - led_on.failed == false
+      - led_on.ext_id == disk_ext_id
+      - led_on.task_ext_id is defined
+      - led_on.task_ext_id | length > 0
+      - led_on.response is defined
+      - led_on.response.status == "SUCCEEDED"
+      - led_on.response.entities_affected is defined
+      - led_on.response.entities_affected | length >= 1
+      - led_on.response.entities_affected | selectattr('ext_id', 'equalto', disk_ext_id) | list | length >= 1
+    fail_msg: "Turning LED ON did not complete successfully"
+    success_msg: "Turned LED ON successfully"
+
+- name: Turn LED OFF for the disk (unlocate)
+  nutanix.ncp.ntnx_disk_led_state_v2:
+    ext_id: "{{ disk_ext_id }}"
+    is_engaged: false
+  register: led_off
+  ignore_errors: true
+
+- name: Verify LED OFF task succeeded
+  ansible.builtin.assert:
+    that:
+      - led_off.changed == true
+      - led_off.failed == false
+      - led_off.ext_id == disk_ext_id
+      - led_off.task_ext_id is defined
+      - led_off.task_ext_id | length > 0
+      - led_off.response is defined
+      - led_off.response.status == "SUCCEEDED"
+      - led_off.response.entities_affected is defined
+      - led_off.response.entities_affected | length >= 1
+      - led_off.response.entities_affected | selectattr('ext_id', 'equalto', disk_ext_id) | list | length >= 1
+    fail_msg: "Turning LED OFF did not complete successfully"
+    success_msg: "Turned LED OFF successfully"
+
+########################################################################
+# wait=false path: the module must return a task submission response
+# (no ``status`` field yet) and still surface the task_ext_id so the
+# caller can poll on their own.
+########################################################################
+
+- name: Turn LED ON but do not wait for the task to complete
+  nutanix.ncp.ntnx_disk_led_state_v2:
+    ext_id: "{{ disk_ext_id }}"
+    is_engaged: true
+    wait: false
+  register: led_on_no_wait
+  ignore_errors: true
+
+- name: Verify wait=false returned the task submission only
+  ansible.builtin.assert:
+    that:
+      - led_on_no_wait.changed == true
+      - led_on_no_wait.failed == false
+      - led_on_no_wait.task_ext_id is defined
+      - led_on_no_wait.task_ext_id | length > 0
+      - led_on_no_wait.response is defined
+      - led_on_no_wait.response.ext_id == led_on_no_wait.task_ext_id
+    fail_msg: "wait=false did not return the initial task submission response"
+    success_msg: "wait=false returned the initial task submission response"
+
+- name: Clean up — turn LED OFF (best-effort) after wait=false test
+  nutanix.ncp.ntnx_disk_led_state_v2:
+    ext_id: "{{ disk_ext_id }}"
+    is_engaged: false
+  register: led_off_cleanup
+  ignore_errors: true
+
+- name: Verify cleanup LED OFF succeeded
+  ansible.builtin.assert:
+    that:
+      - led_off_cleanup.changed == true
+      - led_off_cleanup.failed == false
+      - led_off_cleanup.response.status == "SUCCEEDED"
+    fail_msg: "Cleanup LED OFF did not complete successfully"
+    success_msg: "Cleanup LED OFF completed successfully"
+
+########################################################################
+# Negative: argument spec validation (required fields).
+########################################################################
+
+- name: Negative — missing ext_id must fail (argument spec)
+  nutanix.ncp.ntnx_disk_led_state_v2:
+    is_engaged: true
+  register: neg_missing_ext_id
+  ignore_errors: true
+
+- name: Verify missing ext_id was rejected by the module argument spec
+  ansible.builtin.assert:
+    that:
+      - neg_missing_ext_id.failed == true
+      - neg_missing_ext_id.changed == false
+      - >-
+        (neg_missing_ext_id.msg is defined and 'ext_id' in neg_missing_ext_id.msg)
+        or (neg_missing_ext_id.module_stderr is defined and 'ext_id' in neg_missing_ext_id.module_stderr)
+    fail_msg: "Module did not reject the missing ext_id parameter"
+    success_msg: "Module correctly rejected the missing ext_id parameter"
+
+- name: Negative — missing is_engaged must fail (argument spec)
+  nutanix.ncp.ntnx_disk_led_state_v2:
+    ext_id: "{{ disk_ext_id }}"
+  register: neg_missing_is_engaged
+  ignore_errors: true
+
+- name: Verify missing is_engaged was rejected by the module argument spec
+  ansible.builtin.assert:
+    that:
+      - neg_missing_is_engaged.failed == true
+      - neg_missing_is_engaged.changed == false
+      - >-
+        (neg_missing_is_engaged.msg is defined and 'is_engaged' in neg_missing_is_engaged.msg)
+        or (neg_missing_is_engaged.module_stderr is defined and 'is_engaged' in neg_missing_is_engaged.module_stderr)
+    fail_msg: "Module did not reject the missing is_engaged parameter"
+    success_msg: "Module correctly rejected the missing is_engaged parameter"
+
+########################################################################
+# Negative: invalid disk ext_id (Disk not found).
+########################################################################
+
+- name: Negative — invalid disk ext_id must fail on the API call
+  nutanix.ncp.ntnx_disk_led_state_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    is_engaged: true
+  register: neg_bad_ext_id
+  ignore_errors: true
+
+- name: Verify invalid disk ext_id was rejected by the API
+  ansible.builtin.assert:
+    that:
+      - neg_bad_ext_id.failed == true
+      - neg_bad_ext_id.changed == false
+    fail_msg: "Module did not fail on an invalid disk ext_id"
+    success_msg: "Module correctly failed on an invalid disk ext_id"

--- a/tests/integration/targets/ntnx_disk_led_state_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_disk_led_state_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import disk_led_state.yml
+      ansible.builtin.import_tasks: disk_led_state.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **cluster_management** namespace, entity
**DiskLEDState**, based on the inline `sdk_info.json`. One PR per code-gen run.

The `DiskLEDState` entity in the Nutanix Cluster Management v4 API is an
**action-only** resource — the only API method is a POST to
`/api/clustermgmt/v4.2/config/disks/{extId}/$actions/update-led-state`. There is
no CRUD lifecycle and no list endpoint, so this PR only ships the action
module (`ntnx_disk_led_state_v2`); no `_info_v2` module is generated per the
"skip info module if action type" rule in `INSTRUCTIONS.md`.

- Modules generated: `ntnx_disk_led_state_v2`
- API methods covered: 1 (`update_disk_led_state`)
- Fields in action module spec: 3 (`state`, `ext_id`, `is_engaged`) — every non-connection field
  in the SDK `LEDStateUpdationSpec` request body plus the required `extId` path parameter
- Info module: N/A (entity has no read/list endpoint of its own — Disk read/list is a
  separate entity outside this code-gen run)

## Domain knowledge (from Glean)

### What is DiskLEDState in cluster_management?
**DiskLEDState** is a feature within the Nutanix v4 `clustermgmt` (Cluster Management) API and SDK that allows administrators to programmatically control the physical LED on a hardware disk drive. By toggling the disk's LED state (on or off), users can visually identify specific drives within a dense node chassis—a critical operation for datacenter maintenance tasks such as replacing a failed drive, decommissioning hardware, or verifying slot locations.

---

### Detailed Features
*   **API Endpoint**: Exposed via `/api/clustermgmt/v4.x/config/disks/{extId}/$actions/update-led-state`.
*   **Simple Payload**: Accepts a `LEDStateUpdationSpec` body containing `isEngaged: bool` to turn the LED on (`True`) or off (`False`).
*   **Asynchronous Execution**: The API triggers a background task and returns a `UpdateDiskLEDStateTaskResponse` (Task ID) so the caller can track the progress of the operation.
*   **SDK Support**: Native support in Nutanix v4 SDKs (e.g., `update_disk_led_state` in Python and `UpdateDiskLEDState` in Go).
*   **Multi-Hypervisor Hardware Abstraction**: It abstracts the underlying storage controllers, translating the request into hypervisor-specific low-level commands (e.g., SAS/SATA controller utilities).

---

### Where and How it is Used
*   **Where**: Used primarily in Nutanix Prism interfaces, hardware manageability workflows, and test automation (via Hades/Genesis).
*   **How**:
    1. A script or admin queries the disks using the `list_disks` API to find the target disk's UUID (`extId`).
    2. A POST request is made to the `update-led-state` endpoint with `{"isEngaged": True}` to locate the disk.
    3. An engineer walks into the datacenter, visually identifies the blinking drive, and performs the necessary hardware maintenance.
    4. Afterwards, another API call is made with `{"isEngaged": False}` to turn the LED off.

---

### Prerequisites, Workflow, and Behavioral Details
#### Prerequisites
*   **Valid Disk UUID**: The external identifier (`extId`) of the disk must be known and valid.
*   **Hades Configuration**: The disk must be recognized by the Hades service (Nutanix's disk management component).
*   **Permissions**: The user or service account invoking the API must have appropriate RBAC (Role-Based Access Control) permissions for cluster storage management.

#### Workflow (Under the Hood)
1.  **API Receipt**: The request arrives at the Cluster Management v4 API layer.
2.  **Genesis Delegation**: The API triggers a Genesis operation. In the backend, this translates to Genesis ops `LED_ON` or `LED_OFF`.
3.  **Hardware Command Execution**: The `disk_manager.py` (Hades component) translates the intent to specific hardware commands based on the hypervisor/controller:
    *   **ESXi / AHV**: Uses LSI controller utilities, running commands like `sas2ircu <hba_index> locate <enc_and_slot_id> ON`.
    *   **Hyper-V**: Runs PowerShell cmdlets such as `Update-DiskLEDState -LedToolpath <tool> -EncAndSlotId <id> -State ON`.

#### Behavioral Details
*   **Error Handling**: Submitting an invalid disk UUID or incorrectly formatted payload results in an immediate `400 Bad Request` validation error (in practice this cluster returns HTTP 500 with the `DISK_RPC_ERROR / CLU-11001` code and message `Disk with extId <uuid> not found` — see the "Negative — invalid disk ext_id" test in the log tail below).
*   **Disk States**: The LED state can be successfully updated even if the disk is currently unmounted or marked as bad, facilitating the location of failed drives.
*   **Hot-unplug**: Tests are written to ensure that the system handles edge cases gracefully, such as attempting to update the LED of a disk that has just been hot-unplugged.

---

### Related Engineering Tickets and Documentation
**JIRA / Engineering Tickets:**
*   [ENG-789932](https://jira.nutanix.com/browse/ENG-789932): Update UpdateLEDState API request body.
*   [ENG-763297](https://jira.nutanix.com/browse/ENG-763297): Fixes a `TypeError` where `update_disk_led_state()` was throwing an unexpected keyword argument `isEngaged` in test pipelines.
*   [ENG-922336](https://jira.nutanix.com/browse/ENG-922336): Addresses an `IndexError` in the kCurator task monitor during the `test_led_api` hot-unplug tests.
*   [ENG-743116](https://jira.nutanix.com/browse/ENG-743116): Automation ticket for creating update disk LED state test cases.
*   [AUTO-27848](https://jira.nutanix.com/browse/AUTO-27848): Add `update_disk_led_state` support in the v4 SDK testing framework.
*   [ENG-869058](https://jira.nutanix.com/browse/ENG-869058), [ENG-869065](https://jira.nutanix.com/browse/ENG-869065), [ENG-869063](https://jira.nutanix.com/browse/ENG-869063): Testcase handovers for `disk-v4-sdk`.

**Code & Specification Documents:**
*   **Python SDK Definition**: [disks_api.py](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/clustermgmt/ntnx_clustermgmt_py_client/api/disks_api.py)
*   **Go SDK Definition**: [update_disk_led_state_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/clustermgmt-go-client/models/clustermgmt/v4/request/disks/update_disk_led_state_request.go)
*   **Hades Disk Manager Logic**: [disk_manager.py](https://github.com/nutanix-engineering/hack2022-d352/blob/main/infrastructure/cluster/py/cluster/hades/disk_manager.py)
*   **API Swagger Spec**: [swagger-clustermgmt-v4.r2-all-documentation.yaml](https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/api_artifacts/clustermgmt/v4.r2/diskmgmt-api-definitions-17.6.0.1378.<PHONE_1>-LKG-RELEASE/swagger-clustermgmt-v4.r2-all-documentation.yaml)
*   **DiskLEDState nuTest testcases**: [test_disk_v4_api.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/cdp/hades/disk_api_tests/test_disk_v4_api.py)
*   **DiskLEDState top-level v4 tests**: [test_disk_api.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/manageability/v4/disk/test_disk_api.py)
*   **Performance scenario**: [update_led_state.yaml](https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/performance/scenarios/main/clustermgmt/update_led_state.yaml)
*   **Performance dependency tree (disk)**: [dependency_tree_disk.yaml](https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/performance/dependency_tree/main/dependency_tree_disk.yaml)
*   **Performance dependency tree (level13)**: [dependency_tree_level13.yaml](https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/performance/dependency_tree/main/merged/dependency_tree_level13.yaml)
*   **Disk mgmt controller constants**: [DiskConstants.java](https://github.com/nutanix-core/ntnx-api-disk-mgmt/blob/main/diskmgmt-api-controller/src/main/java/com/nutanix/diskmgmt/util/DiskConstants.java)
*   **Beta review fix commit**: [Address Beta review comments #134 — commit e52abd4c…](https://github.com/nutanix-core/ntnx-api-disk-mgmt/commit/e52abd4c44b3256601fae0b4cb2fd03faa15e5c3)
*   **hack2026 nutanix-clustermgmt connector**: [nutanix-clustermgmt.ts](https://github.com/nutanix-engineering/hack2026-d3102/blob/main/connectors/nutanix-clustermgmt.ts)
*   **hack2026 MCP tool registry**: [mcp_clustermgmt_registry.py](https://github.com/nutanix-engineering/hack2026-d2654/blob/main/mcp_clustermgmt_registry.py) — see also [tool_tags.json](https://github.com/nutanix-engineering/hack2026-d2654/blob/main/tool_tags.json)

---

### Required Domain Skills
To understand this feature end-to-end and contribute to its development, testing, or documentation, you should acquire the following domain skills:

1.  **Nutanix v4 API & SDK Paradigm**: Understand how the `ntnx-api-*` SDKs are generated, how they utilize OData formatting for lists/filters, and how asynchronous tasks are modeled and polled in Prism.
2.  **Hades (Disk Management Service)**: Learn the internal architecture of Hades, including how Nutanix maps physical topologies (Enclosure IDs, Slot IDs) to logical disk entities (`extId`).
3.  **Genesis & Cluster Services**: Understand how Genesis orchestrates node-level operations (like triggering hardware scripts) and how Zookeeper coordinates states across the cluster.
4.  **Hardware Controllers & Storage Utilities**: Gain familiarity with low-level storage controller tools used by different hypervisors, specifically `sas2ircu` / `sas3ircu` for LSI controllers (AHV/ESXi) and `Update-DiskLEDState` PowerShell cmdlets (Hyper-V).
5.  **NuTest Automation Framework**: Since testing involves mocking hardware actions, you should understand how to use `NOSTest` and `DiskWorkflow` classes to simulate disk failures, hot-plugs, and bad sectors during system tests.

## Files changed

- `plugins/modules/`
  - `ntnx_disk_led_state_v2.py` (new) — action module for `POST /config/disks/{extId}/$actions/update-led-state`.
- `plugins/module_utils/v4/clusters_mgmt/`
  - `api_client.py` (edit) — added `get_disks_api_instance(module)` helper for the `DisksApi` client.
  - `helpers.py` (edit) — added `get_disk(module, api_instance, ext_id)` helper (reusable by future Disk CRUD/info modules).
- `meta/`
  - `runtime.yml` (edit) — registered `ntnx_disk_led_state_v2` in the `ntnx` action group so `module_defaults: group/nutanix.ncp.ntnx:` propagates `nutanix_host` / `nutanix_username` / `nutanix_password` / `validate_certs` to the module.
- `examples/cluster_management/DiskLEDState/`
  - `disk_led_state.yml` (new) — single example playbook: locate disk (`is_engaged: true`) and unlocate (`is_engaged: false`).
  - `examples_run.log` (new) — real captured output from running the example against PC `10.44.76.28`.
- `tests/integration/targets/ntnx_disk_led_state_v2/`
  - `aliases` (new) — `disabled` (matches the convention for all v2 targets).
  - `meta/main.yml` (new) — depends on `prepare_env`.
  - `tasks/main.yml` (new) — sets `module_defaults` block and imports `disk_led_state.yml`.
  - `tasks/disk_led_state.yml` (new) — full test plan (see "Test execution" below).

## Test execution

| Metric              | Value                                                                 |
|---------------------|-----------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-disabled --allow-unsupported ntnx_disk_led_state_v2 --python 3.12 -v` |
| Total tasks         | 24                                                                    |
| Passed (`ok`)       | 24                                                                    |
| Changed             | 4 (2 real LED updates + 1 `wait=false` submission + 1 cleanup)        |
| Failed              | 0                                                                     |
| Ignored             | 3 (intentional negative-test failures on missing `ext_id`, missing `is_engaged`, invalid `ext_id`) |
| Skipped             | 0                                                                     |
| Duration            | ~19s                                                                  |
| Cluster (PC)        | `10.44.76.28` (`auto_cluster_prod_36acf9b012ca`, 3 disks discovered)  |

### Analysis

No test failures. Coverage in `tests/integration/targets/ntnx_disk_led_state_v2/tasks/disk_led_state.yml`:

- **Discovery** — used `ansible.builtin.uri` against `/api/clustermgmt/v4.2/config/disks?$limit=1` to pick a real disk `ext_id` from the live cluster (the `_info_v2` module for Disk is not in this codegen run, so we intentionally avoid depending on it).
- **check_mode** — one on-spec check for `is_engaged: true`, one for `is_engaged: false` (per instruction "ONE check_mode test for Create/Update/Delete" — this action module has a single operation with two enum values, so both are covered).
- **Happy path** — LED-on then LED-off against a real disk; asserted `changed=true`, `failed=false`, `status=SUCCEEDED`, and that `entities_affected` contains the target disk.
- **`wait: false` path** — asserted the response is the initial task submission (`response.ext_id == task_ext_id`) and `changed=true`.
- **Negative — missing `ext_id`** — argument-spec rejects; asserted `failed=true`, `changed=false`, and `msg` mentions `ext_id`.
- **Negative — missing `is_engaged`** — argument-spec rejects; asserted `failed=true`, `changed=false`, and `msg` mentions `is_engaged`.
- **Negative — invalid `ext_id`** — the update API returns `DISK_RPC_ERROR / CLU-11001 "Disk with extId ... not found"`; asserted `failed=true`, `changed=false`.

**Root-cause note on `module_defaults`.** Initial runs of the example and integration tests failed with `HTTP 500 "Disk with extId ... not found"` because the CI environment has a global `NUTANIX_HOST=10.44.76.85` env var. `env_fallback` in `plugins/module_utils/base_module.py` was fed into `nutanix_host` because the module was not registered in `meta/runtime.yml`, so the `module_defaults` block never propagated to it. Registering `ntnx_disk_led_state_v2` under `action_groups.ntnx` in `meta/runtime.yml` fixed it; all subsequent runs succeed against `10.44.76.28`.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /bin/python3.12
Creating container database.
Run command: /bin/python3.12 /home/abhinav.bansal1/.local/lib/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_disk_led_state_v2 integration test role
Initializing "/tmp/ansible-test-tw51mq_7-injector" as the temporary injector directory.
Injecting "/tmp/python-8xd70hx7-ansible/python" as a execv wrapper for the "/bin/python3.12" interpreter.
Stream command: ansible-playbook ntnx_disk_led_state_v2-qdqbr99x.yml -i inventory -v
[WARNING]: Found variable using reserved name 'port'.
Origin: /tmp/codegen-artifacts.l1Txos/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_disk_led_state_v2-ql2pvt4a-ÅÑŚÌβŁÈ/tests/integration/integration_config.yml:5:1

3 username: "admin"
4 password: "Nutanix.123"
5 port: 9440
  ^ column 1

Using /tmp/codegen-artifacts.l1Txos/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_disk_led_state_v2-ql2pvt4a-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_disk_led_state_v2 : Start Disk LED State tests] *********************
ok: [testhost] => {
    "msg": "Start Disk LED State tests"
}

TASK [ntnx_disk_led_state_v2 : List disks on the cluster (raw v4 REST call)] ***
ok: [testhost] => {"cache_control": "no-cache, no-store, max-age=0, must-revalidate,no-cache, no-store", "changed": false, "connection": "close", "content": "{\"data\":[{\"$reserved\":{\"$fv\":\"v4.r3\"},\"$objectType\":\"clustermgmt.v4.config.Disk\",\"extId\":\"4542a93c-f79a-43fc-a515-ec8c066000a0\",\"links\":[{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.response.ApiLink\",\"href\":\"https://10.44.76.28:9440/api/clustermgmt/v4.2/config/disks/4542a93c-f79a-43fc-a515-ec8c066000a0\",\"rel\":\"disk\"}],\"clusterName\":\"auto_cluster_prod_36acf9b012ca\",\"clusterExtId\":\"0006555e-4e63-4a5e-185b-ac1f6b6f97e2\",\"storagePoolExtId\":\"df233a93-0480-4f15-a500-1269696fc4b2\",\"serviceVMId\":\"0006555e-4e63-4a5e-185b-ac1f6b6f97e2::2\",\"nodeExtId\":\"adf0c9e0-4051-4cd2-9f6f-ca9f962e941b\",\"mountPath\":\"/home/nutanix/data/stargate-storage/disks/S3F3NX0K903432\",\"location\":1,\"serialNumber\":\"S3F3NX0K903432\",\"diskSizeBytes\":604114121598,\"physicalCapacityBytes\":960197124096,\"model\":\"SAMSUNG MZ7KM960HMJP-00005\",\"vendor\":\"Not Available\",\"firmwareVersion\":\"304Q\",\"targetFirmwareVersion\":\"304Q\",\"hostName\":\"goku-4\",\"status\":\"NORMAL\",\"storageTier\":\"SSD_SATA\",\"cvmIpAddress\":{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.IPAddress\",\"ipv4\":{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.IPv4Address\",\"value\":\"10.46.136.32\",\"prefixLength\":32}},\"nodeIpAddress\":{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.IPAddress\",\"ipv4\":{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.IPv4Address\",\"value\":\"10.46.136.28\",\"prefixLength\":32}},\"diskAdvanceConfig\":{\"$reserved\":{\"$fv\":\"v4.r3\"},\"$objectType\":\"clustermgmt.v4.config.DiskAdvanceConfig\",\"isSelfEncryptingDrive\":false,\"isSelfManagedNvme\":false,\"isBootDisk\":true,\"hasBootPartitionsOnly\":false,\"isSpdkManaged\":false,\"isOnline\":true,\"isMarkedForRemoval\":false,\"isDataMigrated\":false,\"isUnhealthy\":false,\"isSuspectedUnhealthy\":false,\"isMounted\":true,\"isUnderDiagnosis\":false,\"isDiagnosticInfoAvailable\":false,\"isErrorFoundInLog\":false,\"isPlannedOutage\":false}}],\"$reserved\":{\"$fv\":\"v4.r3\"},\"$objectType\":\"clustermgmt.v4.config.ListDisksApiResponse\",\"metadata\":{\"flags\":[{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"hasError\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isPaginated\",\"value\":true},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isTruncated\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isExpandRestricted\",\"value\":false}],\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.response.ApiResponseMetadata\",\"links\":[{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.response.ApiLink\",\"href\":\"https://10.44.76.28:9440/api/clustermgmt/v4.2/config/disks?$limit=1&$page=0\",\"rel\":\"first\"},{\"href\":\"https://10.44.76.28:9440/api/clustermgmt/v4.2/config/disks?$limit=1&$page=0\",\"rel\":\"self\"},{\"href\":\"https://10.44.76.28:9440/api/clustermgmt/v4.2/config/disks?$limit=1&$page=1\",\"rel\":\"next\"},{\"href\":\"https://10.44.76.28:9440/api/clustermgmt/v4.2/config/disks?$limit=1&$page=2\",\"rel\":\"last\"}],\"totalAvailableResults\":3}}", "content_encoding": "identity", "content_length": "2972", "content_security_policy": "connect-src 'self' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; default-src 'self' https://*.nutanix.com; frame-ancestors 'self' https://*.nutanix.com; frame-src 'self' https://*.nutanix.com blob: data:; img-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'", "content_type": "application/json", "cookies": {"NTNX_SESSION_ID": "943f3c44-7ebd-4fa9-89ae-a2f4dc036962"}, "cookies_string": "NTNX_SESSION_ID=943f3c44-7ebd-4fa9-89ae-a2f4dc036962", "date": "Mon, 20 Jul 2026 13:15:40 GMT", "elapsed": 0, "expires": "0,0", "json": {"$objectType": "clustermgmt.v4.config.ListDisksApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": [{"$objectType": "clustermgmt.v4.config.Disk", "$reserved": {"$fv": "v4.r3"}, "clusterExtId": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "clusterName": "auto_cluster_prod_36acf9b012ca", "cvmIpAddress": {"$objectType": "common.v1.config.IPAddress", "$reserved": {"$fv": "v1.r0"}, "ipv4": {"$objectType": "common.v1.config.IPv4Address", "$reserved": {"$fv": "v1.r0"}, "prefixLength": 32, "value": "10.46.136.32"}}, "diskAdvanceConfig": {"$objectType": "clustermgmt.v4.config.DiskAdvanceConfig", "$reserved": {"$fv": "v4.r3"}, "hasBootPartitionsOnly": false, "isBootDisk": true, "isDataMigrated": false, "isDiagnosticInfoAvailable": false, "isErrorFoundInLog": false, "isMarkedForRemoval": false, "isMounted": true, "isOnline": true, "isPlannedOutage": false, "isSelfEncryptingDrive": false, "isSelfManagedNvme": false, "isSpdkManaged": false, "isSuspectedUnhealthy": false, "isUnderDiagnosis": false, "isUnhealthy": false}, "diskSizeBytes": 604114121598, "extId": "4542a93c-f79a-43fc-a515-ec8c066000a0", "firmwareVersion": "304Q", "hostName": "goku-4", "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/clustermgmt/v4.2/config/disks/4542a93c-f79a-43fc-a515-ec8c066000a0", "rel": "disk"}], "location": 1, "model": "SAMSUNG MZ7KM960HMJP-00005", "mountPath": "/home/nutanix/data/stargate-storage/disks/S3F3NX0K903432", "nodeExtId": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "nodeIpAddress": {"$objectType": "common.v1.config.IPAddress", "$reserved": {"$fv": "v1.r0"}, "ipv4": {"$objectType": "common.v1.config.IPv4Address", "$reserved": {"$fv": "v1.r0"}, "prefixLength": 32, "value": "10.46.136.28"}}, "physicalCapacityBytes": 960197124096, "serialNumber": "S3F3NX0K903432", "serviceVMId": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2::2", "status": "NORMAL", "storagePoolExtId": "df233a93-0480-4f15-a500-1269696fc4b2", "storageTier": "SSD_SATA", "targetFirmwareVersion": "304Q", "vendor": "Not Available"}], "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/clustermgmt/v4.2/config/disks?$limit=1&$page=0", "rel": "first"}, {"href": "https://10.44.76.28:9440/api/clustermgmt/v4.2/config/disks?$limit=1&$page=0", "rel": "self"}, {"href": "https://10.44.76.28:9440/api/clustermgmt/v4.2/config/disks?$limit=1&$page=1", "rel": "next"}, {"href": "https://10.44.76.28:9440/api/clustermgmt/v4.2/config/disks?$limit=1&$page=2", "rel": "last"}], "totalAvailableResults": 3}}, "msg": "OK (2972 bytes)", "pragma": "no-cache, no-cache", "redirected": false, "set_cookie": "NTNX_SESSION_ID=943f3c44-7ebd-4fa9-89ae-a2f4dc036962;Max-Age=29700;Path=/;Secure;HttpOnly;SameSite=Lax", "status": 200, "strict_transport_security": "max-age=31536000 ; includeSubDomains, max-age=63072000; includeSubdomains; preload", "url": "https://10.44.76.28:9440/api/clustermgmt/v4.2/config/disks?$limit=1", "vary": "Origin", "x_api_ratelimit_limit": "10", "x_api_ratelimit_refresh_period_seconds": "1", "x_api_ratelimit_remaining": "9", "x_api_ratelimit_reset": "0", "x_content_type_options": "nosniff, nosniff", "x_dns_prefetch_control": "off", "x_envoy_upstream_service_time": "15", "x_frame_options": "DENY, SAMEORIGIN", "x_ntnx_env": "pc", "x_ntnx_product": "pc.7.6", "x_permitted_cross_domain_policies": "master-only", "x_ratelimit_limit": "40", "x_ratelimit_remaining": "39", "x_ratelimit_reset": "0", "x_xss_protection": "0, 1; mode=block"}

TASK [ntnx_disk_led_state_v2 : Verify at least one disk was returned] **********
ok: [testhost] => {
    "changed": false,
    "msg": "Fetched at least one disk from the cluster"
}

TASK [ntnx_disk_led_state_v2 : Capture a disk ext_id for the tests] ************
ok: [testhost] => {"ansible_facts": {"disk_ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0"}, "changed": false}

TASK [ntnx_disk_led_state_v2 : Show the captured disk ext_id] ******************
ok: [testhost] => {
    "disk_ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0"
}

TASK [ntnx_disk_led_state_v2 : Check_mode turn LED ON — spec is built without calling API] ***
ok: [testhost] => {"changed": false, "ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "response": {"is_engaged": true}, "task_ext_id": null}

TASK [ntnx_disk_led_state_v2 : Verify check_mode LED ON] ***********************
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode LED-ON produced the expected spec-only response"
}

TASK [ntnx_disk_led_state_v2 : Check_mode turn LED OFF — spec is built without calling API] ***
ok: [testhost] => {"changed": false, "ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "response": {"is_engaged": false}, "task_ext_id": null}

TASK [ntnx_disk_led_state_v2 : Verify check_mode LED OFF] **********************
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode LED-OFF produced the expected spec-only response"
}

TASK [ntnx_disk_led_state_v2 : Turn LED ON for the disk (locate)] **************
changed: [testhost] => {"changed": true, "ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T13:15:42.984729+00:00", "completion_details": null, "created_time": "2026-07-20T13:15:42.809186+00:00", "entities_affected": [{"ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "name": null, "rel": "clustermgmt:config:disks"}], "error_messages": null, "ext_id": "ZXJnb24=:8eac5168-8bcd-466c-6a72-5bcc4cf4fce3", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T13:15:42.984727+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kUpdateLed", "operation_description": "Update Disk Led state", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T13:15:42.828335+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:8eac5168-8bcd-466c-6a72-5bcc4cf4fce3"}

TASK [ntnx_disk_led_state_v2 : Verify LED ON task succeeded] *******************
ok: [testhost] => {
    "changed": false,
    "msg": "Turned LED ON successfully"
}

TASK [ntnx_disk_led_state_v2 : Turn LED OFF for the disk (unlocate)] ***********
changed: [testhost] => {"changed": true, "ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T13:15:46.517401+00:00", "completion_details": null, "created_time": "2026-07-20T13:15:46.340936+00:00", "entities_affected": [{"ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "name": null, "rel": "clustermgmt:config:disks"}], "error_messages": null, "ext_id": "ZXJnb24=:6430e9b3-bd79-4b33-79fc-1aafaf3c9213", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T13:15:46.517401+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kUpdateLed", "operation_description": "Update Disk Led state", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T13:15:46.359317+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:6430e9b3-bd79-4b33-79fc-1aafaf3c9213"}

TASK [ntnx_disk_led_state_v2 : Verify LED OFF task succeeded] ******************
ok: [testhost] => {
    "changed": false,
    "msg": "Turned LED OFF successfully"
}

TASK [ntnx_disk_led_state_v2 : Turn LED ON but do not wait for the task to complete] ***
changed: [testhost] => {"changed": true, "ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "response": {"ext_id": "ZXJnb24=:022dd024-f729-4356-6a6a-5d537b567814"}, "task_ext_id": "ZXJnb24=:022dd024-f729-4356-6a6a-5d537b567814"}

TASK [ntnx_disk_led_state_v2 : Verify wait=false returned the task submission only] ***
ok: [testhost] => {
    "changed": false,
    "msg": "wait=false returned the initial task submission response"
}

TASK [ntnx_disk_led_state_v2 : Clean up — turn LED OFF (best-effort) after wait=false test] ***
changed: [testhost] => {"changed": true, "ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T13:15:50.794310+00:00", "completion_details": null, "created_time": "2026-07-20T13:15:50.500716+00:00", "entities_affected": [{"ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "name": null, "rel": "clustermgmt:config:disks"}], "error_messages": null, "ext_id": "ZXJnb24=:2628241a-4e97-4278-61ce-d5ad77fa8ae8", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T13:15:50.794309+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kUpdateLed", "operation_description": "Update Disk Led state", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T13:15:50.644821+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:2628241a-4e97-4278-61ce-d5ad77fa8ae8"}

TASK [ntnx_disk_led_state_v2 : Verify cleanup LED OFF succeeded] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "Cleanup LED OFF completed successfully"
}

TASK [ntnx_disk_led_state_v2 : Negative — missing ext_id must fail (argument spec)] ***
[ERROR]: Task failed: Module failed: missing required arguments: ext_id
Origin: /tmp/codegen-artifacts.l1Txos/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_disk_led_state_v2-ql2pvt4a-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_disk_led_state_v2/tasks/disk_led_state.yml:204:3

202 ########################################################################
203
204 - name: Negative — missing ext_id must fail (argument spec)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_disk_led_state_v2 : Verify missing ext_id was rejected by the module argument spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Module correctly rejected the missing ext_id parameter"
}

TASK [ntnx_disk_led_state_v2 : Negative — missing is_engaged must fail (argument spec)] ***
[ERROR]: Task failed: Module failed: missing required arguments: is_engaged
Origin: /tmp/codegen-artifacts.l1Txos/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_disk_led_state_v2-ql2pvt4a-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_disk_led_state_v2/tasks/disk_led_state.yml:221:3

219     success_msg: "Module correctly rejected the missing ext_id parameter"
220
221 - name: Negative — missing is_engaged must fail (argument spec)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: is_engaged"}
...ignoring

TASK [ntnx_disk_led_state_v2 : Verify missing is_engaged was rejected by the module argument spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Module correctly rejected the missing is_engaged parameter"
}

TASK [ntnx_disk_led_state_v2 : Negative — invalid disk ext_id must fail on the API call] ***
[ERROR]: Task failed: Module failed: Api Exception raised while updating disk LED state
Origin: /tmp/codegen-artifacts.l1Txos/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_disk_led_state_v2-ql2pvt4a-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_disk_led_state_v2/tasks/disk_led_state.yml:242:3

240 ########################################################################
241
242 - name: Negative — invalid disk ext_id must fail on the API call
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while updating disk LED state", "response": {"$objectType": "clustermgmt.v4.config.UpdateDiskLEDStateTaskResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "clustermgmt.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "clustermgmt.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "code": "CLU-11001", "errorGroup": "DISK_RPC_ERROR", "locale": "en_US", "message": "Failed to perform the operation as the diskmanagement service encountered an error - Disk with extId 00000000-0000-0000-0000-000000000000 not found.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 500}
...ignoring

TASK [ntnx_disk_led_state_v2 : Verify invalid disk ext_id was rejected by the API] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Module correctly failed on an invalid disk ext_id"
}

PLAY RECAP *********************************************************************
testhost                   : ok=24   changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   

```

</details>

## Examples execution

The single example playbook `examples/cluster_management/DiskLEDState/disk_led_state.yml`
was executed end-to-end against PC `10.44.76.28` with the real disk `ext_id`
substituted in a runnable copy. Both tasks completed with `changed=true` and
task `status: SUCCEEDED`. The full captured output is committed as
`examples/cluster_management/DiskLEDState/examples_run.log`:

```text
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
No config file found; using defaults

PLAY [Disk LED state management playbook] **************************************

TASK [Set disk ext_id used by the play] ****************************************
ok: [localhost] => {"ansible_facts": {"disk_ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0"}, "changed": false}

TASK [Turn ON the LED for the target disk (locate the drive)] ******************
changed: [localhost] => {"changed": true, "ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T13:14:44.070871+00:00", "completion_details": null, "created_time": "2026-07-20T13:14:43.918054+00:00", "entities_affected": [{"ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "name": null, "rel": "clustermgmt:config:disks"}], "error_messages": null, "ext_id": "ZXJnb24=:75a28b33-dfcd-4a52-6e32-b2faf70eb417", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T13:14:44.070870+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kUpdateLed", "operation_description": "Update Disk Led state", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T13:14:43.933314+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:75a28b33-dfcd-4a52-6e32-b2faf70eb417"}

TASK [Turn OFF the LED for the target disk (after maintenance)] ****************
changed: [localhost] => {"changed": true, "ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T13:14:47.525797+00:00", "completion_details": null, "created_time": "2026-07-20T13:14:47.359890+00:00", "entities_affected": [{"ext_id": "4542a93c-f79a-43fc-a515-ec8c066000a0", "name": null, "rel": "clustermgmt:config:disks"}], "error_messages": null, "ext_id": "ZXJnb24=:e744c010-84da-4c92-799d-7f9735f0a081", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T13:14:47.525796+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kUpdateLed", "operation_description": "Update Disk Led state", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T13:14:47.378585+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:e744c010-84da-4c92-799d-7f9735f0a081"}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

```

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
