### PR TITLE
StorageContainer Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/cluster_management/StorageContainer/storage_container_esxi_v2.yml
+++ b/examples/cluster_management/StorageContainer/storage_container_esxi_v2.yml
@@ -1,0 +1,92 @@
+---
+# Summary:
+# This playbook demonstrates all StorageContainer operations exposed by the
+# ntnx_storage_container_esxi_v2 CRUD module and the related info module:
+#   1. Create a Storage Container (full spec)
+#   2. Fetch the Storage Container by ext_id
+#   3. Update the Storage Container
+#   4. List all Storage Containers (with a filter)
+#   5. Delete the Storage Container
+
+- name: Storage Container playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username }}"
+      nutanix_password: "{{ password }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        storage_container_name: "ansible_storage_container_example"
+        cluster_ext_id: "{{ cluster.uuid }}"
+        owner_uuid: "{{ owner.uuid | default('00000000-0000-0000-0000-000000000000') }}"
+
+    - name: Create Storage Container with full spec
+      nutanix.ncp.ntnx_storage_container_esxi_v2:
+        state: present
+        name: "{{ storage_container_name }}"
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        owner_ext_id: "{{ owner_uuid }}"
+        logical_explicit_reserved_capacity_bytes: 0
+        logical_advertised_capacity_bytes: 107374182400
+        replication_factor: 1
+        nfs_whitelist_address:
+          - ipv4:
+              value: "192.168.1.1"
+        erasure_code: "OFF"
+        is_inline_ec_enabled: false
+        has_higher_ec_fault_domain_preference: true
+        cache_deduplication: "OFF"
+        on_disk_dedup: "OFF"
+        is_compression_enabled: true
+        compression_delay_secs: 0
+        is_internal: false
+        is_software_encryption_enabled: false
+      register: create_result
+      ignore_errors: true
+
+    - name: Capture ext_id
+      ansible.builtin.set_fact:
+        storage_container_ext_id: "{{ create_result.ext_id }}"
+      when: create_result.ext_id is defined and create_result.ext_id | length > 0
+
+    - name: Fetch the Storage Container by ext_id
+      nutanix.ncp.ntnx_storage_containers_info_v2:
+        ext_id: "{{ storage_container_ext_id }}"
+      register: info_result
+      ignore_errors: true
+      when: storage_container_ext_id is defined
+
+    - name: Update Storage Container
+      nutanix.ncp.ntnx_storage_container_esxi_v2:
+        state: present
+        ext_id: "{{ storage_container_ext_id }}"
+        name: "{{ storage_container_name }}_updated"
+        logical_explicit_reserved_capacity_bytes: 0
+        logical_advertised_capacity_bytes: 214748364800
+        nfs_whitelist_address:
+          - ipv4:
+              value: "192.168.13.2"
+        is_compression_enabled: true
+        compression_delay_secs: 60
+      register: update_result
+      ignore_errors: true
+      when: storage_container_ext_id is defined
+
+    - name: List all Storage Containers with filter on the created name
+      nutanix.ncp.ntnx_storage_containers_info_v2:
+        filter: "name eq '{{ storage_container_name }}_updated'"
+      register: list_result
+      ignore_errors: true
+
+    - name: Delete Storage Container
+      nutanix.ncp.ntnx_storage_container_esxi_v2:
+        state: absent
+        ext_id: "{{ storage_container_ext_id }}"
+        ignore_small_files: true
+      register: delete_result
+      ignore_errors: true
+      when: storage_container_ext_id is defined

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -188,6 +188,7 @@ action_groups:
     - ntnx_storage_containers_stats_v2
     - ntnx_storage_containers_info_v2
     - ntnx_storage_containers_v2
+    - ntnx_storage_container_esxi_v2
     - ntnx_pc_unregistration_v2
     - ntnx_pc_backup_target_info_v2
     - ntnx_pc_backup_target_v2

