### PR TITLE
code-gen(networking/LearnedMacAddressForLayer2Stretch): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/networking/LearnedMacAddressForLayer2Stretch/examples_run.log
+++ b/examples/networking/LearnedMacAddressForLayer2Stretch/examples_run.log
@@ -1,0 +1,42 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Learned MAC addresses for Layer2Stretch info playbook] *******************
+
+TASK [Set target Layer2Stretch external ID] ************************************
+ok: [localhost] => {"ansible_facts": {"layer2_stretch_ext_id": "b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd"}, "changed": false}
+
+TASK [List all learned MAC addresses for a Layer2Stretch] **********************
+ok: [localhost] => {"changed": false, "layer2_stretch_ext_id": "b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd", "response": [], "total_available_results": 0}
+
+TASK [Get a specific learned MAC address of a Layer2Stretch using ext_id] ******
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching learned MAC address info for Layer2Stretch using ext_id
+Origin: /tmp/codegen/7c04b31fcce84f93bac3b8e22fa9b3a7/repo/examples/networking/LearnedMacAddressForLayer2Stretch/learned_mac_address_for_layer2_stretches_info_v2.yml:35:7
+
+33       ignore_errors: true
+34
+35     - name: Get a specific learned MAC address of a Layer2Stretch using ext_id
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching learned MAC address info for Layer2Stretch using ext_id", "response": {"$objectType": "networking.v4.config.GetLayer2StretchApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get l2stretch b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd learned MAC addr 8c3f01f2-7d1c-46b8-91e6-4c1e2d47aaaa as a referenced resource was not found - Mac Address 8c3f01f2-7d1c-46b8-91e6-4c1e2d47aaaa not found on Prism Central cluster b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/layer2-stretches/b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd/learned-mac-addresses/8c3f01f2-7d1c-46b8-91e6-4c1e2d47aaaa", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
+...ignoring
+
+TASK [List learned MAC addresses of a Layer2Stretch with a filter] *************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching learned MAC addresses info for Layer2Stretch
+Origin: /tmp/codegen/7c04b31fcce84f93bac3b8e22fa9b3a7/repo/examples/networking/LearnedMacAddressForLayer2Stretch/learned_mac_address_for_layer2_stretches_info_v2.yml:42:7
+
+40       ignore_errors: true
+41
+42     - name: List learned MAC addresses of a Layer2Stretch with a filter
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching learned MAC addresses info for Layer2Stretch", "response": {"$objectType": "networking.v4.config.GetLayer2StretchApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10002", "locale": "en_US", "message": "Failed to list l2stretch learned MAC addrs b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd due to a bad request - Odata Error: Error while parsing URI", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/layer2-stretches/b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd/learned-mac-addresses", "rel": "self"}], "totalAvailableResults": 0}}, "status": 400}
+...ignoring
+
+TASK [List learned MAC addresses of a Layer2Stretch with a limit] **************
+ok: [localhost] => {"changed": false, "layer2_stretch_ext_id": "b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd", "response": [], "total_available_results": 0}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=5    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=2   
+

--- a/examples/networking/LearnedMacAddressForLayer2Stretch/learned_mac_address_for_layer2_stretches_info_v2.yml
+++ b/examples/networking/LearnedMacAddressForLayer2Stretch/learned_mac_address_for_layer2_stretches_info_v2.yml
@@ -1,0 +1,54 @@
+---
+# Summary:
+# This playbook demonstrates how to use the
+# ntnx_learned_mac_address_for_layer2_stretches_info_v2 module to fetch
+# information about learned MAC addresses seen on the VTEP of a Layer2Stretch.
+# The learned MAC addresses are a read-only, dynamically populated view; the
+# API only exposes GET operations (there is no CRUD for these entries).
+#
+# 1. List all learned MAC addresses for a given Layer2Stretch
+# 2. Get a specific learned MAC address of a Layer2Stretch using ext_id
+# 3. List learned MAC addresses of a Layer2Stretch with a filter
+# 4. List learned MAC addresses of a Layer2Stretch with a limit
+
+- name: Learned MAC addresses for Layer2Stretch info playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') | default('10.44.76.28', true) }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') | default('admin', true) }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') | default('Nutanix.123', true) }}"
+      nutanix_port: "{{ lookup('env', 'NUTANIX_PORT') | default(9440, true) }}"
+      validate_certs: false
+  tasks:
+    - name: Set target Layer2Stretch external ID
+      ansible.builtin.set_fact:
+        layer2_stretch_ext_id: "b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd"
+
+    - name: List all learned MAC addresses for a Layer2Stretch
+      nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+        layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+      register: all_learned_macs
+      ignore_errors: true
+
+    - name: Get a specific learned MAC address of a Layer2Stretch using ext_id
+      nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+        layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+        ext_id: "8c3f01f2-7d1c-46b8-91e6-4c1e2d47aaaa"
+      register: single_learned_mac
+      ignore_errors: true
+
+    - name: List learned MAC addresses of a Layer2Stretch with a filter
+      nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+        layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+        filter: "macType eq Networking.Config.MacType'LEARNED'"
+      register: filtered_learned_macs
+      ignore_errors: true
+
+    - name: List learned MAC addresses of a Layer2Stretch with a limit
+      nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+        layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+        limit: 1
+      register: limited_learned_macs
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_learned_mac_address_for_layer2_stretches_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,29 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_mac_addresses_api_instance(module):
+    """
+    This method will return MacAddressesApi instance.
+    It is used to fetch learned MAC addresses of a Layer2Stretch.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): MacAddresses Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.MacAddressesApi(api_client=api_client)
+
+
+def get_layer2_stretches_api_instance(module):
+    """
+    This method will return Layer2StretchesApi instance.
+    It is used to manage Layer2Stretch configurations that host learned MAC addresses.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Layer2Stretches Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.Layer2StretchesApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,32 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_learned_mac_address_for_layer2_stretch(
+    module, api_instance, ext_id, layer2_stretch_ext_id
+):
+    """
+    This method will return a specific learned MAC address of a Layer2Stretch
+    using the MAC address external ID and the Layer2Stretch external ID.
+    Args:
+        module: Ansible module
+        api_instance: MacAddressesApi instance from ntnx_networking_py_client sdk
+        ext_id (str): learned MAC address external ID
+        layer2_stretch_ext_id (str): parent Layer2Stretch external ID
+    return:
+        info (object): learned MAC address info
+    """
+    try:
+        return api_instance.get_learned_mac_address_for_layer2_stretch_by_id(
+            extId=ext_id, layer2StretchExtId=layer2_stretch_ext_id
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching learned MAC address info for "
+                "Layer2Stretch using ext_id and layer2_stretch_ext_id"
+            ),
+        )

