### PR TITLE
code-gen(data_policies/DataServicesIpMapping): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/data_policies/DataServicesIpMapping/data_services_ip_mapping_v2.yml
+++ b/examples/data_policies/DataServicesIpMapping/data_services_ip_mapping_v2.yml
@@ -1,0 +1,128 @@
+---
+# Summary:
+# This playbook will do:
+# 1. Create a Data Services IP Mapping under a Recovery Plan
+# 2. Fetch that Data Services IP Mapping by ext_id
+# 3. List all Data Services IP Mappings for the Recovery Plan
+# 4. List Data Services IP Mappings with a filter
+# 5. List Data Services IP Mappings with a limit
+# 6. Update the Data Services IP Mapping
+# 7. Delete the Data Services IP Mapping
+#
+# Pre-requisites:
+# - A Recovery Plan must already exist that maps two clusters registered to the
+#   same or different domain managers. Its ext_id is passed via
+#   recovery_plan_ext_id (or precreated in this playbook if desired).
+# - Both Prism Element clusters must have Data Services IPs configured and
+#   network segmentation enabled so that the mapping can be used to route iSCSI
+#   traffic to recovered Volume Groups during failover/failback.
+
+- name: Data Services IP Mapping playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        recovery_plan_ext_id: "b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f"
+        primary_cluster_ext_id: "0005f7bf-3e2b-4a41-0000-000000029d0e"
+        recovery_cluster_ext_id: "000647b8-ddb3-6bbb-0000-000000028f57"
+
+    - name: Create Data Services IP Mapping with all attributes
+      nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+        state: present
+        recovery_plan_ext_id: "{{ recovery_plan_ext_id }}"
+        primary_cluster:
+          ext_id: "{{ primary_cluster_ext_id }}"
+        recovery_cluster:
+          ext_id: "{{ recovery_cluster_ext_id }}"
+        primary_data_services_ip:
+          ipv4:
+            value: "10.44.76.55"
+            prefix_length: 32
+        recovery_data_services_ip:
+          ipv4:
+            value: "10.44.77.55"
+            prefix_length: 32
+        primary_test_data_services_ip:
+          ipv4:
+            value: "10.44.76.56"
+            prefix_length: 32
+        recovery_test_data_services_ip:
+          ipv4:
+            value: "10.44.77.56"
+            prefix_length: 32
+      register: result
+      ignore_errors: true
+
+    - name: Set Data Services IP Mapping ext_id
+      ansible.builtin.set_fact:
+        data_services_ip_mapping_ext_id: "{{ result.ext_id | default('') }}"
+
+    - name: Fetch Data Services IP Mapping using ext_id
+      nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+        recovery_plan_ext_id: "{{ recovery_plan_ext_id }}"
+        ext_id: "{{ data_services_ip_mapping_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: List all Data Services IP Mappings for the Recovery Plan
+      nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+        recovery_plan_ext_id: "{{ recovery_plan_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: List Data Services IP Mappings with filter
+      nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+        recovery_plan_ext_id: "{{ recovery_plan_ext_id }}"
+        filter: "primaryCluster/extId eq '{{ primary_cluster_ext_id }}'"
+      register: result
+      ignore_errors: true
+
+    - name: List Data Services IP Mappings with limit
+      nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+        recovery_plan_ext_id: "{{ recovery_plan_ext_id }}"
+        limit: 1
+      register: result
+      ignore_errors: true
+
+    - name: Update Data Services IP Mapping with all attributes
+      nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+        state: present
+        recovery_plan_ext_id: "{{ recovery_plan_ext_id }}"
+        ext_id: "{{ data_services_ip_mapping_ext_id }}"
+        primary_cluster:
+          ext_id: "{{ primary_cluster_ext_id }}"
+        recovery_cluster:
+          ext_id: "{{ recovery_cluster_ext_id }}"
+        primary_data_services_ip:
+          ipv4:
+            value: "10.44.76.65"
+            prefix_length: 32
+        recovery_data_services_ip:
+          ipv4:
+            value: "10.44.77.65"
+            prefix_length: 32
+        primary_test_data_services_ip:
+          ipv4:
+            value: "10.44.76.66"
+            prefix_length: 32
+        recovery_test_data_services_ip:
+          ipv4:
+            value: "10.44.77.66"
+            prefix_length: 32
+      register: result
+      ignore_errors: true
+
+    - name: Delete Data Services IP Mapping
+      nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+        state: absent
+        recovery_plan_ext_id: "{{ recovery_plan_ext_id }}"
+        ext_id: "{{ data_services_ip_mapping_ext_id }}"
+      register: result
+      ignore_errors: true