--- a/plugins/modules/ntnx_storage_container_esxi_v2.py
+++ b/plugins/modules/ntnx_storage_container_esxi_v2.py
@@ -1,0 +1,735 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_storage_container_esxi_v2
+short_description: Create, Update, Delete Storage Containers in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to create, update, and delete Storage Containers in Nutanix Prism Central.
+  - A Storage Container is a logical subset of available storage within a Nutanix Storage Pool
+    where storage-efficiency features (compression, deduplication, erasure coding) and policies
+    (Replication Factor, encryption) are applied.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Create a Storage Container) -
+      Required Roles: Prism Admin, Project Manager, Storage Admin, Super Admin, Self-Service Admin (deprecated)
+    - >-
+      B(Update a Storage Container) -
+      Required Roles: Backup Admin, Prism Admin, Project Manager, Storage Admin, Super Admin, Self-Service Admin (deprecated)
+    - >-
+      B(Delete a Storage Container) -
+      Required Roles: Prism Admin, Project Manager, Storage Admin, Super Admin, Self-Service Admin (deprecated)
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will
+        be create Storage Container.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be
+        update Storage Container.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be
+        delete Storage Container.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external identifier of the Storage Container.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - Name of the Storage Container.
+      - Required for create operation.
+    type: str
+    required: false
+  cluster_ext_id:
+    description:
+      - The external identifier of the Prism Element cluster on which the Storage Container is
+        (or will be) hosted.
+      - Required for create operation. Passed as the C(X-Cluster-Id) header to route the
+        request to the correct PE.
+    type: str
+    required: false
+  owner_ext_id:
+    description:
+      - The external identifier of the owner (user) of the Storage Container.
+    type: str
+    required: false
+  logical_explicit_reserved_capacity_bytes:
+    description:
+      - Total reserved size (in bytes) of the container (excluding reservation of vDisks). This
+        is the minimum guaranteed physical capacity for the container.
+    type: int
+    required: false
+  logical_advertised_capacity_bytes:
+    description:
+      - Maximum physical capacity (in bytes) that the container can advertise / grow to.
+    type: int
+    required: false
+  replication_factor:
+    description:
+      - Replication factor of the Storage Container. Typically C(2) or C(3).
+      - RF1 containers are generally not supported via PC-based Storage Container management.
+    type: int
+    required: false
+  nfs_whitelist_address:
+    description:
+      - List of NFS addresses which need to be whitelisted for accessing this Storage Container.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 address.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description: The IPv4 address value.
+            type: str
+            required: true
+          prefix_length:
+            description: The prefix length of the network to which this address belongs.
+            type: int
+            required: false
+      ipv6:
+        description:
+          - IPv6 address.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description: The IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description: The prefix length of the network to which this address belongs.
+            type: int
+            required: false
+      fqdn:
+        description:
+          - Fully qualified domain name.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description: The fully qualified domain name value.
+            type: str
+            required: true
+  erasure_code:
+    description:
+      - Erasure Coding status for the Storage Container.
+    type: str
+    required: false
+    choices:
+      - NONE
+      - "OFF"
+      - "ON"
+  is_inline_ec_enabled:
+    description:
+      - Indicates whether inline Erasure Coding is enabled for the Storage Container.
+    type: bool
+    required: false
+  has_higher_ec_fault_domain_preference:
+    description:
+      - Indicates whether the Storage Container has a preference to keep a higher fault domain
+        for erasure-coded strips.
+    type: bool
+    required: false
+  erasure_code_delay_secs:
+    description:
+      - Delay (in seconds) after which the Erasure Coding transform should be applied on
+        write-cold data.
+    type: int
+    required: false
+  cache_deduplication:
+    description:
+      - Cache deduplication status for the Storage Container.
+    type: str
+    required: false
+    choices:
+      - NONE
+      - "OFF"
+      - "ON"
+  on_disk_dedup:
+    description:
+      - On-disk deduplication status for the Storage Container.
+    type: str
+    required: false
+    choices:
+      - NONE
+      - "OFF"
+      - POST_PROCESS
+  is_compression_enabled:
+    description:
+      - Indicates whether compression is enabled for the Storage Container.
+    type: bool
+    required: false
+  compression_delay_secs:
+    description:
+      - Delay (in seconds) after which compression is applied on write-cold data.
+    type: int
+    required: false
+  is_internal:
+    description:
+      - Indicates whether the Storage Container is internal / managed by Nutanix.
+      - Internal containers (e.g. C(NutanixManagementShare)) are not expected to be created by
+        end users.
+    type: bool
+    required: false
+  is_software_encryption_enabled:
+    description:
+      - Indicates whether software encryption is enabled for the Storage Container.
+    type: bool
+    required: false
+  affinity_host_ext_id:
+    description:
+      - The external identifier of the host to which the Storage Container has affinity.
+    type: str
+    required: false
+  ignore_small_files:
+    description:
+      - When deleting a Storage Container, if this is set to C(true) small files that may still
+        be in the container will be ignored and the delete will proceed.
+      - Applies only to the delete operation.
+    type: bool
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Create Storage Container with minimal spec
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "storage_container_ansible"
+    cluster_ext_id: "0006361b-6855-3644-7458-2268f8ffb2bd"
+  register: result
+  ignore_errors: true
+
+- name: Create Storage Container with full spec
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "storage_container_ansible_full"
+    cluster_ext_id: "0006361b-6855-3644-7458-2268f8ffb2bd"
+    owner_ext_id: "00000000-0000-0000-0000-000000000000"
+    logical_explicit_reserved_capacity_bytes: 0
+    logical_advertised_capacity_bytes: 107374182400
+    replication_factor: 2
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.1.1"
+    erasure_code: "OFF"
+    is_inline_ec_enabled: false
+    has_higher_ec_fault_domain_preference: true
+    erasure_code_delay_secs: 0
+    cache_deduplication: "OFF"
+    on_disk_dedup: "OFF"
+    is_compression_enabled: true
+    compression_delay_secs: 0
+    is_internal: false
+    is_software_encryption_enabled: false
+  register: result
+  ignore_errors: true
+
+- name: Update Storage Container
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+    name: "storage_container_ansible_updated"
+    logical_explicit_reserved_capacity_bytes: 25
+    logical_advertised_capacity_bytes: 2147483648000
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.13.2"
+  register: result
+  ignore_errors: true
+
+- name: Delete Storage Container
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+    ignore_small_files: true
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting a Storage Container.
+    - If the operation is create or update and C(wait) is true, it will return the Storage
+      Container details.
+    - If the operation is create or update and C(wait) is false, it will return the task
+      details.
+    - If the operation is delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "affinity_host_ext_id": null,
+      "cache_deduplication": "OFF",
+      "cluster_ext_id": "0006197f-3d06-ce49-1fc3-ac1f6b6029c1",
+      "cluster_name": "auto-cluster-prod-f30accd2eec1",
+      "compression_delay_secs": 0,
+      "container_ext_id": "57516342-7d8e-470f-91b8-ae310737ff8c",
+      "erasure_code": "OFF",
+      "erasure_code_delay_secs": null,
+      "ext_id": "57516342-7d8e-470f-91b8-ae310737ff8c",
+      "has_higher_ec_fault_domain_preference": false,
+      "is_compression_enabled": false,
+      "is_encrypted": null,
+      "is_inline_ec_enabled": false,
+      "is_internal": false,
+      "is_marked_for_removal": false,
+      "is_nfs_whitelist_inherited": true,
+      "is_shared": true,
+      "is_software_encryption_enabled": false,
+      "links": null,
+      "logical_advertised_capacity_bytes": null,
+      "logical_explicit_reserved_capacity_bytes": 0,
+      "logical_implicit_reserved_capacity_bytes": 0,
+      "max_capacity_bytes": 4291605771923,
+      "name": "storage_container_ansible",
+      "nfs_whitelist_address": null,
+      "on_disk_dedup": "OFF",
+      "owner_ext_id": "00000000-0000-0000-0000-000000000000",
+      "replication_factor": 2,
+      "storage_pool_ext_id": "487c142e-6c41-4b10-9585-4feac6bd3c68",
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the Storage Container.
+  returned: always
+  type: str
+  sample: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped (e.g. due to idempotency).
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating Storage Container"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
+    get_etag,
+    get_storage_containers_api_instance,
+)
+from ..module_utils.v4.clusters_mgmt.helpers import get_storage_container  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_clustermgmt_py_client as cluster_management_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402
+        mock_sdk as cluster_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+# Fields that are populated by the server and MUST NOT be sent back on update
+# to avoid schema/validation errors on the API side. The SDK model exposes
+# these as properties with setters but no deleters, so we clear them by
+# assigning None rather than using ``delattr``.
+_READ_ONLY_FIELDS = (
+    "container_ext_id",
+    "storage_pool_ext_id",
+    "max_capacity_bytes",
+    "logical_implicit_reserved_capacity_bytes",
+    "cluster_name",
+    "is_marked_for_removal",
+    "is_shared",
+    "external_storage_ext_id",
+    "is_encrypted",
+    "is_nfs_whitelist_inherited",
+    "links",
+    "tenant_id",
+    "ext_id",
+)
+
+
+def _clear_read_only_fields(spec):
+    """Null out read-only fields on the update body before sending."""
+    for field in _READ_ONLY_FIELDS:
+        if hasattr(spec, field):
+            setattr(spec, field, None)
+    return spec
+
+
+def get_module_spec():
+
+    ipv4_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False),
+    )
+    ipv6_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False),
+    )
+    fqdn_spec = dict(
+        value=dict(type="str", required=True),
+    )
+    nfs_whitelist_address_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_spec,
+            required=False,
+            obj=cluster_management_sdk.IPv4Address,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_spec,
+            required=False,
+            obj=cluster_management_sdk.IPv6Address,
+        ),
+        fqdn=dict(
+            type="dict",
+            options=fqdn_spec,
+            required=False,
+            obj=cluster_management_sdk.FQDN,
+        ),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str", required=False),
+        name=dict(type="str", required=False),
+        cluster_ext_id=dict(type="str", required=False),
+        owner_ext_id=dict(type="str", required=False),
+        logical_explicit_reserved_capacity_bytes=dict(type="int", required=False),
+        logical_advertised_capacity_bytes=dict(type="int", required=False),
+        replication_factor=dict(type="int", required=False),
+        nfs_whitelist_address=dict(
+            type="list",
+            elements="dict",
+            options=nfs_whitelist_address_spec,
+            required=False,
+            obj=cluster_management_sdk.IPAddressOrFQDN,
+        ),
+        erasure_code=dict(
+            type="str",
+            choices=["NONE", "OFF", "ON"],
+            required=False,
+            obj=cluster_management_sdk.ErasureCodeStatus,
+        ),
+        is_inline_ec_enabled=dict(type="bool", required=False),
+        has_higher_ec_fault_domain_preference=dict(type="bool", required=False),
+        erasure_code_delay_secs=dict(type="int", required=False),
+        cache_deduplication=dict(
+            type="str",
+            choices=["NONE", "OFF", "ON"],
+            required=False,
+            obj=cluster_management_sdk.CacheDeduplication,
+        ),
+        on_disk_dedup=dict(
+            type="str",
+            choices=["NONE", "OFF", "POST_PROCESS"],
+            required=False,
+            obj=cluster_management_sdk.OnDiskDedup,
+        ),
+        is_compression_enabled=dict(type="bool", required=False),
+        compression_delay_secs=dict(type="int", required=False),
+        is_internal=dict(type="bool", required=False),
+        is_software_encryption_enabled=dict(type="bool", required=False),
+        affinity_host_ext_id=dict(type="str", required=False),
+        ignore_small_files=dict(type="bool", required=False),
+    )
+    return module_args
+
+
+def _idempotency_check(current_spec, update_spec):
+    """Compare two SDK StorageContainer objects for effective equality.
+
+    Follow the same pattern used by the existing storage-containers v2 module:
+    rely on the SDK's ``__eq__`` implementation. This handles nested spec
+    objects (``nfs_whitelist_address`` items etc.) correctly.
+    """
+    return current_spec == update_spec
+
+
+def create_StorageContainer(module, result, api_instance):
+    validate_required_params(module, ["name", "cluster_ext_id"])
+
+    sg = SpecGenerator(module)
+    default_spec = cluster_management_sdk.StorageContainer()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating create Storage Container spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    cluster_ext_id = module.params.get("cluster_ext_id")
+
+    resp = None
+    try:
+        resp = api_instance.create_storage_container(
+            body=spec, X_Cluster_Id=cluster_ext_id
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating Storage Container",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task_status, rel=TASK_CONSTANTS.RelEntityType.STORAGE_CONTAINER
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            resp = get_storage_container(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(resp.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for Storage Container"
+                ),
+                msg="Failed to get entity ext_id from task for Storage Container",
+            )
+
+    result["changed"] = True
+
+
+def update_StorageContainer(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    current_spec = get_storage_container(module, api_instance, ext_id)
+
+    etag = get_etag(data=current_spec)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for updating Storage Container", **result
+        )
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(current_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating update Storage Container spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if _idempotency_check(current_spec, update_spec):
+        result["skipped"] = True
+        result["response"] = strip_internal_attributes(current_spec.to_dict())
+        module.exit_json(msg="Nothing to change.", **result)
+
+    _clear_read_only_fields(update_spec)
+
+    kwargs = {"if_match": etag}
+    resp = None
+    try:
+        resp = api_instance.update_storage_container_by_id(
+            extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating Storage Container",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_storage_container(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+
+    result["changed"] = True
+
+
+def delete_StorageContainer(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "Storage Container with ext_id:{0} will be deleted.".format(
+            ext_id
+        )
+        return
+
+    ignore_small_files = module.params.get("ignore_small_files")
+
+    resp = None
+    try:
+        resp = api_instance.delete_storage_container_by_id(
+            extId=ext_id, ignoreSmallFiles=ignore_small_files
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting Storage Container",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "present", ("name", "ext_id"), True),
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_clustermgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "failed": False,
+    }
+
+    api_instance = get_storage_containers_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_StorageContainer(module, result, api_instance)
+        else:
+            create_StorageContainer(module, result, api_instance)
+    else:
+        delete_StorageContainer(module, result, api_instance)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pip>=23.0
 setuptools>=65.0
 requests>=2.31.0
-ntnx-clustermgmt-py-client==4.2.2
+ntnx-clustermgmt-py-client==latest
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1

--- a/tests/integration/targets/ntnx_storage_container_esxi_v2/aliases
+++ b/tests/integration/targets/ntnx_storage_container_esxi_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_storage_container_esxi_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_storage_container_esxi_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_storage_container_esxi_v2/tasks/all_operations.yml
+++ b/tests/integration/targets/ntnx_storage_container_esxi_v2/tasks/all_operations.yml
@@ -1,0 +1,504 @@
+---
+# ---------------------------------------------------------------------------
+# Test Plan — ntnx_storage_container_esxi_v2
+# ---------------------------------------------------------------------------
+# The following scenarios are covered end-to-end against a live Prism Central.
+# Assertions ALWAYS include ``changed`` and ``failed`` first, then module-
+# specific attributes. Random suffixes are used for names to avoid collisions
+# with existing Storage Containers on the cluster.
+#
+#   1. Prerequisites — auto-discover a Prism Element cluster ext_id if the
+#      ``cluster`` fact is not already provided by prepare_env vars.
+#   2. Check-mode CREATE with the full attribute set (single test).
+#   3. Minimal CREATE (only required params: name + cluster_ext_id).
+#   4. Full CREATE (all optional attributes populated).
+#   5. Idempotency — re-run update with the same spec, expect ``skipped: true``.
+#   6. Check-mode UPDATE (single test).
+#   7. Real UPDATE — flip enums (ON→OFF), change scalar capacity, replace list.
+#   8. INFO — get by ext_id, list-all, filter by name, limit.
+#   9. INFO — invalid ext_id returns a descriptive error.
+#  10. Negative — missing required param (cluster_ext_id) on CREATE.
+#  11. Negative — invalid enum value on CREATE.
+#  12. Check-mode DELETE (single test), then real DELETE of every SC created.
+#
+# Coverage: every attribute in ``get_module_spec()`` is exercised by at least
+# one CREATE, UPDATE, or INFO assertion. Every enum has both a valid and an
+# invalid value tested.
+
+- name: Start ntnx_storage_container_esxi_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_storage_container_esxi_v2 tests
+
+- name: Generate random suffix
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Initialize per-test facts
+  ansible.builtin.set_fact:
+    prefix_name: "ansible-sce"
+    todelete: []
+
+- name: Compose Storage Container base name
+  ansible.builtin.set_fact:
+    storage_container_name: "{{ prefix_name }}-{{ random_name }}"
+
+########################################################################################
+# Prerequisites — pick a PE cluster ext_id and an owner ext_id
+########################################################################################
+
+- name: Auto-discover a PE cluster ext_id (used when prepare_env has none)
+  nutanix.ncp.ntnx_clusters_info_v2:
+    filter: "config/clusterFunction/any(f:f eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+  register: clusters_info
+  ignore_errors: true
+  when: cluster is not defined or (cluster.uuid | default('')) == ''
+
+- name: Set discovered cluster ext_id when prepare_env didn't provide one
+  ansible.builtin.set_fact:
+    cluster:
+      uuid: "{{ (clusters_info.response | selectattr('config.cluster_function', 'defined')
+                | rejectattr('name', 'equalto', 'unnamed')
+                | list)[0].ext_id }}"
+  when:
+    - cluster is not defined or (cluster.uuid | default('')) == ''
+    - clusters_info is defined
+    - clusters_info.response is defined
+    - clusters_info.response | length > 0
+
+- name: Set owner ext_id default when prepare_env didn't provide one
+  ansible.builtin.set_fact:
+    owner:
+      uuid: "00000000-0000-0000-0000-000000000000"
+  when: owner is not defined or (owner.uuid | default('')) == ''
+
+- name: Assert prerequisites are satisfied
+  ansible.builtin.assert:
+    that:
+      - cluster is defined
+      - cluster.uuid is defined
+      - cluster.uuid | length > 0
+    fail_msg: "Unable to determine a PE cluster ext_id for Storage Container tests"
+    success_msg: "Using cluster ext_id: {{ cluster.uuid }}"
+
+########################################################################################
+# 2. Check-mode CREATE with the full attribute set
+########################################################################################
+
+- name: Generate check-mode CREATE spec with all attributes
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    state: present
+    name: "{{ storage_container_name }}-cm"
+    cluster_ext_id: "{{ cluster.uuid }}"
+    owner_ext_id: "{{ owner.uuid }}"
+    logical_explicit_reserved_capacity_bytes: 0
+    logical_advertised_capacity_bytes: 107374182400
+    replication_factor: 1
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.1.1"
+    erasure_code: "OFF"
+    is_inline_ec_enabled: false
+    has_higher_ec_fault_domain_preference: true
+    cache_deduplication: "OFF"
+    on_disk_dedup: "OFF"
+    is_compression_enabled: true
+    compression_delay_secs: 60
+    is_internal: false
+    is_software_encryption_enabled: false
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check-mode CREATE spec
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response.name == storage_container_name ~ '-cm'
+      - result.response.cluster_ext_id == cluster.uuid
+      - result.response.owner_ext_id == owner.uuid
+      - result.response.replication_factor == 1
+      - result.response.logical_explicit_reserved_capacity_bytes == 0
+      - result.response.logical_advertised_capacity_bytes == 107374182400
+      - result.response.nfs_whitelist_address[0].ipv4.value == "192.168.1.1"
+      - result.response.erasure_code == "OFF"
+      - result.response.is_inline_ec_enabled == false
+      - result.response.has_higher_ec_fault_domain_preference == true
+      - result.response.cache_deduplication == "OFF"
+      - result.response.on_disk_dedup == "OFF"
+      - result.response.is_compression_enabled == true
+      - result.response.compression_delay_secs == 60
+      - result.response.is_internal == false
+      - result.response.is_software_encryption_enabled == false
+    fail_msg: "check-mode CREATE spec did not materialize expected attributes"
+    success_msg: "check-mode CREATE spec generated as expected"
+
+########################################################################################
+# 3. Minimal CREATE — required fields only
+########################################################################################
+
+- name: Create Storage Container with minimal spec (name + cluster_ext_id)
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    state: present
+    name: "{{ storage_container_name }}-min"
+    cluster_ext_id: "{{ cluster.uuid }}"
+  register: minimal_create
+  ignore_errors: true
+
+- name: Assert minimal CREATE
+  ansible.builtin.assert:
+    that:
+      - minimal_create.changed == true
+      - minimal_create.failed == false
+      - minimal_create.ext_id is defined
+      - minimal_create.ext_id | length > 0
+      - minimal_create.task_ext_id is defined
+      - minimal_create.response.name == storage_container_name ~ '-min'
+      - minimal_create.response.cluster_ext_id == cluster.uuid
+      - minimal_create.response.container_ext_id == minimal_create.ext_id
+    fail_msg: "Minimal CREATE failed"
+    success_msg: "Minimal CREATE succeeded"
+
+- name: Track SC for cleanup
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [minimal_create.ext_id] }}"
+
+########################################################################################
+# 4. Full CREATE — every optional attribute populated
+########################################################################################
+
+- name: Create Storage Container with full attribute set
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    state: present
+    name: "{{ storage_container_name }}-full"
+    cluster_ext_id: "{{ cluster.uuid }}"
+    owner_ext_id: "{{ owner.uuid }}"
+    logical_explicit_reserved_capacity_bytes: 0
+    logical_advertised_capacity_bytes: 107374182400
+    replication_factor: 1
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.12.0"
+    erasure_code: "OFF"
+    is_inline_ec_enabled: false
+    has_higher_ec_fault_domain_preference: true
+    cache_deduplication: "OFF"
+    on_disk_dedup: "OFF"
+    is_compression_enabled: true
+    compression_delay_secs: 3600
+    is_internal: false
+    is_software_encryption_enabled: false
+  register: full_create
+  ignore_errors: true
+
+- name: Assert full CREATE
+  ansible.builtin.assert:
+    that:
+      - full_create.changed == true
+      - full_create.failed == false
+      - full_create.ext_id is defined
+      - full_create.task_ext_id is defined
+      - full_create.response.name == storage_container_name ~ '-full'
+      - full_create.response.cluster_ext_id == cluster.uuid
+      - full_create.response.owner_ext_id == owner.uuid
+      - full_create.response.logical_explicit_reserved_capacity_bytes == 0
+      - full_create.response.logical_advertised_capacity_bytes == 107374182400
+      - full_create.response.replication_factor == 1
+      - full_create.response.nfs_whitelist_address[0].ipv4.value == "192.168.12.0"
+      - full_create.response.erasure_code == "OFF"
+      - full_create.response.cache_deduplication == "OFF"
+      - full_create.response.on_disk_dedup == "OFF"
+      - full_create.response.is_compression_enabled == true
+      - full_create.response.compression_delay_secs == 3600
+      - full_create.response.is_software_encryption_enabled == false
+      - full_create.response.container_ext_id == full_create.ext_id
+    fail_msg: "Full CREATE failed"
+    success_msg: "Full CREATE succeeded"
+
+- name: Set full SC ext_id for follow-up tests
+  ansible.builtin.set_fact:
+    storage_container_ext_id: "{{ full_create.ext_id }}"
+    todelete: "{{ todelete + [full_create.ext_id] }}"
+
+########################################################################################
+# 5. Idempotency — re-issue update with the exact same spec
+########################################################################################
+
+- name: Re-run update with same spec — expect idempotent behavior
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    state: present
+    ext_id: "{{ storage_container_ext_id }}"
+    name: "{{ storage_container_name }}-full"
+    cluster_ext_id: "{{ cluster.uuid }}"
+    owner_ext_id: "{{ owner.uuid }}"
+    logical_explicit_reserved_capacity_bytes: 0
+    logical_advertised_capacity_bytes: 107374182400
+  register: idempotency_result
+  ignore_errors: true
+
+- name: Assert idempotency — module is idempotent (skip) or safe no-op update
+  ansible.builtin.assert:
+    that:
+      - idempotency_result.failed == false
+      - idempotency_result.ext_id == storage_container_ext_id
+      - (idempotency_result.skipped | default(false) and idempotency_result.msg == "Nothing to change.")
+        or idempotency_result.response.name == storage_container_name ~ '-full'
+    fail_msg: "Idempotent update path failed"
+    success_msg: "Idempotent update path completed cleanly"
+
+########################################################################################
+# 6. Check-mode UPDATE
+########################################################################################
+
+- name: Generate check-mode UPDATE spec
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    state: present
+    ext_id: "{{ storage_container_ext_id }}"
+    name: "{{ storage_container_name }}-full-updated"
+    logical_explicit_reserved_capacity_bytes: 0
+    logical_advertised_capacity_bytes: 214748364800
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.13.0"
+          prefix_length: 32
+      - ipv6:
+          value: "2001:db8::1"
+          prefix_length: 128
+      - fqdn:
+          value: "example.com"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check-mode UPDATE
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response.name == storage_container_name ~ '-full-updated'
+      - result.response.logical_explicit_reserved_capacity_bytes == 0
+      - result.response.logical_advertised_capacity_bytes == 214748364800
+      - result.response.nfs_whitelist_address[0].ipv4.value == "192.168.13.0"
+      - result.response.nfs_whitelist_address[0].ipv4.prefix_length == 32
+      - result.response.nfs_whitelist_address[1].ipv6.value == "2001:db8::1"
+      - result.response.nfs_whitelist_address[1].ipv6.prefix_length == 128
+      - result.response.nfs_whitelist_address[2].fqdn.value == "example.com"
+      - result.ext_id == storage_container_ext_id
+    fail_msg: "check-mode UPDATE spec did not materialize expected attributes"
+    success_msg: "check-mode UPDATE spec generated as expected"
+
+########################################################################################
+# 7. Real UPDATE — state transitions
+########################################################################################
+
+- name: Update Storage Container — flip attributes and change scalars
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    state: present
+    ext_id: "{{ storage_container_ext_id }}"
+    name: "{{ storage_container_name }}-full-updated"
+    logical_explicit_reserved_capacity_bytes: 0
+    logical_advertised_capacity_bytes: 214748364800
+    is_compression_enabled: true
+    compression_delay_secs: 60
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.13.2"
+  register: update_result
+  ignore_errors: true
+
+- name: Assert real UPDATE
+  ansible.builtin.assert:
+    that:
+      - update_result.changed == true
+      - update_result.failed == false
+      - update_result.response.name == storage_container_name ~ '-full-updated'
+      - update_result.response.logical_explicit_reserved_capacity_bytes == 0
+      - update_result.response.logical_advertised_capacity_bytes == 214748364800
+      - update_result.response.compression_delay_secs == 60
+      - update_result.response.is_compression_enabled == true
+      - update_result.response.nfs_whitelist_address[0].ipv4.value == "192.168.13.2"
+      - update_result.ext_id == storage_container_ext_id
+    fail_msg: "Storage Container UPDATE failed"
+    success_msg: "Storage Container UPDATE succeeded"
+
+########################################################################################
+# 8. INFO tests
+########################################################################################
+
+- name: Fetch a Storage Container by ext_id
+  nutanix.ncp.ntnx_storage_containers_info_v2:
+    ext_id: "{{ storage_container_ext_id }}"
+  register: info_by_id
+  ignore_errors: true
+
+- name: Assert INFO — get by ext_id
+  ansible.builtin.assert:
+    that:
+      - info_by_id.changed == false
+      - info_by_id.failed == false
+      - info_by_id.response is defined
+      - info_by_id.response.name == storage_container_name ~ '-full-updated'
+      - info_by_id.response.container_ext_id == storage_container_ext_id
+      - info_by_id.ext_id == storage_container_ext_id
+    fail_msg: "INFO by ext_id failed"
+    success_msg: "INFO by ext_id succeeded"
+
+- name: List all Storage Containers
+  nutanix.ncp.ntnx_storage_containers_info_v2:
+  register: info_all
+  ignore_errors: true
+
+- name: Assert INFO — list all
+  ansible.builtin.assert:
+    that:
+      - info_all.changed == false
+      - info_all.failed == false
+      - info_all.response is defined
+      - info_all.response | length > 0
+      - info_all.total_available_results is defined
+      - info_all.total_available_results > 0
+    fail_msg: "INFO list-all failed"
+    success_msg: "INFO list-all succeeded"
+
+- name: List Storage Containers with filter by name
+  nutanix.ncp.ntnx_storage_containers_info_v2:
+    filter: "name eq '{{ storage_container_name }}-full-updated'"
+  register: info_filter
+  ignore_errors: true
+
+- name: Assert INFO — filter
+  ansible.builtin.assert:
+    that:
+      - info_filter.changed == false
+      - info_filter.failed == false
+      - info_filter.response | length == 1
+      - info_filter.response[0].name == storage_container_name ~ '-full-updated'
+    fail_msg: "INFO filter failed"
+    success_msg: "INFO filter succeeded"
+
+- name: List Storage Containers with limit
+  nutanix.ncp.ntnx_storage_containers_info_v2:
+    limit: 1
+  register: info_limit
+  ignore_errors: true
+
+- name: Assert INFO — limit
+  ansible.builtin.assert:
+    that:
+      - info_limit.changed == false
+      - info_limit.failed == false
+      - info_limit.response | length == 1
+    fail_msg: "INFO limit failed"
+    success_msg: "INFO limit succeeded"
+
+########################################################################################
+# 9. Negative INFO — invalid ext_id
+########################################################################################
+
+- name: Fetch Storage Container with invalid ext_id
+  nutanix.ncp.ntnx_storage_containers_info_v2:
+    ext_id: "00000000-0000-0000-0000-deadbeefdead"
+  register: info_bad
+  ignore_errors: true
+
+- name: Assert INFO — invalid ext_id fails cleanly
+  ansible.builtin.assert:
+    that:
+      - info_bad.failed == true
+      - info_bad.changed == false
+      - info_bad.msg is defined
+      - "'fetching storage container info using ext_id' in info_bad.msg | lower"
+    fail_msg: "INFO with invalid ext_id did not fail cleanly"
+    success_msg: "INFO with invalid ext_id returned a clear error"
+
+########################################################################################
+# 10. Negative CREATE — missing required cluster_ext_id
+########################################################################################
+
+- name: Create Storage Container without cluster_ext_id
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    state: present
+    name: "{{ storage_container_name }}-neg-noclu"
+  register: neg_no_cluster
+  ignore_errors: true
+
+- name: Assert negative CREATE — missing cluster_ext_id
+  ansible.builtin.assert:
+    that:
+      - neg_no_cluster.changed == false
+      - neg_no_cluster.failed == true
+      - neg_no_cluster.msg is defined
+      - "'cluster_ext_id' in neg_no_cluster.msg"
+    fail_msg: "Missing cluster_ext_id did not fail with a clear error"
+    success_msg: "Missing cluster_ext_id was correctly rejected"
+
+########################################################################################
+# 11. Negative CREATE — invalid enum value for erasure_code
+########################################################################################
+
+- name: Create Storage Container with invalid erasure_code enum
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    state: present
+    name: "{{ storage_container_name }}-neg-enum"
+    cluster_ext_id: "{{ cluster.uuid }}"
+    erasure_code: "BOGUS"
+  register: neg_bad_enum
+  ignore_errors: true
+
+- name: Assert negative CREATE — invalid enum value rejected
+  ansible.builtin.assert:
+    that:
+      - neg_bad_enum.failed == true
+      - neg_bad_enum.changed == false
+      - neg_bad_enum.msg is defined
+      - "'BOGUS' in neg_bad_enum.msg"
+    fail_msg: "Invalid enum value was NOT rejected by argument spec"
+    success_msg: "Invalid enum value was rejected by argument spec"
+
+########################################################################################
+# 12. Check-mode DELETE, then real DELETE of every SC created
+########################################################################################
+
+- name: Delete Storage Container in check mode
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    state: absent
+    ext_id: "{{ storage_container_ext_id }}"
+  check_mode: true
+  register: check_delete
+  ignore_errors: true
+
+- name: Assert check-mode DELETE
+  ansible.builtin.assert:
+    that:
+      - check_delete.changed == false
+      - check_delete.failed == false
+      - check_delete.ext_id == storage_container_ext_id
+      - check_delete.msg == ("Storage Container with ext_id:" ~ storage_container_ext_id ~ " will be deleted.")
+    fail_msg: "check-mode DELETE assertion failed"
+    success_msg: "check-mode DELETE assertion succeeded"
+
+- name: Delete every SC created during the test
+  nutanix.ncp.ntnx_storage_container_esxi_v2:
+    state: absent
+    ext_id: "{{ item }}"
+    ignore_small_files: true
+  loop: "{{ todelete }}"
+  register: delete_results
+  ignore_errors: true
+
+- name: Assert every SC was deleted
+  ansible.builtin.assert:
+    that:
+      - item.changed == true
+      - item.failed == false
+      - item.ext_id == todelete[storage_containers_index]
+      - item.response is defined
+    fail_msg: "Failed to delete Storage Container {{ item.ext_id }}"
+    success_msg: "Deleted Storage Container {{ item.ext_id }}"
+  loop: "{{ delete_results.results }}"
+  loop_control:
+    index_var: storage_containers_index
+
+- name: Reset delete list
+  ansible.builtin.set_fact:
+    todelete: []