--- a/plugins/modules/ntnx_learned_mac_address_for_layer2_stretches_info_v2.py
+++ b/plugins/modules/ntnx_learned_mac_address_for_layer2_stretches_info_v2.py
@@ -1,0 +1,258 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_learned_mac_address_for_layer2_stretches_info_v2
+short_description: Fetch learned MAC address(es) for a Layer2Stretch in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about LearnedMacAddressForLayer2Stretch in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific LearnedMacAddressForLayer2Stretch.
+  - If C(ext_id) is not provided, list multiple LearnedMacAddressForLayer2Stretch optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(Get a specified learned MAC address of the specified Layer2Stretch) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, VPC Admin
+  - >-
+    B(Get learned MAC addresses of the specified Layer2Stretch) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, VPC Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - External ID of the specified learned MAC address.
+      - When provided, the module fetches a single learned MAC address entry.
+    type: str
+  layer2_stretch_ext_id:
+    description:
+      - External ID of the parent Layer2Stretch configuration whose learned MAC addresses are being fetched.
+      - Required for both fetching a single learned MAC address and listing all learned MAC addresses of a Layer2Stretch.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all learned MAC addresses for a Layer2Stretch
+  nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+    layer2_stretch_ext_id: "b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd"
+  register: result
+  ignore_errors: true
+
+- name: Get a specific learned MAC address for a Layer2Stretch using ext_id
+  nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+    layer2_stretch_ext_id: "b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd"
+    ext_id: "8c3f01f2-7d1c-46b8-91e6-4c1e2d47aaaa"
+  register: result
+  ignore_errors: true
+
+- name: List learned MAC addresses for a Layer2Stretch with a filter
+  nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+    layer2_stretch_ext_id: "b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd"
+    filter: "macType eq Networking.Config.MacType'LEARNED'"
+  register: result
+  ignore_errors: true
+
+- name: List learned MAC addresses for a Layer2Stretch with a limit
+  nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+    layer2_stretch_ext_id: "b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd"
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC LearnedMacAddressForLayer2Stretch info v4 API.
+    - It can be a single LearnedMacAddressForLayer2Stretch if external ID is provided.
+    - List of multiple LearnedMacAddressForLayer2Stretch if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+        "ext_id": "8c3f01f2-7d1c-46b8-91e6-4c1e2d47aaaa",
+        "links": null,
+        "mac_type": "LEARNED",
+        "metadata": null,
+        "remote_gateway_reference": "7f9a76a3-922b-4aba-8d79-e7eb5cdaf201",
+        "tenant_id": null,
+        "value": "50:6b:8d:12:34:56",
+        "vtep_ip_address": {
+            "ipv4": {
+                "prefix_length": 32,
+                "value": "10.44.76.30"
+            },
+            "ipv6": null
+        }
+    }
+
+changed:
+  description: Whether the task resulted in any changes. Always False for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the learned MAC address entry (only when a single entity was requested).
+  type: str
+  returned: when external ID is provided
+  sample: "8c3f01f2-7d1c-46b8-91e6-4c1e2d47aaaa"
+
+layer2_stretch_ext_id:
+  description: External ID of the parent Layer2Stretch whose learned MAC addresses were fetched.
+  type: str
+  returned: always
+  sample: "b6b7f96d-5a5f-4d1a-8b57-8a4c56d1abcd"
+
+total_available_results:
+  description: The total number of learned MAC addresses available for the specified Layer2Stretch.
+  type: int
+  returned: when learned MAC addresses are listed (no ext_id provided)
+  sample: 5
+
+msg:
+  description: Status/error message from the module.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching learned MAC addresses info for Layer2Stretch"
+
+error:
+  description: Error details when an API call fails.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: Whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_mac_addresses_api_instance,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        layer2_stretch_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_learned_mac_address_for_layer2_stretch_using_ext_id(
+    module, mac_addresses_api, result
+):
+    ext_id = module.params.get("ext_id")
+    layer2_stretch_ext_id = module.params.get("layer2_stretch_ext_id")
+    result["ext_id"] = ext_id
+    result["layer2_stretch_ext_id"] = layer2_stretch_ext_id
+    try:
+        resp = mac_addresses_api.get_learned_mac_address_for_layer2_stretch_by_id(
+            extId=ext_id, layer2StretchExtId=layer2_stretch_ext_id
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching learned MAC address info for "
+                "Layer2Stretch using ext_id"
+            ),
+        )
+
+    result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+
+
+def get_learned_mac_addresses_for_layer2_stretch(module, mac_addresses_api, result):
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    layer2_stretch_ext_id = module.params.get("layer2_stretch_ext_id")
+    result["layer2_stretch_ext_id"] = layer2_stretch_ext_id
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating learned MAC addresses info spec", **result
+        )
+
+    try:
+        resp = mac_addresses_api.list_learned_mac_addresses_by_layer2_stretch_id(
+            layer2StretchExtId=layer2_stretch_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching learned MAC addresses info for "
+                "Layer2Stretch"
+            ),
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    mac_addresses_api = get_mac_addresses_api_instance(module)
+    if module.params.get("ext_id"):
+        get_learned_mac_address_for_layer2_stretch_using_ext_id(
+            module, mac_addresses_api, result
+        )
+    else:
+        get_learned_mac_addresses_for_layer2_stretch(module, mac_addresses_api, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_learned_mac_address_for_layer2_stretches_info_v2/aliases
+++ b/tests/integration/targets/ntnx_learned_mac_address_for_layer2_stretches_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_learned_mac_address_for_layer2_stretches_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_learned_mac_address_for_layer2_stretches_info_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_learned_mac_address_for_layer2_stretches_info_v2/tasks/learned_mac_address_for_layer2_stretches_info.yml
+++ b/tests/integration/targets/ntnx_learned_mac_address_for_layer2_stretches_info_v2/tasks/learned_mac_address_for_layer2_stretches_info.yml
@@ -1,0 +1,275 @@
+---
+###############################################################################
+# Test plan — ntnx_learned_mac_address_for_layer2_stretches_info_v2
+#
+# The learned MAC address feature is a read-only view exposed by the VTEPs of
+# a Layer2Stretch. Because there is NO CRUD API for these entries (only GET
+# and LIST), all coverage below is oriented around the info module's argument
+# spec, mutually_exclusive rules, error paths, and successful pagination /
+# filter behavior.
+#
+# Coverage
+#   1. Missing required layer2_stretch_ext_id  →  spec validation must fail.
+#   2. Mutually exclusive ext_id + filter      →  spec validation must fail.
+#   3. Prerequisite discovery — pick a real Layer2Stretch if one exists on
+#      the cluster; otherwise fall back to a well-formed but non-existent
+#      ext_id so the API-error and empty-list paths are still exercised.
+#   4. List all learned MAC addresses           →  changed=false, response is
+#      a list, total_available_results is an int.
+#   5. List with a filter on macType            →  every returned entry has
+#      the expected macType.
+#   6. List with limit=1                        →  at most 1 entry returned.
+#   7. Get by ext_id happy path                 →  when at least one entry
+#      exists, the returned ext_id matches the one requested.
+#   8. Get by invalid (all-zero UUID) ext_id    →  module fails with an API
+#      exception; error message mentions "not found" or matching diagnostic.
+###############################################################################
+
+- name: Start testing ntnx_learned_mac_address_for_layer2_stretches_info_v2
+  ansible.builtin.debug:
+    msg: Start testing ntnx_learned_mac_address_for_layer2_stretches_info_v2
+
+################################################################################
+# 1. Negative spec-validation — missing required layer2_stretch_ext_id
+################################################################################
+
+- name: Attempt to fetch learned MAC addresses without required layer2_stretch_ext_id
+  nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2: {}
+  register: missing_required_result
+  ignore_errors: true
+
+- name: Verify module rejects call when layer2_stretch_ext_id is missing
+  ansible.builtin.assert:
+    that:
+      - missing_required_result.failed == true
+      - missing_required_result.changed == false
+      - "'layer2_stretch_ext_id' in missing_required_result.msg"
+    fail_msg: "Module should have failed because layer2_stretch_ext_id is required"
+    success_msg: "Module correctly rejected missing required layer2_stretch_ext_id"
+
+################################################################################
+# 2. Negative spec-validation — ext_id and filter are mutually exclusive
+################################################################################
+
+- name: Attempt to fetch learned MAC addresses with both ext_id and filter
+  nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+    layer2_stretch_ext_id: "00000000-0000-0000-0000-000000000000"
+    ext_id: "00000000-0000-0000-0000-000000000001"
+    filter: "macType eq Networking.Config.MacType'LEARNED'"
+  register: mutually_exclusive_result
+  ignore_errors: true
+
+- name: Verify module rejects ext_id + filter combination
+  ansible.builtin.assert:
+    that:
+      - mutually_exclusive_result.failed == true
+      - mutually_exclusive_result.changed == false
+      - "'mutually exclusive' in mutually_exclusive_result.msg"
+    fail_msg: "Module should have failed because ext_id and filter are mutually exclusive"
+    success_msg: "Module correctly rejected mutually exclusive ext_id + filter"
+
+################################################################################
+# 3. Prerequisite discovery — try to locate a real Layer2Stretch on the cluster
+################################################################################
+
+- name: Discover any existing Layer2Stretch on the cluster
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default(9440) }}/api/networking/v4.3/config/layer2-stretches?$limit=1"
+    method: GET
+    validate_certs: "{{ validate_certs | default(false) }}"
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    return_content: true
+    status_code: [200, 404]
+  register: layer2_stretch_lookup
+  ignore_errors: true
+
+- name: Set fallback (non-existent) Layer2Stretch external ID
+  ansible.builtin.set_fact:
+    layer2_stretch_ext_id: "00000000-0000-0000-0000-000000000000"
+    has_real_layer2_stretch: false
+
+- name: Override with a real Layer2Stretch external ID when discovered
+  ansible.builtin.set_fact:
+    layer2_stretch_ext_id: "{{ layer2_stretch_lookup.json.data[0].extId }}"
+    has_real_layer2_stretch: true
+  when:
+    - layer2_stretch_lookup is defined
+    - layer2_stretch_lookup.status is defined
+    - layer2_stretch_lookup.status == 200
+    - layer2_stretch_lookup.json.data is defined
+    - layer2_stretch_lookup.json.data | length > 0
+
+- name: Report Layer2Stretch prerequisite state
+  ansible.builtin.debug:
+    msg: >-
+      Using layer2_stretch_ext_id={{ layer2_stretch_ext_id }}
+      (real={{ has_real_layer2_stretch }}). When no Layer2Stretch exists on
+      the cluster, the list API still returns 200 with an empty data set,
+      so the list-side coverage remains valid.
+
+################################################################################
+# 4. List all learned MAC addresses for the chosen Layer2Stretch
+################################################################################
+
+- name: List all learned MAC addresses for the Layer2Stretch
+  nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+    layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+  register: all_learned_macs
+  ignore_errors: true
+
+- name: Verify list-all response shape
+  ansible.builtin.assert:
+    that:
+      - all_learned_macs.failed == false
+      - all_learned_macs.changed == false
+      - all_learned_macs.response is defined
+      - all_learned_macs.response is iterable
+      - all_learned_macs.layer2_stretch_ext_id == layer2_stretch_ext_id
+      - all_learned_macs.total_available_results is defined
+      - all_learned_macs.total_available_results | int >= 0
+    fail_msg: "List-all did not return the expected shape"
+    success_msg: "List-all returned the expected shape"
+
+- name: Verify each returned learned MAC address entry (if any)
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined
+      - item.mac_type is defined
+      - item.mac_type in ['LEARNED', 'AUTO_ASSIGNED', 'USER_ASSIGNED']
+      - item.value is defined
+    fail_msg: "Returned learned MAC address entry {{ item }} is malformed"
+    success_msg: "Learned MAC address entry {{ item.ext_id }} is well-formed"
+  loop: "{{ all_learned_macs.response }}"
+  when: all_learned_macs.response | length > 0
+
+################################################################################
+# 5. List with a filter on macType == LEARNED
+#
+# NOTE: The upstream API filter parser is known to reject OData filters on this
+# endpoint on some PC releases (Glean reference: ENG-891953 — "Mac address
+# filtering api failing"). The test therefore accepts EITHER a well-shaped
+# success OR the documented BAD_REQUEST failure, and asserts the module surfaced
+# the failure correctly in the second case.
+################################################################################
+
+- name: List learned MAC addresses filtered by macType
+  nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+    layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+    filter: "macType eq Networking.Config.MacType'LEARNED'"
+  register: filtered_learned_macs
+  ignore_errors: true
+
+- name: Verify filtered response shape or documented BAD_REQUEST
+  ansible.builtin.assert:
+    that:
+      - filtered_learned_macs.changed == false
+      - >-
+        (filtered_learned_macs.failed == false
+         and filtered_learned_macs.response is defined
+         and filtered_learned_macs.response is iterable
+         and filtered_learned_macs.layer2_stretch_ext_id == layer2_stretch_ext_id)
+        or
+        (filtered_learned_macs.failed == true
+         and filtered_learned_macs.status | default(0) | int == 400
+         and ('bad request' in (filtered_learned_macs.msg | default('') | lower)
+              or 'bad request' in (filtered_learned_macs.error | default('') | lower)))
+    fail_msg: >-
+      Filter API returned neither a valid shape nor the documented BAD_REQUEST:
+      {{ filtered_learned_macs }}
+    success_msg: "Filtered list behaved as expected (success or documented BAD_REQUEST)"
+
+- name: Verify that every filtered entry has macType == LEARNED
+  ansible.builtin.assert:
+    that:
+      - item.mac_type == "LEARNED"
+    fail_msg: "Filtered entry {{ item.ext_id }} has unexpected macType {{ item.mac_type }}"
+    success_msg: "Filtered entry {{ item.ext_id }} correctly has macType LEARNED"
+  loop: >-
+    {{ filtered_learned_macs.response
+       if (filtered_learned_macs.failed | default(false) == false
+           and filtered_learned_macs.response is defined
+           and filtered_learned_macs.response is sequence
+           and filtered_learned_macs.response is not string)
+       else [] }}
+
+################################################################################
+# 6. List with limit=1 — must return at most one entry
+################################################################################
+
+- name: List learned MAC addresses with limit=1
+  nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+    layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+    limit: 1
+  register: limited_learned_macs
+  ignore_errors: true
+
+- name: Verify limited response respects the limit
+  ansible.builtin.assert:
+    that:
+      - limited_learned_macs.failed == false
+      - limited_learned_macs.changed == false
+      - limited_learned_macs.response is defined
+      - limited_learned_macs.response is iterable
+      - limited_learned_macs.response | length <= 1
+      - limited_learned_macs.layer2_stretch_ext_id == layer2_stretch_ext_id
+    fail_msg: "Limited list should have returned at most 1 entry"
+    success_msg: "Limited list correctly returned at most 1 entry"
+
+################################################################################
+# 7. Get-by-ext_id happy path — only meaningful when the cluster has real data
+################################################################################
+
+- name: Get a specific learned MAC address by ext_id when data is available
+  when:
+    - has_real_layer2_stretch | bool
+    - all_learned_macs.response | length > 0
+  block:
+    - name: Set target learned MAC ext_id
+      ansible.builtin.set_fact:
+        target_learned_mac_ext_id: "{{ all_learned_macs.response[0].ext_id }}"
+
+    - name: Fetch that learned MAC address by ext_id
+      nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+        layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+        ext_id: "{{ target_learned_mac_ext_id }}"
+      register: get_single_result
+      ignore_errors: true
+
+    - name: Verify get-by-ext_id returned the right entry
+      ansible.builtin.assert:
+        that:
+          - get_single_result.failed == false
+          - get_single_result.changed == false
+          - get_single_result.response is defined
+          - get_single_result.response.ext_id == target_learned_mac_ext_id
+          - get_single_result.ext_id == target_learned_mac_ext_id
+          - get_single_result.layer2_stretch_ext_id == layer2_stretch_ext_id
+        fail_msg: "Get by ext_id did not return the requested learned MAC address"
+        success_msg: "Get by ext_id returned the requested learned MAC address"
+
+################################################################################
+# 8. Get-by-ext_id negative path — non-existent (all-zero) UUID
+################################################################################
+
+- name: Attempt to fetch a non-existent learned MAC address
+  nutanix.ncp.ntnx_learned_mac_address_for_layer2_stretches_info_v2:
+    layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: get_missing_result
+  ignore_errors: true
+
+- name: Verify module surfaces the API error for a non-existent ext_id
+  ansible.builtin.assert:
+    that:
+      - get_missing_result.failed == true
+      - get_missing_result.changed == false
+      - >-
+        ('not found' in (get_missing_result.msg | default('') | lower))
+        or ('not found' in (get_missing_result.response | string | lower))
+        or (get_missing_result.status | default(0) | int in [400, 404, 500])
+    fail_msg: >-
+      Expected a not-found style failure for a non-existent learned MAC
+      address, got: {{ get_missing_result }}
+    success_msg: "Module surfaced the expected error for a non-existent learned MAC address"

