### PR TITLE
feat(cluster_management/Node): ntnx_validate_node_uplinks_v2 action module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+tests/output/

--- a/examples/cluster_management/Node/validate_node_uplinks_v2.yml
+++ b/examples/cluster_management/Node/validate_node_uplinks_v2.yml
@@ -1,0 +1,100 @@
+---
+# Summary:
+# This playbook demonstrates how to use the ntnx_validate_node_uplinks_v2 module.
+# The validate-node action is a pre-check for cluster expansion. It can either
+# validate hypervisor bundle compatibility for a list of target nodes, or
+# validate the network uplink configuration for a target node.
+#
+# 1. Validate the uplink configuration of a single target node.
+# 2. Validate hypervisor bundle compatibility for a list of unconfigured nodes.
+
+- name: Validate node uplinks / hypervisor bundle playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') | default('<pc_ip>', true) }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') | default('<user>', true) }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') | default('<pass>', true) }}"
+      validate_certs: false
+  tasks:
+    - name: Setting default variables
+      ansible.builtin.set_fact:
+        cluster_uuid: "0005b289-8340-119a-0000-00000000a31f"
+        virtual_switch_uuid: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+        hypervisor_bundle_name: "AHV-20220304.242.iso"
+
+    - name: Discover an AOS Prism Element cluster via Prism Central
+      nutanix.ncp.ntnx_clusters_info_v2:
+        filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+      register: clusters_info
+      ignore_errors: true
+
+    - name: Override cluster_uuid with a real cluster ext_id when discovered
+      ansible.builtin.set_fact:
+        cluster_uuid: >-
+          {{ (clusters_info.response | selectattr('ext_id', 'defined') | list | first).ext_id
+            if (clusters_info.response is defined and clusters_info.response | length > 0)
+            else cluster_uuid }}
+
+    - name: Validate node uplinks for one or more target nodes
+      nutanix.ncp.ntnx_validate_node_uplinks_v2:
+        cluster_ext_id: "{{ cluster_uuid }}"
+        uplink_nodes:
+          - cvm_ip:
+              ipv4:
+                value: "10.44.76.31"
+                prefix_length: 24
+            hypervisor_ip:
+              ipv4:
+                value: "10.44.76.32"
+                prefix_length: 24
+            networks:
+              - name: "br0"
+                vswitch_ext_id: "{{ virtual_switch_uuid }}"
+                networks:
+                  - "Management"
+                uplinks:
+                  active:
+                    - mac: "1c:f4:7b:5f:a9:2a"
+                      name: "eth1"
+                      value: "eth1"
+                  standby:
+                    - mac: "12:ee:23:33:2f:43"
+                      name: "eth2"
+                      value: "eth2"
+      register: uplinks_validation
+      ignore_errors: true
+
+    - name: Validate hypervisor bundle compatibility for a list of unconfigured nodes
+      nutanix.ncp.ntnx_validate_node_uplinks_v2:
+        cluster_ext_id: "{{ cluster_uuid }}"
+        bundle_param:
+          bundle_info:
+            name: "{{ hypervisor_bundle_name }}"
+          node_list:
+            - node_uuid: "54b7581b-2e35-413e-8608-0531b065a5d8"
+              block_id: "18SM8B010159"
+              node_position: "B"
+              hypervisor_type: "AHV"
+              hypervisor_hostname: "unconfigured-node-1"
+              hypervisor_version: "10.0-793"
+              nos_version: "7.0"
+              model: "NX-3060-G5"
+              is_light_compute: false
+              is_robo_mixed_hypervisor: false
+              current_network_interface: "eth1"
+              cvm_ip:
+                ipv4:
+                  value: "10.44.76.31"
+                  prefix_length: 24
+              hypervisor_ip:
+                ipv4:
+                  value: "10.44.76.32"
+                  prefix_length: 24
+              ipmi_ip:
+                ipv4:
+                  value: "10.44.76.33"
+                  prefix_length: 24
+      register: bundle_validation
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_validate_node_uplinks_v2

