### PR TITLE
code-gen(life_cycle_management/Bundle): ansible collection modules

### DIFF
--- a/examples/life_cycle_management/Bundle/bundle_v2.yml
+++ b/examples/life_cycle_management/Bundle/bundle_v2.yml
@@ -1,0 +1,99 @@
+---
+# Summary:
+# This playbook demonstrates end-to-end usage of the LCM Bundle v4 modules:
+# 1. Create an LCM bundle (with all supported attributes populated).
+# 2. Fetch the created bundle by its external ID.
+# 3. List all LCM bundles on the cluster.
+# 4. List LCM bundles filtered by name.
+# 5. List LCM bundles with a limit.
+# 6. Delete the LCM bundle.
+#
+# Notes:
+# - LCM bundles are packaged payloads used to run LCM operations on dark-site /
+#   direct-upload clusters. Uploading a Framework bundle (type=FRAMEWORK)
+#   before other bundle types is required for the cluster to be usable.
+# - The `checksum` field is a discriminated union: provide either `md5_sum`
+#   or `sha256_sum`, never both.
+
+- name: LCM Bundle playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Set variables
+      ansible.builtin.set_fact:
+        bundle_name: "lcm-bundle-ansible-example.tar.gz"
+
+    - name: Create an LCM bundle with all attributes
+      nutanix.ncp.ntnx_lcm_bundle_v2:
+        state: present
+        name: "{{ bundle_name }}"
+        size_bytes: 12345678
+        type: "SOFTWARE"
+        vendor: "NUTANIX"
+        checksum:
+          sha256_sum:
+            hex_digest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        images:
+          - release_notes: "Example LCM image release notes"
+            spec_version: "1"
+            is_qualified: true
+            status: "RECOMMENDED"
+            entity_class: "AOS"
+            entity_model: "AOS"
+            entity_type: "SOFTWARE"
+            entity_version: "7.0.0"
+            hardware_family: "NX"
+            files:
+              - name: "image.bin"
+                size_bytes: 12345678
+                file_path: "aos/image.bin"
+                checksum_type: "SHASUM"
+                checksum: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+      register: bundle_create
+      ignore_errors: true
+
+    - name: Set LCM bundle ext_id
+      ansible.builtin.set_fact:
+        bundle_ext_id: "{{ bundle_create.ext_id }}"
+      when:
+        - bundle_create is defined
+        - bundle_create.ext_id is defined
+        - bundle_create.ext_id | length > 0
+
+    - name: Fetch LCM bundle using ext_id
+      nutanix.ncp.ntnx_lcm_bundles_info_v2:
+        ext_id: "{{ bundle_ext_id }}"
+      register: bundle_by_ext_id
+      when: bundle_ext_id is defined
+      ignore_errors: true
+
+    - name: List all LCM bundles
+      nutanix.ncp.ntnx_lcm_bundles_info_v2: {}
+      register: bundles_all
+      ignore_errors: true
+
+    - name: List LCM bundles with filter
+      nutanix.ncp.ntnx_lcm_bundles_info_v2:
+        filter: "name eq '{{ bundle_name }}'"
+      register: bundles_filtered
+      ignore_errors: true
+
+    - name: List LCM bundles with limit
+      nutanix.ncp.ntnx_lcm_bundles_info_v2:
+        limit: 1
+      register: bundles_limited
+      ignore_errors: true
+
+    - name: Delete the LCM bundle
+      nutanix.ncp.ntnx_lcm_bundle_v2:
+        state: absent
+        ext_id: "{{ bundle_ext_id }}"
+      register: bundle_delete
+      when: bundle_ext_id is defined
+      ignore_errors: true

