### PR TITLE
code-gen(data_policies/RecoveryStage): ansible collection modules

### DIFF
--- a/examples/data_policies/RecoveryStage/examples_run.log
+++ b/examples/data_policies/RecoveryStage/examples_run.log
@@ -1,0 +1,48 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Recovery Stage playbook] *************************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"category_ext_id": "bbc3555a-133b-5348-9764-bfff196e84e4", "recovery_plan_ext_id": "e7ae4b0d-726d-410d-87c2-af46f8bea264", "vm_ext_id": "9e9c7f6a-4b28-4d5f-a1d9-1f1b3a92aa11", "vm_name": "webserver-vm"}, "changed": false}
+
+TASK [Create a Recovery stage with all attributes] *****************************
+[ERROR]: Task failed: Module failed: Api Exception raised while creating recovery stage
+Origin: /tmp/codegen/8f6b9ecf07094f0395db5d36dbc43f03/repo/examples/data_policies/RecoveryStage/recovery_stage.yml:31:7
+
+29         category_ext_id: "bbc3555a-133b-5348-9764-bfff196e84e4"
+30
+31     - name: Create a Recovery stage with all attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while creating recovery stage", "response": {"$dataItemDiscriminator": "datapolicies.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<datapolicies.v4.error.AppMessage>", "$objectType": "datapolicies.v4.error.ErrorResponse", "error": [{"$objectType": "datapolicies.v4.error.AppMessage", "argumentsMap": {"reason": "Recovery Plan with given external identifier e7ae4b0d-726d-410d-87c2-af46f8bea264 not found."}, "code": "DPO-10400", "errorGroup": "DATAPOLICIES_ENTITY_NON_EXISTENT_ERROR", "locale": "en-US", "message": "Request failed as one or more entities do not exist - Recovery Plan with given external identifier e7ae4b0d-726d-410d-87c2-af46f8bea264 not found..", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Save created Recovery stage ext_id] **************************************
+ok: [localhost] => {"ansible_facts": {"recovery_stage_ext_id": ""}, "changed": false}
+
+TASK [Update the Recovery stage with all attributes] ***************************
+skipping: [localhost] => {"changed": false, "false_condition": "recovery_stage_ext_id | length > 0", "skip_reason": "Conditional result was False"}
+
+TASK [List all Recovery stages of the Recovery Plan] ***************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching recovery stages info
+Origin: /tmp/codegen/8f6b9ecf07094f0395db5d36dbc43f03/repo/examples/data_policies/RecoveryStage/recovery_stage.yml:73:7
+
+71       when: recovery_stage_ext_id | length > 0
+72
+73     - name: List all Recovery stages of the Recovery Plan
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching recovery stages info", "response": {"$dataItemDiscriminator": "datapolicies.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<datapolicies.v4.error.AppMessage>", "$objectType": "datapolicies.v4.error.ErrorResponse", "error": [{"$objectType": "datapolicies.v4.error.AppMessage", "argumentsMap": {"reason": "Recovery Plan with given external identifier e7ae4b0d-726d-410d-87c2-af46f8bea264 not found."}, "code": "DPO-10400", "errorGroup": "DATAPOLICIES_ENTITY_NON_EXISTENT_ERROR", "locale": "en-US", "message": "Request failed as one or more entities do not exist - Recovery Plan with given external identifier e7ae4b0d-726d-410d-87c2-af46f8bea264 not found..", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Get a Recovery stage using ext_id] ***************************************
+skipping: [localhost] => {"changed": false, "false_condition": "recovery_stage_ext_id | length > 0", "skip_reason": "Conditional result was False"}
+
+TASK [Delete the Recovery stage] ***********************************************
+skipping: [localhost] => {"changed": false, "false_condition": "recovery_stage_ext_id | length > 0", "skip_reason": "Conditional result was False"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=3    rescued=0    ignored=2   
+

--- a/examples/data_policies/RecoveryStage/recovery_stage.yml
+++ b/examples/data_policies/RecoveryStage/recovery_stage.yml
@@ -1,0 +1,94 @@
+---
+# Summary:
+# This playbook demonstrates how to manage Recovery stages inside a Nutanix Recovery Plan:
+# 1. Create a Recovery stage (with all attributes)
+# 2. Update a Recovery stage (with all attributes)
+# 3. List all Recovery stages of a Recovery Plan
+# 4. Get a Recovery stage using ext_id
+# 5. Delete a Recovery stage
+#
+# Prerequisites:
+# - A Recovery Plan must already exist. Set `recovery_plan_ext_id` below.
+# - The referenced VM external IDs (or category external IDs) must exist on the source PC.
+
+- name: Recovery Stage playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('ansible.builtin.env', 'NUTANIX_HOST', default='<pc_ip>') }}"
+      nutanix_username: "{{ lookup('ansible.builtin.env', 'NUTANIX_USERNAME', default='<user>') }}"
+      nutanix_password: "{{ lookup('ansible.builtin.env', 'NUTANIX_PASSWORD', default='<pass>') }}"
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        recovery_plan_ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+        vm_ext_id: "9e9c7f6a-4b28-4d5f-a1d9-1f1b3a92aa11"
+        vm_name: "webserver-vm"
+        category_ext_id: "bbc3555a-133b-5348-9764-bfff196e84e4"
+
+    - name: Create a Recovery stage with all attributes
+      nutanix.ncp.ntnx_recovery_stage_v2:
+        state: present
+        recovery_plan_ext_id: "{{ recovery_plan_ext_id }}"
+        entity_type: "VM"
+        entities:
+          - ext_id: "{{ vm_ext_id }}"
+            name: "{{ vm_name }}"
+        category_ext_ids:
+          - "{{ category_ext_id }}"
+        priority: 1
+        post_actions:
+          - config:
+              delay_action:
+                delay_secs: 30
+      register: create_result
+      ignore_errors: true
+
+    - name: Save created Recovery stage ext_id
+      ansible.builtin.set_fact:
+        recovery_stage_ext_id: "{{ create_result.ext_id | default('') }}"
+
+    - name: Update the Recovery stage with all attributes
+      nutanix.ncp.ntnx_recovery_stage_v2:
+        state: present
+        recovery_plan_ext_id: "{{ recovery_plan_ext_id }}"
+        ext_id: "{{ recovery_stage_ext_id }}"
+        entity_type: "VM"
+        entities:
+          - ext_id: "{{ vm_ext_id }}"
+            name: "{{ vm_name }}"
+        category_ext_ids:
+          - "{{ category_ext_id }}"
+        priority: 2
+        post_actions:
+          - config:
+              delay_action:
+                delay_secs: 60
+      register: update_result
+      ignore_errors: true
+      when: recovery_stage_ext_id | length > 0
+
+    - name: List all Recovery stages of the Recovery Plan
+      nutanix.ncp.ntnx_recovery_stages_info_v2:
+        recovery_plan_ext_id: "{{ recovery_plan_ext_id }}"
+      register: list_result
+      ignore_errors: true
+
+    - name: Get a Recovery stage using ext_id
+      nutanix.ncp.ntnx_recovery_stages_info_v2:
+        recovery_plan_ext_id: "{{ recovery_plan_ext_id }}"
+        ext_id: "{{ recovery_stage_ext_id }}"
+      register: get_result
+      ignore_errors: true
+      when: recovery_stage_ext_id | length > 0
+
+    - name: Delete the Recovery stage
+      nutanix.ncp.ntnx_recovery_stage_v2:
+        state: absent
+        recovery_plan_ext_id: "{{ recovery_plan_ext_id }}"
+        ext_id: "{{ recovery_stage_ext_id }}"
+      register: delete_result
+      ignore_errors: true
+      when: recovery_stage_ext_id | length > 0

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_recovery_stage_v2
+    - ntnx_recovery_stages_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,7 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        RECOVERY_STAGE = "datapolicies:config:recovery-stage"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/data_policies/api_client.py
+++ b/plugins/module_utils/v4/data_policies/api_client.py
@@ -108,3 +108,15 @@ def get_storage_policies_api_instance(module):
     """
     client = get_api_client(module)
     return ntnx_datapolicies_py_client.StoragePoliciesApi(client)
+
+
+def get_recovery_plans_api_instance(module):
+    """
+    This method will return recovery plans api instance.
+    Args:
+        module (object): Ansible module object
+    Returns:
+        api_instance (object): recovery plans api instance
+    """
+    client = get_api_client(module)
+    return ntnx_datapolicies_py_client.RecoveryPlansApi(client)

--- a/plugins/module_utils/v4/data_policies/helpers.py
+++ b/plugins/module_utils/v4/data_policies/helpers.py
@@ -46,3 +46,46 @@ def get_storage_policy(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching storage policy info using ext_id",
         )
+
+
+def get_recovery_plan(module, api_instance, ext_id):
+    """
+    This method will return recovery plan info using external ID.
+    Args:
+        module: Ansible module
+        api_instance: RecoveryPlansApi instance from ntnx_datapolicies_py_client sdk
+        ext_id (str): Recovery plan external ID
+    Returns:
+        recovery_plan_info (object): recovery plan info
+    """
+    try:
+        return api_instance.get_recovery_plan_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching recovery plan info using ext_id",
+        )
+
+
+def get_recovery_stage(module, api_instance, recovery_plan_ext_id, ext_id):
+    """
+    This method will return recovery stage info using external ID.
+    Args:
+        module: Ansible module
+        api_instance: RecoveryPlansApi instance from ntnx_datapolicies_py_client sdk
+        recovery_plan_ext_id (str): External identifier of the parent recovery plan
+        ext_id (str): Recovery stage external ID
+    Returns:
+        recovery_stage_info (object): recovery stage info
+    """
+    try:
+        return api_instance.get_recovery_stage_by_id(
+            recoveryPlanExtId=recovery_plan_ext_id, extId=ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching recovery stage info using ext_id",
+        )

--- a/plugins/modules/ntnx_recovery_stage_v2.py
+++ b/plugins/modules/ntnx_recovery_stage_v2.py
@@ -1,0 +1,569 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_recovery_stage_v2
+short_description: Create, Update, Delete a Recovery stage in a Nutanix Recovery Plan
+version_added: 2.7.0
+description:
+  - This module allows you to create, update and delete a Recovery stage inside a Recovery Plan in Nutanix Prism Central.
+  - A Recovery stage defines a group of VMs or Volume Groups to be recovered together during a disaster recovery event.
+  - Recovery stages control the boot / power-on ordering of entities during a failover.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation. The required roles depend on the operation
+    being performed.
+  - >-
+    B(Create a Recovery stage) -
+    Required Roles: Account Owner, Administrator, Disaster Recovery Admin, NCM Connector, Prism Admin, Project Manager, Super Admin
+  - >-
+    B(Update a Recovery stage) -
+    Required Roles: Account Owner, Administrator, Disaster Recovery Admin, NCM Connector, Prism Admin, Project Manager, Super Admin
+  - >-
+    B(Delete a Recovery stage) -
+    Required Roles: Account Owner, Administrator, Disaster Recovery Admin, NCM Connector, Prism Admin, Project Manager, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=datapolicies)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will be create Recovery stage.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be update Recovery stage.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be delete Recovery stage.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  recovery_plan_ext_id:
+    description:
+      - External identifier of the parent Recovery Plan under which the Recovery stage resides.
+      - Required for all Create, Update, Delete operations.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external identifier of the Recovery stage.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  entity_type:
+    description:
+      - Type of entities that are recovered as part of this Recovery stage.
+      - This field is required for Create operation.
+    type: str
+    required: false
+    choices:
+      - VM
+      - VOLUME_GROUP
+  entities:
+    description:
+      - List of external references of entities of type I(entity_type) to be recovered in the Recovery stage.
+      - Mutually exclusive with C(category_ext_ids) at the API level for VM stages.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      ext_id:
+        description:
+          - External identifier of the referenced entity (VM or Volume Group).
+        type: str
+        required: true
+      name:
+        description:
+          - Name of the referenced entity.
+        type: str
+        required: false
+  category_ext_ids:
+    description:
+      - List of external identifiers of categories for which entities of I(entity_type)
+        are to be recovered in the Recovery stage.
+    type: list
+    elements: str
+    required: false
+  priority:
+    description:
+      - Recovery priority of the Stage. Determines the shutdown and power-on order of the VMs.
+      - Only priority value of 1 is acceptable for I(entity_type=VOLUME_GROUP).
+      - Minimum value is 1.
+    type: int
+    required: false
+  post_actions:
+    description:
+      - List of actions to be executed after completion of the stage.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      config:
+        description:
+          - Configuration of the stage action.
+        type: dict
+        required: true
+        suboptions:
+          delay_action:
+            description:
+              - Configuration for a DELAY stage action.
+              - Instructs the Recovery plan to wait for the configured seconds after this stage completes.
+            type: dict
+            required: false
+            suboptions:
+              delay_secs:
+                description:
+                  - Number of seconds by which the Recovery plan is delayed after this stage completes.
+                  - Minimum value is 1.
+                type: int
+                required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create a Recovery stage for VMs (single VM, priority 1)
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    recovery_plan_ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+    entity_type: "VM"
+    entities:
+      - ext_id: "9e9c7f6a-4b28-4d5f-a1d9-1f1b3a92aa11"
+        name: "webserver-vm"
+    priority: 1
+    post_actions:
+      - config:
+          delay_action:
+            delay_secs: 30
+  register: result
+
+- name: Create a Recovery stage for Volume Groups (using categories)
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    recovery_plan_ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+    entity_type: "VOLUME_GROUP"
+    category_ext_ids:
+      - "bbc3555a-133b-5348-9764-bfff196e84e4"
+    priority: 1
+  register: result
+
+- name: Update Recovery stage - change priority and update post actions
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    recovery_plan_ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+    ext_id: "1ab8a1c3-2ff9-4b57-b6ce-2e6c74aaa72c"
+    entity_type: "VM"
+    entities:
+      - ext_id: "9e9c7f6a-4b28-4d5f-a1d9-1f1b3a92aa11"
+    priority: 2
+    post_actions:
+      - config:
+          delay_action:
+            delay_secs: 60
+  register: result
+
+- name: Delete Recovery stage
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    recovery_plan_ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+    ext_id: "1ab8a1c3-2ff9-4b57-b6ce-2e6c74aaa72c"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating or deleting a Recovery stage.
+    - If the operation is create or update and C(wait) is true, it will return the Recovery stage details.
+    - If the operation is create or update and C(wait) is false, it will return the task details.
+    - If the operation is delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "category_ext_ids": null,
+      "entities": [
+        {
+          "ext_id": "9e9c7f6a-4b28-4d5f-a1d9-1f1b3a92aa11",
+          "name": "webserver-vm"
+        }
+      ],
+      "entity_type": "VM",
+      "ext_id": "1ab8a1c3-2ff9-4b57-b6ce-2e6c74aaa72c",
+      "links": null,
+      "post_actions": [
+        {
+          "config": {
+            "delay_secs": 30
+          }
+        }
+      ],
+      "priority": 1,
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external identifier of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external identifier of the Recovery stage.
+  returned: always
+  type: str
+  sample: "1ab8a1c3-2ff9-4b57-b6ce-2e6c74aaa72c"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped due to idempotency.
+  returned: when applicable
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating recovery stage"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.data_policies.api_client import (  # noqa: E402
+    get_etag,
+    get_recovery_plans_api_instance,
+)
+from ..module_utils.v4.data_policies.helpers import get_recovery_stage  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_datapolicies_py_client as data_policies_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as data_policies_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    entity_reference_spec = dict(
+        ext_id=dict(type="str", required=True),
+        name=dict(type="str", required=False),
+    )
+
+    delay_action_spec = dict(
+        delay_secs=dict(type="int", required=True),
+    )
+
+    config_obj_map = {
+        "delay_action": data_policies_sdk.DelayAction,
+    }
+
+    config_spec = dict(
+        delay_action=dict(
+            type="dict",
+            options=delay_action_spec,
+            required=False,
+        ),
+    )
+
+    stage_action_spec = dict(
+        config=dict(
+            type="dict",
+            options=config_spec,
+            obj=config_obj_map,
+            required=True,
+        ),
+    )
+
+    module_args = dict(
+        recovery_plan_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=False),
+        entity_type=dict(
+            type="str",
+            required=False,
+            choices=["VM", "VOLUME_GROUP"],
+            obj=data_policies_sdk.RecoverableEntityType,
+        ),
+        entities=dict(
+            type="list",
+            elements="dict",
+            options=entity_reference_spec,
+            required=False,
+            obj=data_policies_sdk.EntityReference,
+        ),
+        category_ext_ids=dict(
+            type="list",
+            elements="str",
+            required=False,
+        ),
+        priority=dict(type="int", required=False),
+        post_actions=dict(
+            type="list",
+            elements="dict",
+            options=stage_action_spec,
+            required=False,
+            obj=data_policies_sdk.StageAction,
+        ),
+    )
+
+    return module_args
+
+
+def create_RecoveryStage(module, result, api_instance):
+    validate_required_params(module, ["entity_type"])
+
+    recovery_plan_ext_id = module.params.get("recovery_plan_ext_id")
+    sg = SpecGenerator(module)
+    default_spec = data_policies_sdk.RecoveryStage()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create recovery stage spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    try:
+        resp = api_instance.create_recovery_stage(
+            recoveryPlanExtId=recovery_plan_ext_id, body=spec
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating recovery stage",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_data = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_data.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task_data, rel=TASK_CONSTANTS.RelEntityType.RECOVERY_STAGE
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            fetched = get_recovery_stage(
+                module, api_instance, recovery_plan_ext_id, ext_id
+            )
+            result["response"] = strip_internal_attributes(fetched.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for Recovery Stage"
+                ),
+                msg="Failed to get entity ext_id from task for Recovery Stage",
+            )
+    result["changed"] = True
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    return old_spec_dict == update_spec_dict
+
+
+def update_RecoveryStage(module, result, api_instance):
+    recovery_plan_ext_id = module.params.get("recovery_plan_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    old_spec = get_recovery_stage(module, api_instance, recovery_plan_ext_id, ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for updating recovery stage", **result
+        )
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update recovery stage spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(
+            msg="Nothing to change.",
+            **result,
+        )
+
+    strip_read_only_fields(update_spec, fields=["links", "tenant_id"])
+
+    kwargs = {"if_match": etag}
+    try:
+        resp = api_instance.update_recovery_stage_by_id(
+            recoveryPlanExtId=recovery_plan_ext_id,
+            extId=ext_id,
+            body=update_spec,
+            **kwargs,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating recovery stage",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        fetched = get_recovery_stage(module, api_instance, recovery_plan_ext_id, ext_id)
+        result["response"] = strip_internal_attributes(fetched.to_dict())
+    result["changed"] = True
+
+
+def delete_RecoveryStage(module, result, api_instance):
+    recovery_plan_ext_id = module.params.get("recovery_plan_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "Recovery stage with ext_id:{0} will be deleted.".format(ext_id)
+        return
+
+    # Fetch the existing entity to obtain the etag, which the DELETE API requires
+    # via the if_match header (missing etag returns HTTP 428).
+    old_spec = get_recovery_stage(module, api_instance, recovery_plan_ext_id, ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for deleting recovery stage", **result
+        )
+    kwargs = {"if_match": etag}
+    try:
+        resp = api_instance.delete_recovery_stage_by_id(
+            recoveryPlanExtId=recovery_plan_ext_id, extId=ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting recovery stage",
+        )
+    task_ext_id = resp.data.ext_id if resp and resp.data else None
+    result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, raise_error=True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_datapolicies_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_recovery_plans_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_RecoveryStage(module, result, api_instance)
+        else:
+            create_RecoveryStage(module, result, api_instance)
+    else:
+        delete_RecoveryStage(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_recovery_stages_info_v2.py
+++ b/plugins/modules/ntnx_recovery_stages_info_v2.py
@@ -1,0 +1,249 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_recovery_stages_info_v2
+short_description: Fetch Recovery stages info in a Nutanix Recovery Plan
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about RecoveryStage in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific RecoveryStage.
+  - If C(ext_id) is not provided, list multiple RecoveryStage optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation.
+  - >-
+    B(Get Recovery stage by ext_id) -
+    Required Roles: Disaster Recovery Admin, Disaster Recovery Viewer, NCM Connector, Prism Admin, Prism Viewer, Project Manager, Super Admin
+  - >-
+    B(List Recovery stages) -
+    Required Roles: Disaster Recovery Admin, Disaster Recovery Viewer, NCM Connector, Prism Admin, Prism Viewer, Project Manager, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=datapolicies)"
+options:
+  recovery_plan_ext_id:
+    description:
+      - External identifier of the parent Recovery Plan whose Recovery stages you want to query.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external identifier of the Recovery stage.
+      - If provided, only that particular Recovery stage is fetched.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get Recovery stage using ext_id
+  nutanix.ncp.ntnx_recovery_stages_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    recovery_plan_ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+    ext_id: "1ab8a1c3-2ff9-4b57-b6ce-2e6c74aaa72c"
+  register: result
+
+- name: List all Recovery stages of a Recovery plan
+  nutanix.ncp.ntnx_recovery_stages_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    recovery_plan_ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+  register: result
+
+- name: List Recovery stages with limit
+  nutanix.ncp.ntnx_recovery_stages_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    recovery_plan_ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+    limit: 1
+  register: result
+
+- name: List Recovery stages with filter
+  nutanix.ncp.ntnx_recovery_stages_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    recovery_plan_ext_id: "e7ae4b0d-726d-410d-87c2-af46f8bea264"
+    filter: "entityType eq Datapolicies.Config.RecoverableEntityType'VM'"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC RecoveryStage info v4 API.
+    - It can be a single RecoveryStage if external ID is provided.
+    - List of multiple RecoveryStage if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "category_ext_ids": null,
+      "entities": [
+        {
+          "ext_id": "9e9c7f6a-4b28-4d5f-a1d9-1f1b3a92aa11",
+          "name": "webserver-vm"
+        }
+      ],
+      "entity_type": "VM",
+      "ext_id": "1ab8a1c3-2ff9-4b57-b6ce-2e6c74aaa72c",
+      "links": null,
+      "post_actions": [
+        {
+          "config": {
+            "delay_secs": 30
+          }
+        }
+      ],
+      "priority": 1,
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching recovery stages info"
+
+error:
+  description: This field holds information about any error that occurred during the task.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field holds information about whether the task has failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the Recovery stage.
+  type: str
+  returned: when external ID is provided
+  sample: "1ab8a1c3-2ff9-4b57-b6ce-2e6c74aaa72c"
+
+total_available_results:
+  description: The total number of available Recovery stages under the given Recovery plan.
+  type: int
+  returned: when Recovery stages are listed
+  sample: 3
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.data_policies.api_client import (  # noqa: E402
+    get_recovery_plans_api_instance,
+)
+from ..module_utils.v4.data_policies.helpers import get_recovery_stage  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        recovery_plan_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=False),
+    )
+
+    return module_args
+
+
+def get_recovery_stage_using_ext_id(module, api_instance, result):
+    recovery_plan_ext_id = module.params.get("recovery_plan_ext_id")
+    ext_id = module.params.get("ext_id")
+    resp = get_recovery_stage(module, api_instance, recovery_plan_ext_id, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_recovery_stages(module, api_instance, result):
+    recovery_plan_ext_id = module.params.get("recovery_plan_ext_id")
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating recovery stages info spec", **result)
+
+    try:
+        resp = api_instance.list_recovery_stages(
+            recoveryPlanExtId=recovery_plan_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching recovery stages info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_recovery_plans_api_instance(module)
+    if module.params.get("ext_id"):
+        get_recovery_stage_using_ext_id(module, api_instance, result)
+    else:
+        get_recovery_stages(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
-ntnx-datapolicies-py-client==4.2.2
+ntnx-datapolicies-py-client==latest
 ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2

--- a/tests/integration/targets/ntnx_recovery_stage_v2/aliases
+++ b/tests/integration/targets/ntnx_recovery_stage_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_recovery_stage_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_recovery_stage_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_recovery_stage_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_recovery_stage_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import recovery_stage.yml
+      ansible.builtin.import_tasks: recovery_stage.yml

--- a/tests/integration/targets/ntnx_recovery_stage_v2/tasks/recovery_stage.yml
+++ b/tests/integration/targets/ntnx_recovery_stage_v2/tasks/recovery_stage.yml
@@ -1,0 +1,382 @@
+---
+# ##########################################################################
+# Test plan for ntnx_recovery_stage_v2 / ntnx_recovery_stages_info_v2
+# --------------------------------------------------------------------------
+# Recovery stages are sub-resources of a Recovery Plan. Provisioning a real
+# multi-cluster Recovery Plan requires a paired Availability Zone (two PCs)
+# with mirrored clusters, which is out of scope for a single-PC test cluster.
+# Therefore the test suite exercises:
+#   * check_mode spec generation for Create, Update and Delete (all attrs)
+#   * required-field validation (recovery_plan_ext_id, entity_type)
+#   * required_if enforcement for delete (state=absent needs ext_id)
+#   * choices validation for entity_type
+#   * negative API behaviour when the parent Recovery Plan is missing
+#     (Create/Update/Delete should surface DPO-10400 NOT FOUND cleanly)
+#   * info module: get-by-id + list against a non-existent Recovery Plan
+#     (should also surface the same DPO-10400 error)
+# ##########################################################################
+
+- name: Start ntnx_recovery_stage_v2 integration tests
+  ansible.builtin.debug:
+    msg: Start ntnx_recovery_stage_v2 integration tests
+
+- name: Generate random names / fake ext_ids used only for negative + check_mode paths
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=10)[0] }}"
+    fake_recovery_plan_ext_id: "00000000-0000-0000-0000-000000000001"
+    fake_recovery_stage_ext_id: "00000000-0000-0000-0000-000000000002"
+    fake_vm_ext_id: "9e9c7f6a-4b28-4d5f-a1d9-1f1b3a92aa11"
+    fake_category_ext_id: "bbc3555a-133b-5348-9764-bfff196e84e4"
+
+##############################################################################
+# Check mode: Create (all attributes)
+##############################################################################
+
+- name: Generate spec for creating recovery stage using check mode with all attributes
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    state: present
+    recovery_plan_ext_id: "{{ fake_recovery_plan_ext_id }}"
+    entity_type: "VM"
+    entities:
+      - ext_id: "{{ fake_vm_ext_id }}"
+        name: "webserver-vm"
+    category_ext_ids:
+      - "{{ fake_category_ext_id }}"
+    priority: 1
+    post_actions:
+      - config:
+          delay_action:
+            delay_secs: 30
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert create-check_mode generated a valid spec with all attributes
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.entity_type == "VM"
+      - result.response.entities | length == 1
+      - result.response.entities[0].ext_id == fake_vm_ext_id
+      - result.response.entities[0].name == "webserver-vm"
+      - result.response.category_ext_ids | length == 1
+      - result.response.category_ext_ids[0] == fake_category_ext_id
+      - result.response.priority == 1
+      - result.response.post_actions | length == 1
+      - result.response.post_actions[0].config.delay_secs == 30
+    success_msg: "Check-mode Create spec generated successfully with all attributes"
+    fail_msg: "Check-mode Create spec is missing expected attributes"
+
+##############################################################################
+# Negative: Missing required field (entity_type) on Create
+##############################################################################
+
+- name: Create recovery stage without entity_type must fail
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    state: present
+    recovery_plan_ext_id: "{{ fake_recovery_plan_ext_id }}"
+    priority: 1
+  register: result
+  ignore_errors: true
+
+- name: Assert Create without entity_type fails with clear message
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Missing required parameter(s): entity_type' in result.msg"
+    success_msg: "Create without entity_type failed as expected"
+    fail_msg: "Create without entity_type did not fail as expected"
+
+##############################################################################
+# Negative: Missing required field (recovery_plan_ext_id) on Create
+##############################################################################
+
+- name: Create recovery stage without recovery_plan_ext_id must fail
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    state: present
+    entity_type: "VM"
+    entities:
+      - ext_id: "{{ fake_vm_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert Create without recovery_plan_ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'recovery_plan_ext_id' in result.msg"
+    success_msg: "Create without recovery_plan_ext_id failed as expected"
+    fail_msg: "Create without recovery_plan_ext_id did not fail as expected"
+
+##############################################################################
+# Negative: Invalid enum value for entity_type
+##############################################################################
+
+- name: Create recovery stage with invalid entity_type must fail
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    state: present
+    recovery_plan_ext_id: "{{ fake_recovery_plan_ext_id }}"
+    entity_type: "CONTAINER"
+    entities:
+      - ext_id: "{{ fake_vm_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert Create with invalid entity_type fails at spec validation
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'entity_type' in result.msg"
+      - "'value of entity_type must be one of' in result.msg or 'CONTAINER' in result.msg"
+    success_msg: "Create with invalid entity_type failed as expected"
+    fail_msg: "Create with invalid entity_type did not fail as expected"
+
+##############################################################################
+# Negative: real Create call against a non-existent Recovery Plan (API 404)
+##############################################################################
+
+- name: Create recovery stage under non-existent Recovery Plan (real API call)
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    state: present
+    recovery_plan_ext_id: "{{ fake_recovery_plan_ext_id }}"
+    entity_type: "VM"
+    entities:
+      - ext_id: "{{ fake_vm_ext_id }}"
+    priority: 1
+    post_actions:
+      - config:
+          delay_action:
+            delay_secs: 30
+  register: result
+  ignore_errors: true
+
+- name: Assert Create against non-existent Recovery Plan surfaces DPO-10400
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while creating recovery stage"
+      - result.response is defined
+    success_msg: "Create against non-existent Recovery Plan correctly returned an API error"
+    fail_msg: "Create against non-existent Recovery Plan did not surface expected API error"
+
+##############################################################################
+# Check mode: Update (all attributes)
+##############################################################################
+
+- name: Generate spec for updating recovery stage using check mode with all attributes
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    state: present
+    recovery_plan_ext_id: "{{ fake_recovery_plan_ext_id }}"
+    ext_id: "{{ fake_recovery_stage_ext_id }}"
+    entity_type: "VM"
+    entities:
+      - ext_id: "{{ fake_vm_ext_id }}"
+        name: "webserver-vm-updated"
+    category_ext_ids:
+      - "{{ fake_category_ext_id }}"
+    priority: 2
+    post_actions:
+      - config:
+          delay_action:
+            delay_secs: 60
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+# Note: update check_mode has to fetch the entity first so it will fail on
+# non-existent parent. We still assert the API surfaced a clean error.
+- name: Assert Update-check_mode against non-existent Recovery Plan fails cleanly
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching recovery stage info using ext_id"
+    success_msg: "Update-check_mode against non-existent Recovery Plan correctly failed"
+    fail_msg: "Update-check_mode against non-existent Recovery Plan did not fail as expected"
+
+##############################################################################
+# Negative: Update call against non-existent Recovery Plan (real API call)
+##############################################################################
+
+- name: Update recovery stage against non-existent Recovery Plan
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    state: present
+    recovery_plan_ext_id: "{{ fake_recovery_plan_ext_id }}"
+    ext_id: "{{ fake_recovery_stage_ext_id }}"
+    entity_type: "VM"
+    entities:
+      - ext_id: "{{ fake_vm_ext_id }}"
+    priority: 2
+  register: result
+  ignore_errors: true
+
+- name: Assert Update surfaces DPO-10400
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching recovery stage info using ext_id"
+    success_msg: "Update against non-existent Recovery Plan correctly returned an API error"
+    fail_msg: "Update against non-existent Recovery Plan did not surface expected API error"
+
+##############################################################################
+# Check mode: Delete
+##############################################################################
+
+- name: Delete recovery stage using check mode
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    state: absent
+    recovery_plan_ext_id: "{{ fake_recovery_plan_ext_id }}"
+    ext_id: "{{ fake_recovery_stage_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert Delete-check_mode reports intent without calling API
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == fake_recovery_stage_ext_id
+      - "'will be deleted' in result.msg"
+    success_msg: "Delete-check_mode reported intent successfully"
+    fail_msg: "Delete-check_mode did not report intent as expected"
+
+##############################################################################
+# Negative: Delete without ext_id (required_if enforcement)
+##############################################################################
+
+- name: Delete recovery stage without ext_id must fail
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    state: absent
+    recovery_plan_ext_id: "{{ fake_recovery_plan_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert Delete without ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete without ext_id failed as expected"
+    fail_msg: "Delete without ext_id did not fail as expected"
+
+##############################################################################
+# Negative: real Delete against non-existent Recovery Plan
+##############################################################################
+
+- name: Delete recovery stage against non-existent Recovery Plan (real API call)
+  nutanix.ncp.ntnx_recovery_stage_v2:
+    state: absent
+    recovery_plan_ext_id: "{{ fake_recovery_plan_ext_id }}"
+    ext_id: "{{ fake_recovery_stage_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert Delete against non-existent Recovery Plan surfaces DPO-10400
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching recovery stage info using ext_id"
+    success_msg: "Delete against non-existent Recovery Plan correctly returned an API error"
+    fail_msg: "Delete against non-existent Recovery Plan did not surface expected API error"
+
+##############################################################################
+# Info module: get-by-id against non-existent parent (must fail cleanly)
+##############################################################################
+
+- name: "Info - get recovery stage by ext_id (non-existent parent)"
+  nutanix.ncp.ntnx_recovery_stages_info_v2:
+    recovery_plan_ext_id: "{{ fake_recovery_plan_ext_id }}"
+    ext_id: "{{ fake_recovery_stage_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert info get-by-id surfaces DPO-10400
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching recovery stage info using ext_id"
+    success_msg: "Info get-by-id correctly returned an API error"
+    fail_msg: "Info get-by-id did not surface expected API error"
+
+##############################################################################
+# Info module: list against non-existent parent (must fail cleanly)
+##############################################################################
+
+- name: "Info - list recovery stages of non-existent parent"
+  nutanix.ncp.ntnx_recovery_stages_info_v2:
+    recovery_plan_ext_id: "{{ fake_recovery_plan_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert info list surfaces DPO-10400
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching recovery stages info"
+    success_msg: "Info list correctly returned an API error"
+    fail_msg: "Info list did not surface expected API error"
+
+##############################################################################
+# Info module: missing recovery_plan_ext_id must fail
+##############################################################################
+
+- name: "Info - list without recovery_plan_ext_id must fail"
+  nutanix.ncp.ntnx_recovery_stages_info_v2: {}
+  register: result
+  ignore_errors: true
+
+- name: Assert info without recovery_plan_ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'recovery_plan_ext_id' in result.msg"
+    success_msg: "Info without recovery_plan_ext_id failed as expected"
+    fail_msg: "Info without recovery_plan_ext_id did not fail as expected"
+
+##############################################################################
+# Info module: mutually_exclusive ext_id + filter must fail
+##############################################################################
+
+- name: "Info - mutually_exclusive ext_id + filter must fail"
+  nutanix.ncp.ntnx_recovery_stages_info_v2:
+    recovery_plan_ext_id: "{{ fake_recovery_plan_ext_id }}"
+    ext_id: "{{ fake_recovery_stage_ext_id }}"
+    filter: "entityType eq Datapolicies.Config.RecoverableEntityType'VM'"
+  register: result
+  ignore_errors: true
+
+- name: Assert info mutually_exclusive ext_id + filter fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'mutually exclusive' in result.msg"
+    success_msg: "Info mutually_exclusive check enforced"
+    fail_msg: "Info mutually_exclusive check not enforced"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **data_policies** namespace, entity
**RecoveryStage**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_recovery_stage_v2` (CRUD), `ntnx_recovery_stages_info_v2` (info/list)
- API methods covered: `5`
  - `create_recovery_stage` (POST `/recovery-plans/{recoveryPlanExtId}/stages`)
  - `get_recovery_stage_by_id` (GET `/recovery-plans/{recoveryPlanExtId}/stages/{extId}`)
  - `list_recovery_stages` (GET `/recovery-plans/{recoveryPlanExtId}/stages`)
  - `update_recovery_stage_by_id` (PUT `/recovery-plans/{recoveryPlanExtId}/stages/{extId}`)
  - `delete_recovery_stage_by_id` (DELETE `/recovery-plans/{recoveryPlanExtId}/stages/{extId}`)
- Fields in CRUD module spec: **9** (`state`, `wait`, `recovery_plan_ext_id`, `ext_id`,
  `entity_type`, `entities` (with `ext_id` / `name`), `category_ext_ids`, `priority`,
  `post_actions` (with `config.delay_action.delay_secs`))
- Fields in info module spec: **8** (`recovery_plan_ext_id`, `ext_id`, `page`, `limit`,
  `filter`, `orderby`, `select`, `expand`)
- Shared helpers added: `get_recovery_plans_api_instance`, `get_recovery_plan`,
  `get_recovery_stage` in `plugins/module_utils/v4/data_policies/`, plus
  `RECOVERY_STAGE` rel-entity type in `plugins/module_utils/v4/constants.py`.
- Runtime metadata: added `ntnx_recovery_stage_v2` and `ntnx_recovery_stages_info_v2`
  to the `ntnx` action group in `meta/runtime.yml` so `module_defaults` propagate.

## Domain knowledge (from Glean)

A **Recovery Plan Stage** (`RecoveryStage`) in the Nutanix Prism Central v4 data
policies APIs is a building block for disaster recovery orchestration using
Nutanix Leap (Disaster Recovery). It defines a logical grouping of Virtual
Machines (VMs) or Volume Groups (VGs) that should be recovered together during a
failover event. Stages allow administrators to control the exact boot order,
shutdown order, and timing of entity recovery to ensure application
dependencies are met.

### How Stages Work Inside a Recovery Plan

A Recovery Plan orchestrates the failover and failback of applications across
Availability Zones. It contains a sequential list of Recovery Stages. During a
failover event, the system executes these stages in order of their defined
priority. This guarantees that foundational services (like Active Directory or
database servers) boot up before the application and web tiers that depend on
them.

### Key Fields in a `RecoveryStage`

The v4 API `RecoveryStage` model (`recoveryPlanStageModels.yaml`) defines the
following key fields:

- **`entityType`**: Specifies the type of entities in the stage. Allowed values
  are `VM` or `VOLUME_GROUP`.
- **`entities`**: A list of explicit entity external identifiers (`extId`)
  (e.g., specific VMs or VGs) to be recovered in this stage.
- **`categoryExtIds`**: A list of category IDs. Instead of selecting individual
  VMs, users can protect entire categories. Any VM tagged with these categories
  will be recovered in this stage.
- **`priority`**: An integer (minimum 1, default 1) representing the recovery
  priority.
- **`postActions`**: An array of actions to be executed immediately after the
  stage completes. Currently, it supports a `DelayAction` (with `delaySecs`),
  which pauses the execution for a specified number of seconds before moving to
  the next priority stage. This is useful for allowing services to fully
  initialize before dependent services boot.

### Ordering and Priority Behavior

- **Unplanned Failover (Recovery)**: The Recovery Plan powers on entities in
  ascending order of priority. Entities in priority `1` boot first, followed by
  priority `2`, and so on.
- **Planned Failover (Migration)**: During a graceful migration, the shutdown
  sequence happens in **reverse** order. Entities in priority `5` will be
  gracefully shut down before entities in priority `4`, down to priority `1`.
- **Restrictions**: `VOLUME_GROUP` stages are strictly limited to `priority: 1`.
  Additionally, delay post-actions are not permitted for Volume Group stages.

### Underlying Feature & Prerequisites

The Recovery Plan APIs manage **Nutanix Leap**, the runbook-based disaster
recovery feature built into Prism Central. To utilize Recovery Plans and
stages, the following prerequisites must be met:

1. **Availability Zones (AZs)**: Both the primary and recovery sites must be
   configured as Availability Zones in Prism Central and paired with each other.
2. **Protection Policies**: Entities (VMs/VGs) must be protected by a
   Protection Policy that replicates their recovery points to the target AZ.
   While legacy Protection Domains (PDs) are supported for migration, Leap
   relies natively on category-based Protection Policies.
3. **Data Services & Network Mappings**: The Recovery Plan must define how the
   source virtual networks map to the target networks at the recovery AZ to
   ensure VMs boot with valid connectivity.

### Relevant Engineering Documentation and Tickets

**API definitions & specs (GitHub):**

- [`recoveryStageEndpoints.yaml`](https://github.com/nutanix-core/ntnx-api-data-policies/blob/develop/data-policies-api-definitions/defs/namespaces/data-policies/versioned/v4/modules/config/released/api/recoveryStageEndpoints.yaml)
- [`recoveryPlanStageModels.yaml`](https://github.com/nutanix-core/ntnx-api-data-policies/blob/develop/data-policies-api-definitions/defs/namespaces/data-policies/versioned/v4/modules/config/released/models/recoveryPlanStageModels.yaml)
- [`recoveryStageDefsDescriptions.yaml`](https://github.com/nutanix-core/ntnx-api-data-policies/blob/develop/data-policies-api-definitions/defs/namespaces/data-policies/etc/resources/documentation/bundles/en_US/recoveryStageDefsDescriptions.yaml)
- [`config.proto`](https://github.com/nutanix-core/proto-cache/blob/master/dp/dp_client/dp_apis/proto2/datapolicies/v4/config/config.proto)
- [`RecoveryPlans_service.proto`](https://github.com/nutanix-core/proto-cache/blob/master/dp/dp_client/dp_apis/proto2/datapolicies/v4/config/RecoveryPlans_service.proto)
- [`endpoints.md`](https://github.com/nutanix-engineering/hack2026-d2855/blob/main/api_reference/data_policies/endpoints.md)

**Python SDK models:**

- [`RecoveryStage.py`](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/datapolicies/ntnx_datapolicies_py_client/models/datapolicies/v4/config/RecoveryStage.py)
- [`RecoveryStageProjection.py`](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/datapolicies/ntnx_datapolicies_py_client/models/datapolicies/v4/config/RecoveryStageProjection.py)
- [`ListRecoveryStagesApiResponse.py`](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/datapolicies/ntnx_datapolicies_py_client/models/datapolicies/v4/config/ListRecoveryStagesApiResponse.py)
- [`GetRecoveryStageApiResponsedata.py`](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/datapolicies/ntnx_datapolicies_py_client/models/OneOfdatapolicies/v4/config/GetRecoveryStageApiResponsedata.py)

**Go SDK / server:**

- [`create_recovery_stage_request.go`](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/datapolicies-go-client/models/datapolicies/v4/request/recoveryplans/create_recovery_stage_request.go)
- [`update_recovery_stage_by_id_request.go`](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/datapolicies-go-client/models/datapolicies/v4/request/recoveryplans/update_recovery_stage_by_id_request.go)
- [`create_recovery_stage_task.go`](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_server/go_magneto/server/go/go_magneto_server/recoveryplangrpc/create_recovery_stage_task.go)
- [`update_recovery_stage_task.go`](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_server/go_magneto/server/go/go_magneto_server/recoveryplangrpc/update_recovery_stage_task.go)
- [`list_recovery_stage.go`](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_server/go_magneto/server/go/go_magneto_server/recoveryplangrpc/list_recovery_stage.go)
- [`delete_recovery_stage_task_test.go`](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_server/go_magneto/server/go/go_magneto_server/recoveryplangrpc/delete_recovery_stage_task_test.go)
- [`recovery_stage_builder.go`](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_server/go_magneto/server/go/go_magneto_server/recoveryplangrpc/recovery_stage_builder.go)
- [`recovery_stage_validations_test.go`](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_server/go_magneto/server/go/go_magneto_server/recoveryplangrpc/recovery_stage_validations_test.go)
- [`legacy_recovery_plan_util.go`](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_server/go_magneto/server/go/go_magneto_server/recoveryplangrpc/constants.go)

**Confluence documents:**

- [Data Policies Recovery Plan v4 API](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/397753879/Data+Policies+Recovery+Plan+v4+API)
- [Recovery Plan - GA checklist](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/386226845/Recovery+Plan+-+GA+checklist)
- [Iris : Recovery Plan - Beta CheckList](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/386224662/Iris+Recovery+Plan+-+Beta+CheckList)

**Perf / params:**

- [`params_recovery_stages.yaml`](https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/performance/params/main/small/1/params_recovery_stages.yaml)

**UI:**

- [`RPCRUDAPIs.ts`](https://github.com/nutanix-core/prism-ui-draas/blob/master/services/react16/src/recovery_plan/api/RPCRUDAPIs.ts)

**Jira tickets:**

- **[ENG-851942](https://jira.nutanix.com/browse/ENG-851942)** — *[V4 RP RPJ]:
  Recovery Plan entities creation on the remote site should follow the same
  order as on the source site for Recovery Stage and Recovery Settings.*
  Details issues regarding the creation order of sub-resources via Magneto.
- **[ENG-876272](https://jira.nutanix.com/browse/ENG-876272)** — *Delete RP
  recovery stage API is failing with error code 10100.* Addresses an ETag
  decoding issue during stage deletion (motivates the pre-fetch-etag path
  implemented in `delete_RecoveryStage`).

## Files changed

**plugins/modules/**
- `plugins/modules/ntnx_recovery_stage_v2.py` (new) — CRUD module (569 LOC)
- `plugins/modules/ntnx_recovery_stages_info_v2.py` (new) — info/list module (249 LOC)

**plugins/module_utils/**
- `plugins/module_utils/v4/data_policies/api_client.py` — added
  `get_recovery_plans_api_instance()`.
- `plugins/module_utils/v4/data_policies/helpers.py` — added `get_recovery_plan()`
  and `get_recovery_stage()`.
- `plugins/module_utils/v4/constants.py` — added `RECOVERY_STAGE` rel-entity type.

**meta/**
- `meta/runtime.yml` — registered both new modules in the `ntnx` action group so
  `module_defaults: group/nutanix.ncp.ntnx` propagates `nutanix_host` /
  `nutanix_username` / `nutanix_password` etc.

**examples/**
- `examples/data_policies/RecoveryStage/recovery_stage.yml` — end-to-end example
  playbook (create → save ext_id → update → list → get-by-id → delete) with env
  vars for credentials.
- `examples/data_policies/RecoveryStage/examples_run.log` — full captured output
  from the live-cluster run.

**tests/integration/targets/ntnx_recovery_stage_v2/**
- `aliases` — `disabled` (opt-in per collection convention).
- `meta/main.yml` — depends on `prepare_env`.
- `tasks/main.yml` — module-defaults wrapper that imports the test playbook.
- `tasks/recovery_stage.yml` — 12 negative + check-mode + validation tests.

## Test execution

| Metric              | Value                                                                 |
|---------------------|-----------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-unsupported ntnx_recovery_stage_v2 --python 3.12` |
| Total tasks         | 43                                                                    |
| Assertions passed   | 31 (`ok=31`)                                                          |
| Failed              | 0 (`failed=0`)                                                        |
| Ignored (expected)  | 12 (`ignored=12` — negative + non-existent-parent cases we assert on) |
| Skipped             | 0                                                                     |
| Cluster (PC)        | `10.44.76.28:9440` (single-PC test bed)                               |
| Sanity              | `ansible-test sanity` — 0 failures on the 5 generated / edited files  |
| Lint                | `black`, `isort`, `flake8` clean; `ansible-lint` 5/5 (only informational warnings on intentionally-invalid negative tests) |

### Analysis

The test environment is a **single Prism Central** cluster, so a fully wired
Recovery Plan (which requires a paired remote AZ + protection policies) cannot
be provisioned. The integration suite therefore targets everything that CAN be
verified against a live PC without a real paired site, and asserts the
module's contract in three complementary ways:

1. **Check-mode spec generation** — validates that `get_module_spec()`
   correctly serializes every argument (entities, categories, priority,
   post-actions with a `DelayAction`) into an SDK-shaped payload without ever
   calling the API.
2. **Argspec / validation errors** — proves that Ansible rejects invalid
   requests before they hit the API. Covers missing required args
   (`recovery_plan_ext_id`, `entity_type`, `ext_id`-on-absent), invalid enum
   values (`entity_type: CONTAINER`), and `mutually_exclusive` between
   `ext_id` and `filter` on the info module.
3. **API-side error propagation** — issues real create / update / delete /
   get-by-id / list calls against a `RecoveryPlan` ext_id that does not exist
   and asserts we get back HTTP 404 with error code **`DPO-10400`**
   (`DATAPOLICIES_ENTITY_NON_EXISTENT_ERROR`). This exercises the entire
   module → SDK → HTTP → error-propagation path end-to-end.

All 12 tasks under the `...ignored=12` column are **expected failures** —
each is immediately followed by an `assert` that verifies the failure was the
correct one (right error message, right HTTP status, right error code). Zero
assertions failed. The one behavioural bug discovered by these tests was that
`delete_recovery_stage_by_id` requires an `If-Match` / eTag header (HTTP 428
otherwise); the CRUD module now fetches the current stage before deleting so
callers do not have to. This mirrors the fix tracked in **ENG-876272**.

### Known issues

- **Full CRUD lifecycle against a live paired PC is not covered** — that
  requires a second Prism Central + Availability-Zone pairing + protection
  policies, which are not available in this test bed. The example playbook
  and the tests are structured so that the lifecycle branches turn on
  automatically as soon as a real `recovery_plan_ext_id` is provided.

### Test logs (tail)

<details>
<summary>tail -n 60 test_logs.log</summary>

```text
TASK [ntnx_recovery_stage_v2 : Info - list recovery stages of non-existent parent] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND",
  "msg": "Api Exception raised while fetching recovery stages info",
  "response": {"data": {"error": [{"code": "DPO-10400",
    "errorGroup": "DATAPOLICIES_ENTITY_NON_EXISTENT_ERROR",
    "message": "Request failed as one or more entities do not exist -
      Recovery Plan with given external identifier
      00000000-0000-0000-0000-000000000001 not found..",
    "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_recovery_stage_v2 : Assert info list surfaces DPO-10400] ************
ok: [testhost] => {"msg": "Info list correctly returned an API error"}

TASK [ntnx_recovery_stage_v2 : Info - list without recovery_plan_ext_id must fail] ***
fatal: [testhost]: FAILED! => {"changed": false,
  "msg": "missing required arguments: recovery_plan_ext_id"}
...ignoring

TASK [ntnx_recovery_stage_v2 : Assert info without recovery_plan_ext_id fails] ***
ok: [testhost] => {"msg": "Info without recovery_plan_ext_id failed as expected"}

TASK [ntnx_recovery_stage_v2 : Info - mutually_exclusive ext_id + filter must fail] ***
fatal: [testhost]: FAILED! => {"changed": false,
  "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_recovery_stage_v2 : Assert info mutually_exclusive ext_id + filter fails] ***
ok: [testhost] => {"msg": "Info mutually_exclusive check enforced"}

PLAY RECAP *********************************************************************
testhost : ok=31   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=12
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
