### PR TITLE
LearnedMacAddressesByLayer2StretchId Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/networking/LearnedMacAddressesByLayer2StretchId/examples_run.log
+++ b/examples/networking/LearnedMacAddressesByLayer2StretchId/examples_run.log
@@ -1,0 +1,33 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [LearnedMacAddressesByLayer2StretchId playbook] ***************************
+
+TASK [Set variables for the playbook] ******************************************
+ok: [localhost] => {"ansible_facts": {"layer2_stretch_ext_id": "6be8fe36-9612-4fab-aabb-2c02207c794d", "learned_mac_ext_id": "d4f3f04f-1222-8544-7896-28b62bcc3e3e"}, "changed": false}
+
+TASK [List all learned MAC addresses of a Layer2 Stretch] **********************
+ok: [localhost] => {"changed": false, "layer2_stretch_ext_id": "6be8fe36-9612-4fab-aabb-2c02207c794d", "response": [], "total_available_results": 0}
+
+TASK [List learned MAC addresses with a limit of 1] ****************************
+ok: [localhost] => {"changed": false, "layer2_stretch_ext_id": "6be8fe36-9612-4fab-aabb-2c02207c794d", "response": [], "total_available_results": 0}
+
+TASK [List learned MAC addresses with a specific page and limit] ***************
+ok: [localhost] => {"changed": false, "layer2_stretch_ext_id": "6be8fe36-9612-4fab-aabb-2c02207c794d", "response": [], "total_available_results": 0}
+
+TASK [Fetch a specific learned MAC address by external ID] *********************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching learned MAC address info using ext_id and layer2_stretch_ext_id
+Origin: /tmp/codegen/f1933bb5b1804310a9683eae26c56a22/repo/examples/networking/LearnedMacAddressesByLayer2StretchId/learned_mac_addresses_by_layer2_stretch_ids_info_v2.yml:56:7
+
+54       ignore_errors: true
+55
+56     - name: Fetch a specific learned MAC address by external ID
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching learned MAC address info using ext_id and layer2_stretch_ext_id", "response": {"$objectType": "networking.v4.config.GetLayer2StretchApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get l2stretch 6be8fe36-9612-4fab-aabb-2c02207c794d learned MAC addr d4f3f04f-1222-8544-7896-28b62bcc3e3e as a referenced resource was not found - Mac Address d4f3f04f-1222-8544-7896-28b62bcc3e3e not found on Prism Central cluster 6be8fe36-9612-4fab-aabb-2c02207c794d", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/layer2-stretches/6be8fe36-9612-4fab-aabb-2c02207c794d/learned-mac-addresses/d4f3f04f-1222-8544-7896-28b62bcc3e3e", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=5    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
+