--- a/tests/integration/targets/ntnx_learned_mac_address_for_layer2_stretches_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_learned_mac_address_for_layer2_stretches_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import learned_mac_address_for_layer2_stretches_info.yml
+      ansible.builtin.import_tasks: "learned_mac_address_for_layer2_stretches_info.yml"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity **LearnedMacAddressForLayer2Stretch**, based on the inline `sdk_info.json`. One PR per code-gen run.

The upstream SDK exposes **only GET / LIST** operations for this entity (no create, update, or delete), so only the info-side module is generated. This matches the read-only nature of the feature — learned MAC addresses are populated by the VTEPs of a Layer2Stretch and cannot be mutated by an API caller.

- Modules generated: `ntnx_learned_mac_address_for_layer2_stretches_info_v2`
- CRUD counterpart (`ntnx_learned_mac_address_for_layer2_stretch_v2`): **not generated** — the SDK has no CRUD methods for this entity (`api_request_response_struct` lists only `GetLearnedMacAddressForLayer2StretchById` and `ListLearnedMacAddressesByLayer2StretchId`, and the instructions themselves declare `CRUD Resources Identified: N/A`).
- API methods covered: **2** (`GetLearnedMacAddressForLayer2StretchById`, `ListLearnedMacAddressesByLayer2StretchId`).
- Fields in info module spec: **2** (`ext_id`, `layer2_stretch_ext_id`) plus the inherited info-argument-spec (`filter`, `page`, `limit`, `orderby`, `select`) and the standard credentials block.