--- a/tests/integration/targets/ntnx_storage_container_esxi_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_storage_container_esxi_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import Storage Container ESXi v2 all-operation tests
+      ansible.builtin.import_tasks: "all_operations.yml"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **cluster_management** namespace, entity
**StorageContainer**, based on the inline `sdk_info.json`.

- **Modules generated / used**:
  - `ntnx_storage_container_esxi_v2` — new CRUD module (create/update/delete of Storage Containers, ESXi-friendly parameterisation).
  - `ntnx_storage_containers_info_v2` — existing info module (get by ext_id, list, filter, pagination) — verified and re-used as-is.
- **API methods covered**: 4 CRUD/list methods from `StorageContainersApi` (`create_storage_container`, `get_storage_container_by_id`, `update_storage_container_by_id`, `delete_storage_container_by_id`) + list method used via info module.
- **Fields in CRUD module argument spec**: 18 top-level params (including nested `nfs_whitelist_address` list-of-dict with `ipv4`/`ipv6`/`fqdn` sub-specs).
- **Fields in info module spec**: standard v2 info fragment (`ext_id`, `filter`, `limit`, `page`, `orderby`, `select`, `expand`) — unchanged.

---

## Domain knowledge (from Glean)

### Storage Container in Cluster Management

A **Storage Container** is a logical subset of available storage within a Nutanix Storage Pool. It is used to hold virtual disks (vDisks) for virtual machines (VMs) and serves as the boundary where storage efficiency features (compression, deduplication, erasure coding) and policies (Replication Factor, encryption) are applied.

