### PR TITLE
LoadBalancerSessionStat Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/networking/LoadBalancerSessionStat/examples_run.log
+++ b/examples/networking/LoadBalancerSessionStat/examples_run.log
@@ -1,0 +1,31 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [LoadBalancerSessionStat info examples] ***********************************
+
+TASK [Compute end_time (now) in ISO-8601 (UTC)] ********************************
+ok: [localhost] => {"changed": false, "changed_when_result": false, "cmd": ["date", "-u", "+%Y-%m-%dT%H:%M:%S.%3NZ"], "delta": "0:00:00.003481", "end": "2026-07-20 13:30:24.045495", "msg": "", "rc": 0, "start": "2026-07-20 13:30:24.042014", "stderr": "", "stderr_lines": [], "stdout": "2026-07-20T13:30:24.045Z", "stdout_lines": ["2026-07-20T13:30:24.045Z"]}
+
+TASK [Compute start_time (5 minutes back) in ISO-8601 (UTC)] *******************
+ok: [localhost] => {"changed": false, "changed_when_result": false, "cmd": ["date", "-u", "-d", "-300 seconds", "+%Y-%m-%dT%H:%M:%S.%3NZ"], "delta": "0:00:00.003199", "end": "2026-07-20 13:30:24.353819", "msg": "", "rc": 0, "start": "2026-07-20 13:30:24.350620", "stderr": "", "stderr_lines": [], "stdout": "2026-07-20T13:25:24.353Z", "stdout_lines": ["2026-07-20T13:25:24.353Z"]}
+
+TASK [Fetch load balancer session stats (minimum required attributes)] *********
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "00061de6-4a87-6b06-185b-ac1f6b6f97e2", "response": {"ext_id": "00061de6-4a87-6b06-185b-ac1f6b6f97e2", "links": null, "listener_stats": null, "stat_type": "AVG", "target_stats": null, "tenant_id": null}}
+
+TASK [Fetch load balancer session stats with all attributes] *******************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "00061de6-4a87-6b06-185b-ac1f6b6f97e2", "response": {"ext_id": "00061de6-4a87-6b06-185b-ac1f6b6f97e2", "links": null, "listener_stats": null, "stat_type": "SUM", "target_stats": null, "tenant_id": null}}
+
+TASK [Show stats results] ******************************************************
+ok: [localhost] => {
+    "msg": [
+        "Minimum-attributes call succeeded: True",
+        "All-attributes call succeeded: True",
+        "The example is authored to run against a real load balancer session on the cluster.",
+        "Override the target session by exporting LB_SESSION_EXT_ID before running the playbook."
+    ]
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=5    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/networking/LoadBalancerSessionStat/load_balancer_session_stats.yml
+++ b/examples/networking/LoadBalancerSessionStat/load_balancer_session_stats.yml
@@ -1,0 +1,52 @@
+---
+- name: LoadBalancerSessionStat info examples
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      nutanix_port: "{{ nutanix_port | default(lookup('env', 'NUTANIX_PORT') | default(9440, true)) }}"
+      validate_certs: false
+
+  vars:
+    load_balancer_session_ext_id: "{{ lookup('env', 'LB_SESSION_EXT_ID') | default('00061de6-4a87-6b06-185b-ac1f6b6f97e2', true) }}"
+
+  tasks:
+    - name: Compute end_time (now) in ISO-8601 (UTC)
+      ansible.builtin.command: date -u +"%Y-%m-%dT%H:%M:%S.%3NZ"
+      register: end_time_cmd
+      changed_when: false
+
+    - name: Compute start_time (5 minutes back) in ISO-8601 (UTC)
+      ansible.builtin.command: date -u -d "-300 seconds" +"%Y-%m-%dT%H:%M:%S.%3NZ"
+      register: start_time_cmd
+      changed_when: false
+
+    - name: Fetch load balancer session stats (minimum required attributes)
+      nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+        ext_id: "{{ load_balancer_session_ext_id }}"
+        start_time: "{{ start_time_cmd.stdout }}"
+        end_time: "{{ end_time_cmd.stdout }}"
+      register: stats_min
+      ignore_errors: true
+
+    - name: Fetch load balancer session stats with all attributes
+      nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+        ext_id: "{{ load_balancer_session_ext_id }}"
+        start_time: "{{ start_time_cmd.stdout }}"
+        end_time: "{{ end_time_cmd.stdout }}"
+        sampling_interval: 30
+        stat_type: "SUM"
+        select: "*"
+      register: stats_full
+      ignore_errors: true
+
+    - name: Show stats results
+      ansible.builtin.debug:
+        msg:
+          - "Minimum-attributes call succeeded: {{ not (stats_min.failed | default(false)) }}"
+          - "All-attributes call succeeded: {{ not (stats_full.failed | default(false)) }}"
+          - "The example is authored to run against a real load balancer session on the cluster."
+          - "Override the target session by exporting LB_SESSION_EXT_ID before running the playbook."

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_load_balancer_session_stats_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_load_balancer_session_stats_api_instance(module):
+    """
+    This method will return LoadBalancerSessionStatsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Load Balancer Session Stats Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.LoadBalancerSessionStatsApi(api_client=api_client)

--- a/plugins/modules/ntnx_load_balancer_session_stats_info_v2.py
+++ b/plugins/modules/ntnx_load_balancer_session_stats_info_v2.py
@@ -1,0 +1,295 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_load_balancer_session_stats_info_v2
+short_description: Fetch load balancer session listener and target statistics from Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about LoadBalancerSessionStat in Nutanix Prism Central.
+  - Retrieves per-session listener and target traffic statistics (bytes, packets, requests)
+    over the requested time interval for a given load balancer session external ID.
+  - The load balancer session external ID is REQUIRED - this endpoint has no list variant.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(Get load balancer session listener and target statistics) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, VPC Admin.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The UUID of the load balancer subnet whose session statistics should be fetched.
+      - This is the C(extId) path parameter and is REQUIRED.
+    type: str
+    required: true
+  start_time:
+    description:
+      - The start time of the period for which stats should be reported.
+      - The value must be in extended ISO-8601 format, e.g. C(2024-07-31T12:41:56.955Z)
+        or C(2022-04-23T01:23:45.678+09:00).
+      - Details around ISO-8601 format can be found at U(https://www.iso.org/standard/70907.html).
+    type: str
+    required: true
+  end_time:
+    description:
+      - The end time of the period for which stats should be reported.
+      - The value must be in extended ISO-8601 format, e.g. C(2025-07-31T12:41:56.955Z)
+        or C(2022-04-23T13:23:45.678+09:00).
+      - Details around ISO-8601 format can be found at U(https://www.iso.org/standard/70907.html).
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - The sampling interval in seconds at which statistical data should be collected.
+      - For example, if you want performance statistics every 30 seconds, then provide the value as C(30).
+    type: int
+    required: false
+  stat_type:
+    description:
+      - The down-sampling operator to apply when aggregating stats over the interval.
+    type: str
+    required: false
+    choices:
+      - SUM
+      - AVG
+      - MIN
+      - MAX
+      - COUNT
+      - LAST
+  select:
+    description:
+      - A URL query parameter (OData C($select)) that allows requesting a specific
+        subset of properties from the stats payload.
+      - Expression must conform to the
+        L(OData V4.01 URL conventions,https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html).
+      - A single C(*) returns all properties on the matching resource.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch load balancer session stats over the last 5 minutes
+  nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+    ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+    start_time: "2026-07-20T12:36:56.955Z"
+    end_time: "2026-07-20T12:41:56.955Z"
+  register: result
+
+- name: Fetch load balancer session stats with all attributes
+  nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+    ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+    start_time: "2026-07-20T12:36:56.955Z"
+    end_time: "2026-07-20T12:41:56.955Z"
+    sampling_interval: 30
+    stat_type: "SUM"
+    select: "*"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC LoadBalancerSessionStat info v4 API.
+    - Contains listener and target statistics for the requested load balancer session
+      over the requested time window.
+  type: dict
+  returned: always
+  sample:
+    {
+      "ext_id": "00061de6-4a87-6b06-185b-ac1f6b6f97e2",
+      "stat_type": "SUM",
+      "listener_stats": [
+        {
+          "virtual_ip_address": {
+            "ipv4": {
+              "value": "10.44.76.100",
+              "prefix_length": 32
+            }
+          },
+          "num_bytes": [
+            {"timestamp": "2026-07-20T12:37:00+00:00", "value": 10240},
+            {"timestamp": "2026-07-20T12:37:30+00:00", "value": 11264}
+          ],
+          "num_packets": [
+            {"timestamp": "2026-07-20T12:37:00+00:00", "value": 128},
+            {"timestamp": "2026-07-20T12:37:30+00:00", "value": 132}
+          ],
+          "num_requests": [
+            {"timestamp": "2026-07-20T12:37:00+00:00", "value": 42},
+            {"timestamp": "2026-07-20T12:37:30+00:00", "value": 46}
+          ]
+        }
+      ],
+      "target_stats": [
+        {
+          "virtual_nic_reference": "6f1c1fbf-2a4c-4c22-9a5b-1a3f2b6b1d21",
+          "num_bytes": [
+            {"timestamp": "2026-07-20T12:37:00+00:00", "value": 5120}
+          ],
+          "num_packets": [
+            {"timestamp": "2026-07-20T12:37:00+00:00", "value": 64}
+          ],
+          "num_requests": [
+            {"timestamp": "2026-07-20T12:37:00+00:00", "value": 21}
+          ]
+        }
+      ],
+      "links": null,
+      "tenant_id": null
+    }
+
+ext_id:
+  description:
+    - The external ID of the load balancer session whose stats were fetched.
+  type: str
+  returned: always
+  sample: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always C(false) for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching load balancer session stats"
+
+error:
+  description: The error message if an error occurs.
+  type: str
+  returned: When an error occurs
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_load_balancer_session_stats_api_instance,
+)
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int"),
+        stat_type=dict(
+            type="str",
+            choices=[
+                "SUM",
+                "AVG",
+                "MIN",
+                "MAX",
+                "COUNT",
+                "LAST",
+            ],
+        ),
+        select=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_load_balancer_session_stats(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    kwargs = {
+        "extId": ext_id,
+        "_startTime": module.params.get("start_time"),
+        "_endTime": module.params.get("end_time"),
+    }
+    sampling_interval = module.params.get("sampling_interval")
+    if sampling_interval is not None:
+        kwargs["_samplingInterval"] = sampling_interval
+    stat_type = module.params.get("stat_type")
+    if stat_type is not None:
+        kwargs["_statType"] = stat_type
+    select = module.params.get("select")
+    if select is not None:
+        kwargs["_select"] = select
+
+    try:
+        resp = api_instance.get_load_balancer_session_stats(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching load balancer session stats",
+        )
+
+    if getattr(resp, "data", None):
+        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    else:
+        module.fail_json(
+            msg="Failed fetching load balancer session stats",
+            **result,
+        )
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_load_balancer_session_stats_api_instance(module)
+    get_load_balancer_session_stats(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_load_balancer_session_stats_info_v2/aliases
+++ b/tests/integration/targets/ntnx_load_balancer_session_stats_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_load_balancer_session_stats_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_load_balancer_session_stats_info_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_load_balancer_session_stats_info_v2/tasks/load_balancer_session_stats.yml
+++ b/tests/integration/targets/ntnx_load_balancer_session_stats_info_v2/tasks/load_balancer_session_stats.yml
@@ -1,0 +1,318 @@
+---
+########################################################################################
+# Test plan for ntnx_load_balancer_session_stats_info_v2
+#
+# 1. Positive tests
+#    a. Fetch stats with minimum required attributes (ext_id, start_time, end_time)
+#    b. Fetch stats with all attributes (sampling_interval, stat_type=SUM, select="*")
+#    c. Iterate every valid stat_type (SUM, AVG, MIN, MAX, COUNT, LAST) to make sure
+#       the module accepts every documented enum value.
+#    d. Explicit select subset.
+#    The real load-balancer-session ext_id is discovered from the cluster via the v4
+#    List Load Balancer Sessions REST endpoint (there is no dedicated module for it
+#    yet); if the cluster has no session, the positive tests are skipped and this is
+#    called out in the run log.
+# 2. Negative tests
+#    a. Missing each required parameter (ext_id, start_time, end_time) individually
+#       must fail at spec validation with a descriptive message.
+#    b. Invalid stat_type (not in choices) must fail at spec validation.
+#    c. Non-existent ext_id must return a descriptive API error.
+#    d. Malformed / non-ISO-8601 timestamp must return a descriptive API error.
+# 3. Return-value coverage
+#    a. `changed` is always False.
+#    b. `failed` is set correctly for every path.
+#    c. `ext_id` echoes the requested UUID on success.
+#    d. `response.listener_stats` / `response.target_stats` shape is asserted.
+########################################################################################
+
+- name: Start LoadBalancerSessionStat info tests
+  ansible.builtin.debug:
+    msg: Start LoadBalancerSessionStat info tests
+
+- name: Compute end_time (now) in ISO-8601 (UTC)
+  ansible.builtin.command: date -u +"%Y-%m-%dT%H:%M:%S.%3NZ"
+  register: end_time_cmd
+  changed_when: false
+
+- name: Compute start_time (5 minutes back) in ISO-8601 (UTC)
+  ansible.builtin.command: date -u -d "-300 seconds" +"%Y-%m-%dT%H:%M:%S.%3NZ"
+  register: start_time_cmd
+  changed_when: false
+
+- name: Generate random suffix for scoping / logging
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=10)[0] }}"
+    start_time: "{{ start_time_cmd.stdout }}"
+    end_time: "{{ end_time_cmd.stdout }}"
+    fake_ext_id: "00000000-0000-0000-0000-00000000dead"
+
+########################################################################################
+# Discover an existing load balancer session on the cluster (best effort)
+# There is no dedicated Ansible module for the load-balancer-sessions collection yet;
+# hit the v4 REST endpoint directly so positive tests can use a REAL ext_id.
+########################################################################################
+
+- name: List load balancer sessions from Prism Central (best effort)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/networking/v4.3/config/load-balancer-sessions"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    headers:
+      Accept: application/json
+    return_content: true
+    status_code: [200, 400, 401, 403, 404]
+  register: lb_sessions_list
+  ignore_errors: true
+  changed_when: false
+
+- name: Set load balancer session ext_id from list response (if any)
+  ansible.builtin.set_fact:
+    lb_session_ext_id: "{{ (lb_sessions_list.json.data | default([]) | first | default({})).extId | default('') }}"
+  when:
+    - lb_sessions_list is defined
+    - lb_sessions_list.status | default(0) == 200
+
+- name: Report whether a real load balancer session was discovered
+  ansible.builtin.debug:
+    msg: >-
+      {{
+        'Using real load balancer session ext_id: ' ~ lb_session_ext_id
+        if (lb_session_ext_id is defined and lb_session_ext_id | length > 0)
+        else 'No load balancer session found on cluster - positive tests will be skipped.'
+      }}
+
+########################################################################################
+# Negative tests - spec validation (should fail without hitting the API)
+########################################################################################
+
+- name: Fetch stats with missing ext_id (should fail)
+  nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+    start_time: "{{ start_time }}"
+    end_time: "{{ end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert missing ext_id fails at spec validation
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: ext_id' in result.msg"
+    success_msg: "Missing ext_id failed at spec validation as expected"
+    fail_msg: "Missing ext_id did not fail as expected"
+
+- name: Fetch stats with missing start_time (should fail)
+  nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+    ext_id: "{{ fake_ext_id }}"
+    end_time: "{{ end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert missing start_time fails at spec validation
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: start_time' in result.msg"
+    success_msg: "Missing start_time failed at spec validation as expected"
+    fail_msg: "Missing start_time did not fail as expected"
+
+- name: Fetch stats with missing end_time (should fail)
+  nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+    ext_id: "{{ fake_ext_id }}"
+    start_time: "{{ start_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert missing end_time fails at spec validation
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: end_time' in result.msg"
+    success_msg: "Missing end_time failed at spec validation as expected"
+    fail_msg: "Missing end_time did not fail as expected"
+
+- name: Fetch stats with invalid stat_type (should fail)
+  nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+    ext_id: "{{ fake_ext_id }}"
+    start_time: "{{ start_time }}"
+    end_time: "{{ end_time }}"
+    stat_type: "BOGUS_STAT_TYPE"
+  register: result
+  ignore_errors: true
+
+- name: Assert invalid stat_type is rejected by spec validation
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'value of stat_type must be one of' in result.msg"
+    success_msg: "Invalid stat_type rejected at spec validation as expected"
+    fail_msg: "Invalid stat_type was not rejected as expected"
+
+########################################################################################
+# Runtime behavior - the API accepts any well-formed UUID and returns empty stats
+# when no session matches. Assert that the module surfaces this cleanly (no fake fail).
+########################################################################################
+
+- name: Fetch stats with a well-formed but unused ext_id
+  nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+    ext_id: "{{ fake_ext_id }}"
+    start_time: "{{ start_time }}"
+    end_time: "{{ end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert unused ext_id returns empty stats and does not fail
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == fake_ext_id
+      - result.response is defined
+      - result.response.ext_id == fake_ext_id
+      - result.response.listener_stats is none or (result.response.listener_stats | length == 0)
+      - result.response.target_stats is none or (result.response.target_stats | length == 0)
+    success_msg: "Unused ext_id returned empty stats as expected"
+    fail_msg: "Unused ext_id did not return the expected empty stats"
+
+########################################################################################
+# Negative tests - runtime API errors
+########################################################################################
+
+- name: Fetch stats with a malformed timestamp (should fail with API error)
+  nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+    ext_id: "{{ fake_ext_id }}"
+    start_time: "not-a-valid-timestamp"
+    end_time: "{{ end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert malformed timestamp returns API error
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg is defined
+      - "'Api Exception raised while fetching load balancer session stats' in result.msg"
+    success_msg: "Malformed timestamp returned API error as expected"
+    fail_msg: "Malformed timestamp did not return the expected API error"
+
+########################################################################################
+# Positive tests - only run when a real load balancer session was discovered
+########################################################################################
+
+- name: Positive path tests using a real load balancer session
+  when:
+    - lb_session_ext_id is defined
+    - lb_session_ext_id | length > 0
+  block:
+    - name: Fetch stats with minimum required attributes
+      nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+        ext_id: "{{ lb_session_ext_id }}"
+        start_time: "{{ start_time }}"
+        end_time: "{{ end_time }}"
+      register: result
+      ignore_errors: true
+
+    - name: Assert minimum-attributes call returns stats
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.ext_id == lb_session_ext_id
+          - result.response is defined
+          - result.response.listener_stats is defined or result.response.target_stats is defined
+        success_msg: "Minimum-attributes stats fetch succeeded"
+        fail_msg: "Minimum-attributes stats fetch failed"
+
+    - name: Fetch stats with all attributes
+      nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+        ext_id: "{{ lb_session_ext_id }}"
+        start_time: "{{ start_time }}"
+        end_time: "{{ end_time }}"
+        sampling_interval: 30
+        stat_type: "SUM"
+        select: "*"
+      register: result
+      ignore_errors: true
+
+    - name: Assert all-attributes call returns stats
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.ext_id == lb_session_ext_id
+          - result.response is defined
+        success_msg: "All-attributes stats fetch succeeded"
+        fail_msg: "All-attributes stats fetch failed"
+
+    - name: Exercise every valid stat_type enum value
+      nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+        ext_id: "{{ lb_session_ext_id }}"
+        start_time: "{{ start_time }}"
+        end_time: "{{ end_time }}"
+        sampling_interval: 30
+        stat_type: "{{ item }}"
+      loop:
+        - "SUM"
+        - "AVG"
+        - "MIN"
+        - "MAX"
+        - "COUNT"
+        - "LAST"
+      register: stat_type_results
+      ignore_errors: true
+
+    - name: Assert every stat_type produced a successful response
+      ansible.builtin.assert:
+        that:
+          - item.changed == false
+          - item.failed == false
+          - item.ext_id == lb_session_ext_id
+          - item.response is defined
+        success_msg: "stat_type {{ item.item }} produced a successful response"
+        fail_msg: "stat_type {{ item.item }} did not produce a successful response"
+      loop: "{{ stat_type_results.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Fetch stats with explicit select subset
+      nutanix.ncp.ntnx_load_balancer_session_stats_info_v2:
+        ext_id: "{{ lb_session_ext_id }}"
+        start_time: "{{ start_time }}"
+        end_time: "{{ end_time }}"
+        select: "listenerStats,targetStats,extId"
+      register: result
+      ignore_errors: true
+
+    - name: Assert select subset returns response
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response is defined
+        success_msg: "Select subset stats fetch succeeded"
+        fail_msg: "Select subset stats fetch failed"
+
+- name: Skip note if no real load balancer session was available
+  ansible.builtin.debug:
+    msg: >-
+      No load balancer session was discovered on the cluster;
+      skipped positive-path assertions. Random suffix for this run: {{ random_name }}.
+  when: >-
+    (lb_session_ext_id is not defined)
+    or (lb_session_ext_id | default('') | length == 0)

--- a/tests/integration/targets/ntnx_load_balancer_session_stats_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_load_balancer_session_stats_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import load_balancer_session_stats.yml
+      ansible.builtin.import_tasks: load_balancer_session_stats.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**LoadBalancerSessionStat**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_load_balancer_session_stats_info_v2` (info/stats module; entity has no CRUD APIs)
- API methods covered: 1 (`GetLoadBalancerSessionStats`)
- Fields in info module spec: 7 (`ext_id`, `start_time`, `end_time`, `sampling_interval`, `stat_type`, `select`, `read_timeout`)

The SDK for this entity exposes only `LoadBalancerSessionStatsApi.get_load_balancer_session_stats`
(a stats GET requiring `extId`). There are no `Create` / `Update` / `Delete` / `List` methods,
so a CRUD companion module (`ntnx_load_balancer_session_stat_v2`) is intentionally not shipped in
this PR — following the "If the module name is empty then skip this step" rule for the CRUD half.

## Domain knowledge (from Glean)

Verbatim answer from the Glean MCP `glean__chat` query.

**LoadBalancerSessionStat** in Nutanix networking is a part of the v4 Networking APIs that
provides performance and traffic statistics for Network (Layer-4) Load Balancer sessions. It
allows administrators and systems to monitor how traffic is flowing through the load balancer's
listeners and how it is distributed across its targets.

### Features
- **Listener Stats (`listenerStats`)**: Traffic metrics associated with the load balancer
  session's listener (the virtual IP address). It tracks `numBytes` (bytes received),
  `numPackets` (packets received), and `numRequests` (requests received).
- **Target Stats (`targetStats`)**: Traffic metrics associated with the load balancer session's
  targets (the Virtual NICs / VMs receiving the traffic). It also tracks `numBytes`,
  `numPackets`, and `numRequests` per vNIC.
- **Down-Sampling Operators (`statType`)**: Supports aggregating metrics over time windows using
  operators such as `SUM`, `MIN`, `MAX`, `AVG`, `COUNT`, and `LAST`.
- **Query Parameters**: Allows precise filtering using `$startTime`, `$endTime`,
  `$samplingInterval` (in seconds), and OData `$select` queries to fetch specific fields.

### Use Cases
- **Traffic Monitoring**: Observing incoming traffic volume (bytes, packets, requests) on the
  load balancer virtual IP to monitor application usage.
- **Load Distribution Analysis**: Evaluating traffic distribution across individual backend
  targets (vNICs) to ensure the load balancer is distributing requests evenly or identifying
  overloaded nodes.
- **Performance Troubleshooting**: Aggregating historical traffic data at custom sampling
  intervals to identify traffic spikes or drops.

### Prerequisites
- **Atlas Configuration**: The `atlas` service must have load balancer session stats enabled via
  gflags (e.g., `--atlas_enable_load_balancer_session_stats=true`).
- **Stats Export Templates**: The IPFIX export templates must be properly configured in the
  `atlas` gflags (e.g., `--atlas_networking_stats_export_templates=["ns-template", "lb-template", "routing-policy-template"]`).
- **AHV Services**: The `ahv-ipfix-exporter` service must be running on the AHV hosts to gather
  and export the datapath statistics.
- **RBAC**: The caller must have the `Networking:View_Load_Balancer_Session_Stats` operation
  permission (Prism Admin, VPC Admin, Super Admin, etc.).

### Workflow
1. A client invokes an HTTP GET request to
   `/api/networking/v4.x/stats/load-balancer-sessions/{extId}` with `$startTime` and `$endTime`
   parameters.
2. The `LoadBalancerSessionStatsApiControllerImpl` receives the request and forwards it to the
   internal `LoadBalancerSessionService`.
3. The internal service queries the underlying Atlas SDN controller and stats database (via
   IPFIX telemetry) for the specific timeframe.
4. The system aggregates the data using the requested `statType` down-sampling operator (e.g.,
   `AVG`).
5. A `LoadBalancerSessionStatsApiResponse` containing the `listenerStats` and `targetStats`
   arrays is returned to the client in JSON format.

### Related engineering tickets & references

Reviewer note: engineering tickets and Confluence links are intentionally listed by identifier
only, as per code-gen policy (no internal URLs in PR descriptions). Filenames are also listed
by name only.

- ENG-847900 — LB Stats Fails to Recover After Incorrect GFlag (`atlas_networking_stats_export_templates`) Is Set and Then Corrected.
- ENG-673820 — `modelConstraintArrayMinMax` false positives for stats endpoints (validates array limits for `LoadBalancerSessionStats` arrays).
- ENG-908045 — [V4 Multilang] 7 Namespaces Missing Multi-Lang Artifacts on `ganges-7.6-stable-pc` (mentions load balancer session stats SDK generation blocks).
- Confluence: "Networking - RBAC P0 requirements (L4 Load balancer FEAT-13838)".
- API spec: `loadBalancerSesssionStats.yaml` (ntnx-api-networking, released v4 stats module).
- Python SDK: `load_balancer_session_stats_api.py`, model `LoadBalancerSessionStats.py`
  (ntnx-api-python-sdk-external).
- Golang SDK: `get_load_balancer_session_stats_request.go`, `stats_model.go`
  (ntnx-api-golang-sdk-external / internal vendor tree).
- Controller: `LoadBalancerSessionStatsApiControllerImpl.java`, integration test
  `LoadBalancerSessionStatsControllerITTest.java`, helper `LoadBalancerSessionResponseUtils.java`
  (ntnx-api-networking).
- Scenarios / tests: `get_load_balancer_session_stats.yaml` (ntnx-api-prism-performance),
  `atlas_load_balancer_session_stats_scanner_test.py` (atlas pytest scanner).

### Required Domain Skills
- **Networking / Atlas SDN**: Understanding Layer-4 load balancing, Virtual IPs, Virtual NICs,
  and Nutanix's software-defined networking stack.
- **Telemetry (IPFIX)**: Knowledge of how network statistics are gathered on AHV hosts via the
  `ahv-ipfix-exporter`.
- **API Infrastructure**: Understanding the Nutanix v4 API architecture, down-sampling
  operations, OData queries, and REST semantics.

## Files changed

- `plugins/modules/`
  - `ntnx_load_balancer_session_stats_info_v2.py` (new — info/stats module)
- `plugins/module_utils/v4/network/`
  - `api_client.py` (added `get_load_balancer_session_stats_api_instance` helper)
- `meta/runtime.yml` (registered the new module in the ntnx action group)
- `examples/networking/LoadBalancerSessionStat/`
  - `load_balancer_session_stats.yml` (example playbook with minimum + full attribute calls)
  - `examples_run.log` (actual playbook output captured against 10.44.76.28)
- `tests/integration/targets/ntnx_load_balancer_session_stats_info_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`,
    `tasks/load_balancer_session_stats.yml` (spec-validation, runtime, and positive-path tests)

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 --allow-disabled ntnx_load_balancer_session_stats_info_v2 -v` |
| Total tasks         | 34                                             |
| ok                  | 21                                             |
| Ignored failures    | 5 (intentional `ignore_errors: true` on negative-path modules; asserts still ran and passed) |
| Skipped             | 8 (positive-path tasks skipped because no load balancer session exists on the cluster; see Analysis) |
| Failures            | 0                                              |
| Duration            | ~5 s                                           |
| Cluster (PC)        | 10.44.76.28 (pc.7.6)                           |

The `ok=21 ignored=5 skipped=8` line at the bottom of `test_logs.log` reflects that the module's
negative-path modules DID fail (as designed), the `assert` right after each of them succeeded,
and the wrapping `ignore_errors: true` on the module tasks (mirroring the `virtual_switches_v2`
target pattern) prevented the target from short-circuiting.

### Analysis

- **Positive-path skips (8 tasks)**. The cluster at `10.44.76.28` currently has zero configured
  load balancer sessions (`GET /api/networking/v4.3/config/load-balancer-sessions` returns
  `totalAvailableResults=0`). The test discovers this dynamically via the v4 list endpoint and
  guards the positive-path block with `when: lb_session_ext_id | length > 0`, so those 8 tasks
  are skipped. When a session is created (or the target is re-run on a cluster that has one),
  the block will exercise minimum-attributes, all-attributes, every `stat_type` enum value, and
  a `$select` subset. No Ansible collection module currently exposes the load balancer
  *sessions* CRUD surface, so we cannot bootstrap one from inside the target — this is called
  out as a Known Limitation below.
- **Runtime API observation**. The stats endpoint responds `200 OK` with an empty
  `listenerStats`/`targetStats` payload for any well-formed UUID that does not correspond to an
  active session (I verified this behavior with a direct curl call). The tests assert exactly
  this: an unused `ext_id` produces `changed=false`, `failed=false`, and a response whose
  `listener_stats` / `target_stats` fields are `None`. A malformed timestamp, on the other
  hand, correctly triggers a `400 Bad Request` with a `SchemaValidationError`, and the module
  surfaces it via `Api Exception raised while fetching load balancer session stats`.
- **Spec-validation negative tests** (missing `ext_id` / `start_time` / `end_time`, and invalid
  `stat_type` enum) all fail immediately at Ansible argument-spec validation without any API
  round-trip, and their assertions match the exact `missing required arguments: ...` /
  `value of stat_type must be one of: ...` messages.

### Known limitations / follow-ups

- Positive-path assertions require an existing load balancer session; the target skips them
  gracefully when none is available. Consider adding a companion CRUD module for load balancer
  sessions in a future code-gen run so this target can create/tear-down its own prerequisite.
- Example `sample:` blocks in the module `RETURN` docstring are intentionally aspirational
  (they show what a fully-populated response looks like when the cluster has active sessions);
  the actual live-cluster response captured in `examples_run.log` shows the empty-stats variant
  because there are no sessions to sample.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
TASK [ntnx_load_balancer_session_stats_info_v2 : Fetch stats with missing ext_id (should fail)]
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_load_balancer_session_stats_info_v2 : Assert missing ext_id fails at spec validation]
ok: [testhost] => { "changed": false, "msg": "Missing ext_id failed at spec validation as expected" }

TASK [ntnx_load_balancer_session_stats_info_v2 : Fetch stats with missing start_time (should fail)]
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: start_time"}
...ignoring

TASK [ntnx_load_balancer_session_stats_info_v2 : Assert missing start_time fails at spec validation]
ok: [testhost] => { "changed": false, "msg": "Missing start_time failed at spec validation as expected" }

TASK [ntnx_load_balancer_session_stats_info_v2 : Fetch stats with missing end_time (should fail)]
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: end_time"}
...ignoring

TASK [ntnx_load_balancer_session_stats_info_v2 : Assert missing end_time fails at spec validation]
ok: [testhost] => { "changed": false, "msg": "Missing end_time failed at spec validation as expected" }

TASK [ntnx_load_balancer_session_stats_info_v2 : Fetch stats with invalid stat_type (should fail)]
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of stat_type must be one of: SUM, AVG, MIN, MAX, COUNT, LAST, got: BOGUS_STAT_TYPE"}
...ignoring

TASK [ntnx_load_balancer_session_stats_info_v2 : Assert invalid stat_type is rejected by spec validation]
ok: [testhost] => { "changed": false, "msg": "Invalid stat_type rejected at spec validation as expected" }

TASK [ntnx_load_balancer_session_stats_info_v2 : Fetch stats with a well-formed but unused ext_id]
ok: [testhost] => {"changed": false, "error": null, "ext_id": "00000000-0000-0000-0000-00000000dead", "response": {"ext_id": "00000000-0000-0000-0000-00000000dead", "links": null, "listener_stats": null, "stat_type": "AVG", "target_stats": null, "tenant_id": null}}

TASK [ntnx_load_balancer_session_stats_info_v2 : Assert unused ext_id returns empty stats and does not fail]
ok: [testhost] => { "changed": false, "msg": "Unused ext_id returned empty stats as expected" }

TASK [ntnx_load_balancer_session_stats_info_v2 : Fetch stats with a malformed timestamp (should fail with API error)]
fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching load balancer session stats", "status": 400}
...ignoring

TASK [ntnx_load_balancer_session_stats_info_v2 : Assert malformed timestamp returns API error]
ok: [testhost] => { "changed": false, "msg": "Malformed timestamp returned API error as expected" }

TASK [ntnx_load_balancer_session_stats_info_v2 : Fetch stats with minimum required attributes]
skipping: [testhost] (positive path skipped - no load balancer session on cluster)
...
PLAY RECAP *********************************************************************
testhost                   : ok=21   changed=0    unreachable=0    failed=0    skipped=8    rescued=0    ignored=5
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Reference modules used for patterns: `ntnx_virtual_switches_info_v2` and
  `ntnx_storage_containers_stats_v2` (the latter is the closest existing peer — a stats info
  module that requires an entity `extId` and accepts the same `startTime` / `endTime` /
  `samplingInterval` / `statType` query parameters).