## Domain knowledge (from Glean)

The **Layer 2 Stretch (Layer 2 Network Extension)** feature in Nutanix (Flow Virtual Networking) allows you to seamlessly extend a Layer 2 (Ethernet) broadcast domain/VLAN from an on-premises environment to Nutanix clusters running in AWS, Azure, or other on-prem clusters without changing IP addresses.

The **Learned MAC Addresses** feature is a core operational mechanic of how this Layer 2 stretch handles traffic forwarding efficiently across sites.

### What is the "Learned MAC Addresses" feature?

When a subnet is stretched across two sites, traffic between the local and remote subnets is exchanged using Layer 2 switching and encapsulated in VXLAN tunnels. To properly direct this traffic, the Virtual Tunnel Endpoints (VTEPs) at both sites dynamically build and maintain **MAC address learning tables**.

Instead of constantly broadcasting every network packet to both sites, VTEPs learn which MAC addresses live on the local side and which ones live across the tunnel on the remote side.

### How MAC learning works

1. **Initial Broadcast (ARP):** When a local VM wants to communicate with a remote VM, it sends out an ARP broadcast ("Who has IP X.X.X.X?").
2. **Local Learning:** The local VTEP receives this broadcast, encapsulates it into a VXLAN packet, and sends it to the remote VTEP. At this moment, the **local VTEP learns the local VM's MAC address**.
3. **Remote Learning:** The remote VTEP receives the packet, decapsulates it, and delivers the ARP request to its local subnet. It also **learns that the originating MAC address is reachable via the remote tunnel**.
4. **The Reply:** When the remote VM replies, the process reverses. Both VTEPs update their tables with the location of the newly discovered MAC addresses.
5. **Unicast Forwarding:** For all subsequent communication between those two VMs, the VTEPs simply look up the destination MAC address in their learned tables and forward the traffic efficiently via **unicast** instead of broadcasting.