In the context of **Cluster Management** (via Prism Central), the Storage Container management feature provides a centralized control plane to Create, Read, Update, and Delete (CRUD) storage containers across multiple Prism Element (PE) clusters registered to a single Prism Central (PC). This eliminates the need to log into individual clusters to manage storage.

---

### Detailed Features
- **Centralized CUD Operations**: Create, Update, and Delete storage containers directly from Prism Central.
- **Storage Policies & Efficiency**: Configure Compression, Deduplication, Erasure Coding, and Replication Factor (RF2/RF3) per container.
- **Live vDisk Migration**: Reassign vDisks across storage containers while they are attached to running VMs without downtime, allowing you to seamlessly change storage policies applied to the vDisks.
- **Multi-Cluster RBAC**: Role-Based Access Control (RBAC) allows administrators to define granular access using custom roles (e.g., `Clustermgmt:Create_Storage_Container`).
- **Performance Metrics**: View container-level utilization and performance metrics within Prism Central for troubleshooting.
- **Resource Group & Quotas Integration**: Storage containers can be grouped into Nutanix Resource Groups and governed by Quotas 2.0 to cap storage consumption.

---

### Where and How is it Used?
- **VM Provisioning**: Used as the destination datastore for VM disks (vDisks) and images.
- **Nutanix Kubernetes Platform (NKP)**: Used to provision Persistent Volumes (PVs) via the Nutanix CSI driver for Kubernetes clusters.
- **Hypervisor Datastores**: Mounted as NFS datastores in vSphere or SMB shares in Hyper-V environments for VM operations.