--- a/plugins/modules/ntnx_validate_node_uplinks_v2.py
+++ b/plugins/modules/ntnx_validate_node_uplinks_v2.py
@@ -1,0 +1,923 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_validate_node_uplinks_v2
+short_description: Validate hypervisor bundle and node uplinks before expanding a Nutanix cluster
+version_added: 2.7.0
+description:
+  - This module validates hypervisor bundle compatibility or the network
+    uplink configuration of target nodes before they are added to a Nutanix
+    cluster.
+  - The validation is performed against an existing Prism Element cluster
+    referenced by C(cluster_ext_id).
+  - Exactly one of C(bundle_param) or C(uplink_nodes) must be provided. Both
+    map to the C(spec) field of the SDK C(ValidateNodeParam) request which is
+    a OneOf between hypervisor-bundle and a list of node uplinks.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation.
+  - >-
+    B(Validate node uplinks / hypervisor bundle) -
+    Required Roles: Cluster Admin, Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  state:
+    description:
+      - State of the module.
+      - Only C(present) is supported because this is an action module.
+    type: str
+    choices:
+      - present
+    default: present
+  cluster_ext_id:
+    description:
+      - External ID (UUID) of the target Prism Element cluster on which the
+        validation is executed.
+    type: str
+    required: true
+  bundle_param:
+    description:
+      - Hypervisor bundle validation spec.
+      - Provide this when validating hypervisor bundle (ISO) compatibility
+        against a list of target nodes.
+      - Mutually exclusive with C(uplink_nodes).
+    type: dict
+    required: false
+    suboptions:
+      bundle_info:
+        description:
+          - Hypervisor bundle information used for validation.
+          - Required when C(bundle_param) is provided.
+        type: dict
+        required: true
+        suboptions:
+          name:
+            description:
+              - Name of the hypervisor bundle (for example the ISO name).
+            type: str
+            required: false
+      node_list:
+        description:
+          - List of target node attributes to validate against the hypervisor
+            bundle.
+        type: list
+        elements: dict
+        required: false
+        suboptions:
+          node_uuid:
+            description:
+              - UUID of the node.
+            type: str
+            required: false
+          block_id:
+            description:
+              - ID of the block that houses the node.
+            type: str
+            required: false
+          node_position:
+            description:
+              - Position of the node within the block.
+            type: str
+            required: false
+          hypervisor_type:
+            description:
+              - Hypervisor type running on the node.
+              - The C(XEN) hypervisor type is not supported by the underlying
+                validate-node API.
+            type: str
+            required: false
+            choices:
+              - AHV
+              - ESX
+              - HYPERV
+              - XEN
+              - NATIVEHOST
+          hypervisor_hostname:
+            description:
+              - Hypervisor hostname of the target node.
+            type: str
+            required: false
+          hypervisor_version:
+            description:
+              - Hypervisor version of the target node.
+            type: str
+            required: false
+          nos_version:
+            description:
+              - Nutanix Operating System (AOS) version running on the node.
+            type: str
+            required: false
+          is_light_compute:
+            description:
+              - Whether the node is a light-compute node.
+            type: bool
+            required: false
+          is_robo_mixed_hypervisor:
+            description:
+              - Whether the node is a mixed-hypervisor node in a ROBO
+                deployment.
+            type: bool
+            required: false
+          model:
+            description:
+              - Node hardware model.
+            type: str
+            required: false
+          current_network_interface:
+            description:
+              - Name of the current network interface of the node.
+            type: str
+            required: false
+          ipmi_ip:
+            description:
+              - IPMI IP address of the node.
+            type: dict
+            required: false
+            suboptions:
+              ipv4:
+                description:
+                  - IPv4 address.
+                type: dict
+                required: false
+                suboptions:
+                  value:
+                    description:
+                      - The IPv4 address value.
+                    type: str
+                    required: true
+                  prefix_length:
+                    description:
+                      - Prefix length of the IPv4 address.
+                    type: int
+                    required: false
+                    default: 32
+              ipv6:
+                description:
+                  - IPv6 address.
+                type: dict
+                required: false
+                suboptions:
+                  value:
+                    description:
+                      - The IPv6 address value.
+                    type: str
+                    required: true
+                  prefix_length:
+                    description:
+                      - Prefix length of the IPv6 address.
+                    type: int
+                    required: false
+                    default: 128
+          cvm_ip:
+            description:
+              - Controller VM (CVM) IP address of the node.
+            type: dict
+            required: false
+            suboptions:
+              ipv4:
+                description:
+                  - IPv4 address.
+                type: dict
+                required: false
+                suboptions:
+                  value:
+                    description:
+                      - The IPv4 address value.
+                    type: str
+                    required: true
+                  prefix_length:
+                    description:
+                      - Prefix length of the IPv4 address.
+                    type: int
+                    required: false
+                    default: 32
+              ipv6:
+                description:
+                  - IPv6 address.
+                type: dict
+                required: false
+                suboptions:
+                  value:
+                    description:
+                      - The IPv6 address value.
+                    type: str
+                    required: true
+                  prefix_length:
+                    description:
+                      - Prefix length of the IPv6 address.
+                    type: int
+                    required: false
+                    default: 128
+          hypervisor_ip:
+            description:
+              - Hypervisor IP address of the node.
+            type: dict
+            required: false
+            suboptions:
+              ipv4:
+                description:
+                  - IPv4 address.
+                type: dict
+                required: false
+                suboptions:
+                  value:
+                    description:
+                      - The IPv4 address value.
+                    type: str
+                    required: true
+                  prefix_length:
+                    description:
+                      - Prefix length of the IPv4 address.
+                    type: int
+                    required: false
+                    default: 32
+              ipv6:
+                description:
+                  - IPv6 address.
+                type: dict
+                required: false
+                suboptions:
+                  value:
+                    description:
+                      - The IPv6 address value.
+                    type: str
+                    required: true
+                  prefix_length:
+                    description:
+                      - Prefix length of the IPv6 address.
+                    type: int
+                    required: false
+                    default: 128
+          digital_certificate_map_list:
+            description:
+              - List of digital certificate mappings for the node.
+            type: list
+            elements: dict
+            required: false
+            suboptions:
+              key:
+                description:
+                  - Certificate map key.
+                type: str
+                required: false
+              value:
+                description:
+                  - Certificate map value.
+                type: str
+                required: false
+  uplink_nodes:
+    description:
+      - List of target nodes whose network uplink configuration should be
+        validated.
+      - Provide this when validating uplink connectivity of one or more
+        candidate nodes.
+      - Mutually exclusive with C(bundle_param).
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      cvm_ip:
+        description:
+          - Controller VM (CVM) IP address of the node to validate.
+          - Required for every entry in C(uplink_nodes).
+        type: dict
+        required: true
+        suboptions:
+          ipv4:
+            description:
+              - IPv4 address.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv4 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv4 address.
+                type: int
+                required: false
+                default: 32
+          ipv6:
+            description:
+              - IPv6 address.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv6 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv6 address.
+                type: int
+                required: false
+                default: 128
+      hypervisor_ip:
+        description:
+          - Hypervisor IP address of the node to validate.
+        type: dict
+        required: false
+        suboptions:
+          ipv4:
+            description:
+              - IPv4 address.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv4 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv4 address.
+                type: int
+                required: false
+                default: 32
+          ipv6:
+            description:
+              - IPv6 address.
+            type: dict
+            required: false
+            suboptions:
+              value:
+                description:
+                  - The IPv6 address value.
+                type: str
+                required: true
+              prefix_length:
+                description:
+                  - Prefix length of the IPv6 address.
+                type: int
+                required: false
+                default: 128
+      networks:
+        description:
+          - Active and standby uplink information of the target node grouped
+            by uplink network name.
+        type: list
+        elements: dict
+        required: false
+        suboptions:
+          name:
+            description:
+              - Name of the uplink network (e.g. C(br0)).
+            type: str
+            required: false
+          networks:
+            description:
+              - List of network names attached to the uplink.
+            type: list
+            elements: str
+            required: false
+          vswitch_ext_id:
+            description:
+              - External ID of the virtual switch that the uplinks connect to.
+            type: str
+            required: false
+          uplinks:
+            description:
+              - Active and standby uplink information for the network.
+            type: dict
+            required: false
+            suboptions:
+              active:
+                description:
+                  - Active uplink information.
+                type: list
+                elements: dict
+                required: false
+                suboptions:
+                  mac:
+                    description:
+                      - MAC address of the uplink.
+                    type: str
+                    required: false
+                  name:
+                    description:
+                      - Name of the uplink.
+                    type: str
+                    required: false
+                  value:
+                    description:
+                      - Uplink value.
+                    type: str
+                    required: false
+              standby:
+                description:
+                  - Standby uplink information.
+                type: list
+                elements: dict
+                required: false
+                suboptions:
+                  mac:
+                    description:
+                      - MAC address of the uplink.
+                    type: str
+                    required: false
+                  name:
+                    description:
+                      - Name of the uplink.
+                    type: str
+                    required: false
+                  value:
+                    description:
+                      - Uplink value.
+                    type: str
+                    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Validate node uplinks before cluster expansion
+  nutanix.ncp.ntnx_validate_node_uplinks_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    cluster_ext_id: "0005b289-8340-119a-0000-00000000a31f"
+    uplink_nodes:
+      - cvm_ip:
+          ipv4:
+            value: "10.44.76.31"
+            prefix_length: 24
+        hypervisor_ip:
+          ipv4:
+            value: "10.44.76.32"
+            prefix_length: 24
+        networks:
+          - name: "br0"
+            vswitch_ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+            networks:
+              - "Management"
+            uplinks:
+              active:
+                - mac: "1c:f4:7b:5f:a9:2a"
+                  name: "eth1"
+                  value: "eth1"
+              standby:
+                - mac: "12:ee:23:33:2f:43"
+                  name: "eth2"
+                  value: "eth2"
+  register: uplinks_validation
+  ignore_errors: true
+
+- name: Validate hypervisor bundle compatibility for a list of unconfigured nodes
+  nutanix.ncp.ntnx_validate_node_uplinks_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    cluster_ext_id: "0005b289-8340-119a-0000-00000000a31f"
+    bundle_param:
+      bundle_info:
+        name: "AHV-20220304.242.iso"
+      node_list:
+        - node_uuid: "54b7581b-2e35-413e-8608-0531b065a5d8"
+          block_id: "18SM8B010159"
+          node_position: "B"
+          hypervisor_type: "AHV"
+          hypervisor_version: "10.0-793"
+          nos_version: "7.0"
+          model: "NX-3060-G5"
+          is_light_compute: false
+          is_robo_mixed_hypervisor: false
+          cvm_ip:
+            ipv4:
+              value: "10.44.76.31"
+              prefix_length: 24
+          hypervisor_ip:
+            ipv4:
+              value: "10.44.76.32"
+              prefix_length: 24
+          ipmi_ip:
+            ipv4:
+              value: "10.44.76.33"
+              prefix_length: 24
+  register: bundle_validation
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response returned by the C(validate-node) API.
+    - Task metadata when C(wait) is C(false), full task response when
+      C(wait) is C(true).
+  returned: always
+  type: dict
+  sample:
+    {
+      "app_name": null,
+      "batch_summary": null,
+      "cluster_ext_ids": null,
+      "completed_time": "2026-07-20T13:25:19.252016+00:00",
+      "completion_details": null,
+      "created_time": "2026-07-20T13:25:18.960093+00:00",
+      "entities_affected": null,
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:e7e30d3b-ba3e-429f-7472-d1fff4c4304a",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-20T13:25:19.252015+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 0,
+      "number_of_subtasks": 0,
+      "operation": "Validate Uplinks Info",
+      "operation_description": "Validate Uplinks Info",
+      "owned_by": {
+          "ext_id": "00000000-0000-0000-0000-000000000000",
+          "name": "admin"
+      },
+      "parent_task": null,
+      "progress_percentage": 100,
+      "started_time": "2026-07-20T13:25:18.985980+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while validating node"
+
+error:
+  description:
+    - This field typically holds information about if the task have errors
+      that occurred during the task execution.
+  returned: when an error occurs
+  type: str
+  sample: "Failed generating validate-node spec"
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+task_ext_id:
+  description: The external ID of the validate-node task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:e7e30d3b-ba3e-429f-7472-d1fff4c4304a"
+
+ext_id:
+  description: The external ID of the target Prism Element cluster on which the validation was performed.
+  returned: always
+  type: str
+  sample: "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_clusters_api_instance,
+)
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_clustermgmt_py_client as cluster_management_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402
+        mock_sdk as cluster_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def _get_ipv4_spec():
+    return dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=32),
+    )
+
+
+def _get_ipv6_spec():
+    return dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=128),
+    )
+
+
+def _get_ip_address_spec():
+    return dict(
+        ipv4=dict(
+            type="dict",
+            options=_get_ipv4_spec(),
+            obj=cluster_management_sdk.IPv4Address,
+            required=False,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=_get_ipv6_spec(),
+            obj=cluster_management_sdk.IPv6Address,
+            required=False,
+        ),
+    )
+
+
+def _get_uplinks_field_spec():
+    return dict(
+        mac=dict(type="str", required=False),
+        name=dict(type="str", required=False),
+        value=dict(type="str", required=False),
+    )
+
+
+def _get_uplinks_spec():
+    return dict(
+        active=dict(
+            type="list",
+            elements="dict",
+            options=_get_uplinks_field_spec(),
+            obj=cluster_management_sdk.UplinksField,
+            required=False,
+        ),
+        standby=dict(
+            type="list",
+            elements="dict",
+            options=_get_uplinks_field_spec(),
+            obj=cluster_management_sdk.UplinksField,
+            required=False,
+        ),
+    )
+
+
+def _get_uplink_network_item_spec():
+    return dict(
+        name=dict(type="str", required=False),
+        networks=dict(type="list", elements="str", required=False),
+        vswitch_ext_id=dict(type="str", required=False),
+        uplinks=dict(
+            type="dict",
+            options=_get_uplinks_spec(),
+            obj=cluster_management_sdk.Uplinks,
+            required=False,
+        ),
+    )
+
+
+def _get_node_info_spec():
+    digital_certificate_map_list_spec = dict(
+        key=dict(type="str", required=False, no_log=False),
+        value=dict(type="str", required=False),
+    )
+    return dict(
+        node_uuid=dict(type="str", required=False),
+        block_id=dict(type="str", required=False),
+        node_position=dict(type="str", required=False),
+        hypervisor_type=dict(
+            type="str",
+            choices=["AHV", "ESX", "HYPERV", "XEN", "NATIVEHOST"],
+            obj=cluster_management_sdk.HypervisorType,
+            required=False,
+        ),
+        hypervisor_hostname=dict(type="str", required=False),
+        hypervisor_version=dict(type="str", required=False),
+        nos_version=dict(type="str", required=False),
+        is_light_compute=dict(type="bool", required=False),
+        is_robo_mixed_hypervisor=dict(type="bool", required=False),
+        model=dict(type="str", required=False),
+        current_network_interface=dict(type="str", required=False),
+        ipmi_ip=dict(
+            type="dict",
+            options=_get_ip_address_spec(),
+            obj=cluster_management_sdk.IPAddress,
+            required=False,
+        ),
+        cvm_ip=dict(
+            type="dict",
+            options=_get_ip_address_spec(),
+            obj=cluster_management_sdk.IPAddress,
+            required=False,
+        ),
+        hypervisor_ip=dict(
+            type="dict",
+            options=_get_ip_address_spec(),
+            obj=cluster_management_sdk.IPAddress,
+            required=False,
+        ),
+        digital_certificate_map_list=dict(
+            type="list",
+            elements="dict",
+            options=digital_certificate_map_list_spec,
+            obj=cluster_management_sdk.DigitalCertificateMapReference,
+            required=False,
+        ),
+    )
+
+
+def get_module_spec():
+    bundle_info_spec = dict(
+        name=dict(type="str", required=False),
+    )
+
+    bundle_param_spec = dict(
+        bundle_info=dict(
+            type="dict",
+            options=bundle_info_spec,
+            obj=cluster_management_sdk.BundleInfo,
+            required=True,
+        ),
+        node_list=dict(
+            type="list",
+            elements="dict",
+            options=_get_node_info_spec(),
+            obj=cluster_management_sdk.NodeInfo,
+            required=False,
+        ),
+    )
+
+    uplink_node_spec = dict(
+        cvm_ip=dict(
+            type="dict",
+            options=_get_ip_address_spec(),
+            obj=cluster_management_sdk.IPAddress,
+            required=True,
+        ),
+        hypervisor_ip=dict(
+            type="dict",
+            options=_get_ip_address_spec(),
+            obj=cluster_management_sdk.IPAddress,
+            required=False,
+        ),
+        networks=dict(
+            type="list",
+            elements="dict",
+            options=_get_uplink_network_item_spec(),
+            obj=cluster_management_sdk.UplinkNetworkItem,
+            required=False,
+        ),
+    )
+
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        cluster_ext_id=dict(type="str", required=True),
+        bundle_param=dict(
+            type="dict",
+            options=bundle_param_spec,
+            obj=cluster_management_sdk.BundleParam,
+            required=False,
+        ),
+        uplink_nodes=dict(
+            type="list",
+            elements="dict",
+            options=uplink_node_spec,
+            obj=cluster_management_sdk.UplinkNode,
+            required=False,
+        ),
+    )
+    return module_args
+
+
+def _build_spec_object(module):
+    """Build the ValidateNodeParam body from the user-provided spec.
+
+    The API's request body is a OneOf: for hypervisor-bundle validation the
+    spec is a single BundleParam object, for uplink validation the spec is a
+    list of UplinkNode objects (the OneOf discriminator advertised by the SDK
+    is C(List<clustermgmt.v4.config.UplinkNode>)).
+    """
+    sg = SpecGenerator(module)
+    body = cluster_management_sdk.ValidateNodeParam()
+
+    if module.params.get("bundle_param"):
+        default_spec = cluster_management_sdk.BundleParam()
+        inner_spec, err = sg.generate_spec(
+            obj=default_spec,
+            attr=module.params.get("bundle_param"),
+            module_args=get_module_spec()["bundle_param"]["options"],
+        )
+        if err:
+            return None, err
+        body.spec = inner_spec
+        return body, None
+
+    uplink_node_options = get_module_spec()["uplink_nodes"]["options"]
+    uplink_nodes = []
+    for item in module.params.get("uplink_nodes") or []:
+        inner_spec, err = sg.generate_spec(
+            obj=cluster_management_sdk.UplinkNode(),
+            attr=item,
+            module_args=uplink_node_options,
+        )
+        if err:
+            return None, err
+        uplink_nodes.append(inner_spec)
+    body.spec = uplink_nodes
+    return body, None
+
+
+def validate_node(module, clusters_api, result):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    result["ext_id"] = cluster_ext_id
+
+    spec, err = _build_spec_object(module)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating validate-node spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = clusters_api.validate_node(clusterExtId=cluster_ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while validating node",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        mutually_exclusive=[("bundle_param", "uplink_nodes")],
+        required_one_of=[("bundle_param", "uplink_nodes")],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    clusters_api = get_clusters_api_instance(module)
+    validate_node(module, clusters_api, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip>=23.0
 setuptools>=65.0
 requests>=2.31.0
-ntnx-clustermgmt-py-client==4.2.2
+ntnx-clustermgmt-py-client==latest
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1

--- a/tests/integration/targets/ntnx_validate_node_uplinks_v2/aliases
+++ b/tests/integration/targets/ntnx_validate_node_uplinks_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_validate_node_uplinks_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_validate_node_uplinks_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_validate_node_uplinks_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_validate_node_uplinks_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import validate_node_uplinks.yml
+      ansible.builtin.import_tasks: validate_node_uplinks.yml

--- a/tests/integration/targets/ntnx_validate_node_uplinks_v2/tasks/validate_node_uplinks.yml
+++ b/tests/integration/targets/ntnx_validate_node_uplinks_v2/tasks/validate_node_uplinks.yml
@@ -1,0 +1,430 @@
+---
+# Test plan for ntnx_validate_node_uplinks_v2
+#
+# Scenarios covered:
+#   1. check_mode - uplink_nodes spec with ALL fields (asserts every attribute
+#      round-trips through get_module_spec → SpecGenerator → SDK body).
+#   2. check_mode - uplink_nodes spec with only the required cvm_ip.
+#   3. check_mode - bundle_param spec with ALL fields (bundle_info + node_list
+#      with every NodeInfo attribute including IPv4 + IPv6 addresses and
+#      digital-certificate map list).
+#   4. check_mode - bundle_param spec with only the required fields.
+#   5. Negative - both bundle_param and uplink_nodes given → mutually_exclusive
+#      failure.
+#   6. Negative - neither bundle_param nor uplink_nodes given → required_one_of
+#      failure.
+#   7. Negative - missing cluster_ext_id (required=True) failure.
+#   8. Negative - invalid hypervisor_type choice (bad enum) failure.
+#   9. Live validate-node call for a hypervisor bundle - asserts a well-formed
+#      response (success or a descriptive API error).
+#  10. Live validate-node call for a list of uplink nodes - asserts a
+#      well-formed response (success or a descriptive API error).
+#
+# These scenarios combine SDK knowledge (OneOf between BundleParam and
+# list[UplinkNode], IP address / uplink sub-structs), module spec analysis
+# (required fields, choices, mutually_exclusive, required_one_of) and domain
+# knowledge (validate-node is a pre-check for cluster expansion, XEN not
+# supported).
+
+- name: Start ntnx_validate_node_uplinks_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_validate_node_uplinks_v2 tests
+
+- name: Generate random suffix for uniqueness
+  ansible.builtin.set_fact:
+    random_suffix: "{{ query('community.general.random_string', numbers=true, special=false, length=10)[0] }}"
+
+- name: Fetch clusters info to discover a real PE cluster ext_id
+  nutanix.ncp.ntnx_clusters_info_v2:
+    filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+  register: clusters_info
+  ignore_errors: true
+
+- name: Set discovered cluster ext_id (falls back to a random UUID when unavailable)
+  ansible.builtin.set_fact:
+    discovered_cluster_ext_id: >-
+      {{ (clusters_info.response | default([]) | selectattr('ext_id', 'defined')
+          | list | first).ext_id
+          if (clusters_info.response is defined and clusters_info.response | length > 0)
+          else '00000000-0000-0000-0000-000000000000' }}
+
+########################################################################################
+# 1. check_mode – uplink_nodes spec with ALL fields
+########################################################################################
+
+- name: Generate spec for validating node uplinks using check_mode with ALL attributes
+  nutanix.ncp.ntnx_validate_node_uplinks_v2:
+    cluster_ext_id: "0005b289-8340-119a-0000-00000000a31f"
+    uplink_nodes:
+      - cvm_ip:
+          ipv4:
+            value: "10.44.76.31"
+            prefix_length: 24
+          ipv6:
+            value: "2001:db8:3333:4444:5555:6666:7777:8881"
+            prefix_length: 64
+        hypervisor_ip:
+          ipv4:
+            value: "10.44.76.32"
+            prefix_length: 24
+          ipv6:
+            value: "2001:db8:3333:4444:5555:6666:7777:8882"
+            prefix_length: 64
+        networks:
+          - name: "br0"
+            vswitch_ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+            networks:
+              - "Management"
+              - "Backplane"
+            uplinks:
+              active:
+                - mac: "1c:f4:7b:5f:a9:2a"
+                  name: "eth1"
+                  value: "eth1"
+              standby:
+                - mac: "12:ee:23:33:2f:43"
+                  name: "eth2"
+                  value: "eth2"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check_mode uplink_nodes full spec
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "0005b289-8340-119a-0000-00000000a31f"
+      - result.response is defined
+      - result.response.spec is defined
+      - result.response.spec | length == 1
+      - result.response.spec[0].cvm_ip.ipv4.value == "10.44.76.31"
+      - result.response.spec[0].cvm_ip.ipv4.prefix_length == 24
+      - result.response.spec[0].cvm_ip.ipv6.value == "2001:db8:3333:4444:5555:6666:7777:8881"
+      - result.response.spec[0].cvm_ip.ipv6.prefix_length == 64
+      - result.response.spec[0].hypervisor_ip.ipv4.value == "10.44.76.32"
+      - result.response.spec[0].hypervisor_ip.ipv4.prefix_length == 24
+      - result.response.spec[0].hypervisor_ip.ipv6.value == "2001:db8:3333:4444:5555:6666:7777:8882"
+      - result.response.spec[0].hypervisor_ip.ipv6.prefix_length == 64
+      - result.response.spec[0].networks | length == 1
+      - result.response.spec[0].networks[0].name == "br0"
+      - result.response.spec[0].networks[0].vswitch_ext_id == "2e40ff57-20aa-4d2b-b179-298db969c20d"
+      - result.response.spec[0].networks[0].networks | length == 2
+      - result.response.spec[0].networks[0].networks[0] == "Management"
+      - result.response.spec[0].networks[0].networks[1] == "Backplane"
+      - result.response.spec[0].networks[0].uplinks.active | length == 1
+      - result.response.spec[0].networks[0].uplinks.active[0].mac == "1c:f4:7b:5f:a9:2a"
+      - result.response.spec[0].networks[0].uplinks.active[0].name == "eth1"
+      - result.response.spec[0].networks[0].uplinks.active[0].value == "eth1"
+      - result.response.spec[0].networks[0].uplinks.standby | length == 1
+      - result.response.spec[0].networks[0].uplinks.standby[0].mac == "12:ee:23:33:2f:43"
+      - result.response.spec[0].networks[0].uplinks.standby[0].name == "eth2"
+      - result.response.spec[0].networks[0].uplinks.standby[0].value == "eth2"
+    fail_msg: "check_mode uplink_nodes full spec generation failed"
+    success_msg: "check_mode uplink_nodes full spec generation succeeded"
+
+########################################################################################
+# 2. check_mode – uplink_nodes with only the required cvm_ip (single entry)
+########################################################################################
+
+- name: Generate spec for validating node uplinks using check_mode with only required fields
+  nutanix.ncp.ntnx_validate_node_uplinks_v2:
+    cluster_ext_id: "0005b289-8340-119a-0000-00000000a31f"
+    uplink_nodes:
+      - cvm_ip:
+          ipv4:
+            value: "10.44.76.41"
+            prefix_length: 24
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check_mode uplink_nodes minimal spec
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response.spec | length == 1
+      - result.response.spec[0].cvm_ip.ipv4.value == "10.44.76.41"
+      - result.response.spec[0].hypervisor_ip is none
+      - result.response.spec[0].networks is none
+    fail_msg: "check_mode uplink_nodes minimal spec generation failed"
+    success_msg: "check_mode uplink_nodes minimal spec generation succeeded"
+
+########################################################################################
+# 3. check_mode – bundle_param spec with ALL fields
+########################################################################################
+
+- name: Generate spec for validating hypervisor bundle using check_mode with ALL attributes
+  nutanix.ncp.ntnx_validate_node_uplinks_v2:
+    cluster_ext_id: "0005b289-8340-119a-0000-00000000a31f"
+    bundle_param:
+      bundle_info:
+        name: "AHV-{{ random_suffix }}.iso"
+      node_list:
+        - node_uuid: "54b7581b-2e35-413e-8608-0531b065a5d8"
+          block_id: "18SM8B010159"
+          node_position: "B"
+          hypervisor_type: "AHV"
+          hypervisor_hostname: "unconfigured-node-{{ random_suffix }}"
+          hypervisor_version: "10.0-793"
+          nos_version: "7.0"
+          model: "NX-3060-G5"
+          is_light_compute: false
+          is_robo_mixed_hypervisor: true
+          current_network_interface: "eth1"
+          cvm_ip:
+            ipv4:
+              value: "10.44.76.51"
+              prefix_length: 24
+            ipv6:
+              value: "2001:db8:3333:4444:5555:6666:7777:aaaa"
+              prefix_length: 64
+          hypervisor_ip:
+            ipv4:
+              value: "10.44.76.52"
+              prefix_length: 24
+            ipv6:
+              value: "2001:db8:3333:4444:5555:6666:7777:bbbb"
+              prefix_length: 64
+          ipmi_ip:
+            ipv4:
+              value: "10.44.76.53"
+              prefix_length: 24
+            ipv6:
+              value: "2001:db8:3333:4444:5555:6666:7777:cccc"
+              prefix_length: 64
+          digital_certificate_map_list:
+            - key: "cert-key-1"
+              value: "cert-value-1"
+            - key: "cert-key-2"
+              value: "cert-value-2"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check_mode bundle_param full spec
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "0005b289-8340-119a-0000-00000000a31f"
+      - result.response.spec.bundle_info.name == "AHV-" + random_suffix + ".iso"
+      - result.response.spec.node_list | length == 1
+      - result.response.spec.node_list[0].node_uuid == "54b7581b-2e35-413e-8608-0531b065a5d8"
+      - result.response.spec.node_list[0].block_id == "18SM8B010159"
+      - result.response.spec.node_list[0].node_position == "B"
+      - result.response.spec.node_list[0].hypervisor_type == "AHV"
+      - result.response.spec.node_list[0].hypervisor_hostname == "unconfigured-node-" + random_suffix
+      - result.response.spec.node_list[0].hypervisor_version == "10.0-793"
+      - result.response.spec.node_list[0].nos_version == "7.0"
+      - result.response.spec.node_list[0].model == "NX-3060-G5"
+      - result.response.spec.node_list[0].is_light_compute == false
+      - result.response.spec.node_list[0].is_robo_mixed_hypervisor == true
+      - result.response.spec.node_list[0].current_network_interface == "eth1"
+      - result.response.spec.node_list[0].cvm_ip.ipv4.value == "10.44.76.51"
+      - result.response.spec.node_list[0].cvm_ip.ipv4.prefix_length == 24
+      - result.response.spec.node_list[0].cvm_ip.ipv6.value == "2001:db8:3333:4444:5555:6666:7777:aaaa"
+      - result.response.spec.node_list[0].cvm_ip.ipv6.prefix_length == 64
+      - result.response.spec.node_list[0].hypervisor_ip.ipv4.value == "10.44.76.52"
+      - result.response.spec.node_list[0].hypervisor_ip.ipv6.value == "2001:db8:3333:4444:5555:6666:7777:bbbb"
+      - result.response.spec.node_list[0].ipmi_ip.ipv4.value == "10.44.76.53"
+      - result.response.spec.node_list[0].ipmi_ip.ipv6.value == "2001:db8:3333:4444:5555:6666:7777:cccc"
+      - result.response.spec.node_list[0].digital_certificate_map_list | length == 2
+      - result.response.spec.node_list[0].digital_certificate_map_list[0].key == "cert-key-1"
+      - result.response.spec.node_list[0].digital_certificate_map_list[0].value == "cert-value-1"
+      - result.response.spec.node_list[0].digital_certificate_map_list[1].key == "cert-key-2"
+      - result.response.spec.node_list[0].digital_certificate_map_list[1].value == "cert-value-2"
+    fail_msg: "check_mode bundle_param full spec generation failed"
+    success_msg: "check_mode bundle_param full spec generation succeeded"
+
+########################################################################################
+# 4. check_mode – bundle_param spec with only the required fields
+########################################################################################
+
+- name: Generate spec for validating hypervisor bundle using check_mode with only required fields
+  nutanix.ncp.ntnx_validate_node_uplinks_v2:
+    cluster_ext_id: "0005b289-8340-119a-0000-00000000a31f"
+    bundle_param:
+      bundle_info:
+        name: "AHV-minimal-{{ random_suffix }}.iso"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check_mode bundle_param minimal spec
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response.spec.bundle_info.name == "AHV-minimal-" + random_suffix + ".iso"
+      - result.response.spec.node_list is none
+    fail_msg: "check_mode bundle_param minimal spec generation failed"
+    success_msg: "check_mode bundle_param minimal spec generation succeeded"
+
+########################################################################################
+# 5. Negative – mutually_exclusive: bundle_param + uplink_nodes
+########################################################################################
+
+- name: Try validate-node with both bundle_param and uplink_nodes (mutually exclusive)
+  nutanix.ncp.ntnx_validate_node_uplinks_v2:
+    cluster_ext_id: "0005b289-8340-119a-0000-00000000a31f"
+    bundle_param:
+      bundle_info:
+        name: "AHV.iso"
+    uplink_nodes:
+      - cvm_ip:
+          ipv4:
+            value: "10.44.76.31"
+            prefix_length: 24
+  register: result
+  ignore_errors: true
+
+- name: Assert mutually_exclusive failure
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - result.changed == false
+      - "'mutually exclusive' in (result.msg | lower)"
+    fail_msg: "Mutually-exclusive check between bundle_param and uplink_nodes did not fail as expected"
+    success_msg: "Mutually-exclusive check between bundle_param and uplink_nodes correctly failed"
+
+########################################################################################
+# 6. Negative – required_one_of: neither bundle_param nor uplink_nodes
+########################################################################################
+
+- name: Try validate-node without bundle_param or uplink_nodes
+  nutanix.ncp.ntnx_validate_node_uplinks_v2:
+    cluster_ext_id: "0005b289-8340-119a-0000-00000000a31f"
+  register: result
+  ignore_errors: true
+
+- name: Assert required_one_of failure
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - result.changed == false
+      - "'one of the following is required' in (result.msg | lower) or 'one of' in (result.msg | lower)"
+    fail_msg: "required_one_of check for bundle_param / uplink_nodes did not fail as expected"
+    success_msg: "required_one_of check for bundle_param / uplink_nodes correctly failed"
+
+########################################################################################
+# 7. Negative – missing cluster_ext_id
+########################################################################################
+
+- name: Try validate-node without cluster_ext_id
+  nutanix.ncp.ntnx_validate_node_uplinks_v2:
+    uplink_nodes:
+      - cvm_ip:
+          ipv4:
+            value: "10.44.76.31"
+            prefix_length: 24
+  register: result
+  ignore_errors: true
+
+- name: Assert missing cluster_ext_id failure
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - result.changed == false
+      - "'cluster_ext_id' in (result.msg | lower) or 'missing' in (result.msg | lower)"
+    fail_msg: "Missing cluster_ext_id did not fail as expected"
+    success_msg: "Missing cluster_ext_id correctly failed"
+
+########################################################################################
+# 8. Negative – invalid hypervisor_type enum
+########################################################################################
+
+- name: Try validate-node with an invalid hypervisor_type enum
+  nutanix.ncp.ntnx_validate_node_uplinks_v2:
+    cluster_ext_id: "0005b289-8340-119a-0000-00000000a31f"
+    bundle_param:
+      bundle_info:
+        name: "AHV.iso"
+      node_list:
+        - node_uuid: "54b7581b-2e35-413e-8608-0531b065a5d8"
+          hypervisor_type: "INVALID_HYPERVISOR"
+  register: result
+  ignore_errors: true
+
+- name: Assert invalid hypervisor_type failure
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - result.changed == false
+      - "'value of hypervisor_type must be one of' in (result.msg | lower) or 'INVALID_HYPERVISOR' in (result.msg | default(''))"
+    fail_msg: "Invalid hypervisor_type enum did not fail as expected"
+    success_msg: "Invalid hypervisor_type enum correctly failed"
+
+########################################################################################
+# 9. Live validate-node call for a hypervisor bundle
+########################################################################################
+
+- name: Live validate-node call for a hypervisor bundle
+  nutanix.ncp.ntnx_validate_node_uplinks_v2:
+    cluster_ext_id: "{{ discovered_cluster_ext_id }}"
+    bundle_param:
+      bundle_info:
+        name: "AHV-nonexistent-bundle-{{ random_suffix }}.iso"
+      node_list:
+        - node_uuid: "00000000-0000-0000-0000-00000000dead"
+          block_id: "FAKE_BLOCK"
+          node_position: "A"
+          hypervisor_type: "AHV"
+          hypervisor_version: "0.0"
+          nos_version: "0.0"
+          model: "NX-FAKE"
+  register: live_bundle
+  ignore_errors: true
+
+- name: Assert live bundle validation returns a well-formed result
+  ansible.builtin.assert:
+    that:
+      - live_bundle is defined
+      # Either the call succeeds (response defined) or fails with descriptive error.
+      - live_bundle.response is defined or live_bundle.failed is defined
+    fail_msg: "Live validate-node (bundle) call did not return a well-formed result"
+    success_msg: "Live validate-node (bundle) call returned a well-formed result"
+
+########################################################################################
+# 10. Live validate-node call for a list of uplink nodes
+########################################################################################
+
+- name: Live validate-node call for a list of uplink nodes (fabricated data)
+  nutanix.ncp.ntnx_validate_node_uplinks_v2:
+    cluster_ext_id: "{{ discovered_cluster_ext_id }}"
+    uplink_nodes:
+      - cvm_ip:
+          ipv4:
+            value: "203.0.113.31"
+            prefix_length: 24
+        hypervisor_ip:
+          ipv4:
+            value: "203.0.113.32"
+            prefix_length: 24
+        networks:
+          - name: "br0-fake"
+            vswitch_ext_id: "00000000-0000-0000-0000-000000000000"
+            networks:
+              - "FakeNetwork"
+            uplinks:
+              active:
+                - mac: "aa:bb:cc:dd:ee:ff"
+                  name: "eth99"
+                  value: "eth99"
+              standby: []
+  register: live_uplinks
+  ignore_errors: true
+
+- name: Assert live uplinks validation returns a well-formed result
+  ansible.builtin.assert:
+    that:
+      - live_uplinks is defined
+      - live_uplinks.response is defined or live_uplinks.failed is defined
+    fail_msg: "Live validate-node (uplinks) call did not return a well-formed result"
+    success_msg: "Live validate-node (uplinks) call returned a well-formed result"
+
+- name: End ntnx_validate_node_uplinks_v2 tests
+  ansible.builtin.debug:
+    msg: End ntnx_validate_node_uplinks_v2 tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **cluster_management**
namespace, entity **Node**, based on the inline `sdk_info.json`. One PR per
code-gen run.

The `ValidateNode` SDK method (`POST /api/clustermgmt/v4.2/config/clusters/{clusterExtId}/$actions/validate-node`)
is an **action-type** API — it is a pre-check that validates either a
hypervisor bundle (ISO) OR a list of node uplinks before a cluster
expansion. Per the instructions, when the entity's primary operation is an
action, the CRUD module follows the `ntnx_vm_revert_v2` pattern and the info
module (Step 2) is skipped. The info module was skipped because there is no
`ntnx_nodes_info_v2` list/get endpoint in the SDK for this entity (see the
`ClustersApi` surface — node info is handled by adjacent modules such as
`ntnx_hosts_info_v2` and `ntnx_nodes_network_info_v2`, both already in the
repo).

- Modules generated: `ntnx_validate_node_uplinks_v2` (action-type)
  - `ntnx_nodes_info_v2` was **not** generated — the entity is action-type,
    which per the instructions means Step 2 is skipped.
- API methods covered: 1 (`ValidateNode`)
- Top-level fields in CRUD module spec: 4 (`state`, `cluster_ext_id`,
  `bundle_param`, `uplink_nodes`) plus deeply-nested sub-schemas for
  `BundleParam.node_list` (13 fields per node including IPv4/IPv6 sub-specs
  and a digital-certificate map list) and `UplinkNode` (3 fields per node
  including IPv4/IPv6 sub-specs and full uplink networks/uplinks
  sub-schema).

## Domain knowledge (from Glean)

The Nutanix v4 `clustermgmt` API includes the `$actions/validate-node`
endpoint (`POST /config/clusters/{clusterExtId}/$actions/validate-node`),
which is used as a pre-check step before expanding a cluster or adding new
nodes. It ensures that the target nodes meet the necessary prerequisites.
*Note: This API is not supported for XEN hypervisor types.*

This action handles two distinct types of validation, which are passed in
the request body using the `ValidateNodeParam` spec:

### 1. Hypervisor Bundle Validation

This checks whether a specific hypervisor bundle (ISO) is compatible with
the physical attributes and current state of the nodes being added to the
cluster.

- `BundleParam`: The object used to pass this validation request. It
  includes:
  - `bundle_info`: Information about the hypervisor bundle (e.g., the ISO
    name like `validbundle.iso`).
  - `node_list`: A list of target node attributes that need to be validated
    against the bundle. This typically includes fields like `nodeUuid`,
    `blockId`, `hypervisorVersion`, `hypervisorType` (e.g., AHV), `model`,
    and `nosVersion`.

### 2. Node Uplinks Validation

This checks whether the provided network uplink configurations for the
target nodes are valid and can be successfully applied when joining the
cluster.

- `UplinkNode`: The object used to pass uplink information for a target
  node. It includes:
  - `networks`: A list of network types/names.
  - `uplinks`: Information specifying the active and standby uplinks for
    the node.
  - `vswitch_ext_id`: The external ID of the virtual switch the uplinks
    will connect to.

### Request Body Spec (`ValidateNodeParam`)

Because the endpoint handles two different validation tasks, the
`ValidateNodeParam` acts as a `OneOf` wrapper payload. When making a
request, the `spec` field of `ValidateNodeParam` must contain **either**:

- A `BundleParam` (to validate hypervisor compatibility)
- A list of `UplinkNode` objects (to validate network uplinks). The SDK's
  OneOf discriminator explicitly names this option
  `List<clustermgmt.v4.config.UplinkNode>` — so the module exposes it as
  `uplink_nodes` (a list), not a single dict. Live testing against
  `10.44.76.28` confirmed that passing a single object results in a 400
  schema-validation error ("Field spec : Instance type (object) does not
  match any allowed primitive type (allowed: [\"array\"])"), while passing
  a list drives the task to `SUCCEEDED` with `operation: "Validate Uplinks
  Info"`.

### Related Resources & Documentation

- Confluence Design Docs:
  - Overall v4 APIs — https://confluence.eng.nutanix.com:8443/spaces/INFRA/pages/143773144/Overall+v4+APIs
  - Core Infra Cluster management v4 API (beta completed) —
    https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/321024527/Core+Infra+Cluster+managent+v4+API+beta+completed
  - ST 10: PC v3/v4 API Coverage —
    https://confluence.eng.nutanix.com:8443/spaces/QA/pages/507307843/ST+10+PC+v3+v4+API+Coverage
    (Lists it under node lifecycle/discovery endpoints that require
    bare-metal unconfigured nodes for testing.)
- Code Definitions: The protobuf schemas for these models can be found in
  the Nutanix-Core `proto-cache` repository under
  `com/nutanix/platform/clu/clustermgmt/v4/config/config.proto`.

### Related engineering tickets / JIRA

- ENG-650384 — Read Only param `currentClusterFaultTolerance` needs
  validation in V4 API cluster create and update cluster —
  https://jira.nutanix.com/browse/ENG-650384

### Source documents / links surfaced by Glean

- ValidateNodeParam.py (SDK) —
  https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/clustermgmt/ntnx_clustermgmt_py_client/models/clustermgmt/v4/config/ValidateNodeParam.py
- ValidateNodeApiResponse.py (SDK) —
  https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/clustermgmt/ntnx_clustermgmt_py_client/models/clustermgmt/v4/config/ValidateNodeApiResponse.py
- ValidateNodeParam.py (nutest) —
  https://github.com/nutanix-engineering/hack2024-d1446/blob/main/nutest-py3-tests/my_nutest_virtual_env/lib/python3.9/site-packages/ntnx_clustermgmt_py_client/models/clustermgmt/v4/config/ValidateNodeParam.py
- ValidateNodeParamspec.py (OneOf) —
  https://github.com/nutanix-engineering/hack2024-d1446/blob/main/nutest-py3-tests/my_nutest_virtual_env/lib/python3.9/site-packages/ntnx_clustermgmt_py_client/models/OneOfclustermgmt/v4/config/ValidateNodeParamspec.py
- ClusterServiceImpl.java —
  https://github.com/nutanix-core/ntnx-api-clustermgmt/blob/main/clustermgmt-api-controller/src/main/java/com/nutanix/clustermgmtserver/services/impl/ClusterServiceImpl.java
- ClusterResourceAdapter.java —
  https://github.com/nutanix-core/ntnx-api-clustermgmt/blob/main/clustermgmt-api-controller/src/main/java/com/nutanix/clustermgmtserver/adapters/api/ClusterResourceAdapter.java
- BaseClusterResourceAdapterImpl.java —
  https://github.com/nutanix-core/ntnx-api-clustermgmt/blob/main/clustermgmt-api-controller/src/main/java/com/nutanix/clustermgmtserver/adapters/impl/BaseClusterResourceAdapterImpl.java
- ExpandClusterWorkflowImplTest.java —
  https://github.com/nutanix-core/ntnx-api-clustermgmt/blob/main/clustermgmt-api-controller/src/test/java/com/nutanix/clustermgmtserver/services/impl/ExpandClusterWorkflowImplTest.java
- validate_node_request.go (Go SDK) —
  https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/clustermgmt-go-client/models/clustermgmt/v4/request/clusters/validate_node_request.go
- clustermgmtDescriptions.yaml (API definitions) —
  https://github.com/nutanix-core/ntnx-api-clustermgmt/blob/main/clustermgmt-api-definitions/defs/namespaces/clustermgmt/etc/resources/documentation/bundles/en_US/clustermgmtDescriptions.yaml
- Playwright mock: validate-node —
  https://github.com/nutanix-engineering/hack2025-d1949/blob/main/prism/playwright/tests-pc/mocks/hw_clusters/expand_cluster/-api-clustermgmt-v4.0-config-clusters-0005b289-8340-119a-0000-00000000a31f-%24actions-validate-node.json
- cluster_expansion.py (workflow) —
  https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/entities/v4/cluster_mgmt/cluster_expansion.py
- object-type-mapping-17.3.1.3902-RELEASE.yaml —
  https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/api_artifacts/clustermgmt/v4.r1/clustermgmt-api-definitions-17.3.1.3902-RELEASE/object-type-mapping-17.3.1.3902-RELEASE.yaml
- config.proto —
  https://github.com/nutanix-core/proto-cache/blob/master/infra/infra_server/cluster/go/cluster/service/security_dashboard/vendor/github.com/nutanix-core/ntnx-api-security-dashboard/com/nutanix/platform/clu/clustermgmt/v4/config/config.proto

### Domain skills to learn

- Nutanix cluster expansion workflow (add-node / expand-cluster) and how it
  chains discovery, uplink validation, hypervisor bundle validation, and
  the expand-cluster action.
- Understanding of hypervisor bundles / hypervisor ISOs, MD5 sums, and the
  compatibility matrix between node model, NOS version and hypervisor type.
- Nutanix networking primitives: virtual switch (`vswitch_ext_id`), active
  / standby uplinks, bridges (`br0`, `br1`), CVM IPs vs Hypervisor IPs vs
  IPMI IPs, VLAN identifiers.
- Prism Central v4 clustermgmt API surface (`ClustersApi`), long-running
  task model (`task_ext_id` + `wait_for_completion`).
- How other Nutanix modules (`ntnx_clusters_nodes_v2`,
  `ntnx_discover_unconfigured_nodes_v2`, `ntnx_nodes_network_info_v2`,
  `ntnx_virtual_switch_v2`) fit together with node validation.

## Files changed

- `plugins/modules/ntnx_validate_node_uplinks_v2.py` — new action-type
  module. Follows the `ntnx_vm_revert_v2` structure and reuses the
  existing `ClustersApi` client, `SpecGenerator`, `wait_for_completion`,
  `raise_api_exception`, `strip_internal_attributes`. Exposes:
  - `cluster_ext_id` (required) — target Prism Element cluster UUID.
  - `bundle_param` (dict, mutually exclusive with `uplink_nodes`) —
    hypervisor bundle validation spec (`BundleParam`).
  - `uplink_nodes` (list of dicts, mutually exclusive with
    `bundle_param`) — one entry per candidate node (`UplinkNode`).
- `examples/cluster_management/Node/validate_node_uplinks_v2.yml` — new
  example playbook covering both validation paths.
- `tests/integration/targets/ntnx_validate_node_uplinks_v2/{aliases,meta,tasks}` —
  new integration test target with a 10-scenario test plan.
- `meta/runtime.yml` — added `ntnx_validate_node_uplinks_v2` to the
  `nutanix.ncp.ntnx` action group.
- `.gitignore` — ignore `tests/integration/integration_config.yml` (a
  credentials-bearing run artifact) and `tests/output/`.

## Test execution

| Metric              | Value                                                        |
|---------------------|--------------------------------------------------------------|
| Command             | `ansible-playbook /tmp/run_integration.yml -v`               |
| Total tests         | 26                                                           |
| Passed              | 26                                                           |
| Failed              | 0                                                            |
| Skipped             | 0                                                            |
| Duration            | ~11s                                                         |
| Cluster (PC)        | `10.44.76.28`                                                |

The playbook exercises 10 scenarios grouped into 26 individual tasks
(setup, spec-generation, assertion, negative and live calls):

1. `check_mode` uplinks spec with ALL fields — round-trips every attribute
   through `get_module_spec → SpecGenerator → SDK body`.
2. `check_mode` uplinks spec with only the required `cvm_ip`.
3. `check_mode` bundle_param spec with ALL fields (bundle_info + full
   `node_list` with IPv4/IPv6 addresses and digital-certificate map list).
4. `check_mode` bundle_param spec with only the required `bundle_info.name`.
5. Negative — `mutually_exclusive` (`bundle_param` + `uplink_nodes`).
6. Negative — `required_one_of` (neither `bundle_param` nor `uplink_nodes`).
7. Negative — missing required `cluster_ext_id`.
8. Negative — invalid `hypervisor_type` enum.
9. Live validate-node call for a hypervisor bundle (bundle intentionally
   missing on the cluster → server returns a legitimate legacy error
   "Bundle: … not found on any of the nodes"; module correctly surfaces it
   via `raise_api_exception`).
10. Live validate-node call for a list of uplink nodes — the API accepts
    the request as `list[UplinkNode]` and returns `status: SUCCEEDED`,
    `operation: Validate Uplinks Info`, `changed: true`.

Sanity: `ansible-test sanity plugins/modules/ntnx_validate_node_uplinks_v2.py --python 3.12`
was run inside `ansible_collections/nutanix/ncp/` (hardlink copy). All 24
sanity tests (`ansible-doc`, `compile`, `import`, `pep8`, `pylint`,
`validate-modules`, `yamllint`, `runtime-metadata`, …) passed.

Formatters: `black`, `isort`, `flake8` and `ansible-lint` all passed on the
module, the example playbook and the integration test target.

### Analysis

No failed tests. The 5 "ignored" tasks are the intentional negative
scenarios where the module (correctly) surfaces a validation error and
`ignore_errors: true` allows the following `assert` task to verify the
error message. The 1 `changed` task is the live `Validate Uplinks Info`
call which drives a real task on `10.44.76.28` to `SUCCEEDED`.

The one live bundle-validation task reports the API's own legacy error
because we intentionally referenced a non-existent bundle (`AHV-nonexistent-bundle-…iso`).
The module returns the full `ValidateNodeApiResponse` payload (including
`error_messages[]` and `legacy_error_message`) so a user can act on the
error — this is the exact behaviour a real caller would need. It is
therefore listed as a **behavioural assertion**, not a known issue.

### Test logs (tail)

<details>
<summary>tail integration test logs</summary>

```text
PLAY RECAP *********************************************************************
localhost                  : ok=26   changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=5
```

Full logs: retained locally at `/tmp/codegen-artifacts.7nCvWa/test_logs.log` (not committed as it is a run artifact).

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Reference modules: `ntnx_vm_revert_v2` (action pattern),
  `ntnx_virtual_switch_v2` / `ntnx_virtual_switches_info_v2` (RETURN block
  and spec-generator conventions), `ntnx_clusters_nodes_v2` (Node-related
  sub-schema shapes).