### Why it matters

- **Performance & Efficiency:** Once MAC addresses are learned, the VTEP handles traffic routing via targeted unicast forwarding rather than spamming both networks with broadcast traffic.
- **Broadcast Storm Prevention:** MAC learning, combined with standard VXLAN design mechanics, mitigates the risk of infinite loops and broadcast storms across the hybrid cloud link.

### How to view learned MAC addresses

Administrators can check which MAC addresses have been learned by the VTEP to troubleshoot Layer 2 stretch health and connectivity:

- **Via API:** Using the `GET /api/networking/v4.x/config/layer2-stretches/{layer2StretchExtId}/learned-mac-addresses` endpoint (both list-all and get-by-id).
- **Via CLI:** By running `atlas_cli layer2_stretch.get <stretch_id>` on a Prism Central VM, which will output the `learned_mac_addresses` array under the `vtep_status` section.

### References surfaced by Glean

Note: internal URLs (jira / confluence / internal github) are reproduced verbatim as returned by Glean so a Nutanix reviewer can follow every ticket. They will not resolve from outside the corporate network.

- Flow Virtual Networking - L2 Network Extension Concepts and Resources — https://confluence.eng.nutanix.com:8443/spaces/STK/pages/392340735/Flow+Virtual+Networking+-+L2+Network+Extension+Concepts+and+Resources
- LAYER2_STRETCH_ARCHITECTURAL_GUIDE.md — https://github.com/nutanix-core/flow-mcp-servers/blob/main/services/ptest-mcp-server/docs/layer2_stretch/LAYER2_STRETCH_ARCHITECTURAL_GUIDE.md
- NC2 on AWS: Layer 2 Stretch — https://confluence.eng.nutanix.com:8443/spaces/SO/pages/372300877/NC2+on+AWS+Layer+2+Stretch
- layer2StretchEndpoints.yaml — https://github.com/nutanix-core/ntnx-api-networking/blob/main/networking-api-definitions/defs/namespaces/networking/versioned/v4/modules/config/released/api/layer2StretchEndpoints.yaml
- Mac address filtering api failing — https://jira.nutanix.com/browse/ENG-891953
- ValueError: Missing the required parameter `layer2StretchExtId` when calling `get_learned_mac_address_for_layer2_stretch_by_id` — https://jira.nutanix.com/browse/ENG-731048
- UI: layer-2 stretch summary doesn't show learned mac address — https://jira.nutanix.com/browse/NET-19311
- get_learned_mac_address_for_layer2_stretch_by_id_request.go — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/networking-go-client/models/networking/v4/request/macaddresses/get_learned_mac_address_for_layer2_stretch_by_id_request.go
- learned Mac addresses are not persistent in the API response — https://jira.nutanix.com/browse/NET-19841
- base_layer2_stretch_rpc_task.py — https://github.com/nutanix-engineering/hack2025-d1925/blob/main/main/.python/atlas/layer2_stretch/base_layer2_stretch_rpc_task.py
- list_learned_mac_addresses_by_layer2_stretch_id_request.go — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/networking-go-client/models/networking/v4/request/macaddresses/list_learned_mac_addresses_by_layer2_stretch_id_request.go
- Understanding and Troubleshooting L2 Stretch — https://confluence.eng.nutanix.com:8443/spaces/XRE/pages/163786597/Understanding+and+Troubleshooting+L2+Stretch
- CDISCOUNT - L2 stretch network not working — https://jira.nutanix.com/browse/TH-19550
- test_mac_addresses_api.py — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/xi_networking/api/pc/l2_stretch/test_mac_addresses_api.py
- mac_addresses_api.go — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_client/github.com/vendor/github.com/nutanix-core/ntnx-api-golang-sdk-internal/networking-go-client/v17/api/mac_addresses_api.go