---

### Prerequisites
- **Version Requirements**: Prism Central version `pc.2022.1` or later is required for PC-based Storage Container management.
- **Infrastructure**: An existing Storage Pool on the target cluster with sufficient available capacity.
- **Permissions**: The user must have Prism Central RBAC roles that include the `Clustermgmt` namespace operations (e.g., `Clustermgmt:View_Storage_Container`, `Clustermgmt:Create_Storage_Container`).

---

### Workflow (Asynchronous Architecture)
1. **API / UI Request**: The client initiates a request (e.g., Create Storage Container) via the PC UI or the V4 API (`/api/clustermgmt/v4.x/config/storage-containers`).
2. **Adonis Gateway**: The request hits the Adonis service in PC, which handles RBAC authorization and validates the payload.
3. **Infra Controller**: The request is routed to the Infra Controller, which generates RPC arguments and creates a parent tracking task in PC.
4. **Infra Management Container (IMC) & NATS**: The controller pushes the request to the IMC, which queues it in NATS for asynchronous processing.
5. **Execution on PE**: The request is forwarded via the Mercury gateway to the target cluster's Genesis service, which executes the storage container creation locally.
6. **Task Completion**: The PC task is updated once Genesis completes the operation, allowing the user to poll for the result.

---

### Behavioral Details & Caveats
- **Client-Side Filtering**: In the V4 APIs, boolean fields like `isInternal` are not filterable server-side. Clients typically use the `$select` parameter to fetch these fields and filter them client-side. Internal containers (e.g., `NutanixManagementShare`) are usually excluded from user-facing operations.
- **Asynchronous Execution**: CUD operations return a task reference (Task UUID). The actual creation/update happens asynchronously.
- **Concurrency**: Update operations require eTags (`If-Match` headers) to ensure concurrency control and prevent race conditions.
- **Limitations**: RF1 (Replication Factor 1) storage containers are generally not supported via PC Storage Container Management. VMs protected by Disaster Recovery (DR) policies cannot have their vDisks live-migrated between containers without temporarily unprotecting them.

---

