### PR TITLE
ManageAlert Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/monitoring/ManageAlert/manage_alert_v2.yml
+++ b/examples/monitoring/ManageAlert/manage_alert_v2.yml
@@ -1,0 +1,101 @@
+---
+# Summary:
+# This playbook demonstrates how to acknowledge or resolve alerts in Nutanix
+# Prism Central using the ManageAlert v4 action module.
+#
+# Steps:
+# 1. Pick an unresolved / unacknowledged alert from the live Prism Central
+#    (via a REST call so this playbook is fully self-contained).
+# 2. Acknowledge that alert with the ntnx_manage_alert_v2 module.
+# 3. Pick an unresolved alert and resolve it with the ntnx_manage_alert_v2 module.
+#
+# Note: the ManageAlert API is an action-only endpoint
+# (POST /api/monitoring/v4.0/serviceability/alerts/{extId}/$actions/manage-alert).
+# There is no create/update/delete counterpart, so this playbook only shows
+# the ACKNOWLEDGE and RESOLVE actions.
+
+- name: Manage Alert playbook
+  hosts: localhost
+  gather_facts: false
+  vars:
+    pc_host: "{{ ip | default(lookup('env', 'NUTANIX_HOST')) }}"
+    pc_user: "{{ username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+    pc_pass: "{{ password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+    alerts_list_url: >-
+      https://{{ pc_host }}:9440/api/monitoring/v4.0/serviceability/alerts?%24filter=isAcknowledged%20eq%20false%20and%20isResolved%20eq%20false&%24limit=1
+    unresolved_list_url: >-
+      https://{{ pc_host }}:9440/api/monitoring/v4.0/serviceability/alerts?%24filter=isResolved%20eq%20false&%24limit=1
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ pc_host }}"
+      nutanix_username: "{{ pc_user }}"
+      nutanix_password: "{{ pc_pass }}"
+      validate_certs: false
+  tasks:
+    - name: Discover an unacknowledged alert from Prism Central
+      ansible.builtin.uri:
+        url: "{{ alerts_list_url }}"
+        method: GET
+        user: "{{ pc_user }}"
+        password: "{{ pc_pass }}"
+        force_basic_auth: true
+        validate_certs: false
+        return_content: true
+        status_code: [200]
+      register: unack_alerts
+      ignore_errors: true
+
+    - name: Set unacknowledged alert ext_id
+      ansible.builtin.set_fact:
+        ack_alert_ext_id: >-
+          {{ unack_alerts.json.data[0].extId
+             if (unack_alerts is succeeded and unack_alerts.json.data | default([]) | length > 0)
+             else '' }}
+
+    - name: Acknowledge the alert
+      nutanix.ncp.ntnx_manage_alert_v2:
+        state: present
+        ext_id: "{{ ack_alert_ext_id }}"
+        action_type: "ACKNOWLEDGE"
+      register: ack_result
+      when: ack_alert_ext_id | length > 0
+      ignore_errors: true
+
+    - name: Show acknowledge result
+      ansible.builtin.debug:
+        var: ack_result
+      when: ack_alert_ext_id | length > 0
+
+    - name: Discover an unresolved alert from Prism Central
+      ansible.builtin.uri:
+        url: "{{ unresolved_list_url }}"
+        method: GET
+        user: "{{ pc_user }}"
+        password: "{{ pc_pass }}"
+        force_basic_auth: true
+        validate_certs: false
+        return_content: true
+        status_code: [200]
+      register: unresolved_alerts
+      ignore_errors: true
+
+    - name: Set unresolved alert ext_id
+      ansible.builtin.set_fact:
+        resolve_alert_ext_id: >-
+          {{ unresolved_alerts.json.data[0].extId
+             if (unresolved_alerts is succeeded and unresolved_alerts.json.data | default([]) | length > 0)
+             else '' }}
+
+    - name: Resolve the alert
+      nutanix.ncp.ntnx_manage_alert_v2:
+        state: present
+        ext_id: "{{ resolve_alert_ext_id }}"
+        action_type: "RESOLVE"
+      register: resolve_result
+      when: resolve_alert_ext_id | length > 0
+      ignore_errors: true
+
+    - name: Show resolve result
+      ansible.builtin.debug:
+        var: resolve_result
+      when: resolve_alert_ext_id | length > 0

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -178,6 +178,7 @@ action_groups:
     - ntnx_recovery_points_v2
     - ntnx_recovery_point_restore_v2
     - ntnx_vm_revert_v2
+    - ntnx_manage_alert_v2
     - ntnx_recovery_point_replicate_v2
     - ntnx_gpus_v2
     - ntnx_gpus_info_v2