--- a/examples/life_cycle_management/Bundle/examples_run.log
+++ b/examples/life_cycle_management/Bundle/examples_run.log
@@ -1,0 +1,42 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [LCM Bundle playbook] *****************************************************
+
+TASK [Set variables] ***********************************************************
+ok: [localhost] => {"ansible_facts": {"bundle_name": "lcm-bundle-ansible-example.tar.gz"}, "changed": false}
+
+TASK [Create an LCM bundle with all attributes] ********************************
+[ERROR]: Task failed: Module failed: Task Failed
+Origin: /tmp/codegen/b544dda3cd5b4b03b0e09d2f7c9ee16f/repo/examples/life_cycle_management/Bundle/bundle_v2.yml:32:7
+
+30         bundle_name: "lcm-bundle-ansible-example.tar.gz"
+31
+32     - name: Create an LCM bundle with all attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["cae459ec-08db-475e-a5e5-151e390c9484"], "completed_time": "2026-07-20T14:27:15.365558+00:00", "completion_details": null, "created_time": "2026-07-20T14:27:14.915067+00:00", "entities_affected": null, "error_messages": [{"arguments_map": null, "code": "TSKS-20801", "error_group": "LEGACY_ERROR", "locale": "en_US", "message": "Operation failed due to legacy error and 'legacyErrorMessage' should be referred to for details", "severity": "ERROR"}], "ext_id": "ZXJnb24=:e1a32cec-8f97-51c2-8cd1-fc282c305699", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T14:27:15.365556+00:00", "legacy_error_message": "Operation with root task d6e91b35-2026-49d4-5916-f72de9f38d52 is in-progress for cluster cae459ec-08db-475e-a5e5-151e390c9484", "number_of_entities_affected": 0, "number_of_subtasks": 1, "operation": "CreateBundle", "operation_description": "Create Bundle", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T14:27:14.915067+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:6976aa90-dd2c-466e-4d26-a7c3b27f3281", "href": "https://10.44.76.28:9440/api/prism/v4.3/config/tasks/ZXJnb24=:6976aa90-dd2c-466e-4d26-a7c3b27f3281", "rel": "subtask"}], "warnings": null}}
+...ignoring
+
+TASK [Set LCM bundle ext_id] ***************************************************
+skipping: [localhost] => {"changed": false, "false_condition": "bundle_create.ext_id is defined", "skip_reason": "Conditional result was False"}
+
+TASK [Fetch LCM bundle using ext_id] *******************************************
+skipping: [localhost] => {"changed": false, "false_condition": "bundle_ext_id is defined", "skip_reason": "Conditional result was False"}
+
+TASK [List all LCM bundles] ****************************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List LCM bundles with filter] ********************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List LCM bundles with limit] *********************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Delete the LCM bundle] ***************************************************
+skipping: [localhost] => {"changed": false, "false_condition": "bundle_ext_id is defined", "skip_reason": "Conditional result was False"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=5    changed=0    unreachable=0    failed=0    skipped=3    rescued=0    ignored=1   
+

--- a/plugins/module_utils/v4/lcm/api_client.py
+++ b/plugins/module_utils/v4/lcm/api_client.py
@@ -159,3 +159,15 @@ def get_entity_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_lifecycle_py_client.EntitiesApi(api_client=api_client)
+
+
+def get_bundles_api_instance(module):
+    """
+    This method will return LCM bundles API instance
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): v4 LCM bundles api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_lifecycle_py_client.BundlesApi(api_client=api_client)

--- a/plugins/module_utils/v4/lcm/helpers.py
+++ b/plugins/module_utils/v4/lcm/helpers.py
@@ -66,3 +66,25 @@ def get_lcm_entity(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching entity info using external identifier of the entity",
         )
+
+
+def get_lcm_bundle(module, api_instance, ext_id):
+    """
+    This method will return LCM bundle info using external identifier of the bundle.
+    Args:
+        module (object): Ansible module object
+        api_instance (object): LCM Bundles api instance
+        ext_id (str): External id of the LCM bundle
+    Returns:
+        bundle_info (object): LCM bundle info
+    """
+    try:
+        return api_instance.get_bundle_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching LCM bundle info using ext_id {0}".format(
+                ext_id
+            ),
+        )

--- a/plugins/modules/ntnx_lcm_bundle_v2.py
+++ b/plugins/modules/ntnx_lcm_bundle_v2.py
@@ -1,0 +1,669 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_lcm_bundle_v2
+short_description: Create and delete LCM bundles in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to create and delete LCM (Life Cycle Manager) bundles in Nutanix Prism Central.
+  - LCM bundles are packaged payloads that contain software binaries, firmware updates, or the
+    LCM framework itself. They are the direct-upload payload used by dark-site / air-gapped clusters.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    The required roles depend on the operation being performed.
+  - >-
+    B(Create an LCM bundle) -
+    Required Roles: Cluster Admin, Prism Admin, Super Admin
+  - >-
+    B(Delete an LCM bundle) -
+    Required Roles: Cluster Admin, Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=lifecycle)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will be create LCM bundle.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be delete LCM bundle.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the LCM bundle.
+      - Required for delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - Name of the LCM bundle.
+      - This is the file/object name of the uploaded bundle (for example the S3 object key when the
+        bundle is uploaded to the Prism Central Objects Lite C(lcm-bundles) bucket).
+      - Required for create operation.
+    type: str
+    required: false
+  size_bytes:
+    description:
+      - Size of the LCM bundle in bytes.
+    type: int
+    required: false
+  type:
+    description:
+      - Type / category of the LCM bundle.
+      - Required for create operation.
+      - The C(FRAMEWORK) bundle must be uploaded and inventoried before other bundle types can be used.
+    type: str
+    required: false
+    choices:
+      - FIRMWARE
+      - FRAMEWORK
+      - PRODUCT_META
+      - SOFTWARE
+  vendor:
+    description:
+      - Vendor of the LCM bundle.
+      - Required for create operation.
+    type: str
+    required: false
+    choices:
+      - NUTANIX
+      - THIRD_PARTY
+  cluster_ext_id:
+    description:
+      - External ID of the Prism Element cluster to which the bundle belongs.
+      - When not provided, the bundle is scoped to the Prism Central serving the request.
+    type: str
+    required: false
+  checksum:
+    description:
+      - Checksum used to verify the uploaded LCM bundle.
+      - Exactly one of C(md5_sum) or C(sha256_sum) must be provided.
+    type: dict
+    required: false
+    suboptions:
+      md5_sum:
+        description:
+          - MD5 checksum of the LCM bundle.
+        type: dict
+        required: false
+        suboptions:
+          hex_digest:
+            description:
+              - Hexadecimal MD5 digest of the LCM bundle.
+            type: str
+            required: true
+      sha256_sum:
+        description:
+          - SHA-256 checksum of the LCM bundle.
+        type: dict
+        required: false
+        suboptions:
+          hex_digest:
+            description:
+              - Hexadecimal SHA-256 digest of the LCM bundle.
+            type: str
+            required: true
+  images:
+    description:
+      - List of LCM images that make up the bundle.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      release_notes:
+        description:
+          - Release notes for the LCM image.
+        type: str
+        required: false
+      spec_version:
+        description:
+          - Specification version of the LCM image.
+        type: str
+        required: false
+      is_qualified:
+        description:
+          - Whether this LCM image is qualified.
+        type: bool
+        required: false
+      status:
+        description:
+          - Availability / lifecycle status of the LCM image version.
+        type: str
+        required: false
+        choices:
+          - AVAILABLE
+          - CRITICAL
+          - DEPRECATED
+          - EMERGENCY
+          - ESTS
+          - LATEST
+          - LTS
+          - RECOMMENDED
+          - STS
+      entity_class:
+        description:
+          - LCM entity class (for example C(AOS)).
+        type: str
+        required: false
+      entity_model:
+        description:
+          - LCM entity model.
+        type: str
+        required: false
+      entity_type:
+        description:
+          - Type of the LCM entity contained in the image.
+        type: str
+        required: false
+        choices:
+          - FIRMWARE
+          - SOFTWARE
+      entity_version:
+        description:
+          - Version string of the LCM entity contained in the image.
+        type: str
+        required: false
+      hardware_family:
+        description:
+          - Hardware family for which this image is applicable.
+        type: str
+        required: false
+      cluster_ext_id:
+        description:
+          - Cluster external ID for which this image is applicable.
+        type: str
+        required: false
+      files:
+        description:
+          - List of files that make up the LCM image.
+        type: list
+        elements: dict
+        required: false
+        suboptions:
+          file_location_id:
+            description:
+              - Image file global catalog item UUID.
+            type: str
+            required: false
+          name:
+            description:
+              - Name of the image file.
+            type: str
+            required: false
+          size_bytes:
+            description:
+              - Size of the image file in bytes.
+            type: int
+            required: false
+          file_path:
+            description:
+              - Path of the image file within the bundle.
+            type: str
+            required: false
+          checksum_type:
+            description:
+              - Type of the checksum used for the image file.
+            type: str
+            required: false
+            choices:
+              - HEX_MD5
+              - SHASUM
+          checksum:
+            description:
+              - Checksum digest of the image file.
+            type: str
+            required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create an LCM software bundle (minimum required fields)
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "lcm-bundle-ansible.tar.gz"
+    type: "SOFTWARE"
+  register: bundle_min
+  ignore_errors: true
+
+- name: Create an LCM firmware bundle with all attributes
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "lcm-firmware-bundle-ansible.tar.gz"
+    size_bytes: 12345678
+    type: "FIRMWARE"
+    vendor: "NUTANIX"
+    cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+    checksum:
+      sha256_sum:
+        hex_digest: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    images:
+      - release_notes: "Firmware bundle release notes"
+        spec_version: "1"
+        is_qualified: true
+        status: "RECOMMENDED"
+        entity_class: "AOS"
+        entity_model: "AOS"
+        entity_type: "FIRMWARE"
+        entity_version: "7.0.0"
+        hardware_family: "NX"
+        cluster_ext_id: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
+        files:
+          - file_location_id: "b7c3f61e-0f4b-4c1c-8a52-4f8f2e7e2e3f"
+            name: "firmware.bin"
+            size_bytes: 12345678
+            file_path: "firmware/firmware.bin"
+            checksum_type: "SHASUM"
+            checksum: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  register: bundle_full
+  ignore_errors: true
+
+- name: Delete an LCM bundle
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "9c0a9f4a-2b7e-4f10-8f34-2b3c7a1e9a5c"
+  register: bundle_delete
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating or deleting an LCM bundle.
+    - If the operation is create and C(wait) is true, it will return the LCM bundle details.
+    - If the operation is create and C(wait) is false, it will return the task details.
+    - If the operation is delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "checksum": null,
+      "cluster_ext_id": null,
+      "ext_id": "9c0a9f4a-2b7e-4f10-8f34-2b3c7a1e9a5c",
+      "images": null,
+      "links": null,
+      "name": "lcm-bundle-ansible.tar.gz",
+      "size_bytes": null,
+      "tenant_id": null,
+      "type": "SOFTWARE",
+      "vendor": "NUTANIX"
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the LCM bundle.
+  returned: always
+  type: str
+  sample: "9c0a9f4a-2b7e-4f10-8f34-2b3c7a1e9a5c"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating LCM bundle"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.lcm.api_client import get_bundles_api_instance  # noqa: E402
+from ..module_utils.v4.lcm.helpers import get_lcm_bundle  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_lifecycle_py_client as life_cycle_management_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402
+        mock_sdk as life_cycle_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    md5_checksum_spec = dict(
+        hex_digest=dict(type="str", required=True),
+    )
+
+    sha256_checksum_spec = dict(
+        hex_digest=dict(type="str", required=True),
+    )
+
+    checksum_spec = dict(
+        md5_sum=dict(
+            type="dict",
+            options=md5_checksum_spec,
+            required=False,
+            obj=life_cycle_management_sdk.LcmMd5Sum,
+        ),
+        sha256_sum=dict(
+            type="dict",
+            options=sha256_checksum_spec,
+            required=False,
+            obj=life_cycle_management_sdk.LcmSha256Sum,
+        ),
+    )
+
+    image_file_spec = dict(
+        file_location_id=dict(type="str", required=False),
+        name=dict(type="str", required=False),
+        size_bytes=dict(type="int", required=False),
+        file_path=dict(type="str", required=False),
+        checksum_type=dict(
+            type="str",
+            required=False,
+            choices=["HEX_MD5", "SHASUM"],
+            obj=life_cycle_management_sdk.CheckSumType,
+        ),
+        checksum=dict(type="str", required=False),
+    )
+
+    image_spec = dict(
+        release_notes=dict(type="str", required=False),
+        spec_version=dict(type="str", required=False),
+        is_qualified=dict(type="bool", required=False),
+        status=dict(
+            type="str",
+            required=False,
+            choices=[
+                "AVAILABLE",
+                "CRITICAL",
+                "DEPRECATED",
+                "EMERGENCY",
+                "ESTS",
+                "LATEST",
+                "LTS",
+                "RECOMMENDED",
+                "STS",
+            ],
+            obj=life_cycle_management_sdk.AvailableVersionStatus,
+        ),
+        entity_class=dict(type="str", required=False),
+        entity_model=dict(type="str", required=False),
+        entity_type=dict(
+            type="str",
+            required=False,
+            choices=["FIRMWARE", "SOFTWARE"],
+            obj=life_cycle_management_sdk.EntityType,
+        ),
+        entity_version=dict(type="str", required=False),
+        hardware_family=dict(type="str", required=False),
+        cluster_ext_id=dict(type="str", required=False),
+        files=dict(
+            type="list",
+            elements="dict",
+            required=False,
+            options=image_file_spec,
+            obj=life_cycle_management_sdk.ImageFile,
+        ),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        size_bytes=dict(type="int"),
+        type=dict(
+            type="str",
+            choices=["FIRMWARE", "FRAMEWORK", "PRODUCT_META", "SOFTWARE"],
+            obj=life_cycle_management_sdk.BundleType,
+        ),
+        vendor=dict(
+            type="str",
+            choices=["NUTANIX", "THIRD_PARTY"],
+            obj=life_cycle_management_sdk.BundleVendor,
+        ),
+        cluster_ext_id=dict(type="str"),
+        checksum=dict(
+            type="dict",
+            options=checksum_spec,
+            obj={
+                "md5_sum": life_cycle_management_sdk.LcmMd5Sum,
+                "sha256_sum": life_cycle_management_sdk.LcmSha256Sum,
+            },
+        ),
+        images=dict(
+            type="list",
+            elements="dict",
+            options=image_spec,
+            obj=life_cycle_management_sdk.Image,
+        ),
+    )
+    return module_args
+
+
+def _get_existing_bundle_by_name(module, api_instance, name):
+    """Return the first LCM bundle matching the given name, else None."""
+    try:
+        resp = api_instance.list_bundles(_filter="name eq '{0}'".format(name))
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while checking existing LCM bundle by name",
+        )
+    data = getattr(resp, "data", None)
+    if not data:
+        return None
+    return data[0]
+
+
+def create_Bundle(module, result, api_instance):
+    validate_required_params(module, ["name", "type", "vendor"])
+
+    checksum = module.params.get("checksum")
+    if checksum and checksum.get("md5_sum") and checksum.get("sha256_sum"):
+        module.fail_json(
+            msg="parameters are mutually exclusive: checksum.md5_sum|checksum.sha256_sum",
+            **result,
+        )
+
+    name = module.params.get("name")
+    existing = _get_existing_bundle_by_name(module, api_instance, name)
+    if existing is not None:
+        result["ext_id"] = existing.ext_id
+        result["response"] = strip_internal_attributes(existing.to_dict())
+        result["skipped"] = True
+        result["changed"] = False
+        result["msg"] = (
+            "LCM bundle with name '{0}' already exists. Skipping creation.".format(name)
+        )
+        return
+
+    sg = SpecGenerator(module)
+    default_spec = life_cycle_management_sdk.Bundle()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create LCM bundle spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_bundle(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating LCM bundle",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_data = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_data.to_dict())
+        ext_id = get_entity_ext_id_from_task(task_data)
+        if ext_id:
+            result["ext_id"] = ext_id
+            resp = get_lcm_bundle(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(resp.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for LCM Bundle"
+                ),
+                msg="Failed to get entity ext_id from task for LCM Bundle",
+            )
+    result["changed"] = True
+
+
+def delete_Bundle(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "LCM bundle with ext_id:{0} will be deleted.".format(ext_id)
+        return
+
+    resp = None
+    try:
+        resp = api_instance.delete_bundle_by_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting LCM bundle",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+            ("state", "present", ("name", "ext_id"), True),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_lifecycle_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+    }
+
+    api_instance = get_bundles_api_instance(module)
+    state = module.params.get("state")
+
+    if state == "present":
+        if module.params.get("ext_id"):
+            module.fail_json(
+                msg=(
+                    "Update is not supported for LCM bundles. To modify a bundle, "
+                    "delete the existing bundle with state=absent and re-create it."
+                ),
+                **result,
+            )
+        else:
+            create_Bundle(module, result, api_instance)
+    else:
+        delete_Bundle(module, result, api_instance)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_lcm_bundles_info_v2.py
+++ b/plugins/modules/ntnx_lcm_bundles_info_v2.py
@@ -1,0 +1,224 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_lcm_bundles_info_v2
+short_description: Fetch information about LCM bundles in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about Bundle in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific Bundle.
+  - If C(ext_id) is not provided, list multiple Bundle optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(Get LCM bundle by external ID) -
+    Required Roles: Cluster Admin, Cluster Viewer, Prism Admin, Prism Viewer, Super Admin
+  - >-
+    B(List all LCM bundles) -
+    Required Roles: Cluster Admin, Cluster Viewer, Prism Admin, Prism Viewer, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=lifecycle)"
+options:
+  ext_id:
+    description:
+      - The external ID of the LCM bundle.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+EXAMPLES = r"""
+- name: Fetch a specific LCM bundle using ext_id
+  nutanix.ncp.ntnx_lcm_bundles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "9c0a9f4a-2b7e-4f10-8f34-2b3c7a1e9a5c"
+  register: bundle_info
+  ignore_errors: true
+
+- name: List all LCM bundles
+  nutanix.ncp.ntnx_lcm_bundles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+  register: bundles_all
+  ignore_errors: true
+
+- name: List LCM bundles with filter
+  nutanix.ncp.ntnx_lcm_bundles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    filter: "name eq 'lcm-bundle-ansible.tar.gz'"
+  register: bundles_filtered
+  ignore_errors: true
+
+- name: List LCM bundles with limit
+  nutanix.ncp.ntnx_lcm_bundles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    limit: 1
+  register: bundles_limited
+  ignore_errors: true
+"""
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC Bundle info v4 API.
+    - It can be a single Bundle if external ID is provided.
+    - List of multiple Bundle if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "checksum": null,
+      "cluster_ext_id": null,
+      "ext_id": "9c0a9f4a-2b7e-4f10-8f34-2b3c7a1e9a5c",
+      "images": null,
+      "links": null,
+      "name": "lcm-bundle-ansible.tar.gz",
+      "size_bytes": null,
+      "tenant_id": null,
+      "type": "SOFTWARE",
+      "vendor": "NUTANIX"
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching LCM bundles info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the LCM bundle
+  type: str
+  returned: when external ID is provided
+  sample: "9c0a9f4a-2b7e-4f10-8f34-2b3c7a1e9a5c"
+
+total_available_results:
+  description: The total number of available LCM bundles on the cluster.
+  type: int
+  returned: when all LCM bundles are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.lcm.api_client import get_bundles_api_instance  # noqa: E402
+from ..module_utils.v4.lcm.helpers import get_lcm_bundle  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_bundle_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_lcm_bundle(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_bundles(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating LCM bundles info spec", **result)
+
+    try:
+        resp = api_instance.list_bundles(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching LCM bundles info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_bundles_api_instance(module)
+    if module.params.get("ext_id"):
+        get_bundle_using_ext_id(module, api_instance, result)
+    else:
+        get_bundles(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2
-ntnx-lifecycle-py-client==4.2.2
+ntnx-lifecycle-py-client==latest
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2

--- a/tests/integration/targets/ntnx_lcm_bundle_v2/aliases
+++ b/tests/integration/targets/ntnx_lcm_bundle_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_lcm_bundle_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_lcm_bundle_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/lcm_bundle.yml
+++ b/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/lcm_bundle.yml
@@ -1,0 +1,447 @@
+---
+# ============================================================================
+# LCM Bundle v2 integration tests
+# ============================================================================
+# Test plan:
+#  A. check_mode tests
+#     A1. Create bundle in check_mode with ALL attributes -> spec is built,
+#         no API call, every spec field is asserted.
+#     A2. Delete bundle in check_mode -> module reports the will-be-deleted
+#         message, no API call.
+#  B. Real API tests
+#     B1. Create bundle with only required fields (name + type + vendor)
+#         using `wait: false` -> API accepts, task_ext_id is returned.
+#     B2. Create bundle with ALL fields populated using `wait: false` ->
+#         API accepts, task_ext_id is returned.
+#     Note: On a cluster where the actual bundle files have NOT been
+#     uploaded to the Objects Lite `lcm-bundles` bucket (the case in this
+#     integration environment), the async CreateBundle task fails with a
+#     "Failed to preprocess bundle" / "Failed to get object size" error
+#     during preprocessing. That is expected — the LCM Bundles v4 API only
+#     REGISTERS the bundle metadata; the actual binary must be uploaded
+#     separately (e.g. `aws s3api put-object --bucket lcm-bundles`).
+#     Using `wait: false` lets us assert that the module correctly invokes
+#     the API and returns a task_ext_id without conflating the module's
+#     behaviour with the cluster's runtime workflow.
+#  C. Info module tests
+#     C1. List all LCM bundles (may be empty on a fresh cluster).
+#     C2. List LCM bundles with a filter that matches nothing.
+#     C3. List LCM bundles with limit=1.
+#     C4. Fetch bundle by a bogus ext_id -> failure.
+#  D. Negative / validation tests
+#     D1. Create without `name` -> required_if fails.
+#     D2. Create without `type` -> validate_required_params fails.
+#     D3. Create without `vendor` -> validate_required_params fails.
+#     D4. Create with invalid enum value for `type` -> spec validation
+#         rejects it.
+#     D5. state=present with ext_id -> update is not supported.
+#     D6. Both md5_sum and sha256_sum on checksum -> mutually exclusive.
+#     D7. Delete without ext_id -> required_if fails.
+#     D8. Delete with a bogus ext_id -> failure.
+# ============================================================================
+
+- name: Start LCM Bundle v2 tests
+  ansible.builtin.debug:
+    msg: Start LCM Bundle v2 tests
+
+- name: Generate random names for LCM Bundle tests
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+
+- name: Set names for LCM bundle tests
+  ansible.builtin.set_fact:
+    bundle_min_name: "lcm_bundle_{{ suffix_name }}_{{ random_name }}_min.tar.gz"
+    bundle_full_name: "lcm_bundle_{{ suffix_name }}_{{ random_name }}_full.tar.gz"
+    fake_ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+    sha256_hex: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    md5_hex: "d41d8cd98f00b204e9800998ecf8427e"
+
+################################################################################
+# A. Check-mode tests
+################################################################################
+
+- name: Generate spec for creating LCM bundle using check mode with all attributes
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    state: present
+    name: "check_mode_lcm_bundle_full"
+    size_bytes: 12345678
+    type: "SOFTWARE"
+    vendor: "NUTANIX"
+    cluster_ext_id: "cae459ec-08db-475e-a5e5-151e390c9484"
+    checksum:
+      sha256_sum:
+        hex_digest: "{{ sha256_hex }}"
+    images:
+      - release_notes: "Check mode release notes"
+        spec_version: "1"
+        is_qualified: true
+        status: "RECOMMENDED"
+        entity_class: "AOS"
+        entity_model: "AOS"
+        entity_type: "SOFTWARE"
+        entity_version: "7.0.0"
+        hardware_family: "NX"
+        cluster_ext_id: "cae459ec-08db-475e-a5e5-151e390c9484"
+        files:
+          - name: "image.bin"
+            size_bytes: 12345678
+            file_path: "aos/image.bin"
+            checksum_type: "SHASUM"
+            checksum: "{{ sha256_hex }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for creating LCM bundle using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_lcm_bundle_full"
+      - result.response.size_bytes == 12345678
+      - result.response.type == "SOFTWARE"
+      - result.response.vendor == "NUTANIX"
+      - result.response.cluster_ext_id == "cae459ec-08db-475e-a5e5-151e390c9484"
+      - result.response.checksum is defined
+      - result.response.checksum.hex_digest == sha256_hex
+      - result.response.images | length == 1
+      - result.response.images[0].release_notes == "Check mode release notes"
+      - result.response.images[0].spec_version == "1"
+      - result.response.images[0].is_qualified == true
+      - result.response.images[0].status == "RECOMMENDED"
+      - result.response.images[0].entity_class == "AOS"
+      - result.response.images[0].entity_model == "AOS"
+      - result.response.images[0].entity_type == "SOFTWARE"
+      - result.response.images[0].entity_version == "7.0.0"
+      - result.response.images[0].hardware_family == "NX"
+      - result.response.images[0].cluster_ext_id == "cae459ec-08db-475e-a5e5-151e390c9484"
+      - result.response.images[0].files | length == 1
+      - result.response.images[0].files[0].name == "image.bin"
+      - result.response.images[0].files[0].size_bytes == 12345678
+      - result.response.images[0].files[0].file_path == "aos/image.bin"
+      - result.response.images[0].files[0].checksum_type == "SHASUM"
+      - result.response.images[0].files[0].checksum == sha256_hex
+    success_msg: "Spec for creating LCM bundle using check mode with all attributes is generated successfully"
+    fail_msg: "Spec for creating LCM bundle using check mode with all attributes is not generated successfully"
+
+- name: Delete LCM bundle with check mode
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    ext_id: "{{ fake_ext_id }}"
+    state: absent
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Delete LCM bundle with check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+      - result.ext_id == fake_ext_id
+    success_msg: "Delete LCM bundle with check mode passed"
+    fail_msg: "Delete LCM bundle with check mode failed"
+
+################################################################################
+# B. Real API tests (wait=false so we do not block on async preprocessing)
+################################################################################
+
+- name: Create LCM bundle with minimum attributes (wait=false)
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    state: present
+    name: "{{ bundle_min_name }}"
+    type: "SOFTWARE"
+    vendor: "NUTANIX"
+    wait: false
+  register: result
+  ignore_errors: true
+
+- name: Create LCM bundle with minimum attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.changed == true
+      - result.task_ext_id is defined
+      - result.task_ext_id | length > 0
+      - result.response is defined
+    success_msg: "LCM bundle create with minimum attributes accepted by API (task_ext_id returned)"
+    fail_msg: "LCM bundle create with minimum attributes failed unexpectedly"
+
+- name: Create LCM bundle with all attributes (wait=false)
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    state: present
+    name: "{{ bundle_full_name }}"
+    size_bytes: 12345678
+    type: "SOFTWARE"
+    vendor: "NUTANIX"
+    checksum:
+      sha256_sum:
+        hex_digest: "{{ sha256_hex }}"
+    images:
+      - release_notes: "Integration test release notes"
+        spec_version: "1"
+        is_qualified: true
+        status: "RECOMMENDED"
+        entity_class: "AOS"
+        entity_model: "AOS"
+        entity_type: "SOFTWARE"
+        entity_version: "7.0.0"
+        hardware_family: "NX"
+        files:
+          - name: "image.bin"
+            size_bytes: 12345678
+            file_path: "aos/image.bin"
+            checksum_type: "SHASUM"
+            checksum: "{{ sha256_hex }}"
+    wait: false
+  register: result
+  ignore_errors: true
+
+- name: Create LCM bundle with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.changed == true
+      - result.task_ext_id is defined
+      - result.task_ext_id | length > 0
+      - result.response is defined
+    success_msg: "LCM bundle create with all attributes accepted by API (task_ext_id returned)"
+    fail_msg: "LCM bundle create with all attributes failed unexpectedly"
+
+################################################################################
+# C. Info module tests
+################################################################################
+
+- name: List all LCM bundles
+  nutanix.ncp.ntnx_lcm_bundles_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List all LCM bundles status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response is iterable
+      - result.total_available_results is defined
+      - result.total_available_results >= 0
+    success_msg: "List all LCM bundles passed"
+    fail_msg: "List all LCM bundles failed"
+
+- name: List LCM bundles with a filter that matches nothing
+  nutanix.ncp.ntnx_lcm_bundles_info_v2:
+    filter: "name eq 'ansible_no_match_bundle_zzz.tar.gz'"
+  register: result
+  ignore_errors: true
+
+- name: List LCM bundles with filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 0
+    success_msg: "List LCM bundles with filter passed"
+    fail_msg: "List LCM bundles with filter failed"
+
+- name: List LCM bundles with limit=1
+  nutanix.ncp.ntnx_lcm_bundles_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List LCM bundles with limit status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length <= 1
+    success_msg: "List LCM bundles with limit passed"
+    fail_msg: "List LCM bundles with limit failed"
+
+- name: Fetch LCM bundle using wrong external ID
+  nutanix.ncp.ntnx_lcm_bundles_info_v2:
+    ext_id: "{{ fake_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch LCM bundle using wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Api Exception raised while fetching LCM bundle info' in result.msg"
+    success_msg: "Fetch LCM bundle using wrong external ID failed as expected"
+    fail_msg: "Fetch LCM bundle using wrong external ID did not fail as expected"
+
+################################################################################
+# D. Negative / validation tests
+################################################################################
+
+- name: Create LCM bundle with missing name (required_if)
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    state: present
+    type: "SOFTWARE"
+    vendor: "NUTANIX"
+  register: result
+  ignore_errors: true
+
+- name: Create LCM bundle with missing name status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - >-
+        result.msg == "state is present but any of the following are missing: name, ext_id"
+    success_msg: "Create LCM bundle with missing name failed as expected"
+    fail_msg: "Create LCM bundle with missing name did not fail as expected"
+
+- name: Create LCM bundle with missing type
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    state: present
+    name: "missing_type_bundle"
+    vendor: "NUTANIX"
+  register: result
+  ignore_errors: true
+
+- name: Create LCM bundle with missing type status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - >-
+        result.msg == "Missing required parameter(s): type"
+    success_msg: "Create LCM bundle with missing type failed as expected"
+    fail_msg: "Create LCM bundle with missing type did not fail as expected"
+
+- name: Create LCM bundle with missing vendor
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    state: present
+    name: "missing_vendor_bundle"
+    type: "SOFTWARE"
+  register: result
+  ignore_errors: true
+
+- name: Create LCM bundle with missing vendor status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - >-
+        result.msg == "Missing required parameter(s): vendor"
+    success_msg: "Create LCM bundle with missing vendor failed as expected"
+    fail_msg: "Create LCM bundle with missing vendor did not fail as expected"
+
+- name: Create LCM bundle with invalid type value
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    state: present
+    name: "invalid_type_bundle"
+    type: "NOT_A_VALID_TYPE"
+    vendor: "NUTANIX"
+  register: result
+  ignore_errors: true
+
+- name: Create LCM bundle with invalid type value status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'value of type must be one of' in result.msg"
+    success_msg: "Create LCM bundle with invalid type value failed as expected"
+    fail_msg: "Create LCM bundle with invalid type value did not fail as expected"
+
+- name: Attempt update (state=present with ext_id) - not supported
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    state: present
+    ext_id: "{{ fake_ext_id }}"
+    name: "should_not_update"
+    type: "SOFTWARE"
+    vendor: "NUTANIX"
+  register: result
+  ignore_errors: true
+
+- name: Attempt update status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Update is not supported' in result.msg"
+    success_msg: "Update rejection worked as expected"
+    fail_msg: "Update rejection did not work as expected"
+
+- name: Create LCM bundle with both md5_sum and sha256_sum (mutually exclusive)
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    state: present
+    name: "mutex_checksum_bundle"
+    type: "SOFTWARE"
+    vendor: "NUTANIX"
+    checksum:
+      md5_sum:
+        hex_digest: "{{ md5_hex }}"
+      sha256_sum:
+        hex_digest: "{{ sha256_hex }}"
+  register: result
+  ignore_errors: true
+
+- name: Mutually exclusive checksum status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'mutually exclusive' in result.msg"
+    success_msg: "Mutually exclusive checksum failed as expected"
+    fail_msg: "Mutually exclusive checksum did not fail as expected"
+
+- name: Delete LCM bundle with missing external ID
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Delete LCM bundle with missing external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete LCM bundle with missing external ID failed as expected"
+    fail_msg: "Delete LCM bundle with missing external ID did not fail as expected"
+
+- name: Delete LCM bundle with wrong external ID
+  nutanix.ncp.ntnx_lcm_bundle_v2:
+    ext_id: "{{ fake_ext_id }}"
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Delete LCM bundle with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Delete LCM bundle with wrong external ID failed as expected"
+    fail_msg: "Delete LCM bundle with wrong external ID did not fail as expected"
+
+- name: LCM Bundle v2 tests summary
+  ansible.builtin.debug:
+    msg: "All LCM Bundle v2 tests completed."

--- a/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import lcm_bundle.yml
+      ansible.builtin.import_tasks: lcm_bundle.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **life_cycle_management** namespace, entity
**Bundle**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_lcm_bundle_v2`, `ntnx_lcm_bundles_info_v2`
- API methods covered: **4** — `CreateBundle`, `DeleteBundleById`, `GetBundleById`, `ListBundles`
  (there is no `UpdateBundle` API in the LCM Bundles v4 SDK, so the CRUD module implements
  create + delete and rejects `state=present` with an `ext_id` with a descriptive message).
- Fields in CRUD module spec: **9** top-level fields
  (`ext_id`, `name`, `size_bytes`, `type`, `vendor`, `cluster_ext_id`, `checksum`, `images`, plus the standard `state`).
  `checksum` is a discriminated union (`md5_sum` OR `sha256_sum`), and every `Image` /
  `ImageFile` field defined by the SDK is exposed as a sub-option.
- Fields in info module spec: **1** module-specific field (`ext_id`), plus the standard
  `filter` / `page` / `limit` / `orderby` / `select` from `BaseInfoModule`.
- New helpers in `plugins/module_utils/v4/lcm/`: `get_bundles_api_instance()` (returns
  `ntnx_lifecycle_py_client.BundlesApi`) and `get_lcm_bundle()` (get-by-ext_id wrapper with
  standard error handling).

## Domain knowledge (from Glean)

# Domain knowledge (from Glean)

Query: "What is an LCM Bundle in Nutanix Life Cycle Management (LCM)?
Explain its features, workflow, prerequisites, how it is used, related
engineering tickets (JIRA/ENG), design and spec documents, and Confluence
pages with URLs. LCM Bundles v4 API is at /api/lifecycle/v4.2/resources/bundles."

### LCM Bundle in Nutanix Life Cycle Management (LCM)

An LCM Bundle is a packaged payload containing software binaries, firmware
updates, or the LCM framework itself. In Nutanix Life Cycle Management, these
bundles are heavily used in "Dark Site" (air-gapped) or strictly
version-controlled environments where clusters cannot or should not
automatically fetch the latest updates from the public Nutanix Portal.

The primary mechanism for managing these bundles natively within the cluster
is the **LCM Direct Upload** feature.

---

### Features and Advantages
* **Simplicity & Infrastructure Reduction:** Eliminates the complexity and
  maintenance overhead of standing up and configuring a dedicated local web
  server for Dark Site upgrades.
* **Strict Version Control:** Allows administrators to dictate exactly which
  validated and tested software/firmware versions are deployed, rather than
  being forced to use the latest versions from the portal.
* **Staged Rollouts & Consistency:** Helps maintain consistency across large
  enterprises by standardizing specific update bundles for deployments.
* **Multi-Cluster LCM (MCL):** In Prism Central (LCM 3.0+), it uses **Objects
  Lite** (a containerized, S3-compatible microservice) to centrally store
  multi-GB bundles in a bucket named `lcm-bundles`. These are then distributed
  to registered Prism Element clusters.

**Disadvantages:** It requires manual effort to upload binaries at scale,
consumes cluster storage resources, and geographic distribution can be less
optimal compared to a localized Dark Site web server.

---

### Prerequisites
* **Prism Element (PE):** Supported starting with LCM version 2.4.1.1.
* **Prism Central (PC):** Supported starting with LCM version 3.0. For PC 7.3
  and later, LCM direct upload requires the **Objects Lite** service to be
  running.
* **Framework First:** You **must** upload the LCM Framework bundle and run
  an inventory *before* the Direct Uploads UI becomes fully available for
  other components (like AOS, AHV, firmware).

---

### Workflow: How It Is Used
1. **Download Bundles:** Obtain the required LCM framework, software binaries,
   and firmware bundles (plus the Nutanix Compatibility Bundle) from the
   Nutanix Support Portal.
2. **Configure Update Source:**
   * In Prism Element or Prism Central, navigate to the LCM Settings.
   * Change the Update Source drop-down to **Dark Site (Direct Upload)**.
3. **Upload Framework & Run Inventory:** Upload the LCM Framework bundle. Run
   an LCM inventory. This updates the framework and fully enables the
   "Direct Uploads" UI tab.
4. **Upload Components:** Upload other required bundles (AOS, AHV, Foundation,
   NCC, etc.) via the "Direct Uploads" tab.
   * *PE Storage:* Stored temporarily in `/NutanixManagementShare/bundle_upload`
     on the cluster's internal NFS container.
   * *PC Storage:* Stored within the Objects Lite service bucket `lcm-bundles`.
5. **Final Inventory & Upgrade:** Perform a final inventory. The uploaded
   bundles will now be listed as available upgrades, allowing you to proceed
   with the cluster update.

---

### LCM Bundles v4 API (`/api/lifecycle/v4.2/resources/bundles`)
The v4 API provides programmable endpoints to manage bundles on the cluster:
* **`POST /api/lifecycle/v4.2/resources/bundles`:** Creates a new LCM bundle.
  This expects a payload defining the `vendor` (e.g., "NUTANIX"), `type`, and
  either an `images` list or an `urlSource` pointing to the bundle's location
  (like an S3 bucket URL). For PC, users can upload the bundle to Objects Lite
  via standard AWS S3 CLI (`aws s3api put-object --bucket lcm-bundles`) and
  then call this API passing the S3 object key as the `name`.
* **`GET /api/lifecycle/v4.2/resources/bundles`:** Lists all uploaded bundles,
  supporting OData filters and pagination.
* **`GET /api/lifecycle/v4.2/resources/bundles/{extId}`:** Retrieves details
  for a specific bundle.
* **`DELETE /api/lifecycle/v4.2/resources/bundles/{extId}`:** Deletes a
  specific uploaded bundle.

---

### Related Engineering Tickets (JIRA / ENG)
* **[ENG-715749](https://jira.nutanix.com/browse/ENG-715749):** Improvement to
  display a warning message in the UI when an incompatible LCM bundle is
  uploaded via direct upload (instead of silently hiding the update).
* **[ENG-803778](https://jira.nutanix.com/browse/ENG-803778):** Fixed a bug
  where LCM multilang SDK API calls were failing with 404 errors due to missing
  v4.2 API endpoints on the server.
* **[ENG-916663](https://jira.nutanix.com/browse/ENG-916663):** Bug involving
  `CreateBundle` tasks failing during unified-uploads on Nutanix Central because
  the UI was passing an `$UNKNOWN` bundle type (resolved by updating MCL UI bits).
* **[CLSTR-22856](https://jira.nutanix.com/browse/CLSTR-22856):** Implementation
  ticket to automate uploading LCM bundles from private S3 buckets using the v4
  Lifecycle APIs for NC2/Veles NIM installations.
* **[ENG-922658](https://jira.nutanix.com/browse/ENG-922658):** Post PC eth0 IP
  reconfig, `GET /api/lifecycle/v4.2/resources/status` giving up after 6
  attempts.
* **[ENG-943456](https://jira.nutanix.com/browse/ENG-943456):** Missing
  `hardwareFamily` field in LCM Entity API Response.
* **[ERA-58591](https://jira.nutanix.com/browse/ERA-58591):** Review design
  spec for NDB Integration with LCM.

---

### Design / Spec Documents & Confluence / SharePoint Pages
* **WF: LCM Direct Upload** — https://confluence.eng.nutanix.com:8443/spaces/STK/pages/528537408/WF+LCM+Direct+Upload
  (Primary workflow and troubleshooting guide for Direct Uploads and Objects Lite.)
* **PC / PE Darksite Upgrade** — https://confluence.eng.nutanix.com:8443/spaces/AHVM/pages/460991393/PC+PE+Darksite+Upgrade
* **Set up an LCM Dark Site Local Web Server** — https://confluence.eng.nutanix.com:8443/spaces/~yusuke.matsui/pages/478151267/Set+up+an+LCM+Dark+Site+Local+Web+Server
* **Module Bundles** — https://confluence.eng.nutanix.com:8443/spaces/~yen.vuong/pages/528536741/Module+Bundles
* **LCM DARK SITE DIRECT UPLOADS (SharePoint)** — https://nutanixinc.sharepoint.com/:p:/g/GlobalSupport/IQBxTiYGtalvTLjgS46FZ5VaAfDxu7unJU0FDPUaYjlz5k8
* **CS: LCM Darksite Troubleshooting** — https://confluence.eng.nutanix.com:8443/spaces/STK/pages/519580423/CS+LCM+Darksite+Troubleshooting
* **Sample LCM Bundles Documentation contents** — https://confluence.eng.nutanix.com:8443/spaces/~yen.vuong/pages/366724140/Sample+LCM+Bundles+Documentation+contents
* **Integrate LCM with Bundles API** — https://confluence.eng.nutanix.com:8443/spaces/LE/pages/183061548/Integrate+LCM+with+Bundles+API
* **LCM Unified RIM for LCM custom rim workflows** — https://confluence.eng.nutanix.com:8443/spaces/LE/pages/424228394/LCM+Unified+RIM+for+LCM+custom+rim+workflows.
* **LCM Artifact Meta: Nutanix certified RIM metadata and darksite or airgap bundles** — https://confluence.eng.nutanix.com:8443/spaces/LE/pages/115724159/LCM+Artifact+Meta+Nutanix+certified+RIM+metadata+and+darksite+or+airgap+bundles
* **🛡️ Dark Site Bundle Creation How-To** — https://confluence.eng.nutanix.com:8443/spaces/GCO/pages/468271342/%F0%9F%9B%A1%EF%B8%8F+Dark+Site+Bundle+Creation+How-To
* **New MSP Bundle Deployment Support** — https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/468268730/New+MSP+Bundle+Deployment+Support
* **LCM v4 API Migration - GA** — https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/487363767/LCM+v4+API+Migration+-+GA
* **LCM Bundling End-to-End Automation** — https://confluence.eng.nutanix.com:8443/spaces/~naresh.busireddy/pages/560102463/LCM+Bundling+End-to-End+Automation
* **LCM Bundling Automation Runbook** — https://confluence.eng.nutanix.com:8443/spaces/~naresh.busireddy/pages/560102471/LCM+Bundling+Automation+Runbook
* **Runbook to release Security Dashboard CVE Data LCM bundle** — https://confluence.eng.nutanix.com:8443/spaces/INFRA/pages/528544004/Runbook+to+release+Security+Dashboard+CVE+Data+LCM+bundle
* **Generation of Darksite MSP and MSP Platform Bundles** — https://confluence.eng.nutanix.com:8443/spaces/INFRA/pages/536667981/Generation+of+Darksite+MSP+and+MSP+Platform+Bundles
* **Service Manager Darksite Workflows** — https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/404286715/Service+Manager+Darksite+Workflows
* **LCM Inventory on PE and PC** — https://confluence.eng.nutanix.com:8443/spaces/STK/pages/443220598/LCM+Inventory+on+PE+and+PC
* **LCM Requirements** — https://confluence.eng.nutanix.com:8443/spaces/SO/pages/289720934/LCM+Requirements
* **Dark site upgrade order and instruction (SharePoint)** — https://nutanixinc.sharepoint.com/sites/ProfessionalServices-EmergingMarket/_layouts/15/Doc.aspx?sourcedoc=%7B62B50427-02DC-40AE-975F-B6C22D41C068%7D&file=Dark%20site%20upgrade%20order%20and%20instruction.docx&action=default&mobileredirect=true
* **OADOCS Upgrade Plan (SharePoint)** — https://nutanixinc.sharepoint.com/sites/PSAPJTAM/_layouts/15/Doc.aspx?sourcedoc=%7BC6EC26B3-8F25-4C1F-811B-096DEB4B651F%7D&file=OADOCS%20Upgrade%20Plan.docx&action=default&mobileredirect=true
* **Design spec (NC)** — https://confluence.eng.nutanix.com:8443/spaces/NC/pages/560101674/Design+spec
* **NC On-Prem Release Activities** — https://confluence.eng.nutanix.com:8443/spaces/NC/pages/496504627/NC+On-Prem+Release+Activities
* **LCM Draft** — https://confluence.eng.nutanix.com:8443/spaces/~mwila.chibuye/pages/519599512/LCM+Draft

---

### Source code / SDK references (GitHub / internal)
* **bundles_api.py (Python v4 SDK)** — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/lifecycle/ntnx_lifecycle_py_client/api/bundles_api.py
* **bundles_api.go (Go v4 SDK)** — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/lifecycle-go-client/api/bundles_api.go
* **bundles-endpoints.js (JS v4 SDK)** — https://github.com/nutanix-engineering/hack2026-d3179/blob/main/site/node_modules/@nutanix-api/lifecycle-js-client/dist/lib/apis/bundles-endpoints.js
* **swagger_lifecycle_v4_2_all.yaml** — https://github.com/nutanix-core/qa-initiatives-cz/blob/main/open_api_spec/swagger_lifecycle_v4_2_all.yaml
* **swagger-lifecycle-v4.2-all-flat.yaml (Hackathon d3320)** — https://github.com/nutanix-engineering/hack2026-d3320/blob/main/hackathon/v4sdk/lifecycle/swagger-lifecycle-v4.2-all-flat.yaml
* **endpoints.md (hack2026-d2855)** — https://github.com/nutanix-engineering/hack2026-d2855/blob/main/api_reference/lifecycle_management/endpoints.md
* **lcm_bundles_api.py (framework)** — https://github.com/nutanix-core/lcm-framework/blob/master/modules/ptest/utils/lcm_bundles_api.py
* **test_lcm_post_bundle_upload_pc.py (framework tests)** — https://github.com/nutanix-core/lcm-framework/blob/master/modules/ptest/tests/test_lcm_post_bundle_upload_pc.py
* **fix: LCM Bundle Upload API support on pTest** — https://github.com/nutanix-core/lcm-framework/pull/9656
* **feat(proto): add custom_image_type to LcmBundleV1** — https://github.com/nutanix-core/lcm-framework/pull/9748
* **fix(ENG-937911): skip IMAGE/LCM_BUNDLE sync on ESX Clusters** — https://github.com/nutanix-core/lcm-framework/pull/9597
* **Feature/clstr 22889 lcm bundle upload (nc2-veles PR #204)** — https://github.com/nutanix-core/nc2-veles/pull/204
* **Swagger Lifecycle v4.3.yaml (nutanix-api-specs)** — https://github.com/nutanix-core/flow-bug-help/blob/main/nutanix-api-specs/Swagger%20Lifecycle%20v4.3.yaml

---

### Required Domain Skills
* **Nutanix Life Cycle Management (LCM):** conceptual understanding of LCM
  framework, LCM inventory, prechecks, upgrades, and the difference between
  connected-site, dark-site (local web server), and dark-site direct-upload
  connectivity types.
* **Prism Central vs Prism Element (PC vs PE):** know where LCM operates,
  how PC federates LCM across PEs, and where bundles are stored on each
  (PE `/NutanixManagementShare/bundle_upload`, PC Objects Lite bucket
  `lcm-bundles`).
* **Objects Lite / S3-compatible storage:** how PC 7.3+ stores multi-GB LCM
  bundles in the `lcm-bundles` bucket, familiarity with `aws s3api put-object`
  style uploads.
* **Bundle categories (`BundleType`):** `FIRMWARE`, `FRAMEWORK`,
  `PRODUCT_META`, `SOFTWARE`, and the ordering constraint (framework first).
* **Bundle vendors (`BundleVendor`):** `NUTANIX`, `THIRD_PARTY`.
* **Bundle checksums:** `LcmMd5Sum` (HEX_MD5) and `LcmSha256Sum` (SHASUM)
  representations used to verify uploaded bundles.
* **LCM entities and images:** how a Bundle's `images` are `EntityType`
  qualified (e.g. `FIRMWARE`, `SOFTWARE`) with `entity_class`, `entity_model`,
  `entity_version`, `hardware_family`, `AvailableVersionStatus`, and
  associated `ImageFile` objects.
* **Nutanix v4 API conventions:** ETag / If-Match for update, async task
  responses (`prism.v4.config.TaskReference`), OData `_filter`, `_orderby`,
  `_select`, `_page`, `_limit` on list endpoints.
* **Ansible collection conventions in `nutanix.ncp`:** v4 module skeleton,
  `BaseModuleV4`, `BaseInfoModule`, `SpecGenerator`, `raise_api_exception`,
  `strip_internal_attributes`, `wait_for_completion`,
  `get_entity_ext_id_from_task`, and the reference module `ntnx_virtual_switch_v2`.


## Files changed

- `plugins/modules/`
  - **new** `ntnx_lcm_bundle_v2.py` — CRUD module (create + delete + safe rejection of
    `state=present` with `ext_id`).
  - **new** `ntnx_lcm_bundles_info_v2.py` — info module (get-by-ID + list with filter /
    limit / orderby / select).
- `plugins/module_utils/v4/lcm/`
  - **modified** `api_client.py` — added `get_bundles_api_instance()` for `BundlesApi`.
  - **modified** `helpers.py` — added `get_lcm_bundle()`.
- `examples/life_cycle_management/Bundle/`
  - **new** `bundle_v2.yml` — end-to-end example playbook (create, get, list, filter, limit, delete).
  - **new** `examples_run.log` — live run against the target Prism Central `10.44.76.28`.
    The create task correctly reaches the CreateBundle API and fails asynchronously with
    `Failed to preprocess bundle for upload root task. Error : Failed to check object size ...`
    which is expected on a cluster where the bundle binary has NOT been uploaded to the
    Objects Lite `lcm-bundles` bucket first (see the Glean section above). The dependent
    get / delete tasks skip cleanly under that condition; the list tasks succeed.
- `tests/integration/targets/ntnx_lcm_bundle_v2/`
  - **new** `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/lcm_bundle.yml` — full test
    target covering check_mode create / delete, real API create with `wait: false`,
    list-all / list-with-filter / list-with-limit / get-by-wrong-ext_id, and every negative
    path (missing `name` / `type` / `vendor`, invalid `type` enum, attempted update, mutually
    exclusive checksum, missing / wrong `ext_id` on delete).

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-playbook /tmp/codegen-artifacts.vmv8H1/run_tests.yml -v` (wraps `tests/integration/targets/ntnx_lcm_bundle_v2/tasks/lcm_bundle.yml`) |
| Total tasks         | 36 assertions + module invocations |
| Passed              | ok=36                                          |
| Failed              | failed=0                                       |
| Skipped             | 0                                              |
| Ignored (expected)  | 9 (negative / API-not-found tests that intentionally raise) |
| Duration            | ~17s                                            |
| Cluster (PC)        | `10.44.76.28`                                  |

### Analysis

There are no failed test tasks. The 9 "ignored" errors are deliberate negative-path
invocations wrapped in `ignore_errors: true` and immediately validated by a follow-up
`assert` (e.g. missing `name` -> `required_if` failure, invalid `type` enum -> spec
validation failure, `state=present` + `ext_id` -> "Update is not supported" module error,
`checksum.md5_sum` + `checksum.sha256_sum` -> "parameters are mutually exclusive", GET
with a bogus `ext_id` -> `Api Exception raised while fetching LCM bundle info`, DELETE
with a bogus `ext_id` -> async `Task Failed`).

Notable runtime observation on the target PC: `POST /api/lifecycle/v4.2/resources/bundles`
accepts the request and returns a task, but that async task fails with
`Failed to get object size for <bundle name>. Error: Unable to locate credentials`
whenever the actual bundle binary has NOT been uploaded to the Objects Lite `lcm-bundles`
bucket first (the standard `aws s3api put-object --bucket lcm-bundles ...` flow described
in the Glean domain-knowledge block). This is a runtime workflow constraint of the LCM
Bundles v4 API — not a module bug — and is why the real-API create tests use `wait: false`
and assert on `task_ext_id` instead of doing a full end-to-end wait-for-success. This
same runtime constraint is why the `examples/.../bundle_v2.yml` create task shows a
"Task Failed" outcome in `examples_run.log`; the module correctly propagates the async
task error, and the downstream tasks that depend on the returned `ext_id` are skipped
via `when: bundle_ext_id is defined` guards.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
[WARNING]: Found variable using reserved name 'port'.
Origin: /home/abhinav.bansal1/.ansible/collections/ansible_collections/nutanix/ncp/tests/integration/integration_config.yml:4:1

2 username: "admin"
3 password: "Nutanix.123"
4 port: 9440
  ^ column 1

No config file found; using defaults

PLAY [Run ntnx_lcm_bundle_v2 integration tests] ********************************

TASK [Start LCM Bundle v2 tests] ***********************************************
ok: [localhost] => {
    "msg": "Start LCM Bundle v2 tests"
}

TASK [Generate random names for LCM Bundle tests] ******************************
ok: [localhost] => {"ansible_facts": {"random_name": "HWHkhfSgexwJ", "suffix_name": "ansible"}, "changed": false}

TASK [Set names for LCM bundle tests] ******************************************
ok: [localhost] => {"ansible_facts": {"bundle_full_name": "lcm_bundle_ansible_HWHkhfSgexwJ_full.tar.gz", "bundle_min_name": "lcm_bundle_ansible_HWHkhfSgexwJ_min.tar.gz", "fake_ext_id": "04595a7b-010c-4a89-58dd-060c94e9a1f0", "md5_hex": "d41d8cd98f00b204e9800998ecf8427e", "sha256_hex": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}, "changed": false}

TASK [Generate spec for creating LCM bundle using check mode with all attributes] ***
ok: [localhost] => {"changed": false, "ext_id": null, "response": {"checksum": {"hex_digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}, "cluster_ext_id": "cae459ec-08db-475e-a5e5-151e390c9484", "ext_id": null, "images": [{"cluster_ext_id": "cae459ec-08db-475e-a5e5-151e390c9484", "entity_class": "AOS", "entity_model": "AOS", "entity_type": "SOFTWARE", "entity_version": "7.0.0", "ext_id": null, "files": [{"checksum": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", "checksum_type": "SHASUM", "file_location_id": null, "file_path": "aos/image.bin", "name": "image.bin", "size_bytes": 12345678}], "hardware_family": "NX", "is_qualified": true, "links": null, "release_notes": "Check mode release notes", "spec_version": "1", "status": "RECOMMENDED", "tenant_id": null}], "links": null, "name": "check_mode_lcm_bundle_full", "size_bytes": 12345678, "tenant_id": null, "type": "SOFTWARE", "vendor": "NUTANIX"}, "task_ext_id": null}

TASK [Generate spec for creating LCM bundle using check mode with all attributes status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Spec for creating LCM bundle using check mode with all attributes is generated successfully"
}

TASK [Delete LCM bundle with check mode] ***************************************
ok: [localhost] => {"changed": false, "ext_id": "04595a7b-010c-4a89-58dd-060c94e9a1f0", "msg": "LCM bundle with ext_id:04595a7b-010c-4a89-58dd-060c94e9a1f0 will be deleted.", "response": null, "task_ext_id": null}

TASK [Delete LCM bundle with check mode status] ********************************
ok: [localhost] => {
    "changed": false,
    "msg": "Delete LCM bundle with check mode passed"
}

TASK [Create LCM bundle with minimum attributes (wait=false)] ******************
changed: [localhost] => {"changed": true, "ext_id": null, "response": {"ext_id": "ZXJnb24=:b3d732a2-613f-516b-affe-1d77763e11df"}, "task_ext_id": "ZXJnb24=:b3d732a2-613f-516b-affe-1d77763e11df"}

TASK [Create LCM bundle with minimum attributes status] ************************
ok: [localhost] => {
    "changed": false,
    "msg": "LCM bundle create with minimum attributes accepted by API (task_ext_id returned)"
}

TASK [Create LCM bundle with all attributes (wait=false)] **********************
changed: [localhost] => {"changed": true, "ext_id": null, "response": {"ext_id": "ZXJnb24=:af67a71f-a2c9-542e-86be-1da433fb9b12"}, "task_ext_id": "ZXJnb24=:af67a71f-a2c9-542e-86be-1da433fb9b12"}

TASK [Create LCM bundle with all attributes status] ****************************
ok: [localhost] => {
    "changed": false,
    "msg": "LCM bundle create with all attributes accepted by API (task_ext_id returned)"
}

TASK [List all LCM bundles] ****************************************************
ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [List all LCM bundles status] *********************************************
ok: [localhost] => {
    "changed": false,
    "msg": "List all LCM bundles passed"
}

TASK [List LCM bundles with a filter that matches nothing] *********************
ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [List LCM bundles with filter status] *************************************
ok: [localhost] => {
    "changed": false,
    "msg": "List LCM bundles with filter passed"
}

TASK [List LCM bundles with limit=1] *******************************************
ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [List LCM bundles with limit status] **************************************
ok: [localhost] => {
    "changed": false,
    "msg": "List LCM bundles with limit passed"
}

TASK [Fetch LCM bundle using wrong external ID] ********************************
[ERROR]: Task failed: Module failed: Api Exception raised while fetching LCM bundle info using ext_id 04595a7b-010c-4a89-58dd-060c94e9a1f0
Origin: /tmp/codegen/b544dda3cd5b4b03b0e09d2f7c9ee16f/repo/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/lcm_bundle.yml:273:3

271     fail_msg: "List LCM bundles with limit failed"
272
273 - name: Fetch LCM bundle using wrong external ID
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching LCM bundle info using ext_id 04595a7b-010c-4a89-58dd-060c94e9a1f0", "response": {"$dataItemDiscriminator": "lifecycle.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<lifecycle.v4.error.AppMessage>", "$objectType": "lifecycle.v4.error.ErrorResponse", "error": [{"$objectType": "lifecycle.v4.error.AppMessage", "argumentsMap": {"ext_id": "04595a7b-010c-4a89-58dd-060c94e9a1f0"}, "code": "10903", "errorGroup": "RESOURCE_NOT_FOUND_ERROR", "locale": "en-US", "message": "Failed to get bundle with 04595a7b-010c-4a89-58dd-060c94e9a1f0 as the resource was not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [Fetch LCM bundle using wrong external ID status] *************************
ok: [localhost] => {
    "changed": false,
    "msg": "Fetch LCM bundle using wrong external ID failed as expected"
}

TASK [Create LCM bundle with missing name (required_if)] ***********************
[ERROR]: Task failed: Module failed: state is present but any of the following are missing: name, ext_id
Origin: /tmp/codegen/b544dda3cd5b4b03b0e09d2f7c9ee16f/repo/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/lcm_bundle.yml:293:3

291 ################################################################################
292
293 - name: Create LCM bundle with missing name (required_if)
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "state is present but any of the following are missing: name, ext_id"}
...ignoring

TASK [Create LCM bundle with missing name status] ******************************
ok: [localhost] => {
    "changed": false,
    "msg": "Create LCM bundle with missing name failed as expected"
}

TASK [Create LCM bundle with missing type] *************************************
[ERROR]: Task failed: Module failed: Missing required parameter(s): type
Origin: /tmp/codegen/b544dda3cd5b4b03b0e09d2f7c9ee16f/repo/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/lcm_bundle.yml:312:3

310     fail_msg: "Create LCM bundle with missing name did not fail as expected"
311
312 - name: Create LCM bundle with missing type
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): type"}
...ignoring

TASK [Create LCM bundle with missing type status] ******************************
ok: [localhost] => {
    "changed": false,
    "msg": "Create LCM bundle with missing type failed as expected"
}

TASK [Create LCM bundle with missing vendor] ***********************************
[ERROR]: Task failed: Module failed: Missing required parameter(s): vendor
Origin: /tmp/codegen/b544dda3cd5b4b03b0e09d2f7c9ee16f/repo/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/lcm_bundle.yml:331:3

329     fail_msg: "Create LCM bundle with missing type did not fail as expected"
330
331 - name: Create LCM bundle with missing vendor
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): vendor"}
...ignoring

TASK [Create LCM bundle with missing vendor status] ****************************
ok: [localhost] => {
    "changed": false,
    "msg": "Create LCM bundle with missing vendor failed as expected"
}

TASK [Create LCM bundle with invalid type value] *******************************
[ERROR]: Task failed: Module failed: value of type must be one of: FIRMWARE, FRAMEWORK, PRODUCT_META, SOFTWARE, got: NOT_A_VALID_TYPE
Origin: /tmp/codegen/b544dda3cd5b4b03b0e09d2f7c9ee16f/repo/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/lcm_bundle.yml:350:3

348     fail_msg: "Create LCM bundle with missing vendor did not fail as expected"
349
350 - name: Create LCM bundle with invalid type value
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of type must be one of: FIRMWARE, FRAMEWORK, PRODUCT_META, SOFTWARE, got: NOT_A_VALID_TYPE"}
...ignoring

TASK [Create LCM bundle with invalid type value status] ************************
ok: [localhost] => {
    "changed": false,
    "msg": "Create LCM bundle with invalid type value failed as expected"
}

TASK [Attempt update (state=present with ext_id) - not supported] **************
[ERROR]: Task failed: Module failed: Update is not supported for LCM bundles. To modify a bundle, delete the existing bundle with state=absent and re-create it.
Origin: /tmp/codegen/b544dda3cd5b4b03b0e09d2f7c9ee16f/repo/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/lcm_bundle.yml:369:3

367     fail_msg: "Create LCM bundle with invalid type value did not fail as expected"
368
369 - name: Attempt update (state=present with ext_id) - not supported
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "ext_id": null, "msg": "Update is not supported for LCM bundles. To modify a bundle, delete the existing bundle with state=absent and re-create it.", "response": null, "task_ext_id": null}
...ignoring

TASK [Attempt update status] ***************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Update rejection worked as expected"
}

TASK [Create LCM bundle with both md5_sum and sha256_sum (mutually exclusive)] ***
[ERROR]: Task failed: Module failed: parameters are mutually exclusive: checksum.md5_sum|checksum.sha256_sum
Origin: /tmp/codegen/b544dda3cd5b4b03b0e09d2f7c9ee16f/repo/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/lcm_bundle.yml:389:3

387     fail_msg: "Update rejection did not work as expected"
388
389 - name: Create LCM bundle with both md5_sum and sha256_sum (mutually exclusive)
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "ext_id": null, "msg": "parameters are mutually exclusive: checksum.md5_sum|checksum.sha256_sum", "response": null, "task_ext_id": null}
...ignoring

TASK [Mutually exclusive checksum status] **************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Mutually exclusive checksum failed as expected"
}

TASK [Delete LCM bundle with missing external ID] ******************************
[ERROR]: Task failed: Module failed: state is absent but all of the following are missing: ext_id
Origin: /tmp/codegen/b544dda3cd5b4b03b0e09d2f7c9ee16f/repo/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/lcm_bundle.yml:413:3

411     fail_msg: "Mutually exclusive checksum did not fail as expected"
412
413 - name: Delete LCM bundle with missing external ID
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id"}
...ignoring

TASK [Delete LCM bundle with missing external ID status] ***********************
ok: [localhost] => {
    "changed": false,
    "msg": "Delete LCM bundle with missing external ID failed as expected"
}

TASK [Delete LCM bundle with wrong external ID] ********************************
[ERROR]: Task failed: Module failed: Task Failed
Origin: /tmp/codegen/b544dda3cd5b4b03b0e09d2f7c9ee16f/repo/tests/integration/targets/ntnx_lcm_bundle_v2/tasks/lcm_bundle.yml:429:3

427     fail_msg: "Delete LCM bundle with missing external ID did not fail as expected"
428
429 - name: Delete LCM bundle with wrong external ID
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["d4203251-bbe2-42af-b70c-3c5c53ab7da0"], "completed_time": "2026-07-20T14:26:59.020036+00:00", "completion_details": null, "created_time": "2026-07-20T14:26:58.817306+00:00", "entities_affected": null, "error_messages": [{"arguments_map": null, "code": "TSKS-20801", "error_group": "LEGACY_ERROR", "locale": "en_US", "message": "Operation failed due to legacy error and 'legacyErrorMessage' should be referred to for details", "severity": "ERROR"}], "ext_id": "ZXJnb24=:674d23fd-3cbd-51f8-8860-0501d12689e6", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T14:26:59.020035+00:00", "legacy_error_message": "Failed to get cluster uuid from bundle uuid", "number_of_entities_affected": 0, "number_of_subtasks": 0, "operation": "DeleteBundleById", "operation_description": "Delete Bundle By Id", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "resource_links": null, "root_task": null, "started_time": "2026-07-20T14:26:58.817306+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": null, "warnings": null}}
...ignoring

TASK [Delete LCM bundle with wrong external ID status] *************************
ok: [localhost] => {
    "changed": false,
    "msg": "Delete LCM bundle with wrong external ID failed as expected"
}

TASK [LCM Bundle v2 tests summary] *********************************************
ok: [localhost] => {
    "msg": "All LCM Bundle v2 tests completed."
}

PLAY RECAP *********************************************************************
localhost                  : ok=36   changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=9
```

</details>

## Lint / sanity

- `black --check .` — pass
- `isort --check .` — pass
- `flake8` on the new modules and helpers — pass (no findings)
- `ansible-lint` on the new modules, example, and test tasks — 0 failures, 0 warnings
  after the ansible-lint noise about deliberately-failing negative tasks was addressed
  (the negative tasks intentionally pass invalid parameters).
- `ansible-test sanity` (Python 3.12) on the new modules and helpers — all sanity tests
  (`compile`, `pep8`, `pylint`, `validate-modules`, `yamllint`, `ansible-doc`, ...) pass
  with 0 errors.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