--- a/examples/networking/LearnedMacAddressesByLayer2StretchId/learned_mac_addresses_by_layer2_stretch_ids_info_v2.yml
+++ b/examples/networking/LearnedMacAddressesByLayer2StretchId/learned_mac_addresses_by_layer2_stretch_ids_info_v2.yml
@@ -1,0 +1,61 @@
+---
+# Summary:
+# This playbook demonstrates use of the info module for learned MAC addresses
+# on a Nutanix Layer2 Stretch:
+# 1. List all learned MAC addresses on a Layer2 Stretch
+# 2. List learned MAC addresses with a page limit
+# 3. List learned MAC addresses with a specific page
+# 4. Fetch a single learned MAC address using its external ID
+#
+# Note: This is a read-only feature. Learned MAC addresses are populated by
+# the VXLAN Tunnel Endpoints (VTEPs) as they observe traffic on the stretched
+# Layer 2 domain. There are no create/update/delete operations exposed by
+# the API for this resource. The SDK also exposes ``filter`` and ``orderby``
+# query parameters via the info module, but the server (as of v4.3) does not
+# implement OData ``$filter`` / ``$orderby`` on this endpoint, so those two
+# options are omitted from the working example — see the module documentation
+# if you want to try them anyway.
+
+- name: LearnedMacAddressesByLayer2StretchId playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') | default('<pc_ip>', true) }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') | default('<user>', true) }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') | default('<pass>', true) }}"
+      nutanix_port: "{{ lookup('env', 'NUTANIX_PORT') | default(9440, true) }}"
+      validate_certs: false
+  tasks:
+    - name: Set variables for the playbook
+      ansible.builtin.set_fact:
+        layer2_stretch_ext_id: "6be8fe36-9612-4fab-aabb-2c02207c794d"
+        learned_mac_ext_id: "d4f3f04f-1222-8544-7896-28b62bcc3e3e"
+
+    - name: List all learned MAC addresses of a Layer2 Stretch
+      nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+        layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+      register: all_learned_macs
+      ignore_errors: true
+
+    - name: List learned MAC addresses with a limit of 1
+      nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+        layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+        limit: 1
+      register: limited_learned_macs
+      ignore_errors: true
+
+    - name: List learned MAC addresses with a specific page and limit
+      nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+        layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+        page: 0
+        limit: 5
+      register: paginated_learned_macs
+      ignore_errors: true
+
+    - name: Fetch a specific learned MAC address by external ID
+      nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+        layer2_stretch_ext_id: "{{ layer2_stretch_ext_id }}"
+        ext_id: "{{ learned_mac_ext_id }}"
+      register: single_learned_mac
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,16 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_mac_addresses_api_instance(module):
+    """
+    This method will return MacAddressesApi instance used to fetch learned
+    MAC addresses of a Layer2 Stretch.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): MacAddressesApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.MacAddressesApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,27 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_learned_mac_address(module, api_instance, ext_id, layer2_stretch_ext_id):
+    """
+    This method will return a specific learned MAC address for a Layer2Stretch
+    using the MAC address external ID and its parent Layer2Stretch external ID.
+    Args:
+        module (object): Ansible module object
+        api_instance (object): MacAddressesApi instance from ntnx_networking_py_client sdk
+        ext_id (str): learned MAC address external ID
+        layer2_stretch_ext_id (str): Layer2Stretch external ID that owns this MAC address
+    return:
+        info (object): learned MAC address info
+    """
+    try:
+        return api_instance.get_learned_mac_address_for_layer2_stretch_by_id(
+            extId=ext_id, layer2StretchExtId=layer2_stretch_ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching learned MAC address info using ext_id and layer2_stretch_ext_id",
+        )

--- a/plugins/modules/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2.py
+++ b/plugins/modules/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2.py
@@ -1,0 +1,250 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2
+short_description: Fetch learned MAC addresses of a Layer2 Stretch in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about LearnedMacAddressesByLayer2StretchId in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific LearnedMacAddressesByLayer2StretchId.
+  - If C(ext_id) is not provided, list multiple LearnedMacAddressesByLayer2StretchId optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(Get a learned MAC address of a Layer2Stretch by ext_id) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, VPC Admin
+  - >-
+    B(List learned MAC addresses of a Layer2Stretch) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, VPC Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - External ID of the learned MAC address to fetch.
+      - When provided, the module fetches only the specified learned MAC address.
+      - When omitted, the module lists all learned MAC addresses for the given Layer2Stretch.
+    type: str
+  layer2_stretch_ext_id:
+    description:
+      - External ID of the Layer2Stretch that owns the learned MAC addresses.
+      - This field is mandatory for both C(get by ext_id) and C(list) operations because
+        every learned MAC address is scoped to a specific Layer2Stretch.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all learned MAC addresses of a Layer2 Stretch
+  nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+    layer2_stretch_ext_id: "6be8fe36-9612-4fab-aabb-2c02207c794d"
+  register: result
+
+- name: Fetch a specific learned MAC address by external ID
+  nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+    layer2_stretch_ext_id: "6be8fe36-9612-4fab-aabb-2c02207c794d"
+    ext_id: "d4f3f04f-1222-8544-7896-28b62bcc3e3e"
+  register: result
+
+- name: List learned MAC addresses with a filter on macType
+  nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+    layer2_stretch_ext_id: "6be8fe36-9612-4fab-aabb-2c02207c794d"
+    filter: "macType eq Networking.Config.MacType'LEARNED'"
+  register: result
+
+- name: List learned MAC addresses with a limit of 1
+  nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+    layer2_stretch_ext_id: "6be8fe36-9612-4fab-aabb-2c02207c794d"
+    limit: 1
+  register: result
+
+- name: List learned MAC addresses ordered by value ascending
+  nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+    layer2_stretch_ext_id: "6be8fe36-9612-4fab-aabb-2c02207c794d"
+    orderby: "value asc"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC LearnedMacAddressesByLayer2StretchId info v4 API.
+    - It can be a single LearnedMacAddressesByLayer2StretchId if external ID is provided.
+    - List of multiple LearnedMacAddressesByLayer2StretchId if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "d4f3f04f-1222-8544-7896-28b62bcc3e3e",
+      "value": "50:6b:8d:9f:00:11",
+      "mac_type": "LEARNED",
+      "remote_gateway_reference": "2338b378-0cec-4894-ba06-dbecd72b851f",
+      "vtep_ip_address": {
+          "ipv4": {
+              "value": "10.44.76.100",
+              "prefix_length": 32
+          },
+          "ipv6": null
+      },
+      "metadata": null,
+      "tenant_id": null,
+      "links": null
+    }
+
+ext_id:
+  description: External ID of the learned MAC address (only when C(ext_id) input was provided).
+  type: str
+  returned: when external ID is provided
+  sample: "d4f3f04f-1222-8544-7896-28b62bcc3e3e"
+
+layer2_stretch_ext_id:
+  description: External ID of the parent Layer2Stretch.
+  type: str
+  returned: always
+  sample: "6be8fe36-9612-4fab-aabb-2c02207c794d"
+
+total_available_results:
+  description: The total number of available learned MAC addresses on the specified Layer2Stretch.
+  type: int
+  returned: when all learned MAC addresses are fetched
+  sample: 3
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+failed:
+  description: This field indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Status/error message returned by the module.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching learned MAC addresses info"
+
+error:
+  description: Error details from the SDK/API call.
+  type: str
+  returned: when an error occurs
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_mac_addresses_api_instance,
+)
+from ..module_utils.v4.network.helpers import get_learned_mac_address  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        layer2_stretch_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_learned_mac_address_by_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    layer2_stretch_ext_id = module.params.get("layer2_stretch_ext_id")
+    result["ext_id"] = ext_id
+    result["layer2_stretch_ext_id"] = layer2_stretch_ext_id
+    resp = get_learned_mac_address(
+        module=module,
+        api_instance=api_instance,
+        ext_id=ext_id,
+        layer2_stretch_ext_id=layer2_stretch_ext_id,
+    )
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def list_learned_mac_addresses(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    layer2_stretch_ext_id = module.params.get("layer2_stretch_ext_id")
+    result["layer2_stretch_ext_id"] = layer2_stretch_ext_id
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating learned MAC addresses info spec", **result
+        )
+
+    # The list SDK method does not accept _select; drop it if BaseInfoModule added it.
+    kwargs.pop("_select", None)
+
+    try:
+        resp = api_instance.list_learned_mac_addresses_by_layer2_stretch_id(
+            layer2StretchExtId=layer2_stretch_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching learned MAC addresses info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_mac_addresses_api_instance(module)
+    if module.params.get("ext_id"):
+        get_learned_mac_address_by_ext_id(module, api_instance, result)
+    else:
+        list_learned_mac_addresses(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2/aliases
+++ b/tests/integration/targets/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2/tasks/learned_mac_addresses.yml
+++ b/tests/integration/targets/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2/tasks/learned_mac_addresses.yml
@@ -1,0 +1,245 @@
+---
+###############################################################################
+# Test plan
+# -----------------------------------------------------------------------------
+# The info module ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2
+# only reads data — the Layer2Stretch MAC address feature exposes no CRUD
+# operations. Coverage below therefore focuses on:
+#   * argument-spec / required-param validation (negative)
+#   * mutually exclusive rules (negative)
+#   * shape and semantics of the list response (empty / non-empty)
+#   * shape and semantics of the get-by-ext_id response
+#   * API-level negative tests when the MAC ext_id is bogus (server returns
+#     "not found" with a specific error code)
+#   * pagination (page/limit) — the only two OData query params that the
+#     server actually implements for this endpoint today; ``filter`` and
+#     ``orderby`` are advertised by the SDK but currently rejected by the
+#     server with ``NETWORKING-10002`` ("Odata Error: Error while parsing
+#     URI"), so we do not assert them here.
+# The tests are written to run against a live Prism Central with or without
+# an existing Layer2 Stretch — when one is found, we exercise the full happy
+# path; when none exists, the list happy-path still succeeds and returns an
+# empty payload while the get-by-ext_id negative paths still fire.
+###############################################################################
+
+- name: Start LearnedMacAddressesByLayer2StretchId info tests
+  ansible.builtin.debug:
+    msg: Start LearnedMacAddressesByLayer2StretchId info tests
+
+- name: Set fixed synthetic UUIDs used by negative tests
+  ansible.builtin.set_fact:
+    fake_layer2_stretch_ext_id: "00000000-0000-0000-0000-0000000ffff1"
+    fake_mac_ext_id: "00000000-0000-0000-0000-0000000ffff2"
+
+###############################################################################
+# Negative — argument spec / mutually exclusive validation
+###############################################################################
+
+- name: Call info module without layer2_stretch_ext_id (should fail)
+  nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2: {}
+  register: result
+  ignore_errors: true
+
+- name: Verify missing layer2_stretch_ext_id fails as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: layer2_stretch_ext_id' in result.msg"
+    success_msg: "Missing required layer2_stretch_ext_id failed as expected"
+    fail_msg: "Missing required layer2_stretch_ext_id did not fail with the expected message"
+
+- name: Call info module with mutually exclusive ext_id and filter (should fail)
+  nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+    layer2_stretch_ext_id: "{{ fake_layer2_stretch_ext_id }}"
+    ext_id: "{{ fake_mac_ext_id }}"
+    filter: "value eq '50:6b:8d:9f:00:11'"
+  register: result
+  ignore_errors: true
+
+- name: Verify mutually exclusive ext_id + filter fails as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'parameters are mutually exclusive: ext_id|filter' in result.msg"
+    success_msg: "Mutually exclusive ext_id + filter failed as expected"
+    fail_msg: "Mutually exclusive ext_id + filter did not fail with the expected message"
+
+###############################################################################
+# Positive (list) — list against an arbitrary UUID returns an empty payload,
+# not an error. This proves the module handles the empty case correctly and
+# populates the expected result keys.
+###############################################################################
+
+- name: List learned MAC addresses for a synthetic parent stretch (list is empty)
+  nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+    layer2_stretch_ext_id: "{{ fake_layer2_stretch_ext_id }}"
+  register: result
+
+- name: Verify empty list response has correct shape
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response == []
+      - result.layer2_stretch_ext_id == fake_layer2_stretch_ext_id
+      - result.total_available_results == 0
+    success_msg: "Empty list response has correct shape"
+    fail_msg: "Empty list response shape did not match expectations"
+
+- name: List learned MAC addresses with limit=1 (pagination)
+  nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+    layer2_stretch_ext_id: "{{ fake_layer2_stretch_ext_id }}"
+    limit: 1
+  register: result
+
+- name: Verify limit=1 result
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - (result.response | length) <= 1
+      - result.layer2_stretch_ext_id == fake_layer2_stretch_ext_id
+    success_msg: "List with limit=1 returned the expected shape"
+    fail_msg: "List with limit=1 returned an unexpected shape"
+
+- name: List learned MAC addresses with page=0 and limit=5 (pagination)
+  nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+    layer2_stretch_ext_id: "{{ fake_layer2_stretch_ext_id }}"
+    page: 0
+    limit: 5
+  register: result
+
+- name: Verify page + limit pagination response
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - (result.response | length) <= 5
+    success_msg: "List with page + limit returned the expected shape"
+    fail_msg: "List with page + limit returned an unexpected shape"
+
+###############################################################################
+# Discover an existing Layer2Stretch on the cluster (if any) so we can also
+# exercise the happy path with real data. Skip the block gracefully when no
+# stretches exist on the target cluster (this is the case for most lab PCs
+# that don't have Flow Virtual Networking L2 extensions configured).
+###############################################################################
+
+- name: Query Prism Central for existing Layer2 Stretches
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default(9440) }}/api/networking/v4.3/config/layer2-stretches"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs | default(false) }}"
+    return_content: true
+    status_code: [200, 401, 403, 404]
+  register: layer2_stretch_lookup
+  ignore_errors: true
+
+- name: Determine whether a real Layer2 Stretch exists
+  ansible.builtin.set_fact:
+    real_layer2_stretch_ext_id: >-
+      {{
+        (layer2_stretch_lookup.json.data
+          | default([], true)
+          | list
+          | first
+          | default({})).extId
+        | default('')
+      }}
+
+- name: Debug — Layer2Stretch discovery outcome
+  ansible.builtin.debug:
+    msg: >-
+      Discovered Layer2 Stretch:
+      {{ real_layer2_stretch_ext_id
+         if real_layer2_stretch_ext_id
+         else 'none (only negative + empty-list paths exercised)' }}
+
+- name: Positive — list all learned MAC addresses on the real stretch
+  when: real_layer2_stretch_ext_id | length > 0
+  block:
+    - name: List all learned MAC addresses (real stretch)
+      nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+        layer2_stretch_ext_id: "{{ real_layer2_stretch_ext_id }}"
+      register: result
+
+    - name: Verify list-all response
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response is defined
+          - result.response is iterable
+          - result.layer2_stretch_ext_id == real_layer2_stretch_ext_id
+          - result.total_available_results is defined
+        success_msg: "List all learned MAC addresses succeeded on the real stretch"
+        fail_msg: "List all learned MAC addresses failed on the real stretch"
+
+    - name: Capture a learned MAC ext_id for follow-up tests (if any exist)
+      ansible.builtin.set_fact:
+        real_mac_ext_id: >-
+          {{ (result.response | first | default({})).ext_id | default('') }}
+
+    - name: Positive — get by ext_id when a learned MAC address exists
+      when: real_mac_ext_id | length > 0
+      block:
+        - name: Fetch learned MAC address by external ID
+          nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+            layer2_stretch_ext_id: "{{ real_layer2_stretch_ext_id }}"
+            ext_id: "{{ real_mac_ext_id }}"
+          register: result
+
+        - name: Verify get-by-ext_id response
+          ansible.builtin.assert:
+            that:
+              - result is defined
+              - result.changed == false
+              - result.failed == false
+              - result.response is defined
+              - result.ext_id == real_mac_ext_id
+              - result.layer2_stretch_ext_id == real_layer2_stretch_ext_id
+              - result.response.ext_id == real_mac_ext_id
+              - result.response.value is defined
+              - result.response.mac_type is defined
+            success_msg: "Fetch learned MAC address by ext_id succeeded"
+            fail_msg: "Fetch learned MAC address by ext_id failed"
+
+###############################################################################
+# Negative — API-level errors when the MAC ext_id is bogus. The API returns
+# 500 with the specific "MAC Address ... not found" error code.
+###############################################################################
+
+- name: Negative — get learned MAC address using a bogus ext_id
+  nutanix.ncp.ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2:
+    layer2_stretch_ext_id: "{{ fake_layer2_stretch_ext_id }}"
+    ext_id: "{{ fake_mac_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify get with bogus ext_id fails at the API layer
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - >-
+        'Api Exception raised while fetching learned MAC address info using ext_id and layer2_stretch_ext_id'
+        in result.msg
+      - result.status == 500
+      - result.error == "INTERNAL SERVER ERROR"
+    success_msg: "Get with bogus ext_id failed as expected"
+    fail_msg: "Get with bogus ext_id did not fail as expected"

--- a/tests/integration/targets/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import learned_mac_addresses.yml
+      ansible.builtin.import_tasks: "learned_mac_addresses.yml"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection module for the **networking** namespace, entity
**LearnedMacAddressesByLayer2StretchId**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2`
- Note: the SDK only exposes `GetLearnedMacAddressForLayer2StretchById` and `ListLearnedMacAddressesByLayer2StretchId` (both **info** methods). There are no Create / Update / Delete operations on the SDK, so a CRUD companion (`ntnx_learned_mac_addresses_by_layer2_stretch_id_v2`) was intentionally NOT generated — this is a read-only resource surfaced by the VXLAN Tunnel Endpoints as they observe traffic on the stretched Layer 2 domain.
- API methods covered: **2** (`get_learned_mac_address_for_layer2_stretch_by_id`, `list_learned_mac_addresses_by_layer2_stretch_id`)
- Fields in info module spec: **2** entity-specific inputs (`ext_id`, `layer2_stretch_ext_id`) + the standard `BaseInfoModule` query params (`filter`, `page`, `limit`, `orderby`, `select`) + the standard credential / logger / proxy args pulled in from the shared documentation fragments.

## Domain knowledge (from Glean)

The Glean MCP `glean__chat` tool returned the full write-up below along with the reference documents Glean surfaced. Both are reproduced verbatim so a reviewer can follow every link.

### Answer

> The Nutanix Layer 2 Network Extension (often referred to as "L2 Stretch") is a core capability within Flow Virtual Networking (FVN). It allows administrators to seamlessly extend a Layer 2 broadcast domain (VLAN/subnet) across different physical locations — such as from an on-premises datacenter to Nutanix Cloud Clusters (NC2) in AWS or Azure, or between two on-prem clusters.
>
> By maintaining the exact same subnet prefix on both sides, this feature prevents Layer 3 routing conflicts and serves as Nutanix's primary solution for IP mobility and high availability in hybrid cloud architectures.
>
> #### Use Cases
> * **Seamless Workload Migration:** Migrate virtual machines between on-premises and the cloud without the need to re-IP workloads or reconfigure network policies.
> * **Disaster Recovery (DR):** Perform partial or full failovers to the cloud during an outage without losing network connectivity, as VMs retain their original IP addresses.
> * **Hybrid Cloud Consistency:** Ideal for split-tier applications (e.g., database on-prem, web frontend in the cloud), allowing workloads to interact as if they are on the same local network switch.
> * **Testing and Development:** Replicate production networks exactly within cloud staging environments to simplify testing pipelines.
>
> #### Workflow and MAC Address Learning
> At the core of an L2 Stretch is a VXLAN Tunnel Endpoint (VTEP), which typically runs on a Nutanix-customized VyOS Network Gateway VM. The VTEP bridges the gap between networks by encapsulating local frames and sending them across a tunnel (via unencrypted VXLAN or IPSec VPN) to the remote site.
>
> To do this efficiently, the system uses **Dynamic MAC Address Learning**:
> 1. **Initial Broadcast (ARP/DHCP):** When a local VM sends a broadcast, such as an ARP request looking for an IP address, the local VTEP encapsulates this broadcast in a VXLAN packet (mapped to a specific VXLAN Network Identifier, or VNI) and transmits it to the remote VTEP.
> 2. **Remote Learning:** The remote VTEP receives the packet, decapsulates it, and floods it to the remote subnet. In doing so, the remote VTEP *learns* the source MAC address of the original VM and records it in its MAC table, noting that this MAC is reachable via the tunnel.
> 3. **Unicast Reply:** When the destination VM replies, its response is encapsulated by the remote VTEP and sent back. The local VTEP then *learns* the remote VM's MAC address.
> 4. **Optimized Flow:** For all subsequent traffic between these two VMs, the VTEPs use their populated MAC address tables to forward traffic directly as VXLAN-encapsulated unicast packets, avoiding unnecessary broadcasts over the wide area network.
>
> #### Prerequisites in NC2 and Flow Virtual Networking
> To configure an L2 Stretch, the following prerequisites and components must be in place:
> * **Prism Central & AHV:** The environments must be managed by Prism Central and run the AHV hypervisor.
> * **Flow Virtual Networking (FVN):** Customers must have FVN enabled to utilize overlay networks and VPCs.
> * **Network Gateways:** A VTEP Gateway VM (for unencrypted traffic between local Availability Zones) or a VPN Gateway VM (for secure IPSec communication over the WAN) must be deployed to handle VXLAN encapsulation.
> * **NAT External Subnet:** If connecting two VPCs using VPN gateway VMs over an external network, each VPN VM requires an external floating IP address. If the VPC was previously using exclusively "Routed" or "NoNAT" subnets, a NAT external subnet with available floating IPs must be added.
> * **Policy Based Routing (PBR):** While strictly optional, Nutanix highly recommends configuring PBR to explicitly control how traffic is forwarded between the stretched on-prem and NC2 clusters, improving traffic efficiency and reducing latency.

### Reference documents surfaced by Glean

The following internal references were returned. The URLs are Nutanix-internal (Confluence / Jira / internal GitHub) so they will only resolve on the corporate network — please open on VPN.

- Flow Virtual Networking - L2 Network Extension Concepts and Resources (Confluence, STK space, page 392340735)
- NC2 on AWS: Layer 2 Stretch (Confluence, SO space, page 372300877)
- Mac address filtering api failing (Jira ENG-891953)
- LAYER2_STRETCH_ARCHITECTURAL_GUIDE.md (internal GitHub `nutanix-core/flow-mcp-servers`)
- layer2StretchEndpoints.yaml (internal GitHub `nutanix-core/ntnx-api-networking`)
- `ValueError: Missing the required parameter layer2StretchExtId when calling get_learned_mac_address_for_layer2_stretch_by_id` (Jira ENG-731048)
- UI: layer-2 stretch summary doesn't show learned mac address (Jira NET-19311)
- `get_learned_mac_address_for_layer2_stretch_by_id_request.go` (internal GitHub `nutanix-core/ntnx-api-golang-sdk-external`)
- `list_learned_mac_addresses_by_layer2_stretch_id_request.go` (internal GitHub `nutanix-engineering/move-ntnx-api-golang-sdk-internal`)
- `mac_addresses_api.go` (internal GitHub `nutanix-engineering/hack2026-d3051`)
- Learned MAC addresses are not persistent in the API response (Jira NET-19841)
- Layer-2 stretch on ESXi (Confluence, NET space, page 223313923)
- Understanding and Troubleshooting L2 Stretch (Confluence, XRE space, page 163786597)
- `test_mac_addresses_api.py` (internal GitHub `nutanix-engineering/hack2026-d3051/nutest-py3-tests`)
- `get_l2_stretch_mac_address.yaml` (internal GitHub `nutanix-core/ntnx-api-prism-performance`)

## Files changed

- **plugins/**
  - `plugins/modules/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2.py` — new info module.
  - `plugins/module_utils/v4/network/api_client.py` — added `get_mac_addresses_api_instance()`.
  - `plugins/module_utils/v4/network/helpers.py` — added `get_learned_mac_address()` helper.
- **meta/**
  - `meta/runtime.yml` — registered the new module in the `ntnx` action group so play/task-level `module_defaults` (`group/nutanix.ncp.ntnx`) are picked up correctly.
- **tests/**
  - `tests/integration/targets/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2/{aliases,meta/main.yml,tasks/main.yml,tasks/learned_mac_addresses.yml}` — new integration target (disabled by default, matching `ntnx_virtual_switches_v2`).
- **examples/**
  - `examples/networking/LearnedMacAddressesByLayer2StretchId/learned_mac_addresses_by_layer2_stretch_ids_info_v2.yml` — new example playbook.
  - `examples/networking/LearnedMacAddressesByLayer2StretchId/examples_run.log` — captured real playbook output against Prism Central `10.44.76.28`.

## Test execution

| Metric              | Value                                                                                     |
|---------------------|-------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 --allow-unsupported --allow-disabled --python 3.12 -v` |
| Total tasks         | 26                                                                                        |
| Passed (`ok`)       | 18                                                                                        |
| Failed              | 0                                                                                         |
| Skipped             | 5 (guarded by `when: real_layer2_stretch_ext_id | length > 0` — no L2 stretch on the test PC) |
| Ignored             | 3 (intentional `ignore_errors: true` on the negative cases)                               |
| Duration            | ~8s                                                                                       |
| Cluster (PC)        | `10.44.76.28` (Prism Central 7.6)                                                         |

Sanity: `ansible-test sanity plugins/modules/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2.py plugins/module_utils/v4/network/helpers.py plugins/module_utils/v4/network/api_client.py --python 3.12` — **all 25 sanity tests passed** (`action-plugin-docs`, `ansible-doc`, `changelog`, `compile`, `empty-init`, `ignores`, `import`, `line-endings`, `no-assert`, `no-get-exception`, `no-illegal-filenames`, `no-smart-quotes`, `pep8`, `pslint`, `pylint`, `replace-urlopen`, `runtime-metadata`, `shebang`, `shellcheck`, `symlinks`, `use-argspec-type-path`, `use-compat-six`, `validate-modules`, `yamllint`).

Lint: `black --check`, `isort --check`, `flake8`, `ansible-lint` — all clean (0 fatal violations, 5/5 star rating from ansible-lint; the remaining warnings are the same "missing required arguments: nutanix_host" pattern that exists on the reference `ntnx_virtual_switches_v2` example because those args come from `module_defaults`).

### Analysis

- The test target passed end-to-end. There are **no failed tests**.
- Five tasks were **skipped** because the target Prism Central has no Layer 2 Stretch configured (`totalAvailableResults: 0`). Those tasks are guarded by `when: real_layer2_stretch_ext_id | length > 0` and would be exercised automatically on any cluster that does have an L2 stretch — they read a real MAC and assert the response shape.
- Three tasks are intentional `ignore_errors: true` negatives (missing required arg, mutually-exclusive `ext_id + filter`, and `NETWORKING-10060` — "Mac Address ... not found on Prism Central cluster ..." — from the `get_learned_mac_address_for_layer2_stretch_by_id` call with a bogus ext_id). Each of them is followed by an `assert` task that confirms the module surfaced the expected message.
- The list happy-path was exercised with three variants (bare list, `limit=1`, `page=0/limit=5`) and returned the expected empty payload shape (`response == []`, `total_available_results == 0`).
- **Known behaviour, not a bug**: the SDK method advertises `_filter` and `_orderby`, but the server (as of v4.3) rejects them for this endpoint with `NETWORKING-10002` ("Odata Error: Error while parsing URI"). The info module still accepts these params via `BaseInfoModule`, but the example playbook and the integration tests intentionally do not use them; the module docstring calls this out.
- **Runtime prerequisite fix**: the initial run of the example produced an SSL verification error even though `validate_certs: false` was set in `module_defaults`. Root cause was that the new module was not listed in the `ntnx` action group in `meta/runtime.yml`, so `group/nutanix.ncp.ntnx` defaults were not applied and `validate_certs` fell back to its `True` default. Adding the module to `meta/runtime.yml` fixed this and is the pattern used by every other v2 module in the collection.

### Test logs (tail)

<details>
<summary>tail of ansible-test integration output</summary>

```text
TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Verify mutually exclusive ext_id + filter fails as expected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Mutually exclusive ext_id + filter failed as expected"
}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : List learned MAC addresses for a synthetic parent stretch (list is empty)] ***
ok: [testhost] => {"changed": false, "layer2_stretch_ext_id": "00000000-0000-0000-0000-0000000ffff1", "response": [], "total_available_results": 0}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Verify empty list response has correct shape] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Empty list response has correct shape"
}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : List learned MAC addresses with limit=1 (pagination)] ***
ok: [testhost] => {"changed": false, "layer2_stretch_ext_id": "00000000-0000-0000-0000-0000000ffff1", "response": [], "total_available_results": 0}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Verify limit=1 result] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List with limit=1 returned the expected shape"
}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : List learned MAC addresses with page=0 and limit=5 (pagination)] ***
ok: [testhost] => {"changed": false, "layer2_stretch_ext_id": "00000000-0000-0000-0000-0000000ffff1", "response": [], "total_available_results": 0}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Verify page + limit pagination response] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List with page + limit returned the expected shape"
}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Query Prism Central for existing Layer2 Stretches] ***
ok: [testhost] => {"cache_control": "no-cache, no-store, max-age=0, must-revalidate,no-cache, no-store", "changed": false, "connection": "close", "content": "{\"$reserved\":{\"$fv\":\"v4.r4\"},\"$objectType\":\"networking.v4.config.ListLayer2StretchesApiResponse\",\"metadata\":{\"flags\":[{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"hasError\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isPaginated\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isTruncated\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isExpandRestricted\",\"value\":false}],\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.response.ApiResponseMetadata\",\"totalAvailableResults\":0}}", "content_encoding": "identity", "content_length": "645", "content_security_policy": "connect-src 'self' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; default-src 'self' https://*.nutanix.com; frame-ancestors 'self' https://*.nutanix.com; frame-src 'self' https://*.nutanix.com blob: data:; img-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'", "content_type": "application/json", "cookies": {"NTNX_SESSION_ID": "785be26f-1f00-431f-9696-3c49097be92b"}, "cookies_string": "NTNX_SESSION_ID=785be26f-1f00-431f-9696-3c49097be92b", "date": "Mon, 20 Jul 2026 13:43:55 GMT", "elapsed": 0, "expires": "0,0", "json": {"$objectType": "networking.v4.config.ListLayer2StretchesApiResponse", "$reserved": {"$fv": "v4.r4"}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "totalAvailableResults": 0}}, "msg": "OK (645 bytes)", "pragma": "no-cache, no-cache", "redirected": false, "set_cookie": "NTNX_SESSION_ID=785be26f-1f00-431f-9696-3c49097be92b;Max-Age=29700;Path=/;Secure;HttpOnly;SameSite=Lax", "status": 200, "strict_transport_security": "max-age=31536000 ; includeSubDomains, max-age=63072000; includeSubdomains; preload", "url": "https://10.44.76.28:9440/api/networking/v4.3/config/layer2-stretches", "vary": "Origin", "x_api_ratelimit_limit": "5", "x_api_ratelimit_refresh_period_seconds": "1", "x_api_ratelimit_remaining": "4", "x_api_ratelimit_reset": "0", "x_content_type_options": "nosniff, nosniff", "x_dns_prefetch_control": "off", "x_envoy_upstream_service_time": "16", "x_frame_options": "DENY, SAMEORIGIN", "x_ntnx_env": "pc", "x_ntnx_product": "pc.7.6", "x_permitted_cross_domain_policies": "master-only", "x_ratelimit_limit": "40", "x_ratelimit_remaining": "39", "x_ratelimit_reset": "0", "x_xss_protection": "0, 1; mode=block"}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Determine whether a real Layer2 Stretch exists] ***
ok: [testhost] => {"ansible_facts": {"real_layer2_stretch_ext_id": ""}, "changed": false}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Debug — Layer2Stretch discovery outcome] ***
ok: [testhost] => {
    "msg": "Discovered Layer2 Stretch: none (only negative + empty-list paths exercised)"
}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : List all learned MAC addresses (real stretch)] ***
skipping: [testhost] => {"changed": false, "false_condition": "real_layer2_stretch_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Verify list-all response] ***
skipping: [testhost] => {"changed": false, "false_condition": "real_layer2_stretch_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Capture a learned MAC ext_id for follow-up tests (if any exist)] ***
skipping: [testhost] => {"changed": false, "false_condition": "real_layer2_stretch_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Fetch learned MAC address by external ID] ***
skipping: [testhost] => {"changed": false, "false_condition": "real_layer2_stretch_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Verify get-by-ext_id response] ***
skipping: [testhost] => {"changed": false, "false_condition": "real_layer2_stretch_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Negative — get learned MAC address using a bogus ext_id] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching learned MAC address info using ext_id and layer2_stretch_ext_id
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2-kbwl9xu0-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2/tasks/learned_mac_addresses.yml:226:3

224 ###############################################################################
225
226 - name: Negative — get learned MAC address using a bogus ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching learned MAC address info using ext_id and layer2_stretch_ext_id", "response": {"$objectType": "networking.v4.config.GetLayer2StretchApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get l2stretch 00000000-0000-0000-0000-0000000ffff1 learned MAC addr 00000000-0000-0000-0000-0000000ffff2 as a referenced resource was not found - Mac Address 00000000-0000-0000-0000-0000000ffff2 not found on Prism Central cluster 00000000-0000-0000-0000-0000000ffff1", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/layer2-stretches/00000000-0000-0000-0000-0000000ffff1/learned-mac-addresses/00000000-0000-0000-0000-0000000ffff2", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
...ignoring

TASK [ntnx_learned_mac_addresses_by_layer2_stretch_ids_info_v2 : Verify get with bogus ext_id fails at the API layer] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Get with bogus ext_id failed as expected"
}

PLAY RECAP *********************************************************************
testhost                   : ok=18   changed=0    unreachable=0    failed=0    skipped=5    rescued=0    ignored=3   

```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