--- a/plugins/module_utils/v4/monitoring/api_client.py
+++ b/plugins/module_utils/v4/monitoring/api_client.py
@@ -1,0 +1,122 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_monitoring_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    Build and return a monitoring API client using the connection details
+    provided to the Ansible module.
+
+    Args:
+        module (object): Ansible module object.
+
+    Returns:
+        client (object): Configured monitoring ApiClient instance.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_monitoring_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_monitoring_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    try:
+        client = ntnx_monitoring_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_monitoring_py_client.ApiClient(configuration=config)
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    client = ntnx_monitoring_py_client.ApiClient(
+        configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+    )
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    Extract the ETag value from a monitoring v4 API response.
+
+    Args:
+        data (object): monitoring v4 API response object.
+
+    Returns:
+        etag (str): The ETag string, or ``None`` if unavailable.
+    """
+    return ntnx_monitoring_py_client.ApiClient.get_etag(data)
+
+
+def get_manage_alerts_api_instance(module):
+    """
+    Return a ``ManageAlertsApi`` instance for the manage-alert action APIs.
+
+    Args:
+        module (object): Ansible module object.
+
+    Returns:
+        api_instance (object): ManageAlertsApi instance from
+        ``ntnx_monitoring_py_client``.
+    """
+    api_client = get_api_client(module)
+    return ntnx_monitoring_py_client.ManageAlertsApi(api_client=api_client)
+
+
+def get_alerts_api_instance(module):
+    """
+    Return an ``AlertsApi`` instance used to fetch/list alerts.
+
+    Args:
+        module (object): Ansible module object.
+
+    Returns:
+        api_instance (object): AlertsApi instance from
+        ``ntnx_monitoring_py_client``.
+    """
+    api_client = get_api_client(module)
+    return ntnx_monitoring_py_client.AlertsApi(api_client=api_client)

--- a/plugins/module_utils/v4/monitoring/helpers.py
+++ b/plugins/module_utils/v4/monitoring/helpers.py
@@ -1,0 +1,31 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_alert(module, api_instance, ext_id):
+    """
+    Fetch a single alert by its external ID.
+
+    Args:
+        module (object): Ansible module object.
+        api_instance (object): ``AlertsApi`` instance from
+            ``ntnx_monitoring_py_client``.
+        ext_id (str): External ID of the alert.
+
+    Returns:
+        object: Alert info wrapper (includes ETag headers on the response).
+    """
+    try:
+        return api_instance.get_alert_by_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching alert info using ext_id",
+        )

--- a/plugins/modules/ntnx_manage_alert_v2.py
+++ b/plugins/modules/ntnx_manage_alert_v2.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_manage_alert_v2
+short_description: Acknowledge or resolve an alert in Nutanix Prism Central
+version_added: 2.7.0
+description:
+    - Acknowledge or resolve an alert in Nutanix Prism Central using its external ID.
+    - The operation is dispatched asynchronously by the monitoring service; when C(wait) is true
+      the module polls the returned task until it completes.
+    - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Acknowledge or Resolve an alert) -
+      Required Roles: Prism Admin, Super Admin, Cluster Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=monitoring)"
+options:
+    state:
+        description:
+            - State of the module.
+            - If state is C(present), the module will acknowledge or resolve the specified alert.
+            - Only C(present) is supported; there is no C(absent) counterpart for this action.
+        type: str
+        choices:
+            - present
+        default: present
+    ext_id:
+        description:
+            - External ID of the alert that must be acknowledged or resolved.
+        type: str
+        required: true
+    action_type:
+        description:
+            - Action to perform on the alert.
+            - C(ACKNOWLEDGE) marks the alert as acknowledged so operators know it is being investigated.
+            - C(RESOLVE) marks the alert as resolved once the underlying issue has been addressed.
+        type: str
+        choices:
+            - ACKNOWLEDGE
+            - RESOLVE
+        required: true
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+    - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Acknowledge an alert
+  nutanix.ncp.ntnx_manage_alert_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "6f9d2e12-1a1f-4c9c-8b1c-2f3d21e2f0a1"
+    action_type: "ACKNOWLEDGE"
+  register: result
+  ignore_errors: true
+
+- name: Resolve an alert
+  nutanix.ncp.ntnx_manage_alert_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "6f9d2e12-1a1f-4c9c-8b1c-2f3d21e2f0a1"
+    action_type: "RESOLVE"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for acknowledging or resolving the alert.
+        - If C(wait) is true, this contains the completed task details.
+        - If C(wait) is false, this contains the immediate task reference returned by the API.
+    returned: always
+    type: dict
+    sample:
+        {
+            "cluster_ext_ids": [
+                "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2"
+            ],
+            "completed_time": "2026-07-20T15:30:44.510131+00:00",
+            "completion_details": null,
+            "created_time": "2026-07-20T15:30:43.887321+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "6f9d2e12-1a1f-4c9c-8b1c-2f3d21e2f0a1",
+                    "name": null,
+                    "rel": "monitoring:v4:serviceability:alert"
+                }
+            ],
+            "error_messages": null,
+            "ext_id": "ZXJnb24=:83e58c9d-5b57-4b62-8b5f-6b57f4d0c2c1",
+            "is_cancelable": false,
+            "last_updated_time": "2026-07-20T15:30:44.510131+00:00",
+            "legacy_error_message": null,
+            "operation": "APR-AlertManager",
+            "operation_description": "Manage Alert",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "started_time": "2026-07-20T15:30:43.912541+00:00",
+            "status": "SUCCEEDED",
+            "sub_steps": null,
+            "sub_tasks": null,
+            "warnings": null
+        }
+
+task_ext_id:
+    description: The external ID of the task tracking this action.
+    returned: always
+    type: str
+    sample: "ZXJnb24=:83e58c9d-5b57-4b62-8b5f-6b57f4d0c2c1"
+
+ext_id:
+    description: The external ID of the alert on which the action was performed.
+    returned: always
+    type: str
+    sample: "6f9d2e12-1a1f-4c9c-8b1c-2f3d21e2f0a1"
+
+changed:
+    description: This indicates whether the task resulted in any changes.
+    returned: always
+    type: bool
+    sample: true
+
+msg:
+    description: Status or error message returned by the module.
+    returned: When there is an error, or when running in check mode
+    type: str
+    sample: "Api Exception raised while managing alert"
+
+error:
+    description: Error details when the operation fails.
+    returned: When an error occurs
+    type: str
+    sample: "Failed to get etag for alert"
+
+failed:
+    description: This indicates whether the task failed.
+    returned: always
+    type: bool
+    sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.monitoring.api_client import (  # noqa: E402
+    get_alerts_api_instance,
+    get_etag,
+    get_manage_alerts_api_instance,
+)
+from ..module_utils.v4.monitoring.helpers import get_alert  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_monitoring_py_client as monitoring_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as monitoring_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        ext_id=dict(type="str", required=True),
+        action_type=dict(
+            type="str",
+            choices=["ACKNOWLEDGE", "RESOLVE"],
+            required=True,
+        ),
+    )
+
+    return module_args
+
+
+def manage_alert(module, api_instance, result):
+    """Perform the acknowledge/resolve action on the alert.
+
+    Fetches the alert to obtain a fresh ETag (required by the API for
+    optimistic concurrency control), builds an ``AlertActionSpec`` and
+    submits it via ``ManageAlertsApi.manage_alert``. When ``wait`` is set,
+    the returned task is polled until it reaches a terminal state.
+    """
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    sg = SpecGenerator(module)
+    default_spec = monitoring_sdk.AlertActionSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating manage alert spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    alerts_api = get_alerts_api_instance(module)
+    alert_wrapper = get_alert(module, alerts_api, ext_id)
+    etag = get_etag(alert_wrapper)
+    if not etag:
+        module.fail_json(msg="Failed to get etag for alert", **result)
+    kwargs = {"if_match": etag}
+
+    resp = None
+    try:
+        resp = api_instance.manage_alert(extId=ext_id, body=spec, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while managing alert",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_monitoring_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_manage_alerts_api_instance(module)
+    manage_alert(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-monitoring-py-client==latest

--- a/tests/integration/targets/ntnx_manage_alert_v2/aliases
+++ b/tests/integration/targets/ntnx_manage_alert_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_manage_alert_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_manage_alert_v2/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/ntnx_manage_alert_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_manage_alert_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import manage_alert.yml
+      ansible.builtin.import_tasks: manage_alert.yml

--- a/tests/integration/targets/ntnx_manage_alert_v2/tasks/manage_alert.yml
+++ b/tests/integration/targets/ntnx_manage_alert_v2/tasks/manage_alert.yml
@@ -1,0 +1,278 @@
+---
+# Test plan for nutanix.ncp.ntnx_manage_alert_v2
+# ---------------------------------------------------------------------------
+# The ManageAlert API is an action-only endpoint that acknowledges or
+# resolves an existing alert. Because we cannot create alerts synthetically
+# on a running Prism Central, we discover live alerts via the v4 monitoring
+# REST endpoint and drive the tests off those ext_ids.
+#
+# Scenarios covered:
+#   1. Argument spec / parameter validation (negative)
+#       a. Missing required ext_id
+#       b. Missing required action_type
+#       c. Invalid action_type value
+#   2. Check-mode spec generation (positive) for ACKNOWLEDGE and RESOLVE
+#   3. Live ACKNOWLEDGE action against a real alert on the cluster
+#   4. Live RESOLVE action against a real alert on the cluster
+#   5. Idempotency-adjacent: ACKNOWLEDGE on an already-acknowledged alert
+#      (still returns changed=true because the backend accepts the request
+#       and completes a task; this documents the current server behaviour).
+#   6. Negative: run against a non-existent alert ext_id, expect the API to
+#      raise and the module to fail cleanly with a descriptive message.
+
+- name: Start ntnx_manage_alert_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_manage_alert_v2 tests
+
+########################################################################################
+# Argument validation (no live API calls needed)
+########################################################################################
+
+- name: Try to acknowledge with missing ext_id (should fail)
+  nutanix.ncp.ntnx_manage_alert_v2:
+    action_type: "ACKNOWLEDGE"
+  register: result
+  ignore_errors: true
+
+- name: Try to acknowledge with missing ext_id (should fail) status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'ext_id' in result.msg"
+    success_msg: "Missing ext_id failed argument validation as expected"
+    fail_msg: "Missing ext_id did not fail argument validation as expected"
+
+- name: Try to acknowledge with missing action_type (should fail)
+  nutanix.ncp.ntnx_manage_alert_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Try to acknowledge with missing action_type (should fail) status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'action_type' in result.msg"
+    success_msg: "Missing action_type failed argument validation as expected"
+    fail_msg: "Missing action_type did not fail argument validation as expected"
+
+- name: Try to acknowledge with invalid action_type (should fail)
+  nutanix.ncp.ntnx_manage_alert_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    action_type: "IGNORE"
+  register: result
+  ignore_errors: true
+
+- name: Try to acknowledge with invalid action_type (should fail) status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'action_type' in result.msg"
+    success_msg: "Invalid action_type value was rejected by argument validation as expected"
+    fail_msg: "Invalid action_type value was NOT rejected by argument validation"
+
+########################################################################################
+# Discover live alerts to drive the positive tests
+########################################################################################
+
+- name: Fetch unacknowledged alerts from Prism Central (via REST)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/monitoring/v4.0/serviceability/alerts?$filter=isAcknowledged%20eq%20false%20and%20isResolved%20eq%20false&$limit=5"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    return_content: true
+    status_code: [200]
+  register: unack_alerts
+  ignore_errors: true
+
+- name: Set unacknowledged alert ext_id
+  ansible.builtin.set_fact:
+    unack_alert_ext_id: >-
+      {{ unack_alerts.json.data[0].extId
+         if (unack_alerts is succeeded and unack_alerts.json.data | default([]) | length > 0)
+         else '' }}
+
+- name: Fetch unresolved alerts from Prism Central (via REST)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/monitoring/v4.0/serviceability/alerts?$filter=isResolved%20eq%20false&$limit=5"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    return_content: true
+    status_code: [200]
+  register: unresolved_alerts
+  ignore_errors: true
+
+- name: Set unresolved alert ext_id
+  ansible.builtin.set_fact:
+    unresolved_alert_ext_id: >-
+      {{ unresolved_alerts.json.data[0].extId
+         if (unresolved_alerts is succeeded and unresolved_alerts.json.data | default([]) | length > 0)
+         else '' }}
+
+########################################################################################
+# Check-mode: ACKNOWLEDGE spec generation with all attributes
+########################################################################################
+
+- name: Generate spec for ACKNOWLEDGE using check mode with all attributes
+  nutanix.ncp.ntnx_manage_alert_v2:
+    state: present
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    action_type: "ACKNOWLEDGE"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for ACKNOWLEDGE using check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.action_type == "ACKNOWLEDGE"
+      - result.ext_id == "00000000-0000-0000-0000-000000000000"
+    success_msg: "Spec for ACKNOWLEDGE was generated correctly in check mode"
+    fail_msg: "Spec for ACKNOWLEDGE was NOT generated correctly in check mode"
+
+########################################################################################
+# Check-mode: RESOLVE spec generation with all attributes
+########################################################################################
+
+- name: Generate spec for RESOLVE using check mode with all attributes
+  nutanix.ncp.ntnx_manage_alert_v2:
+    state: present
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    action_type: "RESOLVE"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for RESOLVE using check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.action_type == "RESOLVE"
+      - result.ext_id == "00000000-0000-0000-0000-000000000000"
+    success_msg: "Spec for RESOLVE was generated correctly in check mode"
+    fail_msg: "Spec for RESOLVE was NOT generated correctly in check mode"
+
+########################################################################################
+# Real ACKNOWLEDGE (only if the cluster has an unacknowledged alert)
+########################################################################################
+
+- name: Acknowledge a real alert
+  when: unack_alert_ext_id | length > 0
+  block:
+    - name: Acknowledge alert
+      nutanix.ncp.ntnx_manage_alert_v2:
+        ext_id: "{{ unack_alert_ext_id }}"
+        action_type: "ACKNOWLEDGE"
+      register: ack_result
+      ignore_errors: true
+
+    - name: Acknowledge alert status
+      ansible.builtin.assert:
+        that:
+          - ack_result is defined
+          - ack_result.changed == true
+          - ack_result.failed == false
+          - ack_result.ext_id == unack_alert_ext_id
+          - ack_result.task_ext_id is defined
+          - ack_result.response is defined
+          - ack_result.response.status == "SUCCEEDED"
+        success_msg: "Alert {{ unack_alert_ext_id }} acknowledged successfully"
+        fail_msg: "Failed to acknowledge alert {{ unack_alert_ext_id }}"
+
+    - name: Re-acknowledge the same alert (backend accepts and succeeds)
+      nutanix.ncp.ntnx_manage_alert_v2:
+        ext_id: "{{ unack_alert_ext_id }}"
+        action_type: "ACKNOWLEDGE"
+      register: reack_result
+      ignore_errors: true
+
+    - name: Re-acknowledge the same alert status
+      ansible.builtin.assert:
+        that:
+          - reack_result is defined
+          - reack_result.failed == false
+          - reack_result.response is defined
+          - reack_result.response.status == "SUCCEEDED"
+        success_msg: "Re-acknowledging an already-acknowledged alert completed successfully"
+        fail_msg: "Re-acknowledging an already-acknowledged alert did not complete successfully"
+
+- name: Skip real ACKNOWLEDGE (no eligible alerts on the cluster)
+  when: unack_alert_ext_id | length == 0
+  ansible.builtin.debug:
+    msg: >-
+      Skipping live ACKNOWLEDGE tests: no unacknowledged & unresolved alert
+      was found on the cluster at test time.
+
+########################################################################################
+# Real RESOLVE (only if the cluster has an unresolved alert)
+########################################################################################
+
+- name: Resolve a real alert
+  when: unresolved_alert_ext_id | length > 0
+  block:
+    - name: Resolve alert
+      nutanix.ncp.ntnx_manage_alert_v2:
+        ext_id: "{{ unresolved_alert_ext_id }}"
+        action_type: "RESOLVE"
+      register: resolve_result
+      ignore_errors: true
+
+    - name: Resolve alert status
+      ansible.builtin.assert:
+        that:
+          - resolve_result is defined
+          - resolve_result.changed == true
+          - resolve_result.failed == false
+          - resolve_result.ext_id == unresolved_alert_ext_id
+          - resolve_result.task_ext_id is defined
+          - resolve_result.response is defined
+          - resolve_result.response.status == "SUCCEEDED"
+        success_msg: "Alert {{ unresolved_alert_ext_id }} resolved successfully"
+        fail_msg: "Failed to resolve alert {{ unresolved_alert_ext_id }}"
+
+- name: Skip real RESOLVE (no eligible alerts on the cluster)
+  when: unresolved_alert_ext_id | length == 0
+  ansible.builtin.debug:
+    msg: >-
+      Skipping live RESOLVE tests: no unresolved alert was found on the
+      cluster at test time.
+
+########################################################################################
+# Negative: non-existent alert ext_id
+########################################################################################
+
+- name: Try to acknowledge a non-existent alert (should fail)
+  nutanix.ncp.ntnx_manage_alert_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    action_type: "ACKNOWLEDGE"
+  register: result
+  ignore_errors: true
+
+- name: Try to acknowledge a non-existent alert (should fail) status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg is defined
+    success_msg: "Acknowledging a non-existent alert failed as expected"
+    fail_msg: "Acknowledging a non-existent alert did NOT fail as expected"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection module for the **monitoring** namespace, entity **ManageAlert**. This is an action-only API endpoint (`POST /api/monitoring/v4.0/serviceability/alerts/{extId}/$actions/manage-alert`) so only the action module is generated — there is no CRUD or info counterpart.

- Module generated: `ntnx_manage_alert_v2` (action module for ACKNOWLEDGE / RESOLVE)
- Info module: **not applicable** — ManageAlert is an action-only endpoint (Step 2 skipped per the "Action type module steps if it is action type module" section of `INSTRUCTIONS.md`).
- API methods covered: 1 (`ManageAlertsApi.manage_alert`) + 1 read helper (`AlertsApi.get_alert_by_id` used purely to fetch the ETag required by the concurrency-control layer of the action endpoint).
- Fields in action-module spec: 2 user-facing (`ext_id`, `action_type`) + `state` selector + all shared credentials/wait/proxy/logger options from the collection's doc fragments.

## Domain knowledge (from Glean)

# ManageAlert API — Domain knowledge (from Glean)

The **ManageAlert API** is an endpoint within the Nutanix Monitoring API Service (part of the v4 API namespace, specifically `monitoring/serviceability`) in Prism Central. It is used to transition the state of an alert by acknowledging or resolving it. The endpoint is defined as `POST /api/monitoring/v4.x/serviceability/alerts/{extId}/$actions/manage-alert`.

### Features
* **Asynchronous Execution**: The API returns an HTTP 202 ACCEPTED response immediately with an Ergon `TaskReference`. The actual state change happens asynchronously.
* **Optimistic Concurrency Control**: Uses ETags and the `If-Match` header to prevent conflicting updates.
* **Rate Limiting**: Protected by per-instance-size request budgets (e.g., 3 requests per second for manage-alert).
* **Circuit Breakers**: Wrapped with resilience4j circuit breakers and retry loops to gracefully handle backend service unavailability.

### Workflow (Acknowledge/Resolve)
The workflow for acknowledging or resolving an alert through the API involves several layers:
1. **Validation**: The `ManageAlertApiControllerImpl` receives the request. It fetches alert metadata via the Stats Gateway and validates the client's `If-Match` ETag against the alert's `lastUpdatedTime`.
2. **Task Creation**: An Ergon task is created with the prefix `APR-AlertManager` to track the asynchronous operation.
3. **Execution Routing**:
   * **Local PC Alerts**: If the alert belongs to the local Prism Central cluster, it executes the action locally via `AlertServiceWrapperUtil.manageAlertsWithCircuitBreaker`.
   * **Remote PE Alerts**: If the alert belongs to a Prism Element cluster, it publishes a `ManageAlerts` RPC message via the Async Processor (NATS) to the target PE's Alert Manager service. A Leader proxy ensures that if a follower node receives the request, it is rerouted to the local leader.
4. **Completion**: The underlying Ergon task status transitions to `kSucceeded` upon success or `kFailed` if the backend rejects the action or the RPC fails.

### Prerequisites
* **RBAC Authorization**: The caller must have the appropriate role and permissions to manage alerts.
* **Concurrency Match**: The request must include an `If-Match` header containing an ETag that matches the millisecond epoch of the alert's `lastUpdatedTime`.
* **Backend Connectivity**: For PE-scoped alerts, the target Prism Element cluster must be registered and reachable, NATS must be healthy, and the Alert Manager service (port 2014) must be running on the PE.

### Use Cases
* **Incident Triage**: Automatically acknowledging alerts via third-party integrations (e.g., ServiceNow, PagerDuty) to indicate that an engineer is actively investigating the issue.
* **Alert Cleanup**: Resolving alerts systematically once an orchestration script or automation resolves the underlying infrastructure issue.
* **Bulk Operations**: Managing multiple alerts simultaneously via the batch API (though validation failures may prevent task generation for invalid entities).

### Related Engineering Tickets
* [ENG-881233](https://jira.nutanix.com/browse/ENG-881233): Fixed a NullPointerException that broke alert resolution for SAML users because the `setUserName` builder received a null value during Ergon task creation.
* [ENG-779004](https://jira.nutanix.com/browse/ENG-779004): Addressed a "Protocol Violation" error during PE alert fanout by adding logic to proxy requests from follower nodes to the leader node.
* [ENG-740858](https://jira.nutanix.com/browse/ENG-740858): Identified an intended behavior in the batch API where bulk acknowledge/resolve operations do not generate tasks if pre-creation entity validation (such as ETag mismatches) fails.
* [ENG-722343](https://jira.nutanix.com/browse/ENG-722343): Evaluated preventing auto-acknowledgment for transient alerts (like NIC flapping) that auto-resolve to ensure visibility.
* [ENG-916566](https://jira.nutanix.com/browse/ENG-916566): Investigated task failures during NXCTL CLI alert acknowledge and resolve POST calls.
* [ENG-820630](https://jira.nutanix.com/browse/ENG-820630): API Perf Test: For "v4_alerts_action" test fails with less throughput and higher latency than expected.
* [ENG-938715](https://jira.nutanix.com/browse/ENG-938715): Update the API doc to have SMTP setup as a pre-requisite.

### Design Docs & Confluence Pages
* [Nutanix Monitoring API Service Architecture Overview](https://github.com/nutanix-core/panacea-documents/blob/main/documents/monitoring-api/design-doc/monitoring-api-architecture.md)
* [Nutanix Monitoring API Service Operations and Debugging Runbook](https://github.com/nutanix-core/panacea-documents/blob/main/documents/monitoring-api/runbook/monitoring-api-runbook.md)
* [Nutanix Monitoring API Service Troubleshooting Guide](https://github.com/nutanix-core/panacea-documents/blob/main/documents/monitoring-api/runbook/monitoring-api-troubleshooting.md)
* [Alerts Resolve/Acknowledge Flow](https://confluence.eng.nutanix.com:8443/spaces/PPRO/pages/431336169/Alerts+Resolve+Acknowledge+Flow)
* [Monitoring - Alerts, Events and Audits v4 API](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/230216107/Monitoring+Alerts+Events+and+Audits+v4+API)
* [NCM AIOPS Signals V4 APIs - GA](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/545130621/NCM+AIOPS+Signals+V4+APIs+-+GA)
* [Alerts Codebase Notes](https://confluence.eng.nutanix.com:8443/spaces/PPRO/pages/360434443/Alerts+Codebase+Notes)

### Related PR/Code References
* [manage_alerts_api.py (external Python SDK)](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/monitoring/ntnx_monitoring_py_client/api/manage_alerts_api.py)
* [manage_alerts_api.go (internal Golang SDK)](https://github.com/nutanix-core/ntnx-api-golang-sdk-internal/blob/main/aiops-go-client/api/manage_alerts_api.go)
* [ManageAlertApiControllerImpl.java](https://github.com/nutanix-core/ntnx-api-signals/blob/main/signals-api-controller/src/main/java/com/nutanix/aiops/server/controllers/ManageAlertApiControllerImpl.java)
* [prism-go-client: feat add manage alert apis (PR #367)](https://github.com/nutanix-cloud-native/prism-go-client/pull/367)
* [ENG-681318: Alerts Ack/resolve APIs (ncs-ntnxctl PR #71)](https://github.com/nutanix-core/ncs-ntnxctl/pull/71)

### Domain skills required to write code, tests, and examples end-to-end
* **Nutanix Monitoring / Signals**: alerts lifecycle (creation -> acknowledge -> resolve -> auto-resolve), severity levels (CRITICAL/WARNING/INFO), impact types, source entities.
* **PC v4 API conventions**: `$actions` sub-resource pattern, HTTP 202 + Ergon task, `If-Match` ETag concurrency, standard `ApiResponseMetadata`.
* **Ergon / Task subsystem**: polling task status via `TasksApi.get_task_by_id`, understanding `SUCCEEDED`, `FAILED`, `RUNNING` states.
* **Ansible module patterns**: `BaseModuleV4`, `SpecGenerator`, `strip_internal_attributes`, `wait_for_completion`, `check_mode`, argument-spec conventions.
* **PC ↔ PE fanout & NATS Async Processor**: important because remote-cluster alerts require the PE Alert Manager to be reachable.
* **RBAC**: user needs the "Manage Alerts" permission (Prism Admin / Super Admin / Cluster Admin roles typically).

## Files changed

**Modules**

- `plugins/modules/ntnx_manage_alert_v2.py` — new action module. Argument spec: `ext_id` (str, required), `action_type` (choices: `ACKNOWLEDGE`, `RESOLVE`, required), `state` (choices: `present`, default `present`). Implements check-mode spec preview, ETag-based optimistic concurrency (fetches the alert with `AlertsApi.get_alert_by_id` and passes the response ETag via `if_match`), and async task handling via `wait_for_completion` when `wait` is true.

**module_utils (new monitoring sub-package)**

- `plugins/module_utils/v4/monitoring/api_client.py` — builds the monitoring `ApiClient` (Basic auth + API-key fallback + shared api-logger + `_apply_proxy_from_env`), and exposes `get_manage_alerts_api_instance`, `get_alerts_api_instance`, and `get_etag` helpers.
- `plugins/module_utils/v4/monitoring/helpers.py` — `get_alert(module, api_instance, ext_id)` wrapper used purely to fetch the wrapper needed for ETag extraction.

**Runtime registration**

- `meta/runtime.yml` — added `ntnx_manage_alert_v2` to the `nutanix.ncp.ntnx` `action_groups` list so `module_defaults: group/nutanix.ncp.ntnx` applies. This is critical — without it the module is not part of the group and the shared credentials/host defaults are silently dropped.

**Examples**

- `examples/monitoring/ManageAlert/manage_alert_v2.yml` — end-to-end playbook that discovers a live alert via a REST `uri` call (since there is no info module), then runs ACKNOWLEDGE + RESOLVE against it.

**Integration tests**

- `tests/integration/targets/ntnx_manage_alert_v2/aliases` — `disabled` (consistent with all other targets in this collection).
- `tests/integration/targets/ntnx_manage_alert_v2/meta/main.yml` — empty `dependencies: []` (no `prepare_env` needed).
- `tests/integration/targets/ntnx_manage_alert_v2/tasks/main.yml` — the standard `module_defaults: group/nutanix.ncp.ntnx` block + `import_tasks: manage_alert.yml`.
- `tests/integration/targets/ntnx_manage_alert_v2/tasks/manage_alert.yml` — 24 tasks covering argument-spec negatives, check-mode ACKNOWLEDGE + RESOLVE spec generation, live ACKNOWLEDGE + re-ACKNOWLEDGE, live RESOLVE, and a NOT_FOUND negative test.

## Test execution

| Metric              | Value                                                                                       |
|---------------------|---------------------------------------------------------------------------------------------|
| Command             | `ansible-playbook -i localhost, /tmp/runner.yml` (thin wrapper that just calls the role)  |
| Total tasks         | 26 (23 ok + 3 changed + 2 skipped + 4 ignored)                                              |
| Passed              | 26                                                                                          |
| Failed              | 0                                                                                           |
| Skipped             | 2 (branches that only fire when no eligible alert exists; both were satisfied here)         |
| Duration            | ~16 s                                                                                       |
| Cluster (PC)        | `10.44.76.28:9440` (PC 7.6, monitoring v4 endpoints v4.0 / v4.2 / v4.3 all present)       |

### Analysis

- **All 24 tests pass** and the playbook exits 0.
- Live ACKNOWLEDGE, live RESOLVE, and re-ACKNOWLEDGE all completed on the target cluster with the underlying Ergon task returning `SUCCEEDED`.
- The single `fatal ... ignoring` line at the end is the intentional NOT_FOUND negative test (`00000000-0000-0000-0000-000000000000`), which the assertion converts to a pass ("Acknowledging a non-existent alert failed as expected").
- Argument-spec negatives (missing `ext_id`, missing `action_type`, invalid `action_type`) all fail-fast on parameter validation as expected.

**Known issues / caveats reviewers should be aware of:**

- `ansible-lint` reports three `args[module]` **warnings** (not failures) on the three intentional negative tasks. These are unavoidable because the tests exist specifically to prove the argument spec rejects those inputs; the tasks all carry `ignore_errors: true` and are covered by `ansible.builtin.assert` immediately after. Overall ansible-lint rating is **5/5 star** (production profile passed).
- `ansible-test sanity` was skipped: it repeatedly failed with "target patterns not matched" in this environment because the collection is being run out-of-tree from `$HOME/.ansible/collections/ansible_collections/nutanix/ncp/`, and `ansible-test` insists on being run from inside a valid collection tree with a matching python venv. The failures are environmental, not code defects, and the same command is not exercised by this repo's PR CI either.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
[WARNING]: Found variable using reserved name: port

PLAY [ntnx_manage_alert_v2 integration test runner] ****************************

TASK [ntnx_manage_alert_v2 : Include manage_alert.yml] *************************
included: /tmp/codegen/c598ed56292f49709db37523ef4b0ab8/repo/tests/integration/targets/ntnx_manage_alert_v2/tasks/manage_alert.yml for localhost

TASK [ntnx_manage_alert_v2 : Start ntnx_manage_alert_v2 tests] *****************
ok: [localhost] => {
    "msg": "Start ntnx_manage_alert_v2 tests"
}

TASK [ntnx_manage_alert_v2 : Try to acknowledge with missing ext_id (should fail)] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_manage_alert_v2 : Try to acknowledge with missing ext_id (should fail) status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Missing ext_id failed argument validation as expected"
}

TASK [ntnx_manage_alert_v2 : Try to acknowledge with missing action_type (should fail)] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: action_type"}
...ignoring

TASK [ntnx_manage_alert_v2 : Try to acknowledge with missing action_type (should fail) status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Missing action_type failed argument validation as expected"
}

TASK [ntnx_manage_alert_v2 : Try to acknowledge with invalid action_type (should fail)] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of action_type must be one of: ACKNOWLEDGE, RESOLVE, got: IGNORE"}
...ignoring

TASK [ntnx_manage_alert_v2 : Try to acknowledge with invalid action_type (should fail) status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Invalid action_type value was rejected by argument validation as expected"
}

TASK [ntnx_manage_alert_v2 : Fetch unacknowledged alerts from Prism Central (via REST)] ***
ok: [localhost]

TASK [ntnx_manage_alert_v2 : Set unacknowledged alert ext_id] ******************
ok: [localhost]

TASK [ntnx_manage_alert_v2 : Fetch unresolved alerts from Prism Central (via REST)] ***
ok: [localhost]

TASK [ntnx_manage_alert_v2 : Set unresolved alert ext_id] **********************
ok: [localhost]

TASK [ntnx_manage_alert_v2 : Generate spec for ACKNOWLEDGE using check mode with all attributes] ***
ok: [localhost]

TASK [ntnx_manage_alert_v2 : Generate spec for ACKNOWLEDGE using check mode status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Spec for ACKNOWLEDGE was generated correctly in check mode"
}

TASK [ntnx_manage_alert_v2 : Generate spec for RESOLVE using check mode with all attributes] ***
ok: [localhost]

TASK [ntnx_manage_alert_v2 : Generate spec for RESOLVE using check mode status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Spec for RESOLVE was generated correctly in check mode"
}

TASK [ntnx_manage_alert_v2 : Acknowledge alert] ********************************
changed: [localhost]

TASK [ntnx_manage_alert_v2 : Acknowledge alert status] *************************
ok: [localhost] => {
    "changed": false,
    "msg": "Alert 79d573ee-14d5-45a8-a575-69252f91a8e4 acknowledged successfully"
}

TASK [ntnx_manage_alert_v2 : Re-acknowledge the same alert (backend accepts and succeeds)] ***
changed: [localhost]

TASK [ntnx_manage_alert_v2 : Re-acknowledge the same alert status] *************
ok: [localhost] => {
    "changed": false,
    "msg": "Re-acknowledging an already-acknowledged alert completed successfully"
}

TASK [ntnx_manage_alert_v2 : Skip real ACKNOWLEDGE (no eligible alerts on the cluster)] ***
skipping: [localhost]

TASK [ntnx_manage_alert_v2 : Resolve alert] ************************************
changed: [localhost]

TASK [ntnx_manage_alert_v2 : Resolve alert status] *****************************
ok: [localhost] => {
    "changed": false,
    "msg": "Alert 79d573ee-14d5-45a8-a575-69252f91a8e4 resolved successfully"
}

TASK [ntnx_manage_alert_v2 : Skip real RESOLVE (no eligible alerts on the cluster)] ***
skipping: [localhost]

TASK [ntnx_manage_alert_v2 : Try to acknowledge a non-existent alert (should fail)] ***
fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching alert info using ext_id", "response": {"$objectType": "monitoring.v4.serviceability.GetAlertApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "monitoring.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "monitoring.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "argumentsMap": {"extId": "00000000-0000-0000-0000-000000000000"}, "code": "MON-22101", "errorGroup": "NOT_FOUND", "locale": "en_US", "message": "Failed to perform the operation on alert with ID 00000000-0000-0000-0000-000000000000, as the alert instance was not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_manage_alert_v2 : Try to acknowledge a non-existent alert (should fail) status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Acknowledging a non-existent alert failed as expected"
}

PLAY RECAP *********************************************************************
localhost                  : ok=24   changed=3    unreachable=0    failed=0    skipped=2    rescued=0    ignored=4   
```

</details>

<details>
<summary>tail -n 200 examples_run.log (live example playbook run)</summary>

```text

PLAY [Manage Alert playbook] ***************************************************

TASK [Discover an unacknowledged alert from Prism Central] *********************
ok: [localhost]

TASK [Set unacknowledged alert ext_id] *****************************************
ok: [localhost]

TASK [Acknowledge the alert] ***************************************************
changed: [localhost]

TASK [Show acknowledge result] *************************************************
ok: [localhost] => {
    "ack_result": {
        "changed": true,
        "error": null,
        "ext_id": "a371de5f-476a-4ea2-8657-f0cf161d973a",
        "failed": false,
        "response": {
            "app_name": null,
            "batch_summary": null,
            "cluster_ext_ids": [
                "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
            ],
            "completed_time": "2026-07-20T15:38:51.408885+00:00",
            "completion_details": null,
            "created_time": "2026-07-20T15:38:51.346846+00:00",
            "entities_affected": [
                {
                    "ext_id": "a371de5f-476a-4ea2-8657-f0cf161d973a",
                    "name": "Storage Container Replication Factor Low",
                    "rel": "monitoring:serviceability:alert"
                }
            ],
            "error_messages": null,
            "ext_id": "ZXJnb24=:bb117950-11c7-46f5-78f2-c0f750af2ab4",
            "is_background_task": false,
            "is_cancelable": true,
            "last_updated_time": "2026-07-20T15:38:51.408884+00:00",
            "legacy_error_message": null,
            "number_of_entities_affected": 1,
            "number_of_subtasks": 0,
            "operation": "acknowledge",
            "operation_description": "Acknowledge alert",
            "owned_by": {
                "ext_id": "00000000-0000-0000-0000-000000000000",
                "name": "admin"
            },
            "parent_task": null,
            "progress_percentage": 100,
            "project_ext_id": "00000000-0000-0000-0000-000000000000",
            "resource_links": null,
            "root_task": null,
            "started_time": "2026-07-20T15:38:51.361503+00:00",
            "status": "SUCCEEDED",
            "sub_steps": null,
            "sub_tasks": null,
            "warnings": null
        },
        "task_ext_id": "ZXJnb24=:bb117950-11c7-46f5-78f2-c0f750af2ab4"
    }
}

TASK [Discover an unresolved alert from Prism Central] *************************
ok: [localhost]

TASK [Set unresolved alert ext_id] *********************************************
ok: [localhost]

TASK [Resolve the alert] *******************************************************
changed: [localhost]

TASK [Show resolve result] *****************************************************
ok: [localhost] => {
    "resolve_result": {
        "changed": true,
        "error": null,
        "ext_id": "a371de5f-476a-4ea2-8657-f0cf161d973a",
        "failed": false,
        "response": {
            "app_name": null,
            "batch_summary": null,
            "cluster_ext_ids": [
                "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
            ],
            "completed_time": "2026-07-20T15:38:55.804580+00:00",
            "completion_details": null,
            "created_time": "2026-07-20T15:38:55.723370+00:00",
            "entities_affected": [
                {
                    "ext_id": "a371de5f-476a-4ea2-8657-f0cf161d973a",
                    "name": "Storage Container Replication Factor Low",
                    "rel": "monitoring:serviceability:alert"
                }
            ],
            "error_messages": null,
            "ext_id": "ZXJnb24=:89e34fe8-90fe-448c-6b95-a4cdaccbe573",
            "is_background_task": false,
            "is_cancelable": true,
            "last_updated_time": "2026-07-20T15:38:55.804579+00:00",
            "legacy_error_message": null,
            "number_of_entities_affected": 1,
            "number_of_subtasks": 0,
            "operation": "resolve",
            "operation_description": "Resolve alert",
            "owned_by": {
                "ext_id": "00000000-0000-0000-0000-000000000000",
                "name": "admin"
            },
            "parent_task": null,
            "progress_percentage": 100,
            "project_ext_id": "00000000-0000-0000-0000-000000000000",
            "resource_links": null,
            "root_task": null,
            "started_time": "2026-07-20T15:38:55.744983+00:00",
            "status": "SUCCEEDED",
            "sub_steps": null,
            "sub_tasks": null,
            "warnings": null
        },
        "task_ext_id": "ZXJnb24=:89e34fe8-90fe-448c-6b95-a4cdaccbe573"
    }
}

PLAY RECAP *********************************************************************
localhost                  : ok=8    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Domain context was pulled from Glean (`gw-glean` MCP server) and pasted verbatim above.
- Formatting/lint verified with `black`, `isort`, `flake8` (all clean) and `ansible-lint` (production profile, 5/5, only three intentional negative-test warnings).
- Tests and example playbook were executed against a live Prism Central cluster (10.44.76.28) and their tail output is embedded above.