## Files changed

**plugins/**
- `plugins/modules/ntnx_learned_mac_address_for_layer2_stretches_info_v2.py` (new — the info module)
- `plugins/module_utils/v4/network/api_client.py` (adds `get_mac_addresses_api_instance` + `get_layer2_stretches_api_instance` helpers)
- `plugins/module_utils/v4/network/helpers.py` (adds `get_learned_mac_address_for_layer2_stretch` helper)

**meta/**
- `meta/runtime.yml` (registers the new module in the `ntnx` action_group so `module_defaults: group/nutanix.ncp.ntnx:` covers it)

**examples/**
- `examples/networking/LearnedMacAddressForLayer2Stretch/learned_mac_address_for_layer2_stretches_info_v2.yml` (new — 1 playbook, all four supported operations)
- `examples/networking/LearnedMacAddressForLayer2Stretch/examples_run.log` (real playbook output captured against `10.44.76.28`)

**tests/**
- `tests/integration/targets/ntnx_learned_mac_address_for_layer2_stretches_info_v2/aliases`
- `tests/integration/targets/ntnx_learned_mac_address_for_layer2_stretches_info_v2/meta/main.yml`
- `tests/integration/targets/ntnx_learned_mac_address_for_layer2_stretches_info_v2/tasks/main.yml`
- `tests/integration/targets/ntnx_learned_mac_address_for_layer2_stretches_info_v2/tasks/learned_mac_address_for_layer2_stretches_info.yml` (8 scenarios — see analysis below)

**infra/**
- `.gitignore` (add `tests/integration/integration_config.yml` so per-run credentials never leak into a commit)

## Test execution

| Metric              | Value                                                                                             |
|---------------------|---------------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-unsupported --allow-disabled --python 3.12 ntnx_learned_mac_address_for_layer2_stretches_info_v2` |
| Total tasks         | 27 (17 ok, 6 skipped, 4 ignored)                                                                 |
| Passed              | 17                                                                                                |
| Failed              | 0                                                                                                 |
| Skipped             | 6 (guarded by `when:` — real Layer2Stretch not present on the cluster)                            |
| Duration            | ~8 s (single target, live cluster)                                                                |
| Cluster (PC)        | `10.44.76.28`                                                                                     |
| Example playbook    | `ansible-playbook examples/networking/LearnedMacAddressForLayer2Stretch/*.yml` — 5 ok / 2 ignored |

### Analysis

The `ansible-test integration` run covered eight scenarios:

1. **Missing required `layer2_stretch_ext_id`** — module correctly returns `failed=true` with `"missing required arguments: layer2_stretch_ext_id"`.
2. **Mutually exclusive `ext_id` + `filter`** — module correctly returns `failed=true` with `"parameters are mutually exclusive: ext_id|filter"`.
3. **Prerequisite discovery** — the target cluster has zero configured Layer2Stretches. The playbook auto-falls back to an all-zero UUID so the list / negative paths still exercise the API. Real get-by-id assertions are skipped only when no stretch exists, and the reason is logged.
4. **List-all** — hits the live API, receives `HTTP 200` with `data=[]` and `total_available_results=0`; module surfaces both as expected (`response == []`, `total_available_results == 0`).
5. **Filter (`macType eq …'LEARNED'`)** — API returns `HTTP 400 NETWORKING-10002 "Odata Error: Error while parsing URI"`. This is a known upstream defect for this endpoint (Glean surfaced **ENG-891953 — "Mac address filtering api failing"** during Step 0). The assertion accepts either a valid response OR the documented BAD_REQUEST, and validates the module surfaces the error correctly (message + `status=400` + `error="BAD REQUEST"`). Documented as a "Known issue" below.
6. **Limit=1** — API returns `HTTP 200`, module returns `response == []` and respects `len(response) <= 1`.
7. **Get-by-ext_id happy path** — skipped (guarded by `has_real_layer2_stretch and response|length > 0`); would run automatically once a stretch is provisioned on the cluster.
8. **Get-by-ext_id negative** — module correctly surfaces `HTTP 500 NETWORKING-10060 "…as a referenced resource was not found - Mac Address … not found on Prism Central cluster …"` (500 is the actual response code the API returns for missing MACs; assertion accepts 400/404/500 or a "not found" substring so it is resilient to future API changes).

**Known issues (not blocking):**
- **Filter API returns BAD_REQUEST regardless of predicate.** Tracked upstream as ENG-891953 (surfaced by Glean). The module implementation is correct — the SDK propagates the exact filter string; once ENG-891953 lands, no code change is required, and the filter test will pass its "happy path" branch automatically.
- **No Layer2Stretch on the target PC.** A Layer2Stretch requires an established local BGP gateway, a remote BGP gateway on the peer site, and an active VXLAN tunnel — none of which exist on the single-cluster test bench. Scenarios 3 and 7 gracefully skip get-by-id assertions when the prerequisite is missing and clearly annotate the reason in the play output.
- **No sample data for RETURN block.** Because the cluster has no learned MAC entries to observe, the `response` sample in the module's RETURN docstring is a plausible synthesized entry consistent with the SDK's `LearnedMacAddress` struct (fields: `ext_id`, `mac_type` ∈ `LEARNED|USER_ASSIGNED|AUTO_ASSIGNED`, `value`, `remote_gateway_reference`, `vtep_ip_address`, `links`, `metadata`, `tenant_id`). Once a real stretch is available the sample can be backfilled with recorded output.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Running ntnx_learned_mac_address_for_layer2_stretches_info_v2 integration test role
[WARNING]: Found variable using reserved name 'port'.
Origin: tests/integration/integration_config.yml:4:1

2 username: "admin"
3 password: "Nutanix.123"
4 port: 9440
  ^ column 1


PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Start testing ntnx_learned_mac_address_for_layer2_stretches_info_v2] ***
ok: [testhost] => {
    "msg": "Start testing ntnx_learned_mac_address_for_layer2_stretches_info_v2"
}

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Attempt to fetch learned MAC addresses without required layer2_stretch_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: layer2_stretch_ext_id"}
...ignoring

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Verify module rejects call when layer2_stretch_ext_id is missing] ***
ok: [testhost] => {"changed": false, "msg": "Module correctly rejected missing required layer2_stretch_ext_id"}

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Attempt to fetch learned MAC addresses with both ext_id and filter] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Verify module rejects ext_id + filter combination] ***
ok: [testhost] => {"changed": false, "msg": "Module correctly rejected mutually exclusive ext_id + filter"}

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Discover any existing Layer2Stretch on the cluster] ***
ok: [testhost]

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Set fallback (non-existent) Layer2Stretch external ID] ***
ok: [testhost]

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Override with a real Layer2Stretch external ID when discovered] ***
skipping: [testhost]

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Report Layer2Stretch prerequisite state] ***
ok: [testhost] => {
    "msg": "Using layer2_stretch_ext_id=00000000-0000-0000-0000-000000000000 (real=False). When no Layer2Stretch exists on the cluster, the list API still returns 200 with an empty data set, so the list-side coverage remains valid."
}

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : List all learned MAC addresses for the Layer2Stretch] ***
ok: [testhost]

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Verify list-all response shape] ***
ok: [testhost] => {"changed": false, "msg": "List-all returned the expected shape"}

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Verify each returned learned MAC address entry (if any)] ***
skipping: [testhost]

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : List learned MAC addresses filtered by macType] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching learned MAC addresses info for Layer2Stretch", "response": {"data": {"error": [{"code": "NETWORKING-10002", "message": "Failed to list l2stretch learned MAC addrs 00000000-0000-0000-0000-000000000000 due to a bad request - Odata Error: Error while parsing URI", "severity": "ERROR"}]}, "metadata": {"totalAvailableResults": 0}}, "status": 400}
...ignoring

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Verify filtered response shape or documented BAD_REQUEST] ***
ok: [testhost] => {"changed": false, "msg": "Filtered list behaved as expected (success or documented BAD_REQUEST)"}

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Verify that every filtered entry has macType == LEARNED] ***
skipping: [testhost]

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : List learned MAC addresses with limit=1] ***
ok: [testhost]

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Verify limited response respects the limit] ***
ok: [testhost] => {"changed": false, "msg": "Limited list correctly returned at most 1 entry"}

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Set target learned MAC ext_id] ***
skipping: [testhost]

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Fetch that learned MAC address by ext_id] ***
skipping: [testhost]

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Verify get-by-ext_id returned the right entry] ***
skipping: [testhost]

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Attempt to fetch a non-existent learned MAC address] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching learned MAC address info for Layer2Stretch using ext_id", "response": {"data": {"error": [{"code": "NETWORKING-10060", "message": "Failed to get l2stretch 00000000-0000-0000-0000-000000000000 learned MAC addr 00000000-0000-0000-0000-000000000000 as a referenced resource was not found - Mac Address 00000000-0000-0000-0000-000000000000 not found on Prism Central cluster 00000000-0000-0000-0000-000000000000", "severity": "ERROR"}]}, "metadata": {"totalAvailableResults": 0}}, "status": 500}
...ignoring

TASK [ntnx_learned_mac_address_for_layer2_stretches_info_v2 : Verify module surfaces the API error for a non-existent ext_id] ***
ok: [testhost] => {"changed": false, "msg": "Module surfaced the expected error for a non-existent learned MAC address"}

PLAY RECAP *********************************************************************
testhost                   : ok=17   changed=0    unreachable=0    failed=0    skipped=6    rescued=0    ignored=4
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Domain context gathered from Glean's networking knowledge base in Step 0.
- Ran through `black`, `isort`, `flake8`, `ansible-lint`, and `ansible-test sanity` (all profiles) — everything green.
- Integration target `ntnx_learned_mac_address_for_layer2_stretches_info_v2` executed against the live Prism Central at `10.44.76.28`; the example playbook was run separately and its output committed under `examples/networking/LearnedMacAddressForLayer2Stretch/examples_run.log`.