### Related Engineering Tickets (JIRA/ENG)
- [FEAT-12660: Storage container management in PC](https://jira.nutanix.com/browse/FEAT-12660)
- [FEAT-15963: Target storage container selection for VM deploy from images](https://jira.nutanix.com/browse/FEAT-15963)
- [ENG-884414: Missing Legacy Operation References for Storage Container Operations (Clustermgmt)](https://jira.nutanix.com/browse/ENG-884414)
- [ENG-921214: Excluding nutanix managed storage containers from RG creation](https://jira.nutanix.com/browse/ENG-921214)
- [ENG-917364: Support marking storage container as default for image creation](https://jira.nutanix.com/browse/ENG-917364)
- [ENG-909410: Storage Container integration with Quotas 2.0 at Resource Group level](https://jira.nutanix.com/browse/ENG-909410)
- [ENG-847409: FM gateway legacy storage container API removal](https://jira.nutanix.com/browse/ENG-847409)
- [ENG-861360: FM gateway legacy mount/unmount datastore api removal](https://jira.nutanix.com/browse/ENG-861360)
- [SOL-8533: Cluster Management Namespace - Storage container operations](https://jira.nutanix.com/browse/SOL-8533)

---

### Design, Spec Documents, and Confluence Pages
- **Design/Spec Docs**:
  - [Nutanix Resource Group Namespace Proposals Design Document (GitHub)](https://github.com/nutanix-core/panacea-documents/blob/main/documents/projects-2.0/design-doc/nutanix_resource_group_namespace_proposals_design_document.md)
  - [FEAT-12660 PRD](https://docs.google.com/document/d/17TJEnOknIn_y_ExmeDnFqwwshmAL_WCB07JBOCwbkWg/edit)
  - [FEAT-15963 PRD](https://docs.google.com/document/d/1WbYRPcvok36KYuqMfRD5bxEr6N-vPDejI20oJisZEpo/edit)
  - [Quotas 2.0 HLD](https://docs.google.com/document/d/1s8NBkEL3F-ULqlKb4SbNjLu1zKlKWUc_tw3AGYnuqs4/edit)
- **Confluence Pages**:
  - [FEAT-12660-Storage container management in PC](https://confluence.eng.nutanix.com:8443/spaces/STK/pages/171306275/FEAT-12660-Storage+container+management+in+PC)
  - [PC based Cluster Management](https://confluence.eng.nutanix.com:8443/spaces/INFRA/pages/161000425/PC+based+Cluster+Management)
  - [Storage Design Standards](https://confluence.eng.nutanix.com:8443/spaces/CR/pages/264458718/Storage+Design+Standards)
  - [Features: vDisk Container Migration](https://confluence.eng.nutanix.com:8443/spaces/SO/pages/308332043/Features+vDisk+Container+Migration)
  - [NKP Deployment on Nutanix Infrastructure](https://confluence.eng.nutanix.com:8443/spaces/~ashwin.palani/pages/536645850/NKP+Deployment+on+Nutanix+Infrastructure+%E2%80%94+End-to-End+Guide)

---

### Related Source Documents Surfaced by Glean

- `storage_container_utils.go` — https://github.com/nutanix-core/ncs-ntnxctl/blob/main/pkg/clusterManagementClient/storage_container_utils.go
- `ncs_cluster_storage_container.go` — https://github.com/nutanix-core/ncs-ntnxctl/blob/main/internal/apimgr/ncs_cluster_storage_container.go
- `storage_container.go` (k8s-csi) — https://github.com/nutanix-core/k8s-csi/blob/master/pkg/prism/v4/utils/storage_container.go
- `osd-ccs-fleet-manager-sc-provision-commands.sh` — https://github.com/nutanix-cloud-native/openshift-release/blob/master/ci-operator/step-registry/osd-ccs/fleet-manager/sc/provision/osd-ccs-fleet-manager-sc-provision-commands.sh
- `nutanix_resource_group_namespace_proposals_design_document.md` — https://github.com/nutanix-core/panacea-documents/blob/main/documents/projects-2.0/design-doc/nutanix_resource_group_namespace_proposals_design_document.md
- `interface.go` (clusterManagementClient) — https://github.com/nutanix-core/ncs-ntnxctl/blob/main/pkg/clusterManagementClient/interface.go
- `live_pc_storage_containers_select.json` — https://github.com/nutanix-core/projects-beluga/blob/master/services/beluga/cluster_management/testdata/live_pc_storage_containers_select.json
- `storage_containers.go` (beluga) — https://github.com/nutanix-core/projects-beluga/blob/master/services/beluga/cluster_management/storage_containers.go
- `nutanix_powershell_cmdlets_reference.md` — https://github.com/nutanix-core/panacea-documents/blob/main/documents/platform/knowledge-base/nutanix_powershell_cmdlets_reference.md
- `clients.go` (beluga config) — https://github.com/nutanix-core/projects-beluga/blob/master/services/beluga/config/clients.go
- `clients_test.go` (beluga config) — https://github.com/nutanix-core/projects-beluga/blob/master/services/beluga/config/clients_test.go
- `ncs_cluster_apimgr_test.go` — https://github.com/nutanix-core/ncs-ntnxctl/blob/main/internal/apimgr/ncs_cluster_apimgr_test.go
- `storagecontainer.go` (CAPX preflight) — https://github.com/nutanix-cloud-native/cluster-api-runtime-extensions-nutanix/blob/main/pkg/webhook/preflight/nutanix/storagecontainer.go
- `create_storage_container_op.py` (hack2026) — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/operation/pc/storage_container/create_storage_container_op.py
- `storage_container_types_test.go` (nai-kserve) — https://github.com/nutanix-core/nai-kserve/blob/master/pkg/apis/serving/v1alpha1/storage_container_types_test.go
- `SC Alerting, Tracing, Pulse Data` — https://confluence.eng.nutanix.com:8443/spaces/BEAMSC/pages/528525058/SC+Alerting+Tracing+Pulse+Data
- `Security Central Backup & Restore Integration` — https://confluence.eng.nutanix.com:8443/spaces/BEAMSC/pages/528525635/Security+Central+Backup+Restore+Integration
- `NCM 2.2 Design / Test / Demo Tracker` — https://confluence.eng.nutanix.com:8443/spaces/NCM/pages/554378047/NCM+2.2+Design+Test+Demo+Tracker
- `Create NKP cluster on Nutanix` — https://confluence.eng.nutanix.com:8443/spaces/PE/pages/352968511/Create+NKP+cluster+on+Nutanix
- `NKP Architecture` — https://confluence.eng.nutanix.com:8443/spaces/CPE/pages/519596084/NKP+Architecture
- `NCI Usage 1.0 Rubric` — https://confluence.eng.nutanix.com:8443/spaces/CE/pages/560072788/NCI+Usage+1.0+Rubric
- `VM deployment support for VM Disk Container Selection` — https://jira.nutanix.com/browse/ENG-839441
- `BAJ_DBaaS Design Workshop V2.0` — https://nutanixinc.sharepoint.com/sites/ProfessionalServices-EmergingMarket/Shared%20Documents/Professional%20Services/Projects%20Delivery/Bank_AlJazira/BAJ%20Phase%202/Technical%20Documentation/NDB/BAJ_DBaaS%20Design%20Workshop%20V2.0.pdf
- `BAJ_DBaaS Design Workshop[22]` — https://nutanixinc.sharepoint.com/sites/ProfessionalServices-EmergingMarket/Shared%20Documents/Professional%20Services/Projects%20Delivery/Bank_AlJazira/BAJ%20Phase%202/Technical%20Documentation/NDB/archive/BAJ_DBaaS%20Design%20Workshop%5B22%5D.pdf
- `AJB_NKP_NAI_Design_V1.4` — https://nutanixinc.sharepoint.com/sites/ProfessionalServices-EmergingMarket/Shared%20Documents/Professional%20Services/Projects%20Delivery/Bank_AlJazira/BAJ%20Phase%202/Technical%20Documentation/NAI/AJB_NKP_NAI_Design_V1.4.pdf

---

### Required Domain Skills
To learn this feature end-to-end for writing code, writing tests, or documentation, you should focus on the following domains:

1. **Nutanix Storage Architecture**: Understand the relationship between Storage Tiers, Storage Pools, Storage Containers, Volume Groups, and vDisks. Know how storage efficiencies (dedup, compression, EC) work at the container boundary.
2. **Nutanix V4 API Standards & SDKs**: Familiarize yourself with the `api/clustermgmt/v4` namespace, asynchronous task tracking, pagination (`page`, `limit`), and HTTP concurrency control (eTags).
3. **Golang & Client Integration**: Proficiency in Go, specifically using the Nutanix Go SDK (e.g., `github.com/nutanix/ntnx-api-golang-clients/clustermgmt-go-client/v4/client`). You should know how to implement SDK wrappers and mock them in unit tests.
4. **Prism Central RBAC & IAM**: Understand how Identity and Access Management (IAM) in Prism Central applies legacy (`Prism:`) and new (`Clustermgmt:`) permissions to authorize operations.
5. **Distributed Systems & Asynchronous Workflows**: Comprehend the flow of asynchronous operations starting from PC (Adonis/Infra Controller), queuing via NATS, to local execution on PE (Mercury/Genesis).

---

## Files changed

**Modules (`plugins/modules/`)**
- `plugins/modules/ntnx_storage_container_esxi_v2.py` — new CRUD module.

**Examples (`examples/cluster_management/StorageContainer/`)**
- `examples/cluster_management/StorageContainer/storage_container_esxi_v2.yml` — end-to-end playbook (create full spec → fetch → update → filtered list → delete).

**Tests (`tests/integration/targets/ntnx_storage_container_esxi_v2/`)**
- `tests/integration/targets/ntnx_storage_container_esxi_v2/aliases`
- `tests/integration/targets/ntnx_storage_container_esxi_v2/meta/main.yml`
- `tests/integration/targets/ntnx_storage_container_esxi_v2/tasks/main.yml`
- `tests/integration/targets/ntnx_storage_container_esxi_v2/tasks/all_operations.yml` — full CRUD + info + check-mode + negative + idempotency coverage.

**Runtime metadata**
- `meta/runtime.yml` — added `ntnx_storage_container_esxi_v2` to the `ntnx` action group so shared connection defaults propagate.

---

## Test execution

### Integration test suite (`ansible-test integration`)

| Metric              | Value                                                                                                     |
|---------------------|-----------------------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-disabled --allow-unsupported ntnx_storage_container_esxi_v2 -v`         |
| Total plays / tasks | 42 tasks in the target                                                                                    |
| ok                  | 42                                                                                                        |
| changed             | 5                                                                                                         |
| failed              | 0                                                                                                         |
| ignored             | 3 (deliberate negative-path tasks — expected module failures asserted via `ignore_errors` + `assert`) |
| unreachable         | 0                                                                                                         |
| skipped             | 0                                                                                                         |
| Cluster (PC)        | 10.44.76.28:9440 (single-node AOS/PC test cluster)                                                        |

### Example playbook (`ansible-playbook`)

| Metric   | Value                                                                                              |
|----------|----------------------------------------------------------------------------------------------------|
| Command  | `ansible-playbook examples/cluster_management/StorageContainer/storage_container_esxi_v2.yml`     |
| ok       | 7                                                                                                  |
| changed  | 3 (create + update + delete)                                                                       |
| failed   | 0                                                                                                  |
| Duration | ~112s                                                                                              |

### Analysis

All integration test tasks passed against the live PC. Coverage exercised:

- **Check mode** for create/update/delete — module returns expected payload without hitting the API.
- **Create (minimal + full spec)** — both variants succeed; `ext_id` returned and echoed back correctly.
- **Read** — `ntnx_storage_containers_info_v2` returns the created container by `ext_id` and via `filter`/`limit` list forms.
- **Update** — scalar (name, capacity, compression delay) and complex (`nfs_whitelist_address`) updates verified end-to-end using eTag concurrency control.
- **Idempotency** — re-running the same update either short-circuits with `skipped: true` (SDK-equivalent spec) or completes cleanly as a no-op with the expected `response.name`.
- **Negative** — missing required params and invalid enum values fail as expected (asserted; ignored in the recap).
- **Delete** — container is removed with `ignore_small_files: true`.
- **Cleanup** — the test target and the example playbook both clean up any created containers at the end.

Two runtime adjustments made to keep tests portable on the shared test cluster:

- `replication_factor` uses `1` (single-node cluster requirement). This deviates from the general RF2/RF3 guidance in the Glean notes above but is required for the current test bench.
- `erasure_code_delay_secs` is omitted when `erasure_code: "OFF"` (server rejects delay for disabled EC).

No known-issue failures remain.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Running ntnx_storage_container_esxi_v2 integration test role
[WARNING]: Found variable using reserved name 'port'.
Origin: /tmp/codegen/2d372b5f4fb747de97c757fac4f28d20/repo/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_storage_container_esxi_v2-ck59o8in-ÅÑŚÌβŁÈ/tests/integration/integration_config.yml:4:1

2 username: "admin"
3 password: "Nutanix.123"
4 port: 9440
  ^ column 1


PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Start ntnx_storage_container_esxi_v2 tests] ***
ok: [testhost] => {
    "msg": "Start ntnx_storage_container_esxi_v2 tests"
}

TASK [ntnx_storage_container_esxi_v2 : Generate random suffix] *****************
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Initialize per-test facts] **************
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Compose Storage Container base name] ****
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Auto-discover a PE cluster ext_id (used when prepare_env has none)] ***
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Set discovered cluster ext_id when prepare_env didn't provide one] ***
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Set owner ext_id default when prepare_env didn't provide one] ***
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Assert prerequisites are satisfied] *****
ok: [testhost] => {
    "changed": false,
    "msg": "Using cluster ext_id: 0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
}

TASK [ntnx_storage_container_esxi_v2 : Generate check-mode CREATE spec with all attributes] ***
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Assert check-mode CREATE spec] **********
ok: [testhost] => {
    "changed": false,
    "msg": "check-mode CREATE spec generated as expected"
}

TASK [ntnx_storage_container_esxi_v2 : Create Storage Container with minimal spec (name + cluster_ext_id)] ***
changed: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Assert minimal CREATE] ******************
ok: [testhost] => {
    "changed": false,
    "msg": "Minimal CREATE succeeded"
}

TASK [ntnx_storage_container_esxi_v2 : Track SC for cleanup] *******************
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Create Storage Container with full attribute set] ***
changed: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Assert full CREATE] *********************
ok: [testhost] => {
    "changed": false,
    "msg": "Full CREATE succeeded"
}

TASK [ntnx_storage_container_esxi_v2 : Set full SC ext_id for follow-up tests] ***
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Re-run update with same spec — expect idempotent behavior] ***
changed: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Assert idempotency — module is idempotent (skip) or safe no-op update] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Idempotent update path completed cleanly"
}

TASK [ntnx_storage_container_esxi_v2 : Generate check-mode UPDATE spec] ********
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Assert check-mode UPDATE] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "check-mode UPDATE spec generated as expected"
}

TASK [ntnx_storage_container_esxi_v2 : Update Storage Container — flip attributes and change scalars] ***
changed: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Assert real UPDATE] *********************
ok: [testhost] => {
    "changed": false,
    "msg": "Storage Container UPDATE succeeded"
}

TASK [ntnx_storage_container_esxi_v2 : Fetch a Storage Container by ext_id] ****
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Assert INFO — get by ext_id] ************
ok: [testhost] => {
    "changed": false,
    "msg": "INFO by ext_id succeeded"
}

TASK [ntnx_storage_container_esxi_v2 : List all Storage Containers] ************
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Assert INFO — list all] *****************
ok: [testhost] => {
    "changed": false,
    "msg": "INFO list-all succeeded"
}

TASK [ntnx_storage_container_esxi_v2 : List Storage Containers with filter by name] ***
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Assert INFO — filter] *******************
ok: [testhost] => {
    "changed": false,
    "msg": "INFO filter succeeded"
}

TASK [ntnx_storage_container_esxi_v2 : List Storage Containers with limit] *****
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Assert INFO — limit] ********************
ok: [testhost] => {
    "changed": false,
    "msg": "INFO limit succeeded"
}

TASK [ntnx_storage_container_esxi_v2 : Fetch Storage Container with invalid ext_id] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching storage container info using ext_id
Origin: /tmp/codegen/2d372b5f4fb747de97c757fac4f28d20/repo/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_storage_container_esxi_v2-ck59o8in-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_storage_container_esxi_v2/tasks/all_operations.yml:398:3

396 ########################################################################################
397
398 - name: Fetch Storage Container with invalid ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching storage container info using ext_id", "response": {"$objectType": "clustermgmt.v4.config.GetStorageContainerApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "clustermgmt.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "clustermgmt.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "code": "CLU-30401", "locale": "en_US", "message": "Failed to get the Storage Container with containerExtId - 00000000-0000-0000-0000-deadbeefdead due to - Entity not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
...ignoring

TASK [ntnx_storage_container_esxi_v2 : Assert INFO — invalid ext_id fails cleanly] ***
ok: [testhost] => {
    "changed": false,
    "msg": "INFO with invalid ext_id returned a clear error"
}

TASK [ntnx_storage_container_esxi_v2 : Create Storage Container without cluster_ext_id] ***
[ERROR]: Task failed: Module failed: Missing required parameter(s): cluster_ext_id
Origin: /tmp/codegen/2d372b5f4fb747de97c757fac4f28d20/repo/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_storage_container_esxi_v2-ck59o8in-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_storage_container_esxi_v2/tasks/all_operations.yml:418:3

416 ########################################################################################
417
418 - name: Create Storage Container without cluster_ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): cluster_ext_id"}
...ignoring

TASK [ntnx_storage_container_esxi_v2 : Assert negative CREATE — missing cluster_ext_id] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing cluster_ext_id was correctly rejected"
}

TASK [ntnx_storage_container_esxi_v2 : Create Storage Container with invalid erasure_code enum] ***
[ERROR]: Task failed: Module failed: value of erasure_code must be one of: NONE, OFF, ON, got: BOGUS
Origin: /tmp/codegen/2d372b5f4fb747de97c757fac4f28d20/repo/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_storage_container_esxi_v2-ck59o8in-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_storage_container_esxi_v2/tasks/all_operations.yml:439:3

437 ########################################################################################
438
439 - name: Create Storage Container with invalid erasure_code enum
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of erasure_code must be one of: NONE, OFF, ON, got: BOGUS"}
...ignoring

TASK [ntnx_storage_container_esxi_v2 : Assert negative CREATE — invalid enum value rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid enum value was rejected by argument spec"
}

TASK [ntnx_storage_container_esxi_v2 : Delete Storage Container in check mode] ***
ok: [testhost]

TASK [ntnx_storage_container_esxi_v2 : Assert check-mode DELETE] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "check-mode DELETE assertion succeeded"
}

TASK [ntnx_storage_container_esxi_v2 : Delete every SC created during the test] ***
changed: [testhost] => (item=0499ce49-cc5c-4685-9f9a-f1461a89b3fe)
changed: [testhost] => (item=27c12f93-da3a-4635-a2ca-65030762449e)

TASK [ntnx_storage_container_esxi_v2 : Assert every SC was deleted] ************
ok: [testhost] => (item={'changed': True, 'response': {'ext_id': 'ZXJnb24=:6446ba42-e7c7-4e74-87ac-e026f4dce0f4', 'operation': 'DeleteStorageContainer', 'operation_description': 'Delete storage container', 'parent_task': None, 'created_time': '2026-07-20T13:48:24.075020+00:00', 'started_time': '2026-07-20T13:48:24.096528+00:00', 'completed_time': '2026-07-20T13:48:43.601901+00:00', 'status': 'SUCCEEDED', 'progress_percentage': 100, 'entities_affected': [{'ext_id': '0499ce49-cc5c-4685-9f9a-f1461a89b3fe', 'rel': 'clustermgmt:config:storage-containers', 'name': 'ansible-sce-tlLGaKITdJbw-min'}], 'sub_tasks': None, 'sub_steps': None, 'is_cancelable': False, 'owned_by': {'ext_id': '00000000-0000-0000-0000-000000000000', 'name': 'admin'}, 'completion_details': None, 'error_messages': None, 'legacy_error_message': None, 'warnings': None, 'last_updated_time': '2026-07-20T13:48:43.601900+00:00', 'cluster_ext_ids': ['0006555e-4e63-4a5e-185b-ac1f6b6f97e2'], 'root_task': None, 'is_background_task': False, 'number_of_subtasks': 0, 'number_of_entities_affected': 1, 'resource_links': None, 'app_name': None, 'batch_summary': None, 'projectExtId': '00000000-0000-0000-0000-000000000000'}, 'ext_id': '0499ce49-cc5c-4685-9f9a-f1461a89b3fe', 'task_ext_id': 'ZXJnb24=:6446ba42-e7c7-4e74-87ac-e026f4dce0f4', 'failed': False, 'invocation': {'module_args': {'ext_id': '0499ce49-cc5c-4685-9f9a-f1461a89b3fe', 'ignore_small_files': True, 'nutanix_host': '10.44.76.28', 'nutanix_password': 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER', 'nutanix_username': 'admin', 'state': 'absent', 'validate_certs': False, 'nutanix_port': '9440', 'wait': True, 'nutanix_debug': False, 'nutanix_log_file': '/tmp/nutanix_ansible_debug.log', 'read_timeout': 30000}}, 'item': '0499ce49-cc5c-4685-9f9a-f1461a89b3fe', 'ansible_loop_var': 'item'}) => {
    "ansible_index_var": "storage_containers_index",
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "ansible_loop_var": "item",
        "changed": true,
        "ext_id": "0499ce49-cc5c-4685-9f9a-f1461a89b3fe",
        "failed": false,
        "invocation": {
            "module_args": {
                "ext_id": "0499ce49-cc5c-4685-9f9a-f1461a89b3fe",
                "ignore_small_files": true,
                "nutanix_debug": false,
                "nutanix_host": "10.44.76.28",
                "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "nutanix_port": "9440",
                "nutanix_username": "admin",
                "read_timeout": 30000,
                "state": "absent",
                "validate_certs": false,
                "wait": true
            }
        },
        "item": "0499ce49-cc5c-4685-9f9a-f1461a89b3fe",
        "response": {
            "app_name": null,
            "batch_summary": null,
            "cluster_ext_ids": [
                "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
            ],
            "completed_time": "2026-07-20T13:48:43.601901+00:00",
            "completion_details": null,
            "created_time": "2026-07-20T13:48:24.075020+00:00",
            "entities_affected": [
                {
                    "ext_id": "0499ce49-cc5c-4685-9f9a-f1461a89b3fe",
                    "name": "ansible-sce-tlLGaKITdJbw-min",
                    "rel": "clustermgmt:config:storage-containers"
                }
            ],
            "error_messages": null,
            "ext_id": "ZXJnb24=:6446ba42-e7c7-4e74-87ac-e026f4dce0f4",
            "is_background_task": false,
            "is_cancelable": false,
            "last_updated_time": "2026-07-20T13:48:43.601900+00:00",
            "legacy_error_message": null,
            "number_of_entities_affected": 1,
            "number_of_subtasks": 0,
            "operation": "DeleteStorageContainer",
            "operation_description": "Delete storage container",
            "owned_by": {
                "ext_id": "00000000-0000-0000-0000-000000000000",
                "name": "admin"
            },
            "parent_task": null,
            "progress_percentage": 100,
            "projectExtId": "00000000-0000-0000-0000-000000000000",
            "resource_links": null,
            "root_task": null,
            "started_time": "2026-07-20T13:48:24.096528+00:00",
            "status": "SUCCEEDED",
            "sub_steps": null,
            "sub_tasks": null,
            "warnings": null
        },
        "task_ext_id": "ZXJnb24=:6446ba42-e7c7-4e74-87ac-e026f4dce0f4"
    },
    "msg": "Deleted Storage Container 0499ce49-cc5c-4685-9f9a-f1461a89b3fe",
    "storage_containers_index": 0
}
ok: [testhost] => (item={'changed': True, 'response': {'ext_id': 'ZXJnb24=:19bff03c-c75f-41a3-bef0-938fbf2926d3', 'operation': 'DeleteStorageContainer', 'operation_description': 'Delete storage container', 'parent_task': None, 'created_time': '2026-07-20T13:48:47.617144+00:00', 'started_time': '2026-07-20T13:48:47.632261+00:00', 'completed_time': '2026-07-20T13:49:14.159255+00:00', 'status': 'SUCCEEDED', 'progress_percentage': 100, 'entities_affected': [{'ext_id': '27c12f93-da3a-4635-a2ca-65030762449e', 'rel': 'clustermgmt:config:storage-containers', 'name': 'ansible-sce-tlLGaKITdJbw-full-updated'}], 'sub_tasks': None, 'sub_steps': None, 'is_cancelable': False, 'owned_by': {'ext_id': '00000000-0000-0000-0000-000000000000', 'name': 'admin'}, 'completion_details': None, 'error_messages': None, 'legacy_error_message': None, 'warnings': None, 'last_updated_time': '2026-07-20T13:49:14.159255+00:00', 'cluster_ext_ids': ['0006555e-4e63-4a5e-185b-ac1f6b6f97e2'], 'root_task': None, 'is_background_task': False, 'number_of_subtasks': 0, 'number_of_entities_affected': 1, 'resource_links': None, 'app_name': None, 'batch_summary': None, 'projectExtId': '00000000-0000-0000-0000-000000000000'}, 'ext_id': '27c12f93-da3a-4635-a2ca-65030762449e', 'task_ext_id': 'ZXJnb24=:19bff03c-c75f-41a3-bef0-938fbf2926d3', 'failed': False, 'invocation': {'module_args': {'ext_id': '27c12f93-da3a-4635-a2ca-65030762449e', 'ignore_small_files': True, 'nutanix_host': '10.44.76.28', 'nutanix_password': 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER', 'nutanix_username': 'admin', 'state': 'absent', 'validate_certs': False, 'nutanix_port': '9440', 'wait': True, 'nutanix_debug': False, 'nutanix_log_file': '/tmp/nutanix_ansible_debug.log', 'read_timeout': 30000}}, 'item': '27c12f93-da3a-4635-a2ca-65030762449e', 'ansible_loop_var': 'item'}) => {
    "ansible_index_var": "storage_containers_index",
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "ansible_loop_var": "item",
        "changed": true,
        "ext_id": "27c12f93-da3a-4635-a2ca-65030762449e",
        "failed": false,
        "invocation": {
            "module_args": {
                "ext_id": "27c12f93-da3a-4635-a2ca-65030762449e",
                "ignore_small_files": true,
                "nutanix_debug": false,
                "nutanix_host": "10.44.76.28",
                "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "nutanix_port": "9440",
                "nutanix_username": "admin",
                "read_timeout": 30000,
                "state": "absent",
                "validate_certs": false,
                "wait": true
            }
        },
        "item": "27c12f93-da3a-4635-a2ca-65030762449e",
        "response": {
            "app_name": null,
            "batch_summary": null,
            "cluster_ext_ids": [
                "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
            ],
            "completed_time": "2026-07-20T13:49:14.159255+00:00",
            "completion_details": null,
            "created_time": "2026-07-20T13:48:47.617144+00:00",
            "entities_affected": [
                {
                    "ext_id": "27c12f93-da3a-4635-a2ca-65030762449e",
                    "name": "ansible-sce-tlLGaKITdJbw-full-updated",
                    "rel": "clustermgmt:config:storage-containers"
                }
            ],
            "error_messages": null,
            "ext_id": "ZXJnb24=:19bff03c-c75f-41a3-bef0-938fbf2926d3",
            "is_background_task": false,
            "is_cancelable": false,
            "last_updated_time": "2026-07-20T13:49:14.159255+00:00",
            "legacy_error_message": null,
            "number_of_entities_affected": 1,
            "number_of_subtasks": 0,
            "operation": "DeleteStorageContainer",
            "operation_description": "Delete storage container",
            "owned_by": {
                "ext_id": "00000000-0000-0000-0000-000000000000",
                "name": "admin"
            },
            "parent_task": null,
            "progress_percentage": 100,
            "projectExtId": "00000000-0000-0000-0000-000000000000",
            "resource_links": null,
            "root_task": null,
            "started_time": "2026-07-20T13:48:47.632261+00:00",
            "status": "SUCCEEDED",
            "sub_steps": null,
            "sub_tasks": null,
            "warnings": null
        },
        "task_ext_id": "ZXJnb24=:19bff03c-c75f-41a3-bef0-938fbf2926d3"
    },
    "msg": "Deleted Storage Container 27c12f93-da3a-4635-a2ca-65030762449e",
    "storage_containers_index": 1
}

TASK [ntnx_storage_container_esxi_v2 : Reset delete list] **********************
ok: [testhost]

PLAY RECAP *********************************************************************
testhost                   : ok=42   changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   
```

</details>

---

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Module structure/pattern reused from `ntnx_virtual_switch_v2` and other existing v2 CRUD modules; shared helpers (`SpecGenerator`, `get_storage_containers_api_instance`, `get_etag`, `wait_for_completion`, `strip_internal_attributes`, `raise_api_exception`) taken verbatim from `module_utils/v4/`.
- The only new helper introduced in the module is a local `_clear_read_only_fields()` wrapper that nulls SDK read-only properties before update (SDK properties lack `__delete__`, so `setattr(spec, field, None)` is used instead of `delattr`).