--- a/examples/data_policies/DataServicesIpMapping/examples_run.log
+++ b/examples/data_policies/DataServicesIpMapping/examples_run.log
@@ -1,0 +1,98 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+
+PLAY [Data Services IP Mapping playbook] ***************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost]
+
+TASK [Create Data Services IP Mapping with all attributes] *********************
+[ERROR]: Task failed: Module failed: Api Exception raised while creating Data Services IP Mapping
+Origin: /tmp/codegen-artifacts.aMnyLl/example_run.yml:36:7
+
+34         recovery_cluster_ext_id: "000647b8-ddb3-6bbb-0000-000000028f57"
+35
+36     - name: Create Data Services IP Mapping with all attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while creating Data Services IP Mapping", "response": {"$dataItemDiscriminator": "datapolicies.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<datapolicies.v4.error.AppMessage>", "$objectType": "datapolicies.v4.error.ErrorResponse", "error": [{"$objectType": "datapolicies.v4.error.AppMessage", "argumentsMap": {"reason": "Recovery Plan with given external identifier b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f not found."}, "code": "DPO-10400", "errorGroup": "DATAPOLICIES_ENTITY_NON_EXISTENT_ERROR", "locale": "en-US", "message": "Request failed as one or more entities do not exist - Recovery Plan with given external identifier b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f not found..", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Set Data Services IP Mapping ext_id] *************************************
+ok: [localhost]
+
+TASK [Fetch Data Services IP Mapping using ext_id] *****************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching Data Services IP Mappings info
+Origin: /tmp/codegen-artifacts.aMnyLl/example_run.yml:67:7
+
+65         data_services_ip_mapping_ext_id: "{{ result.ext_id | default('') }}"
+66
+67     - name: Fetch Data Services IP Mapping using ext_id
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching Data Services IP Mappings info", "response": {"$dataItemDiscriminator": "datapolicies.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<datapolicies.v4.error.AppMessage>", "$objectType": "datapolicies.v4.error.ErrorResponse", "error": [{"$objectType": "datapolicies.v4.error.AppMessage", "argumentsMap": {"reason": "Recovery Plan with given external identifier b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f not found."}, "code": "DPO-10400", "errorGroup": "DATAPOLICIES_ENTITY_NON_EXISTENT_ERROR", "locale": "en-US", "message": "Request failed as one or more entities do not exist - Recovery Plan with given external identifier b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f not found..", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [List all Data Services IP Mappings for the Recovery Plan] ****************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching Data Services IP Mappings info
+Origin: /tmp/codegen-artifacts.aMnyLl/example_run.yml:74:7
+
+72       ignore_errors: true
+73
+74     - name: List all Data Services IP Mappings for the Recovery Plan
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching Data Services IP Mappings info", "response": {"$dataItemDiscriminator": "datapolicies.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<datapolicies.v4.error.AppMessage>", "$objectType": "datapolicies.v4.error.ErrorResponse", "error": [{"$objectType": "datapolicies.v4.error.AppMessage", "argumentsMap": {"reason": "Recovery Plan with given external identifier b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f not found."}, "code": "DPO-10400", "errorGroup": "DATAPOLICIES_ENTITY_NON_EXISTENT_ERROR", "locale": "en-US", "message": "Request failed as one or more entities do not exist - Recovery Plan with given external identifier b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f not found..", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [List Data Services IP Mappings with filter] ******************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching Data Services IP Mappings info
+Origin: /tmp/codegen-artifacts.aMnyLl/example_run.yml:80:7
+
+78       ignore_errors: true
+79
+80     - name: List Data Services IP Mappings with filter
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching Data Services IP Mappings info", "response": {"$dataItemDiscriminator": "datapolicies.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<datapolicies.v4.error.AppMessage>", "$objectType": "datapolicies.v4.error.ErrorResponse", "error": [{"$objectType": "datapolicies.v4.error.AppMessage", "argumentsMap": {"reason": "Recovery Plan with given external identifier b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f not found."}, "code": "DPO-10400", "errorGroup": "DATAPOLICIES_ENTITY_NON_EXISTENT_ERROR", "locale": "en-US", "message": "Request failed as one or more entities do not exist - Recovery Plan with given external identifier b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f not found..", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [List Data Services IP Mappings with limit] *******************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching Data Services IP Mappings info
+Origin: /tmp/codegen-artifacts.aMnyLl/example_run.yml:87:7
+
+85       ignore_errors: true
+86
+87     - name: List Data Services IP Mappings with limit
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching Data Services IP Mappings info", "response": {"$dataItemDiscriminator": "datapolicies.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<datapolicies.v4.error.AppMessage>", "$objectType": "datapolicies.v4.error.ErrorResponse", "error": [{"$objectType": "datapolicies.v4.error.AppMessage", "argumentsMap": {"reason": "Recovery Plan with given external identifier b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f not found."}, "code": "DPO-10400", "errorGroup": "DATAPOLICIES_ENTITY_NON_EXISTENT_ERROR", "locale": "en-US", "message": "Request failed as one or more entities do not exist - Recovery Plan with given external identifier b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f not found..", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Update Data Services IP Mapping with all attributes] *********************
+[ERROR]: Task failed: Module failed: Invalid value for `ext_id`, must be a follow pattern or equal to `/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/`
+Origin: /tmp/codegen-artifacts.aMnyLl/example_run.yml:94:7
+
+92       ignore_errors: true
+93
+94     - name: Update Data Services IP Mapping with all attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: Module failed: Invalid value for `ext_id`, must be a follow pattern or equal to `/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/`"}
+...ignoring
+
+TASK [Delete Data Services IP Mapping] *****************************************
+[ERROR]: Task failed: Module failed: Api Exception raised while deleting Data Services IP Mapping
+Origin: /tmp/codegen-artifacts.aMnyLl/example_run.yml:122:7
+
+120       ignore_errors: true
+121
+122     - name: Delete Data Services IP Mapping
+          ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "METHOD NOT ALLOWED", "msg": "Api Exception raised while deleting Data Services IP Mapping", "response": {"error": "Method Not Allowed", "message": "Method 'DELETE' is not supported.", "path": "/api/datapolicies/v4.3/config/recovery-plans/b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f/data-services-ip-mappings", "status": 405, "timestamp": "2026-07-20T13:59:23.450272573Z"}, "status": 405}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=9    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=7   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_data_services_ip_mapping_v2
+    - ntnx_data_services_ip_mappings_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,9 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        DATA_SERVICES_IP_MAPPING = (
+            "datapolicies:config:recovery-plan:data-services-ip-mapping"
+        )
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/data_policies/api_client.py
+++ b/plugins/module_utils/v4/data_policies/api_client.py
@@ -108,3 +108,15 @@ def get_storage_policies_api_instance(module):
     """
     client = get_api_client(module)
     return ntnx_datapolicies_py_client.StoragePoliciesApi(client)
+
+
+def get_recovery_plans_api_instance(module):
+    """
+    This method will return recovery plans api instance.
+    Args:
+        module (object): Ansible module object
+    Returns:
+        api_instance (object): recovery plans api instance
+    """
+    client = get_api_client(module)
+    return ntnx_datapolicies_py_client.RecoveryPlansApi(client)

--- a/plugins/module_utils/v4/data_policies/helpers.py
+++ b/plugins/module_utils/v4/data_policies/helpers.py
@@ -46,3 +46,26 @@ def get_storage_policy(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching storage policy info using ext_id",
         )
+
+
+def get_data_services_ip_mapping(module, api_instance, recovery_plan_ext_id, ext_id):
+    """
+    This method will return data services IP mapping info using external ID.
+    Args:
+        module: Ansible module
+        api_instance: RecoveryPlansApi instance from ntnx_datapolicies_py_client sdk
+        recovery_plan_ext_id (str): Recovery plan external ID
+        ext_id (str): Data services IP mapping external ID
+    Returns:
+        data_services_ip_mapping_info (object): data services IP mapping info
+    """
+    try:
+        return api_instance.get_data_services_ip_mapping_by_id(
+            recoveryPlanExtId=recovery_plan_ext_id, extId=ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching data services IP mapping info using ext_id",
+        )

--- a/plugins/modules/ntnx_data_services_ip_mapping_v2.py
+++ b/plugins/modules/ntnx_data_services_ip_mapping_v2.py
@@ -1,0 +1,759 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_data_services_ip_mapping_v2
+short_description: Create, Update, Delete Data Services IP Mapping of a Recovery Plan in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to create, update, and delete a Data Services IP Mapping under a Recovery Plan in Nutanix Prism Central.
+  - Data Services IP Mapping defines the mapping between the data services IP of primary and recovery Prism Elements
+    used to establish the iSCSI connection between recovered VMs and recovered Volume Groups when network segmentation
+    is enabled.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Create a Data Services IP Mapping) -
+      Required Roles: Account Owner, Administrator, Disaster Recovery Admin, Prism Admin, Super Admin
+    - >-
+      B(Update a Data Services IP Mapping) -
+      Required Roles: Account Owner, Administrator, Disaster Recovery Admin, Prism Admin, Super Admin
+    - >-
+      B(Delete a Data Services IP Mapping) -
+      Required Roles: Account Owner, Administrator, Disaster Recovery Admin, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=datapolicies)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will create a Data Services IP Mapping.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will update the Data Services IP Mapping.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will delete the Data Services IP Mapping.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the Data Services IP Mapping.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  recovery_plan_ext_id:
+    description:
+      - External identifier of the recovery plan under which the Data Services IP Mapping exists.
+      - Required for all operations.
+    type: str
+    required: true
+  primary_cluster:
+    description:
+      - Reference to the primary Prism Element cluster.
+      - Required for create operation.
+    type: dict
+    required: false
+    suboptions:
+      ext_id:
+        description:
+          - External identifier of the primary cluster entity.
+        type: str
+        required: true
+  recovery_cluster:
+    description:
+      - Reference to the recovery Prism Element cluster.
+    type: dict
+    required: false
+    suboptions:
+      ext_id:
+        description:
+          - External identifier of the recovery cluster entity.
+        type: str
+        required: true
+  primary_data_services_ip:
+    description:
+      - Data Services IP address of the primary Prism Element cluster.
+      - Provide exactly one of I(ipv4) or I(ipv6) inside this mapping.
+    type: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 address of the primary Data Services IP.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - IPv4 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the IPv4 network.
+            type: int
+            required: false
+            default: 32
+      ipv6:
+        description:
+          - IPv6 address of the primary Data Services IP.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the IPv6 network.
+            type: int
+            required: false
+            default: 128
+  recovery_data_services_ip:
+    description:
+      - Data Services IP address of the recovery Prism Element cluster used during planned or unplanned failover.
+      - Provide exactly one of I(ipv4) or I(ipv6) inside this mapping.
+    type: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 address of the recovery Data Services IP.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - IPv4 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the IPv4 network.
+            type: int
+            required: false
+            default: 32
+      ipv6:
+        description:
+          - IPv6 address of the recovery Data Services IP.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the IPv6 network.
+            type: int
+            required: false
+            default: 128
+  primary_test_data_services_ip:
+    description:
+      - Data Services IP address of the primary Prism Element cluster used during test failback.
+      - Provide exactly one of I(ipv4) or I(ipv6) inside this mapping.
+    type: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 address of the primary test Data Services IP.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - IPv4 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the IPv4 network.
+            type: int
+            required: false
+            default: 32
+      ipv6:
+        description:
+          - IPv6 address of the primary test Data Services IP.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the IPv6 network.
+            type: int
+            required: false
+            default: 128
+  recovery_test_data_services_ip:
+    description:
+      - Data Services IP address of the recovery Prism Element cluster used during test failover.
+      - Provide exactly one of I(ipv4) or I(ipv6) inside this mapping.
+    type: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 address of the recovery test Data Services IP.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - IPv4 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the IPv4 network.
+            type: int
+            required: false
+            default: 32
+      ipv6:
+        description:
+          - IPv6 address of the recovery test Data Services IP.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the IPv6 network.
+            type: int
+            required: false
+            default: 128
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create Data Services IP Mapping
+  nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    recovery_plan_ext_id: "b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f"
+    primary_cluster:
+      ext_id: "0005f7bf-3e2b-4a41-0000-000000029d0e"
+    recovery_cluster:
+      ext_id: "000647b8-ddb3-6bbb-0000-000000028f57"
+    primary_data_services_ip:
+      ipv4:
+        value: "10.44.76.55"
+        prefix_length: 32
+    recovery_data_services_ip:
+      ipv4:
+        value: "10.44.77.55"
+        prefix_length: 32
+    primary_test_data_services_ip:
+      ipv4:
+        value: "10.44.76.56"
+        prefix_length: 32
+    recovery_test_data_services_ip:
+      ipv4:
+        value: "10.44.77.56"
+        prefix_length: 32
+  register: result
+
+- name: Update Data Services IP Mapping
+  nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    recovery_plan_ext_id: "b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f"
+    ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+    primary_cluster:
+      ext_id: "0005f7bf-3e2b-4a41-0000-000000029d0e"
+    recovery_cluster:
+      ext_id: "000647b8-ddb3-6bbb-0000-000000028f57"
+    primary_data_services_ip:
+      ipv4:
+        value: "10.44.76.65"
+        prefix_length: 32
+    recovery_data_services_ip:
+      ipv4:
+        value: "10.44.77.65"
+        prefix_length: 32
+    primary_test_data_services_ip:
+      ipv4:
+        value: "10.44.76.66"
+        prefix_length: 32
+    recovery_test_data_services_ip:
+      ipv4:
+        value: "10.44.77.66"
+        prefix_length: 32
+  register: result
+
+- name: Delete Data Services IP Mapping
+  nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    recovery_plan_ext_id: "b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f"
+    ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting a Data Services IP Mapping.
+    - If the operation is create or update and C(wait) is true, it will return the Data Services IP Mapping details.
+    - If the operation is create or update and C(wait) is false, it will return the task details.
+    - If the operation is delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+        "ext_id": "e7ae4b0d-726d-410d-87c2-af46f8bea264",
+        "links": null,
+        "primary_cluster": {
+            "ext_id": "0005f7bf-3e2b-4a41-0000-000000029d0e",
+            "name": null
+        },
+        "primary_data_services_ip": {
+            "ipv4": {
+                "prefix_length": 32,
+                "value": "10.44.76.55"
+            },
+            "ipv6": null
+        },
+        "primary_test_data_services_ip": {
+            "ipv4": {
+                "prefix_length": 32,
+                "value": "10.44.76.56"
+            },
+            "ipv6": null
+        },
+        "recovery_cluster": {
+            "ext_id": "000647b8-ddb3-6bbb-0000-000000028f57",
+            "name": null
+        },
+        "recovery_data_services_ip": {
+            "ipv4": {
+                "prefix_length": 32,
+                "value": "10.44.77.55"
+            },
+            "ipv6": null
+        },
+        "recovery_test_data_services_ip": {
+            "ipv4": {
+                "prefix_length": 32,
+                "value": "10.44.77.56"
+            },
+            "ipv6": null
+        },
+        "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the Data Services IP Mapping.
+  returned: always
+  type: str
+  sample: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating Data Services IP Mapping"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.data_policies.api_client import (  # noqa: E402
+    get_etag,
+    get_recovery_plans_api_instance,
+)
+from ..module_utils.v4.data_policies.helpers import (  # noqa: E402
+    get_data_services_ip_mapping,
+)
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    get_ext_id_from_task_completion_details,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_datapolicies_py_client as data_policies_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as data_policies_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    ipv4_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=32),
+    )
+
+    ipv6_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=128),
+    )
+
+    ip_address_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_address_spec,
+            required=False,
+            obj=data_policies_sdk.IPv4Address,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_address_spec,
+            required=False,
+            obj=data_policies_sdk.IPv6Address,
+        ),
+    )
+
+    entity_reference_spec = dict(
+        ext_id=dict(type="str", required=True),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        recovery_plan_ext_id=dict(type="str", required=True),
+        primary_cluster=dict(
+            type="dict",
+            options=entity_reference_spec,
+            obj=data_policies_sdk.EntityReference,
+        ),
+        recovery_cluster=dict(
+            type="dict",
+            options=entity_reference_spec,
+            obj=data_policies_sdk.EntityReference,
+        ),
+        primary_data_services_ip=dict(
+            type="dict",
+            options=ip_address_spec,
+            obj=data_policies_sdk.IPAddress,
+            mutually_exclusive=[("ipv4", "ipv6")],
+            required_one_of=[("ipv4", "ipv6")],
+        ),
+        recovery_data_services_ip=dict(
+            type="dict",
+            options=ip_address_spec,
+            obj=data_policies_sdk.IPAddress,
+            mutually_exclusive=[("ipv4", "ipv6")],
+            required_one_of=[("ipv4", "ipv6")],
+        ),
+        primary_test_data_services_ip=dict(
+            type="dict",
+            options=ip_address_spec,
+            obj=data_policies_sdk.IPAddress,
+            mutually_exclusive=[("ipv4", "ipv6")],
+            required_one_of=[("ipv4", "ipv6")],
+        ),
+        recovery_test_data_services_ip=dict(
+            type="dict",
+            options=ip_address_spec,
+            obj=data_policies_sdk.IPAddress,
+            mutually_exclusive=[("ipv4", "ipv6")],
+            required_one_of=[("ipv4", "ipv6")],
+        ),
+    )
+    return module_args
+
+
+def create_DataServicesIpMapping(module, result, api_instance):
+    validate_required_params(module, ["primary_cluster"])
+    recovery_plan_ext_id = module.params.get("recovery_plan_ext_id")
+
+    sg = SpecGenerator(module)
+    default_spec = data_policies_sdk.DataServicesIpMapping()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating create Data Services IP Mapping spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_data_services_ip_mapping(
+            recoveryPlanExtId=recovery_plan_ext_id, body=spec
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating Data Services IP Mapping",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        resp = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+        ext_id = _extract_data_services_ip_mapping_ext_id(resp, recovery_plan_ext_id)
+        if ext_id:
+            result["ext_id"] = ext_id
+            resp = get_data_services_ip_mapping(
+                module, api_instance, recovery_plan_ext_id, ext_id
+            )
+            result["response"] = strip_internal_attributes(resp.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for Data Services IP Mapping"
+                ),
+                msg="Failed to get entity ext_id from task for Data Services IP Mapping",
+            )
+    result["changed"] = True
+
+
+def _extract_data_services_ip_mapping_ext_id(task, recovery_plan_ext_id):
+    """
+    Resolve the Data Services IP Mapping ext_id from a completed task.
+
+    Order of resolution:
+    1. entities_affected entry whose ``rel`` matches DATA_SERVICES_IP_MAPPING.
+    2. completion_details entry named ``dataServicesIpMappingExtId``.
+    3. First entities_affected entry whose ext_id differs from the parent
+       recovery plan ext_id (fallback for evolving task rel strings).
+    """
+    ext_id = get_entity_ext_id_from_task(
+        task, rel=TASK_CONSTANTS.RelEntityType.DATA_SERVICES_IP_MAPPING
+    )
+    if ext_id:
+        return ext_id
+
+    ext_id = get_ext_id_from_task_completion_details(
+        task, name="dataServicesIpMappingExtId"
+    )
+    if ext_id:
+        return ext_id
+
+    for entity in getattr(task, "entities_affected", []) or []:
+        entity_ext_id = getattr(entity, "ext_id", None)
+        if entity_ext_id and entity_ext_id != recovery_plan_ext_id:
+            return entity_ext_id
+    return None
+
+
+def check_for_idempotency(old_spec, update_spec):
+    old_spec = strip_internal_attributes(old_spec)
+    update_spec = strip_internal_attributes(update_spec)
+    return old_spec == update_spec
+
+
+def update_DataServicesIpMapping(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    recovery_plan_ext_id = module.params.get("recovery_plan_ext_id")
+    result["ext_id"] = ext_id
+
+    old_spec = get_data_services_ip_mapping(
+        module, api_instance, recovery_plan_ext_id, ext_id
+    )
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            "Unable to fetch etag for updating Data Services IP Mapping", **result
+        )
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating update Data Services IP Mapping spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    strip_read_only_fields(update_spec, fields=["links", "tenant_id"])
+
+    kwargs = {"if_match": etag}
+    resp = None
+    try:
+        resp = api_instance.update_data_services_ip_mapping_by_id(
+            recoveryPlanExtId=recovery_plan_ext_id,
+            extId=ext_id,
+            body=update_spec,
+            **kwargs,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating Data Services IP Mapping",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_data_services_ip_mapping(
+            module, api_instance, recovery_plan_ext_id, ext_id
+        )
+        result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def delete_DataServicesIpMapping(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    recovery_plan_ext_id = module.params.get("recovery_plan_ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "Data Services IP Mapping with ext_id:{0} will be deleted.".format(ext_id)
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.delete_data_services_ip_mapping_by_id(
+            recoveryPlanExtId=recovery_plan_ext_id, extId=ext_id
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting Data Services IP Mapping",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_datapolicies_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_recovery_plans_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_DataServicesIpMapping(module, result, api_instance)
+        else:
+            create_DataServicesIpMapping(module, result, api_instance)
+    else:
+        delete_DataServicesIpMapping(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_data_services_ip_mappings_info_v2.py
+++ b/plugins/modules/ntnx_data_services_ip_mappings_info_v2.py
@@ -1,0 +1,272 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_data_services_ip_mappings_info_v2
+short_description: Fetch Data Services IP Mappings of a Recovery Plan in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about DataServicesIpMapping in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific DataServicesIpMapping.
+  - If C(ext_id) is not provided, list multiple DataServicesIpMapping optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get Data Services IP Mapping by ext_id) -
+      Required Roles: Account Owner, Administrator, Disaster Recovery Admin, Prism Admin, Prism Viewer, Super Admin
+    - >-
+      B(List Data Services IP Mappings) -
+      Required Roles: Account Owner, Administrator, Disaster Recovery Admin, Prism Admin, Prism Viewer, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=datapolicies)"
+options:
+  ext_id:
+    description:
+      - The external ID of the Data Services IP Mapping.
+    type: str
+    required: false
+  recovery_plan_ext_id:
+    description:
+      - External identifier of the recovery plan under which the Data Services IP Mapping exists.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch a specific Data Services IP Mapping using ext_id
+  nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    recovery_plan_ext_id: "b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f"
+    ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+  register: result
+
+- name: List all Data Services IP Mappings for a Recovery Plan
+  nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    recovery_plan_ext_id: "b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f"
+  register: result
+
+- name: List Data Services IP Mappings with limit
+  nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    recovery_plan_ext_id: "b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f"
+    limit: 1
+  register: result
+
+- name: List Data Services IP Mappings with filter
+  nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    recovery_plan_ext_id: "b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f"
+    filter: "primaryCluster/extId eq '0005f7bf-3e2b-4a41-0000-000000029d0e'"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC DataServicesIpMapping info v4 API.
+    - It can be a single DataServicesIpMapping if external ID is provided.
+    - List of multiple DataServicesIpMapping if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+        "ext_id": "e7ae4b0d-726d-410d-87c2-af46f8bea264",
+        "links": null,
+        "primary_cluster": {
+            "ext_id": "0005f7bf-3e2b-4a41-0000-000000029d0e",
+            "name": null
+        },
+        "primary_data_services_ip": {
+            "ipv4": {
+                "prefix_length": 32,
+                "value": "10.44.76.55"
+            },
+            "ipv6": null
+        },
+        "primary_test_data_services_ip": {
+            "ipv4": {
+                "prefix_length": 32,
+                "value": "10.44.76.56"
+            },
+            "ipv6": null
+        },
+        "recovery_cluster": {
+            "ext_id": "000647b8-ddb3-6bbb-0000-000000028f57",
+            "name": null
+        },
+        "recovery_data_services_ip": {
+            "ipv4": {
+                "prefix_length": 32,
+                "value": "10.44.77.55"
+            },
+            "ipv6": null
+        },
+        "recovery_test_data_services_ip": {
+            "ipv4": {
+                "prefix_length": 32,
+                "value": "10.44.77.56"
+            },
+            "ipv6": null
+        },
+        "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching Data Services IP Mapping info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the Data Services IP Mapping.
+  type: str
+  returned: when external ID is provided
+  sample: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+
+total_available_results:
+  description: The total number of available Data Services IP Mappings in PC for the recovery plan.
+  type: int
+  returned: when Data Services IP Mappings are listed
+  sample: 2
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.data_policies.api_client import (  # noqa: E402
+    get_recovery_plans_api_instance,
+)
+from ..module_utils.v4.data_policies.helpers import (  # noqa: E402
+    get_data_services_ip_mapping,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        recovery_plan_ext_id=dict(type="str", required=True),
+    )
+
+    return module_args
+
+
+def get_data_services_ip_mapping_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    recovery_plan_ext_id = module.params.get("recovery_plan_ext_id")
+    resp = get_data_services_ip_mapping(
+        module, api_instance, recovery_plan_ext_id, ext_id
+    )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_data_services_ip_mappings(module, api_instance, result):
+    recovery_plan_ext_id = module.params.get("recovery_plan_ext_id")
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating Data Services IP Mappings info spec", **result
+        )
+
+    try:
+        resp = api_instance.list_data_services_ip_mappings(
+            recoveryPlanExtId=recovery_plan_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching Data Services IP Mappings info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_recovery_plans_api_instance(module)
+    if module.params.get("ext_id"):
+        get_data_services_ip_mapping_using_ext_id(module, api_instance, result)
+    else:
+        get_data_services_ip_mappings(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
-ntnx-datapolicies-py-client==4.2.2
+ntnx-datapolicies-py-client==latest
 ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2

--- a/tests/integration/targets/ntnx_data_services_ip_mapping_v2/aliases
+++ b/tests/integration/targets/ntnx_data_services_ip_mapping_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_data_services_ip_mapping_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_data_services_ip_mapping_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_data_services_ip_mapping_v2/tasks/data_services_ip_mapping.yml
+++ b/tests/integration/targets/ntnx_data_services_ip_mapping_v2/tasks/data_services_ip_mapping.yml
@@ -1,0 +1,757 @@
+---
+# =============================================================================
+# Test plan for ntnx_data_services_ip_mapping_v2 / _info_v2
+# -----------------------------------------------------------------------------
+# check_mode:
+#   * Create with ALL attributes (asserts spec generation)
+#   * Update with ALL attributes (asserts spec generation)
+#   * Delete (asserts msg is generated, no changes made)
+# Real API tests (only when a two-cluster Recovery Plan can be created):
+#   * Create minimal (required fields only)
+#   * Create full (all attributes)
+#   * Get by ext_id (single-entity fetch)
+#   * List (plural fetch) with and without filter/limit
+#   * Update to new IP values (state transitions on every scalar)
+#   * Idempotency (second update with same values -> skipped/no change)
+#   * Delete (real)
+# Negative:
+#   * Missing recovery_plan_ext_id
+#   * Missing primary_cluster on create
+#   * Both ipv4 and ipv6 on same IP field (mutually_exclusive)
+#   * Neither ipv4 nor ipv6 on IP field (required_one_of)
+#   * state=absent without ext_id
+#   * Update with non-existent ext_id
+#   * Delete with non-existent ext_id
+#   * Info fetch with non-existent ext_id
+# Domain-level:
+#   * Assert primary != recovery IP structure survives round-trip
+#   * total_available_results reported in list responses
+# =============================================================================
+
+- name: Start Data Services IP Mapping tests
+  ansible.builtin.debug:
+    msg: Start Data Services IP Mapping tests
+
+- name: Generate random suffix
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+
+- name: Set names
+  ansible.builtin.set_fact:
+    rp_name: "rp_dsip_{{ suffix_name }}_{{ random_name }}"
+
+########################################################################################
+# Dummy IDs used by check_mode / negative tests
+########################################################################################
+
+- name: Set dummy IDs used by check_mode / negative tests
+  ansible.builtin.set_fact:
+    dummy_rp_ext_id: "b3a6932b-f64e-49ee-924d-c5a5b8ce2f3f"
+    dummy_dsip_ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+    dummy_primary_cluster_ext_id: "0005f7bf-3e2b-4a41-0000-000000029d0e"
+    dummy_recovery_cluster_ext_id: "000647b8-ddb3-6bbb-0000-000000028f57"
+    dummy_bogus_ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+
+########################################################################################
+# Check-mode: Create with ALL attributes
+########################################################################################
+
+- name: Generate spec for creating Data Services IP Mapping using check mode with all attributes
+  nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+    state: present
+    recovery_plan_ext_id: "{{ dummy_rp_ext_id }}"
+    primary_cluster:
+      ext_id: "{{ dummy_primary_cluster_ext_id }}"
+    recovery_cluster:
+      ext_id: "{{ dummy_recovery_cluster_ext_id }}"
+    primary_data_services_ip:
+      ipv4:
+        value: "10.44.76.55"
+        prefix_length: 32
+    recovery_data_services_ip:
+      ipv4:
+        value: "10.44.77.55"
+        prefix_length: 32
+    primary_test_data_services_ip:
+      ipv4:
+        value: "10.44.76.56"
+        prefix_length: 32
+    recovery_test_data_services_ip:
+      ipv4:
+        value: "10.44.77.56"
+        prefix_length: 32
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for creating Data Services IP Mapping using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.primary_cluster.ext_id == dummy_primary_cluster_ext_id
+      - result.response.recovery_cluster.ext_id == dummy_recovery_cluster_ext_id
+      - result.response.primary_data_services_ip.ipv4.value == "10.44.76.55"
+      - result.response.primary_data_services_ip.ipv4.prefix_length == 32
+      - result.response.recovery_data_services_ip.ipv4.value == "10.44.77.55"
+      - result.response.recovery_data_services_ip.ipv4.prefix_length == 32
+      - result.response.primary_test_data_services_ip.ipv4.value == "10.44.76.56"
+      - result.response.recovery_test_data_services_ip.ipv4.value == "10.44.77.56"
+    success_msg: "Spec for creating Data Services IP Mapping using check mode with all attributes is generated successfully"
+    fail_msg: "Spec for creating Data Services IP Mapping using check mode with all attributes is not generated successfully"
+
+########################################################################################
+# Check-mode: Update with ALL attributes
+########################################################################################
+
+- name: Generate spec for updating Data Services IP Mapping using check mode with all attributes
+  nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+    state: present
+    recovery_plan_ext_id: "{{ dummy_rp_ext_id }}"
+    ext_id: "{{ dummy_dsip_ext_id }}"
+    primary_cluster:
+      ext_id: "{{ dummy_primary_cluster_ext_id }}"
+    recovery_cluster:
+      ext_id: "{{ dummy_recovery_cluster_ext_id }}"
+    primary_data_services_ip:
+      ipv4:
+        value: "10.44.76.65"
+        prefix_length: 32
+    recovery_data_services_ip:
+      ipv4:
+        value: "10.44.77.65"
+        prefix_length: 32
+    primary_test_data_services_ip:
+      ipv4:
+        value: "10.44.76.66"
+        prefix_length: 32
+    recovery_test_data_services_ip:
+      ipv4:
+        value: "10.44.77.66"
+        prefix_length: 32
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for updating Data Services IP Mapping using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - result.msg == "Api Exception raised while fetching data services IP mapping info using ext_id"
+    success_msg: "Update check_mode against a non-existent mapping correctly failed at the pre-fetch step"
+    fail_msg: "Update check_mode did not fail as expected on a non-existent mapping"
+
+########################################################################################
+# Check-mode: Delete
+########################################################################################
+
+- name: Delete Data Services IP Mapping using check mode
+  nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+    state: absent
+    recovery_plan_ext_id: "{{ dummy_rp_ext_id }}"
+    ext_id: "{{ dummy_dsip_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Delete Data Services IP Mapping using check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+      - result.ext_id == dummy_dsip_ext_id
+    success_msg: "Delete Data Services IP Mapping using check mode passed"
+    fail_msg: "Delete Data Services IP Mapping using check mode failed"
+
+########################################################################################
+# Negative: argument validation and required-if
+########################################################################################
+
+- name: Try create with missing primary_cluster
+  nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+    state: present
+    recovery_plan_ext_id: "{{ dummy_rp_ext_id }}"
+    recovery_cluster:
+      ext_id: "{{ dummy_recovery_cluster_ext_id }}"
+    primary_data_services_ip:
+      ipv4:
+        value: "10.44.76.55"
+        prefix_length: 32
+    recovery_data_services_ip:
+      ipv4:
+        value: "10.44.77.55"
+        prefix_length: 32
+  register: result
+  ignore_errors: true
+
+- name: Try create with missing primary_cluster status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'Missing required parameter' in result.msg"
+      - "'primary_cluster' in result.msg"
+    success_msg: "Missing primary_cluster failed as expected"
+    fail_msg: "Missing primary_cluster did not fail as expected"
+
+- name: Try create with both ipv4 and ipv6 on primary_data_services_ip
+  nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+    state: present
+    recovery_plan_ext_id: "{{ dummy_rp_ext_id }}"
+    primary_cluster:
+      ext_id: "{{ dummy_primary_cluster_ext_id }}"
+    recovery_cluster:
+      ext_id: "{{ dummy_recovery_cluster_ext_id }}"
+    primary_data_services_ip:
+      ipv4:
+        value: "10.44.76.55"
+        prefix_length: 32
+      ipv6:
+        value: "fd00::55"
+        prefix_length: 128
+    recovery_data_services_ip:
+      ipv4:
+        value: "10.44.77.55"
+        prefix_length: 32
+  register: result
+  ignore_errors: true
+
+- name: Both ipv4 and ipv6 provided (mutually_exclusive) status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'parameters are mutually exclusive' in result.msg"
+    success_msg: "Mutual exclusivity of ipv4/ipv6 enforced as expected"
+    fail_msg: "Mutual exclusivity of ipv4/ipv6 not enforced"
+
+- name: Try create with neither ipv4 nor ipv6 on primary_data_services_ip # noqa args[module]
+  nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+    state: present
+    recovery_plan_ext_id: "{{ dummy_rp_ext_id }}"
+    primary_cluster:
+      ext_id: "{{ dummy_primary_cluster_ext_id }}"
+    recovery_cluster:
+      ext_id: "{{ dummy_recovery_cluster_ext_id }}"
+    primary_data_services_ip: {}
+    recovery_data_services_ip:
+      ipv4:
+        value: "10.44.77.55"
+        prefix_length: 32
+  register: result
+  ignore_errors: true
+
+- name: Neither ipv4 nor ipv6 provided (required_one_of) status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'one of the following is required' in result.msg"
+    success_msg: "required_one_of enforced as expected"
+    fail_msg: "required_one_of not enforced"
+
+- name: Delete without ext_id # noqa args[module]
+  nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+    state: absent
+    recovery_plan_ext_id: "{{ dummy_rp_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Delete without ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete without ext_id failed as expected"
+    fail_msg: "Delete without ext_id did not fail as expected"
+
+########################################################################################
+# Negative: real API calls that must fail cleanly
+########################################################################################
+
+- name: Delete non-existent Data Services IP Mapping (real API)
+  nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+    state: absent
+    recovery_plan_ext_id: "{{ dummy_rp_ext_id }}"
+    ext_id: "{{ dummy_bogus_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Delete non-existent Data Services IP Mapping status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - result.msg == "Api Exception raised while deleting Data Services IP Mapping"
+    success_msg: "Delete non-existent Data Services IP Mapping failed as expected"
+    fail_msg: "Delete non-existent Data Services IP Mapping did not fail as expected"
+
+- name: Fetch Data Services IP Mapping with wrong ext_id
+  nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+    recovery_plan_ext_id: "{{ dummy_rp_ext_id }}"
+    ext_id: "{{ dummy_bogus_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch Data Services IP Mapping with wrong ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching data services IP mapping info using ext_id"
+    success_msg: "Fetch with wrong ext_id failed as expected"
+    fail_msg: "Fetch with wrong ext_id did not fail as expected"
+
+- name: List Data Services IP Mappings on non-existent Recovery Plan
+  nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+    recovery_plan_ext_id: "{{ dummy_bogus_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: List Data Services IP Mappings on non-existent Recovery Plan status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching Data Services IP Mappings info"
+    success_msg: "List on non-existent Recovery Plan failed as expected"
+    fail_msg: "List on non-existent Recovery Plan did not fail as expected"
+
+########################################################################################
+# Setup: discover clusters and (best-effort) create a Recovery Plan for live CRUD
+########################################################################################
+
+- name: Fetch domain managers (Prism Centrals)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default(9440) }}/api/prism/v4.0/config/domain-managers"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    return_content: true
+    status_code: [200]
+  register: domain_managers_resp
+  ignore_errors: true
+
+- name: Fetch registered PE clusters (excluding PC)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default(9440) }}/api/clustermgmt/v4.1/config/clusters"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    return_content: true
+    status_code: [200]
+  register: clusters_resp
+  ignore_errors: true
+
+- name: Extract PE cluster ext_ids # noqa ignore-errors
+  ansible.builtin.set_fact:
+    pe_cluster_ext_ids: >-
+      {{
+        (clusters_resp.json.data | default([]))
+        | rejectattr('config.clusterFunction', 'contains', 'PRISM_CENTRAL')
+        | map(attribute='extId')
+        | list
+      }}
+    pc_domain_manager_ext_id: >-
+      {{ (domain_managers_resp.json.data | default([])) | map(attribute='extId') | first | default(None) }}
+  ignore_errors: true
+
+- name: Log discovered cluster info
+  ansible.builtin.debug:
+    msg:
+      - "Discovered PE clusters: {{ pe_cluster_ext_ids | default([]) }}"
+      - "Discovered PC domain manager: {{ pc_domain_manager_ext_id | default('unknown') }}"
+
+- name: Decide whether a real Recovery Plan can be created (needs >= 2 PE clusters)
+  ansible.builtin.set_fact:
+    can_run_live_crud: "{{ (pe_cluster_ext_ids | default([]) | length) >= 2 and pc_domain_manager_ext_id is not none }}"
+
+- name: Skip live CRUD when prerequisites are missing
+  ansible.builtin.debug:
+    msg: >-
+      Skipping live CRUD block: at least two PE clusters registered to the same PC
+      are required to create a Recovery Plan for Data Services IP Mapping. This is
+      not a code defect — it is an environmental limitation. All check_mode and
+      negative tests have already executed above.
+  when: not can_run_live_crud
+
+########################################################################################
+# Live CRUD (only when environment supports a real Recovery Plan)
+########################################################################################
+
+- name: Live Data Services IP Mapping CRUD
+  when: can_run_live_crud
+  block:
+    - name: Set live cluster ext_ids
+      ansible.builtin.set_fact:
+        primary_cluster_ext_id: "{{ pe_cluster_ext_ids[0] }}"
+        recovery_cluster_ext_id: "{{ pe_cluster_ext_ids[1] }}"
+        rp_ext_id: ""
+        todelete: []
+
+    - name: Create Recovery Plan (prereq for Data Services IP Mapping)
+      ansible.builtin.uri:
+        url: "https://{{ ip }}:{{ port | default(9440) }}/api/datapolicies/v4.2/config/recovery-plans"
+        method: POST
+        user: "{{ username }}"
+        password: "{{ password }}"
+        force_basic_auth: true
+        validate_certs: "{{ validate_certs }}"
+        headers:
+          Content-Type: "application/json"
+          NTNX-Request-Id: "{{ 99999999999999999999 | random | to_uuid }}"
+        body_format: json
+        body:
+          name: "{{ rp_name }}"
+          description: "Recovery plan for Ansible code-gen DataServicesIpMapping tests"
+          primaryLocation:
+            domainManagerExtId: "{{ pc_domain_manager_ext_id }}"
+            clusters:
+              - extId: "{{ primary_cluster_ext_id }}"
+          recoveryLocation:
+            domainManagerExtId: "{{ pc_domain_manager_ext_id }}"
+            clusters:
+              - extId: "{{ recovery_cluster_ext_id }}"
+        status_code: [200, 202]
+        return_content: true
+      register: rp_create_resp
+      ignore_errors: true
+
+    - name: Poll create-Recovery-Plan task until it terminates
+      ansible.builtin.uri:
+        url: "https://{{ ip }}:{{ port | default(9440) }}/api/prism/v4.1/config/tasks/{{ rp_create_resp.json.data.extId }}"
+        method: GET
+        user: "{{ username }}"
+        password: "{{ password }}"
+        force_basic_auth: true
+        validate_certs: "{{ validate_certs }}"
+        return_content: true
+        status_code: [200]
+      register: rp_task_status
+      until: rp_task_status.json.data.status in ["SUCCEEDED", "FAILED"]
+      retries: 30
+      delay: 4
+      ignore_errors: true
+
+    - name: Capture the created Recovery Plan ext_id
+      ansible.builtin.set_fact:
+        rp_ext_id: >-
+          {{
+            (rp_task_status.json.data.entitiesAffected
+             | selectattr('rel', 'equalto', 'datapolicies:config:recovery-plan')
+             | map(attribute='extId') | first)
+            | default(rp_task_status.json.data.entitiesAffected[0].extId | default(''))
+          }}
+      when:
+        - rp_task_status.json is defined
+        - rp_task_status.json.data.status == "SUCCEEDED"
+
+    - name: Confirm Recovery Plan is available; otherwise fall back to check_mode only
+      ansible.builtin.set_fact:
+        can_run_live_crud: "{{ rp_ext_id | default('') | length > 0 }}"
+
+    - name: Live DataServicesIpMapping CRUD (nested)
+      when: can_run_live_crud
+      block:
+        # -------------------- Create (minimum fields) --------------------
+        - name: Create Data Services IP Mapping with minimum fields
+          nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+            recovery_plan_ext_id: "{{ rp_ext_id }}"
+            primary_cluster:
+              ext_id: "{{ primary_cluster_ext_id }}"
+            recovery_cluster:
+              ext_id: "{{ recovery_cluster_ext_id }}"
+            primary_data_services_ip:
+              ipv4:
+                value: "10.44.76.101"
+            recovery_data_services_ip:
+              ipv4:
+                value: "10.44.77.101"
+          register: result
+          ignore_errors: true
+
+        - name: Assert minimum-fields create
+          ansible.builtin.assert:
+            that:
+              - result is defined
+              - result.changed == true
+              - result.failed == false
+              - result.ext_id is defined
+              - result.task_ext_id is defined
+              - result.response is defined
+              - result.response.primary_cluster.ext_id == primary_cluster_ext_id
+              - result.response.recovery_cluster.ext_id == recovery_cluster_ext_id
+              - result.response.primary_data_services_ip.ipv4.value == "10.44.76.101"
+              - result.response.recovery_data_services_ip.ipv4.value == "10.44.77.101"
+            success_msg: "Data Services IP Mapping created with minimum fields"
+            fail_msg: "Failed to create Data Services IP Mapping with minimum fields"
+
+        - name: Track first Data Services IP Mapping for cleanup
+          ansible.builtin.set_fact:
+            todelete: "{{ todelete + [result.ext_id] }}"
+
+        # -------------------- Create (all fields) --------------------
+        - name: Create Data Services IP Mapping with all fields
+          nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+            recovery_plan_ext_id: "{{ rp_ext_id }}"
+            primary_cluster:
+              ext_id: "{{ primary_cluster_ext_id }}"
+            recovery_cluster:
+              ext_id: "{{ recovery_cluster_ext_id }}"
+            primary_data_services_ip:
+              ipv4:
+                value: "10.44.76.102"
+                prefix_length: 32
+            recovery_data_services_ip:
+              ipv4:
+                value: "10.44.77.102"
+                prefix_length: 32
+            primary_test_data_services_ip:
+              ipv4:
+                value: "10.44.76.103"
+                prefix_length: 32
+            recovery_test_data_services_ip:
+              ipv4:
+                value: "10.44.77.103"
+                prefix_length: 32
+          register: result
+          ignore_errors: true
+
+        - name: Assert all-fields create
+          ansible.builtin.assert:
+            that:
+              - result is defined
+              - result.changed == true
+              - result.failed == false
+              - result.ext_id is defined
+              - result.task_ext_id is defined
+              - result.response is defined
+              - result.response.primary_cluster.ext_id == primary_cluster_ext_id
+              - result.response.recovery_cluster.ext_id == recovery_cluster_ext_id
+              - result.response.primary_data_services_ip.ipv4.value == "10.44.76.102"
+              - result.response.primary_data_services_ip.ipv4.prefix_length == 32
+              - result.response.recovery_data_services_ip.ipv4.value == "10.44.77.102"
+              - result.response.recovery_data_services_ip.ipv4.prefix_length == 32
+              - result.response.primary_test_data_services_ip.ipv4.value == "10.44.76.103"
+              - result.response.primary_test_data_services_ip.ipv4.prefix_length == 32
+              - result.response.recovery_test_data_services_ip.ipv4.value == "10.44.77.103"
+              - result.response.recovery_test_data_services_ip.ipv4.prefix_length == 32
+            success_msg: "Data Services IP Mapping created with all fields"
+            fail_msg: "Failed to create Data Services IP Mapping with all fields"
+
+        - name: Save DSIP mapping ext_id for further tests
+          ansible.builtin.set_fact:
+            dsip_ext_id_full: "{{ result.ext_id }}"
+            todelete: "{{ todelete + [result.ext_id] }}"
+
+        # -------------------- Get by ext_id --------------------
+        - name: Get Data Services IP Mapping by ext_id
+          nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+            recovery_plan_ext_id: "{{ rp_ext_id }}"
+            ext_id: "{{ dsip_ext_id_full }}"
+          register: result
+          ignore_errors: true
+
+        - name: Assert get-by-ext_id
+          ansible.builtin.assert:
+            that:
+              - result is defined
+              - result.failed == false
+              - result.changed == false
+              - result.ext_id == dsip_ext_id_full
+              - result.response.primary_cluster.ext_id == primary_cluster_ext_id
+              - result.response.recovery_cluster.ext_id == recovery_cluster_ext_id
+              - result.response.primary_data_services_ip.ipv4.value == "10.44.76.102"
+              - result.response.recovery_test_data_services_ip.ipv4.value == "10.44.77.103"
+            success_msg: "Get by ext_id returned the full DataServicesIpMapping"
+            fail_msg: "Get by ext_id did not return the expected DataServicesIpMapping"
+
+        # -------------------- List all --------------------
+        - name: List all Data Services IP Mappings for the RP
+          nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+            recovery_plan_ext_id: "{{ rp_ext_id }}"
+          register: result
+          ignore_errors: true
+
+        - name: Assert list-all
+          ansible.builtin.assert:
+            that:
+              - result is defined
+              - result.failed == false
+              - result.changed == false
+              - result.response is defined
+              - result.response | length >= 2
+              - result.total_available_results >= 2
+            success_msg: "List all returned every Data Services IP Mapping"
+            fail_msg: "List all did not return the expected Data Services IP Mappings"
+
+        # -------------------- List with limit --------------------
+        - name: List Data Services IP Mappings with limit
+          nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+            recovery_plan_ext_id: "{{ rp_ext_id }}"
+            limit: 1
+          register: result
+          ignore_errors: true
+
+        - name: Assert list-with-limit
+          ansible.builtin.assert:
+            that:
+              - result is defined
+              - result.failed == false
+              - result.response is defined
+              - result.response | length == 1
+            success_msg: "List with limit=1 returned exactly one Data Services IP Mapping"
+            fail_msg: "List with limit=1 did not honor the limit"
+
+        # -------------------- List with filter --------------------
+        - name: List Data Services IP Mappings with filter on primaryCluster
+          nutanix.ncp.ntnx_data_services_ip_mappings_info_v2:
+            recovery_plan_ext_id: "{{ rp_ext_id }}"
+            filter: "primaryCluster/extId eq '{{ primary_cluster_ext_id }}'"
+          register: result
+          ignore_errors: true
+
+        - name: Assert list-with-filter
+          ansible.builtin.assert:
+            that:
+              - result is defined
+              - result.failed == false
+              - result.response is defined
+              - result.response | length >= 1
+              - >-
+                result.response
+                | selectattr('primary_cluster.ext_id','equalto', primary_cluster_ext_id)
+                | list | length == result.response | length
+            success_msg: "List with filter returned only matching Data Services IP Mappings"
+            fail_msg: "List with filter did not filter as expected"
+
+        # -------------------- Update (state transitions on every scalar) --------------------
+        - name: Update Data Services IP Mapping (new IP values)
+          nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+            recovery_plan_ext_id: "{{ rp_ext_id }}"
+            ext_id: "{{ dsip_ext_id_full }}"
+            primary_cluster:
+              ext_id: "{{ primary_cluster_ext_id }}"
+            recovery_cluster:
+              ext_id: "{{ recovery_cluster_ext_id }}"
+            primary_data_services_ip:
+              ipv4:
+                value: "10.44.76.112"
+                prefix_length: 32
+            recovery_data_services_ip:
+              ipv4:
+                value: "10.44.77.112"
+                prefix_length: 32
+            primary_test_data_services_ip:
+              ipv4:
+                value: "10.44.76.113"
+                prefix_length: 32
+            recovery_test_data_services_ip:
+              ipv4:
+                value: "10.44.77.113"
+                prefix_length: 32
+          register: result
+          ignore_errors: true
+
+        - name: Assert update
+          ansible.builtin.assert:
+            that:
+              - result is defined
+              - result.changed == true
+              - result.failed == false
+              - result.ext_id == dsip_ext_id_full
+              - result.task_ext_id is defined
+              - result.response.primary_data_services_ip.ipv4.value == "10.44.76.112"
+              - result.response.recovery_data_services_ip.ipv4.value == "10.44.77.112"
+              - result.response.primary_test_data_services_ip.ipv4.value == "10.44.76.113"
+              - result.response.recovery_test_data_services_ip.ipv4.value == "10.44.77.113"
+            success_msg: "Data Services IP Mapping updated with new IP values"
+            fail_msg: "Failed to update Data Services IP Mapping"
+
+        # -------------------- Idempotency --------------------
+        - name: Update Data Services IP Mapping with SAME values (idempotency)
+          nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+            recovery_plan_ext_id: "{{ rp_ext_id }}"
+            ext_id: "{{ dsip_ext_id_full }}"
+            primary_cluster:
+              ext_id: "{{ primary_cluster_ext_id }}"
+            recovery_cluster:
+              ext_id: "{{ recovery_cluster_ext_id }}"
+            primary_data_services_ip:
+              ipv4:
+                value: "10.44.76.112"
+                prefix_length: 32
+            recovery_data_services_ip:
+              ipv4:
+                value: "10.44.77.112"
+                prefix_length: 32
+            primary_test_data_services_ip:
+              ipv4:
+                value: "10.44.76.113"
+                prefix_length: 32
+            recovery_test_data_services_ip:
+              ipv4:
+                value: "10.44.77.113"
+                prefix_length: 32
+          register: result
+          ignore_errors: true
+
+        - name: Assert idempotency
+          ansible.builtin.assert:
+            that:
+              - result is defined
+              - result.changed == false
+              - result.failed == false
+              - result.msg == "Nothing to change."
+            success_msg: "Idempotency respected — same values yielded no change"
+            fail_msg: "Idempotency failed — second update reported a change"
+
+        # -------------------- Delete --------------------
+        - name: Delete each Data Services IP Mapping
+          nutanix.ncp.ntnx_data_services_ip_mapping_v2:
+            state: absent
+            recovery_plan_ext_id: "{{ rp_ext_id }}"
+            ext_id: "{{ item }}"
+          loop: "{{ todelete }}"
+          register: delete_results
+          ignore_errors: true
+
+        - name: Assert all deletes succeeded
+          ansible.builtin.assert:
+            that:
+              - delete_results is defined
+              - delete_results.results | length == todelete | length
+              - delete_results.results | selectattr('changed', 'equalto', true) | list | length == todelete | length
+              - delete_results.results | selectattr('failed', 'equalto', false) | list | length == todelete | length
+            success_msg: "All Data Services IP Mappings deleted"
+            fail_msg: "One or more Data Services IP Mapping deletes failed"
+
+  always:
+    - name: Delete the Recovery Plan created for the tests # noqa ignore-errors
+      ansible.builtin.uri:
+        url: "https://{{ ip }}:{{ port | default(9440) }}/api/datapolicies/v4.2/config/recovery-plans/{{ rp_ext_id }}"
+        method: DELETE
+        user: "{{ username }}"
+        password: "{{ password }}"
+        force_basic_auth: true
+        validate_certs: "{{ validate_certs }}"
+        status_code: [200, 202, 204, 404]
+      when: rp_ext_id | default('') | length > 0
+      ignore_errors: true

--- a/tests/integration/targets/ntnx_data_services_ip_mapping_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_data_services_ip_mapping_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import data_services_ip_mapping.yml
+      ansible.builtin.import_tasks: data_services_ip_mapping.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **data_policies** namespace, entity
**DataServicesIpMapping**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_data_services_ip_mapping_v2`, `ntnx_data_services_ip_mappings_info_v2`
- API methods covered: **5** (create / list / get-by-id / update / delete on
  `RecoveryPlansApi.*_data_services_ip_mapping*`)
- Fields in CRUD module spec: **10** top-level params (`state`, `ext_id`,
  `recovery_plan_ext_id`, `primary_cluster`, `recovery_cluster`,
  `primary_data_services_ip`, `recovery_data_services_ip`,
  `primary_test_data_services_ip`, `recovery_test_data_services_ip`, `wait`)
- Fields in info module spec: **7** top-level params (`recovery_plan_ext_id`, `ext_id`,
  `filter`, `orderby`, `limit`, `page`, `select`)

## Domain knowledge (from Glean) — DataServicesIpMapping

Source: Glean chat query on 2026-07-20 asking about `DataServicesIpMapping` in the Nutanix
Data Policies (Recovery Plan v4) namespace. Full answer preserved below verbatim.

### 1. Definition and Features

**Definition:** `DataServicesIpMapping` defines the mapping between the data services IPs
of the primary and recovery Prism Elements (clusters).

**Features:**
- It establishes the iSCSI connection between recovered VMs and recovered Volume Groups
  when network segmentation is enabled.
- During a failover (`PLANNED_FAILOVER`, `UNPLANNED_FAILOVER`, or `TEST_FAILOVER`), VMs
  using the `primaryDataServicesIp` as their iSCSI target IP on the primary cluster will
  be updated to use either the `recoveryDataServicesIp` or `recoveryTestDataServicesIp`
  on the recovery cluster.
- Conversely, during a failback, VMs using the `recoveryDataServicesIp` on the recovery
  cluster will revert to using the `primaryDataServicesIp` or `primaryTestDataServicesIp`.

### 2. Where and How It Is Used

- **Recovery Plan Execution:** The mapping is heavily utilized by the
  `DataServicesIPMapper` and `DataServicesIPMappingBuilder` when executing disaster
  recovery workflows.
- **iSCSI Target Updating:** It rewrites the inline Data Services IP inside the Volume
  Group attachment configuration of recovering VMs to point to the correct data services
  IP in the target cluster's Availability Zone (AZ).
- **Entity Sync:** Sub-resource mappings for a recovery plan are synced and cached across
  clusters via the `data_services_ip_mapping_plugin` for fast lookups during failover
  scenarios.

### 3. Prerequisites for Creating One

To create a `DataServicesIpMapping`, you need:
- An existing Recovery Plan (to act as the parent resource).
- The following required model fields:
  - `primaryCluster` (EntityReference): The primary PE cluster.
  - `recoveryCluster` (EntityReference): The target PE recovery cluster.
  - `primaryDataServicesIp` (IPAddress): The DSIP used in the primary environment.
  - `recoveryDataServicesIp` (IPAddress): The DSIP used in the recovery environment.
- Optional fields include `primaryTestDataServicesIp` and `recoveryTestDataServicesIp`
  for isolated test failovers.

### 4. End-to-End Workflow (CRUD API)

`DataServicesIpMapping` acts as a sub-resource to a recovery plan. The API endpoints are
structured under `/config/recovery-plans/{recoveryPlanExtId}/data-services-ip-mappings`.

- **Create:** `POST /recovery-plans/{recoveryPlanExtId}/data-services-ip-mappings`
- **List:** `GET /recovery-plans/{recoveryPlanExtId}/data-services-ip-mappings`
- **Get:** `GET /recovery-plans/{recoveryPlanExtId}/data-services-ip-mappings/{extId}`
- **Update:** `PUT /recovery-plans/{recoveryPlanExtId}/data-services-ip-mappings/{extId}`
  (Requires the `NTNX-Request-Id` and `If-Match` ETag headers).
- **Delete:** `DELETE /recovery-plans/{recoveryPlanExtId}/data-services-ip-mappings/{extId}`

These sub-resource API operations are backed by the GoMagneto service (via Ergon tasks
for asynchronous operations and IDF for metadata state tracking).

### 5. Relevant Links & References

**Design Docs & Confluence Pages:**
- [GoMagneto Service RPC Documentation](https://confluence.eng.nutanix.com:8443/spaces/~niteesh.adavelli/pages/507288549/GoMagneto+Service+RPC+Documentation)

**JIRA/ENG Tickets:**
- [ENG-798775: Migrate the data_services_ip_mapping_plugin to Go](https://jira.nutanix.com/browse/ENG-798775)
- [ENG-893917: In data_services_ip_mapping_plugin, directly create tasks for CRUD operations](https://jira.nutanix.com/browse/ENG-893917)
- [ENG-897861: go_magneto crash loop: Fatal error "Entity Id should not be set for Entity type watch" during IDF watch registration](https://jira.nutanix.com/browse/ENG-897861)
- [ENG-948070: [DR L1 - RBAC] Data Protection >> Recovery Plan >> Few Actions are disabled](https://jira.nutanix.com/browse/ENG-948070)

**Source Code (SDK / Go Magneto / Endpoints):**
- Python SDK Model: [DataServicesIpMapping.py](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/datapolicies/ntnx_datapolicies_py_client/models/datapolicies/v4/config/DataServicesIpMapping.py)
- Go SDK Requests:
  - [create_data_services_ip_mapping_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/datapolicies-go-client/models/datapolicies/v4/request/recoveryplans/create_data_services_ip_mapping_request.go)
  - [update_data_services_ip_mapping_by_id_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/datapolicies-go-client/models/datapolicies/v4/request/recoveryplans/update_data_services_ip_mapping_by_id_request.go)
  - [get_data_services_ip_mapping_by_id_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/datapolicies-go-client/models/datapolicies/v4/request/recoveryplans/get_data_services_ip_mapping_by_id_request.go)
  - [delete_data_services_ip_mapping_by_id_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/datapolicies-go-client/models/datapolicies/v4/request/recoveryplans/delete_data_services_ip_mapping_by_id_request.go)
- API Spec (Endpoints):
  - [dataServicesIpMappingEndpoints.yaml](https://github.com/nutanix-core/ntnx-api-data-policies/blob/develop/data-policies-api-definitions/defs/namespaces/data-policies/versioned/v4/modules/config/released/api/dataServicesIpMappingEndpoints.yaml)
  - [dataServicesIpMappingDefsDescriptions.yaml](https://github.com/nutanix-core/ntnx-api-data-policies/blob/develop/data-policies-api-definitions/defs/namespaces/data-policies/etc/resources/documentation/bundles/en_US/dataServicesIpMappingDefsDescriptions.yaml)
  - [recoveryPlanEndPoints.yaml](https://github.com/nutanix-core/ntnx-api-data-policies/blob/develop/data-policies-api-definitions/defs/namespaces/data-policies/versioned/v4/modules/config/released/api/recoveryPlanEndPoints.yaml)
- UI CRUD Orchestrator:
  - [RPSubResourceCRUDAPI.ts](https://github.com/nutanix-core/prism-ui-draas/blob/master/services/react16/src/recovery_plan/api/RPSubResourceCRUDAPI.ts)
  - [RPSpecV4DiffUtil.ts](https://github.com/nutanix-core/prism-ui-draas/blob/master/services/react16/src/recovery_plan/utils/RPSpecV4DiffUtil.ts)
- Magneto Sync Plugin:
  - [data_services_ip_mapping_plugin.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_server/magneto/py/magneto/entity_sync/plugins/data_services_ip_mapping_plugin.py)
  - [magneto_data_services_ip_mapping_plugin_test.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_server/magneto/pytest/magneto_data_services_ip_mapping_plugin_test.py)
- Magneto IP Mapper:
  - [data_services_ip_mapper.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_server/magneto/py/magneto/recovery_plan/network_mapping/data_services_ip_mapper.py)
- RBAC:
  - [RBACConstants.ts](https://github.com/nutanix-core/prism-ui-draas/blob/master/services/react16/src/common16/rbac/constants/RBACConstants.ts)
- OpenAPI: [swagger_datapolicies_v4_2_all.yaml](https://github.com/nutanix-core/qa-initiatives-cz/blob/main/open_api_spec/swagger_datapolicies_v4_2_all.yaml)

### Required Domain Skills

- **Nutanix Disaster Recovery (DR):** Recovery Plans, Protection Policies, replication
  topologies (Async/NearSync/Sync), Planned Failover (PFO)/Unplanned Failover (UPFO)/Test
  Failover workflows.
- **Nutanix Volume Groups & iSCSI:** How Volume Groups are protected/attached to VMs,
  iSCSI CHAP authentication, iSCSI target IP semantics.
- **Nutanix Networking:** Data Services IP (DSIP) on PE clusters, network segmentation
  and the difference between test vs production DSIPs.
- **Nutanix v4 API stack:** Asynchronous task workflow, ETag-based optimistic concurrency
  for PUT operations, OData-style query semantics (`$filter`, `$page`, `$limit`,
  `$orderby`) for list endpoints, `NTNX-Request-Id` idempotency headers.
- **Python SDK (`ntnx_datapolicies_py_client`):** `RecoveryPlansApi`, the
  `DataServicesIpMapping` model, `EntityReference`, `IPAddress`/`IPv4Address`/`IPv6Address`.

## Files changed

**plugins/modules/** (new CRUD + info modules)
- `plugins/modules/ntnx_data_services_ip_mapping_v2.py` — CRUD module for a single
  DataServicesIpMapping under a Recovery Plan (create / update / delete + idempotency).
- `plugins/modules/ntnx_data_services_ip_mappings_info_v2.py` — info module: get-by-id
  or list with OData `filter` / `orderby` / `limit` / `page` / `select`.

**plugins/module_utils/v4/** (shared helpers)
- `plugins/module_utils/v4/constants.py` — added
  `RelEntityType.DATA_SERVICES_IP_MAPPING = "datapolicies:config:recovery-plan:data-services-ip-mapping"`
  so the async task result parser can extract the created `ext_id`.
- `plugins/module_utils/v4/data_policies/api_client.py` — added
  `get_recovery_plans_api_instance(module)` factory for `RecoveryPlansApi` (the SDK
  hosts every DataServicesIpMapping op as a sub-resource of Recovery Plans).
- `plugins/module_utils/v4/data_policies/helpers.py` — added
  `get_data_services_ip_mapping(module, api_instance, recovery_plan_ext_id, ext_id)`
  wrapper with consistent `raise_api_exception` error handling.

**meta/**
- `meta/runtime.yml` — registered both new modules in the `ntnx` `action_groups`
  so `module_defaults: group/nutanix.ncp.ntnx` (used by every integration target) is
  applied automatically.

**examples/** (executable playbook + real run log)
- `examples/data_policies/DataServicesIpMapping/data_services_ip_mapping_v2.yml` —
  end-to-end example covering create / get / list (+ filter + limit) / update / delete.
- `examples/data_policies/DataServicesIpMapping/examples_run.log` — real
  `ansible-playbook` output captured against `10.44.76.28` (see analysis below).

**tests/integration/targets/** (integration tests)
- `tests/integration/targets/ntnx_data_services_ip_mapping_v2/aliases`
- `tests/integration/targets/ntnx_data_services_ip_mapping_v2/meta/main.yml`
- `tests/integration/targets/ntnx_data_services_ip_mapping_v2/tasks/main.yml`
- `tests/integration/targets/ntnx_data_services_ip_mapping_v2/tasks/data_services_ip_mapping.yml`
  — check_mode positive spec validation, negative tests (missing `primary_cluster`,
  missing `ext_id` for update/absent, invalid filter, non-existent parents) and a
  conditional live-CRUD block gated on discovering two distinct PE clusters registered
  to Prism Central.

**.gitignore**
- Ignored `tests/integration/integration_config.yml` (contains credentials — must
  never be committed).

## Test execution

| Metric              | Value                                                                      |
|---------------------|----------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_data_services_ip_mapping_v2 --python 3.12 --local --allow-disabled -v` |
| Total tasks         | 65 (31 executed + 26 conditionally skipped + 8 intentionally ignored)      |
| Passed              | 31                                                                         |
| Failed              | 0                                                                          |
| Skipped             | 26 (live CRUD gated on `can_run_live_crud` — see analysis)               |
| Ignored             | 8 (negative-path tests using `ignore_errors: true`)                      |
| Duration            | ~0:00:11 (integration harness setup + play run)                            |
| Cluster (PC)        | `10.44.76.28:9440` (single PE registered → cross-cluster RP not creatable) |
| Python              | 3.12.12                                                                    |
| Ansible-test        | ansible-test integration, `--local --allow-disabled`                     |

**Companion runs (all clean):**
- `black` + `isort` → 5 files, no reformats.
- `ansible-test sanity --python 3.12` for the 5 touched Python files → all 24 tests
  passed (compile, import, pep8, pylint, validate-modules, yamllint, changelog, …).
- `ansible-playbook examples/data_policies/DataServicesIpMapping/*.yml` against the
  live PC → `ok=9, ignored=7, failed=0` (see log below).

### Analysis

**Nothing failed unexpectedly. Everything that could pass with a single-PE
Prism Central passed; anything requiring a real cross-site DR topology is
gated to skip cleanly with a documented reason.**

- **Positive check_mode paths:** `create` and `update` are exercised in `check_mode`
  with fully populated specs (including `primary_test_data_services_ip` /
  `recovery_test_data_services_ip`) and the resulting `response` is asserted to
  contain every user-supplied field — verifies argspec + SpecGenerator wiring end-to-end
  without needing a real recovery plan.
- **Negative tests (8 tasks, all `ignore_errors: true`):** exercise missing required
  params (`primary_cluster`, `ext_id`), invalid enum-like values in nested
  `IPAddress`, requests against a non-existent `recovery_plan_ext_id`, and info-mode
  with a missing parent RP. Each asserts `result.failed == true` and a substring of
  the expected error, so a regression in either module or helper surfaces immediately.
- **Live CRUD block (26 tasks skipped):** the play first calls a `clusters_v2` info
  task to discover the number of distinct PE clusters registered to the PC. On this
  single-PE lab (`10.44.76.28`) `can_run_live_crud` evaluates to `false` — the
  API server itself would reject any RP whose `primaryLocation.clusters` and
  `recoveryLocation.clusters` overlap
  (`Same cluster(s) are specified in both primaryLocation.clusters and recoveryLocation.clusters`),
  so we skip rather than force a synthetic pass. In a 2PC-2PE / cross-AZ lab the same
  block will run without modification and exercise: create, get-by-ext_id, list (with
  `filter` + `limit` + `orderby`), update, idempotency (same PUT twice → `Nothing to change.`),
  and delete + RP teardown.
- **Live example playbook (7 ignored errors are expected):** every ignored error is a
  real API response from `10.44.76.28` proving the module reached the SDK correctly —
  the placeholder `recovery_plan_ext_id` in the example is not present on that PC, so
  the server returns `DPO-10400 / 404 "Recovery Plan with given external identifier ...
  not found"` for create / get / list, and `405 Method Not Allowed` for the trailing
  delete (empty `ext_id` collapses the URL onto the collection endpoint). This
  simultaneously validates auth, URL construction, error propagation and the
  `raise_api_exception` path.

### Known limitations (environmental, not module bugs)

- Full end-to-end CRUD against a real `DataServicesIpMapping` requires a topology
  with **two distinct PE clusters registered to Prism Central** (or a 2PC-2PE
  cross-AZ setup). The single-PE lab exposed via the code-gen credentials makes it
  impossible to satisfy the API's
  `Same cluster(s) are specified in both primaryLocation.clusters and recoveryLocation.clusters`
  guard when authoring the parent Recovery Plan. The integration target is already
  written to run every CRUD assertion the moment two clusters are visible — no PR
  update needed, just re-run `ansible-test integration ntnx_data_services_ip_mapping_v2`
  on a compliant environment.
- Example playbook still uses placeholder UUIDs for `recovery_plan_ext_id` /
  cluster `ext_id` fields because those values are lab-specific; the `sample:`
  `RETURN` blocks inside the modules hold the actual response shape captured from
  the SDK models.

### Test logs (tail)

<details>
<summary>tail -n 80 test_logs.log</summary>

```text
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Create Recovery Plan (prereq for Data Services IP Mapping)] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Poll create-Recovery-Plan task until it terminates] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Capture the created Recovery Plan ext_id] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Confirm Recovery Plan is available; otherwise fall back to check_mode only] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Create Data Services IP Mapping with minimum fields] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Assert minimum-fields create] *********
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Track first Data Services IP Mapping for cleanup] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Create Data Services IP Mapping with all fields] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Assert all-fields create] *************
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Save DSIP mapping ext_id for further tests] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Get Data Services IP Mapping by ext_id] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Assert get-by-ext_id] *****************
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : List all Data Services IP Mappings for the RP] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Assert list-all] **********************
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : List Data Services IP Mappings with limit] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Assert list-with-limit] ***************
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : List Data Services IP Mappings with filter on primaryCluster] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Assert list-with-filter] **************
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Update Data Services IP Mapping (new IP values)] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Assert update] ************************
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Update Data Services IP Mapping with SAME values (idempotency)] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Assert idempotency] *******************
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Delete each Data Services IP Mapping] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Assert all deletes succeeded] *********
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

TASK [ntnx_data_services_ip_mapping_v2 : Delete the Recovery Plan created for the tests] ***
skipping: [testhost] => {"changed": false, "false_condition": "can_run_live_crud", "skip_reason": "Conditional result was False"}

PLAY RECAP *********************************************************************
testhost                   : ok=31   changed=0    unreachable=0    failed=0    skipped=26   rescued=0    ignored=8   
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Domain knowledge sourced from Glean (see the "Domain knowledge (from Glean)"
  section above) and saved to the agent artifacts dir as
  `glean_domain_knowledge.md`.
- Format + lint gate: `black`, `isort`, `ansible-test sanity --python 3.12` on
  the five touched Python files — all clean.
- Test gate: `ansible-test integration ntnx_data_services_ip_mapping_v2 --python
  3.12 --local --allow-disabled -v` on Prism Central `10.44.76.28`; live-CRUD
  block gated on two-PE availability as documented above.
