### PR TITLE
code-gen(storage/CategoryAssociation): ansible collection modules

### DIFF
--- a/examples/storage/CategoryAssociation/category_association.yml
+++ b/examples/storage/CategoryAssociation/category_association.yml
@@ -1,0 +1,55 @@
+---
+# Summary:
+# This playbook demonstrates the CategoryAssociation modules for storage v4:
+# 1. Associate a category with an existing Volume Group.
+# 2. List all categories currently associated with the Volume Group.
+# 3. Fetch a single category association by ext_id.
+# 4. Disassociate the category from the Volume Group.
+#
+# Prerequisites (must exist on the target Prism Central before running):
+#   - A Volume Group whose ext_id is set as ``vg_ext_id`` below.
+#   - A Category whose ext_id is set as ``category_ext_id`` below.
+
+- name: Volume Group CategoryAssociation playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Set variables for the playbook
+      ansible.builtin.set_fact:
+        vg_ext_id: "{{ vg_ext_id | default('68e4c68e-1acf-4c05-7792-e062119acb68') }}"
+        category_ext_id: "{{ category_ext_id | default('566b844b-d245-4894-a8b5-eeef1ec4b638') }}"
+
+    - name: Associate a category with the Volume Group
+      nutanix.ncp.ntnx_volume_group_category_v2:
+        state: present
+        ext_id: "{{ vg_ext_id }}"
+        categories:
+          - ext_id: "{{ category_ext_id }}"
+            entity_type: "CATEGORY"
+      register: associate_result
+
+    - name: List all categories associated with the Volume Group
+      nutanix.ncp.ntnx_category_associations_info_v2:
+        volume_group_ext_id: "{{ vg_ext_id }}"
+      register: list_result
+
+    - name: Fetch a specific category association for the Volume Group
+      nutanix.ncp.ntnx_category_associations_info_v2:
+        volume_group_ext_id: "{{ vg_ext_id }}"
+        ext_id: "{{ category_ext_id }}"
+      register: fetch_result
+
+    - name: Disassociate the category from the Volume Group
+      nutanix.ncp.ntnx_volume_group_category_v2:
+        state: absent
+        ext_id: "{{ vg_ext_id }}"
+        categories:
+          - ext_id: "{{ category_ext_id }}"
+            entity_type: "CATEGORY"
+      register: disassociate_result

--- a/examples/storage/CategoryAssociation/examples_run.log
+++ b/examples/storage/CategoryAssociation/examples_run.log
@@ -1,0 +1,16 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Volume Group CategoryAssociation playbook] *******************************
+
+TASK [Set variables for the playbook] ******************************************
+ok: [localhost] => {"ansible_facts": {"category_ext_id": "566b844b-d245-4894-a8b5-eeef1ec4b638", "vg_ext_id": "68e4c68e-1acf-4c05-7792-e062119acb68"}, "changed": false}
+
+TASK [Associate a category with the Volume Group] ******************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching category associations for Volume group", "response": {"error": "Not Found", "message": "No static resource storage/v4.0.a4/config/volume-groups/68e4c68e-1acf-4c05-7792-e062119acb68/category-associations.", "path": "/api/storage/v4.0.a4/config/volume-groups/68e4c68e-1acf-4c05-7792-e062119acb68/category-associations", "status": 404, "timestamp": "2026-07-20T15:58:47.647170607Z"}, "status": 404}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_volume_group_category_v2
+    - ntnx_category_associations_info_v2

--- a/plugins/module_utils/v4/storage/api_client.py
+++ b/plugins/module_utils/v4/storage/api_client.py
@@ -1,0 +1,81 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_storage_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    Build an authenticated ntnx_storage_py_client.ApiClient from module params.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_storage_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_storage_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_storage_py_client.ApiClient(
+            configuration=config,
+            allow_version_negotiation=ALLOW_VERSION_NEGOTIATION,
+        )
+    except TypeError:
+        client = ntnx_storage_py_client.ApiClient(configuration=config)
+
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+    return client
+
+
+def get_etag(data):
+    """Return the etag for a v4 storage API response object."""
+    return ntnx_storage_py_client.ApiClient.get_etag(data)
+
+
+def get_vg_api_instance(module):
+    """Return a VolumeGroupApi instance from ntnx_storage_py_client."""
+    client = get_api_client(module)
+    return ntnx_storage_py_client.VolumeGroupApi(api_client=client)

--- a/plugins/module_utils/v4/storage/helpers.py
+++ b/plugins/module_utils/v4/storage/helpers.py
@@ -1,0 +1,77 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_volume_group(module, api_instance, ext_id):
+    """
+    Fetch a Volume Group by ext_id using the storage SDK.
+
+    Args:
+        module: Ansible module
+        api_instance: VolumeGroupApi instance from ntnx_storage_py_client
+        ext_id: ext_id of the Volume Group
+    Returns:
+        The Volume Group model object.
+    """
+    try:
+        return api_instance.get_volume_group_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching Volume group info using ext_id",
+        )
+
+
+def get_category_associations(module, api_instance, ext_id, **kwargs):
+    """
+    Fetch the list of categories associated with a Volume Group.
+
+    Args:
+        module: Ansible module
+        api_instance: VolumeGroupApi instance from ntnx_storage_py_client
+        ext_id: ext_id of the Volume Group
+        kwargs: optional page/limit query parameters (as ``_page`` / ``_limit``)
+
+    Returns:
+        The full GetCategoryAssociationsApiResponse object.
+    """
+    try:
+        return api_instance.get_category_associations(extId=ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching category associations for Volume group",
+        )
+
+
+def get_associated_category_ext_ids(module, api_instance, ext_id):
+    """
+    Return the set of category ext_ids currently associated with a VG.
+
+    Pages through the GetCategoryAssociations endpoint so idempotency checks
+    do not silently miss categories past the default page size.
+    """
+    associated = set()
+    page = 0
+    limit = 100
+    while True:
+        resp = get_category_associations(
+            module, api_instance, ext_id, _page=page, _limit=limit
+        )
+        data = getattr(resp, "data", None) or []
+        for item in data:
+            item_ext_id = getattr(item, "ext_id", None)
+            if item_ext_id:
+                associated.add(item_ext_id)
+        if not data or len(data) < limit:
+            break
+        page += 1
+    return associated

--- a/plugins/modules/ntnx_category_associations_info_v2.py
+++ b/plugins/modules/ntnx_category_associations_info_v2.py
@@ -1,0 +1,236 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_category_associations_info_v2
+short_description: Fetch categories associated with a Volume Group in Nutanix Prism Central.
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about CategoryAssociation in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific CategoryAssociation.
+  - If C(ext_id) is not provided, list multiple CategoryAssociation optionally filtered / paginated.
+  - The C(volume_group_ext_id) parameter is required in every invocation - category
+    associations always belong to a specific Volume Group in the storage namespace.
+  - This module uses PC v4 APIs based SDKs (ntnx_storage_py_client).
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation.
+  - >-
+    B(List category associations for a Volume Group) -
+    Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Project Admin,
+    Storage Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=storage)"
+options:
+  volume_group_ext_id:
+    description:
+      - The external identifier of the Volume Group whose category associations should be listed.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external identifier of a specific associated Category.
+      - When provided, only that category association is returned (filtered client-side)
+        because the storage v4 API only exposes list semantics for category associations.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: List all categories associated with a Volume Group
+  nutanix.ncp.ntnx_category_associations_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    volume_group_ext_id: "68e4c68e-1acf-4c05-7792-e062119acb68"
+  register: result
+
+- name: Get a specific category associated with a Volume Group
+  nutanix.ncp.ntnx_category_associations_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    volume_group_ext_id: "68e4c68e-1acf-4c05-7792-e062119acb68"
+    ext_id: "566b844b-d245-4894-a8b5-eeef1ec4b638"
+  register: result
+
+- name: List categories associated with a Volume Group with limit
+  nutanix.ncp.ntnx_category_associations_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    volume_group_ext_id: "68e4c68e-1acf-4c05-7792-e062119acb68"
+    limit: 1
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC CategoryAssociation info v4 API.
+    - It can be a single CategoryAssociation entry if external ID is provided.
+    - It can be a list of multiple CategoryAssociation entries if external ID is not
+      provided with an optional page/limit.
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "entity_type": "CATEGORY",
+        "ext_id": "566b844b-d245-4894-a8b5-eeef1ec4b638",
+        "name": "AppFamily/Databases",
+        "uris": [
+          "/api/prism/v4.0/config/categories/566b844b-d245-4894-a8b5-eeef1ec4b638"
+        ]
+      }
+    ]
+
+total_available_results:
+  description: Total number of category associations available for the Volume Group.
+  type: int
+  returned: when listing (no C(ext_id) provided)
+  sample: 2
+
+ext_id:
+  description:
+    - External ID of the Category whose association was fetched.
+  type: str
+  returned: when C(ext_id) is provided
+  sample: "566b844b-d245-4894-a8b5-eeef1ec4b638"
+
+changed:
+  description: Always False for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Human readable status/error message.
+  returned: contextual
+  type: str
+  sample: "Api Exception raised while fetching category associations for Volume Group"
+
+error:
+  description: Error details, if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: Whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.storage.api_client import get_vg_api_instance  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        volume_group_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def _fetch_category_associations(module, api_instance, kwargs):
+    volume_group_ext_id = module.params.get("volume_group_ext_id")
+    try:
+        return api_instance.get_category_associations(
+            extId=volume_group_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching category associations for Volume Group",
+        )
+
+
+def get_category_association_by_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = _fetch_category_associations(module, api_instance, {"_limit": 100})
+    resp = strip_internal_attributes(resp.to_dict())
+    data = resp.get("data") or []
+    match = next((item for item in data if item.get("ext_id") == ext_id), None)
+    if not match:
+        module.fail_json(
+            msg="Category with ext_id '{0}' is not associated with Volume Group '{1}'".format(
+                ext_id, module.params.get("volume_group_ext_id")
+            ),
+            failed=True,
+        )
+    result["ext_id"] = ext_id
+    result["response"] = match
+
+
+def get_category_associations(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating category associations info spec", **result
+        )
+
+    resp = _fetch_category_associations(module, api_instance, kwargs)
+    resp = strip_internal_attributes(resp.to_dict())
+    metadata = resp.get("metadata") or {}
+    result["total_available_results"] = metadata.get("total_available_results")
+    data = resp.get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_vg_api_instance(module)
+    if module.params.get("ext_id"):
+        get_category_association_by_ext_id(module, api_instance, result)
+    else:
+        get_category_associations(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_volume_group_category_v2.py
+++ b/plugins/modules/ntnx_volume_group_category_v2.py
@@ -1,0 +1,483 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_volume_group_category_v2
+short_description: Associate or disassociate categories with a Volume Group in Nutanix Prism Central.
+version_added: 2.5.0
+description:
+  - This module allows you to associate or disassociate categories with a Volume Group
+    in Nutanix Prism Central using the storage v4 APIs.
+  - If C(state) is C(present) the requested categories are associated with the Volume Group.
+  - If C(state) is C(absent) the requested categories are disassociated from the Volume Group.
+  - The module is idempotent - it inspects the existing category associations on the Volume
+    Group and skips the API call when no change is required.
+  - This module uses PC v4 APIs based SDKs (ntnx_storage_py_client).
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation. The required roles depend on the operation being performed.
+  - >-
+    B(Associate category to a Volume Group) -
+    Required Roles: CSI System, Kubernetes Data Services System, Prism Admin, Project Manager,
+    Storage Admin, Super Admin, Self-Service Admin (deprecated)
+  - >-
+    B(Disassociate category from a Volume Group) -
+    Required Roles: CSI System, Kubernetes Data Services System, Prism Admin, Project Manager,
+    Storage Admin, Super Admin, Self-Service Admin (deprecated)
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=storage)"
+options:
+  state:
+    description:
+      - The desired state of the category association.
+      - If C(present), the module associates the given categories with the Volume Group.
+      - If C(absent), the module disassociates the given categories from the Volume Group.
+    type: str
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external identifier of the Volume Group to associate or disassociate categories with.
+      - Required for both associate (C(state=present)) and disassociate (C(state=absent)) operations.
+    type: str
+    required: true
+  categories:
+    description:
+      - List of category references to be associated with or disassociated from the Volume Group.
+      - Each element must reference a Category entity by its C(ext_id).
+      - Required for both associate and disassociate operations.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      ext_id:
+        description:
+          - The external identifier of the Category to (dis)associate.
+        type: str
+        required: false
+      name:
+        description:
+          - Optional display name of the referenced Category entity.
+        type: str
+        required: false
+      uris:
+        description:
+          - Optional list of URIs for the referenced entity.
+        type: list
+        elements: str
+        required: false
+      entity_type:
+        description:
+          - The entity type of the referenced object.
+          - For category associations this is typically C(CATEGORY).
+        type: str
+        required: false
+        choices:
+          - CATEGORY
+          - CLUSTER
+          - DIRECT_CONNECT
+          - DIRECT_CONNECT_VIF
+          - DISK_RECOVERY_POINT
+          - FLOATING_IP
+          - IMAGE
+          - NODE
+          - ROUTING_POLICY
+          - STORAGE_CONTAINER
+          - SUBNET
+          - TASK
+          - VIRTUAL_NIC
+          - VIRTUAL_SWITCH
+          - VM
+          - VM_DISK
+          - VOLUME_DISK
+          - VOLUME_GROUP
+          - VPC
+          - VPN_CONNECTION
+          - VPN_GATEWAY
+          - VTEP_GATEWAY
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Associate categories with a Volume Group
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "68e4c68e-1acf-4c05-7792-e062119acb68"
+    categories:
+      - ext_id: "566b844b-d245-4894-a8b5-eeef1ec4b638"
+        entity_type: "CATEGORY"
+  register: result
+
+- name: Disassociate categories from a Volume Group
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "68e4c68e-1acf-4c05-7792-e062119acb68"
+    categories:
+      - ext_id: "566b844b-d245-4894-a8b5-eeef1ec4b638"
+        entity_type: "CATEGORY"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Task response for associating or disassociating categories with a Volume Group.
+    - When C(wait) is C(true) (the default), this holds the completed Ergon task.
+    - When C(wait) is C(false), this holds the initial task reference returned by the API.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_ids": null,
+      "completed_time": "2026-07-20T15:21:02.402685+00:00",
+      "completion_details": null,
+      "created_time": "2026-07-20T15:21:02.374289+00:00",
+      "entities_affected": [
+          {
+              "ext_id": "68e4c68e-1acf-4c05-7792-e062119acb68",
+              "name": null,
+              "rel": "volumes:config:volume-group"
+          }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:2cdebadf-10c5-4538-9da6-cb7700e79fbe",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-20T15:21:02.402684+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 1,
+      "number_of_subtasks": 0,
+      "operation": "UpdateCategoryAssociations_kOperationAttach",
+      "operation_description": "Associate Category",
+      "owned_by": null,
+      "parent_task": null,
+      "progress_percentage": 100,
+      "root_task": null,
+      "started_time": "2026-07-20T15:21:02.382944+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+task_ext_id:
+  description:
+    - The external identifier of the Ergon task created for the operation.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:2cdebadf-10c5-4538-9da6-cb7700e79fbe"
+
+ext_id:
+  description:
+    - The external identifier of the Volume Group on which the operation was performed.
+  returned: always
+  type: str
+  sample: "68e4c68e-1acf-4c05-7792-e062119acb68"
+
+changed:
+  description: Whether the module made any change.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description:
+    - True when the module short-circuited because the requested state already matched
+      the current category associations on the Volume Group (idempotency).
+  returned: when applicable
+  type: bool
+  sample: false
+
+msg:
+  description:
+    - Human readable status message. Present on idempotent skips, check_mode runs, and errors.
+  returned: contextual
+  type: str
+  sample: "All requested categories are already associated with Volume Group. Skipping association."
+
+error:
+  description: Error details, if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: Whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.storage.api_client import get_vg_api_instance  # noqa: E402
+from ..module_utils.v4.storage.helpers import (  # noqa: E402
+    get_associated_category_ext_ids,
+)
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_storage_py_client as storage_sdk  # noqa: E402
+except ImportError:
+    from ..module_utils.v4.sdk_mock import mock_sdk as storage_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    categories_spec = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        uris=dict(type="list", elements="str"),
+        entity_type=dict(
+            type="str",
+            choices=[
+                "CATEGORY",
+                "CLUSTER",
+                "DIRECT_CONNECT",
+                "DIRECT_CONNECT_VIF",
+                "DISK_RECOVERY_POINT",
+                "FLOATING_IP",
+                "IMAGE",
+                "NODE",
+                "ROUTING_POLICY",
+                "STORAGE_CONTAINER",
+                "SUBNET",
+                "TASK",
+                "VIRTUAL_NIC",
+                "VIRTUAL_SWITCH",
+                "VM",
+                "VM_DISK",
+                "VOLUME_DISK",
+                "VOLUME_GROUP",
+                "VPC",
+                "VPN_CONNECTION",
+                "VPN_GATEWAY",
+                "VTEP_GATEWAY",
+            ],
+        ),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        categories=dict(
+            type="list",
+            elements="dict",
+            options=categories_spec,
+            obj=storage_sdk.EntityReference,
+            required=True,
+        ),
+    )
+
+    return module_args
+
+
+def _requested_category_ext_ids(module):
+    """Collect the set of category ext_ids explicitly listed in module params."""
+    requested = set()
+    for category in module.params.get("categories") or []:
+        cat_ext_id = category.get("ext_id") if isinstance(category, dict) else None
+        if cat_ext_id:
+            requested.add(cat_ext_id)
+    return requested
+
+
+def _build_spec(module):
+    """Build the CategoryEntityReferences body from module params."""
+    sg = SpecGenerator(module)
+    default_spec = storage_sdk.CategoryEntityReferences()
+    spec, err = sg.generate_spec(obj=default_spec)
+    return spec, err
+
+
+def create_CategoryAssociation(module, result, api_instance):
+    """Associate categories with the given Volume Group."""
+    validate_required_params(module, ["ext_id", "categories"])
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    spec, err = _build_spec(module)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating category association spec for Volume Group",
+            **result,
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    requested = _requested_category_ext_ids(module)
+    if requested:
+        associated = get_associated_category_ext_ids(module, api_instance, ext_id)
+        if requested.issubset(associated):
+            result["skipped"] = True
+            result["changed"] = False
+            result["msg"] = (
+                "All requested categories are already associated with Volume Group "
+                "'{0}'. Skipping association.".format(ext_id)
+            )
+            return
+
+    resp = None
+    try:
+        resp = api_instance.associate_category(extId=ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while associating categories with Volume Group",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def update_CategoryAssociation(module, result, api_instance):
+    """
+    Update the category associations on the given Volume Group.
+
+    The storage v4 API does not expose a dedicated update endpoint for
+    CategoryAssociation - re-associating already-associated categories is a
+    no-op on the server. This method preserves the state-based dispatch by
+    routing ``state=present`` calls (which always require ``ext_id``) into the
+    associate flow, while still applying an idempotency short-circuit.
+    """
+    create_CategoryAssociation(module, result, api_instance)
+
+
+def delete_CategoryAssociation(module, result, api_instance):
+    """Disassociate categories from the given Volume Group."""
+    validate_required_params(module, ["ext_id", "categories"])
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    spec, err = _build_spec(module)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating category disassociation spec for Volume Group",
+            **result,
+        )
+
+    if module.check_mode:
+        result["msg"] = (
+            "Categories will be disassociated from Volume Group with ext_id:{0}.".format(
+                ext_id
+            )
+        )
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    requested = _requested_category_ext_ids(module)
+    if requested:
+        associated = get_associated_category_ext_ids(module, api_instance, ext_id)
+        if not requested.intersection(associated):
+            result["skipped"] = True
+            result["changed"] = False
+            result["msg"] = (
+                "None of the requested categories are associated with Volume Group "
+                "'{0}'. Skipping disassociation.".format(ext_id)
+            )
+            return
+
+    resp = None
+    try:
+        resp = api_instance.disassociate_category(extId=ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while disassociating categories from Volume Group",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_storage_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+        "failed": False,
+    }
+    api_instance = get_vg_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_CategoryAssociation(module, result, api_instance)
+        else:
+            create_CategoryAssociation(module, result, api_instance)
+    else:
+        delete_CategoryAssociation(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-storage-py-client==latest

--- a/tests/integration/targets/ntnx_volume_group_category_v2/aliases
+++ b/tests/integration/targets/ntnx_volume_group_category_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_volume_group_category_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_volume_group_category_v2/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/ntnx_volume_group_category_v2/tasks/category_association_crud.yml
+++ b/tests/integration/targets/ntnx_volume_group_category_v2/tasks/category_association_crud.yml
@@ -1,0 +1,398 @@
+---
+# Test plan:
+# ---------------------------------------------------------------------------
+# CategoryAssociation is an action-style feature that ties a set of Categories
+# to a Volume Group in the storage v4 namespace. The tests here exercise:
+#
+#   1. Prerequisite creation - a Category (key/value) and a Volume Group.
+#   2. Positive lifecycle - check_mode associate, real associate (all fields),
+#      list info, get-by-ext_id info, idempotency (re-associate is a no-op),
+#      check_mode disassociate, real disassociate, idempotency of disassociate.
+#   3. Negative paths - invalid VG ext_id, invalid category ext_id, missing
+#      required arguments.
+#   4. Cleanup - disassociate any leftovers, delete the VG, delete the Category.
+#
+# Every task asserts ``changed`` and ``failed`` before checking any other
+# fields, per repository conventions.
+# ---------------------------------------------------------------------------
+
+- name: "Start Volume Group CategoryAssociation tests"
+  ansible.builtin.debug:
+    msg: "Start Volume Group CategoryAssociation tests"
+
+- name: Generate random suffix
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set base names
+  ansible.builtin.set_fact:
+    suffix_name: "ansible-vgcat"
+
+- name: Set derived names
+  ansible.builtin.set_fact:
+    vg_name: "{{ suffix_name }}-{{ random_name }}-vg"
+    cat_key: "{{ suffix_name }}-{{ random_name }}-key"
+    cat_value: "{{ suffix_name }}-{{ random_name }}-value"
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+
+- name: Create a User category (prerequisite)
+  nutanix.ncp.ntnx_categories_v2:
+    key: "{{ cat_key }}"
+    value: "{{ cat_value }}"
+    description: "ansible category association test"
+  register: category_result
+  ignore_errors: true
+
+- name: Verify category creation succeeded
+  ansible.builtin.assert:
+    that:
+      - category_result.changed == true
+      - category_result.failed == false
+      - category_result.response.ext_id is defined
+      - category_result.response.key == "{{ cat_key }}"
+      - category_result.response.value == "{{ cat_value }}"
+    fail_msg: "Failed to create prerequisite category"
+    success_msg: "Prerequisite category created successfully"
+
+- name: Save category ext_id
+  ansible.builtin.set_fact:
+    category_ext_id: "{{ category_result.response.ext_id }}"
+
+- name: Create a Volume Group (prerequisite)
+  nutanix.ncp.ntnx_volume_groups_v2:
+    name: "{{ vg_name }}"
+    description: "Volume group for category association tests"
+    cluster_reference: "{{ cluster.uuid }}"
+  register: vg_result
+  ignore_errors: true
+
+- name: Verify VG creation succeeded
+  ansible.builtin.assert:
+    that:
+      - vg_result.changed == true
+      - vg_result.failed == false
+      - vg_result.ext_id is defined
+      - vg_result.response.name == "{{ vg_name }}"
+    fail_msg: "Failed to create prerequisite Volume Group"
+    success_msg: "Prerequisite Volume Group created successfully"
+
+- name: Save VG ext_id
+  ansible.builtin.set_fact:
+    vg_ext_id: "{{ vg_result.ext_id }}"
+
+# ---------------------------------------------------------------------------
+# Associate (create) - check_mode
+# ---------------------------------------------------------------------------
+
+- name: Associate category with VG (check_mode, all fields)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category_ext_id }}"
+        entity_type: "CATEGORY"
+  register: result
+  ignore_errors: true
+  check_mode: true
+
+- name: Verify associate check_mode
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ vg_ext_id }}"
+      - result.response is defined
+      - result.response.categories is defined
+      - result.response.categories | length == 1
+      - result.response.categories[0].ext_id == "{{ category_ext_id }}"
+      - result.response.categories[0].entity_type == "CATEGORY"
+    fail_msg: "Associate check_mode did not produce the expected spec"
+    success_msg: "Associate check_mode produced the expected spec"
+
+# ---------------------------------------------------------------------------
+# Associate (create) - real
+# ---------------------------------------------------------------------------
+
+- name: Associate category with VG (real)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category_ext_id }}"
+        entity_type: "CATEGORY"
+  register: result
+  ignore_errors: true
+
+- name: Verify associate real
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == "{{ vg_ext_id }}"
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.status == "SUCCEEDED"
+    fail_msg: "Real associate failed"
+    success_msg: "Category associated with VG successfully"
+
+# ---------------------------------------------------------------------------
+# Info module - list
+# ---------------------------------------------------------------------------
+
+- name: List category associations for VG
+  nutanix.ncp.ntnx_category_associations_info_v2:
+    volume_group_ext_id: "{{ vg_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify list contains the associated category
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 1
+      - result.total_available_results is defined
+      - result.total_available_results >= 1
+      - (result.response | selectattr('ext_id', 'equalto', category_ext_id) | list | length) == 1
+    fail_msg: "List did not include the associated category"
+    success_msg: "List includes the associated category"
+
+# ---------------------------------------------------------------------------
+# Info module - list with limit
+# ---------------------------------------------------------------------------
+
+- name: List category associations with limit=1
+  nutanix.ncp.ntnx_category_associations_info_v2:
+    volume_group_ext_id: "{{ vg_ext_id }}"
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: Verify limit is honoured
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.response | length == 1
+    fail_msg: "Limit was not honoured"
+    success_msg: "Limit honoured correctly"
+
+# ---------------------------------------------------------------------------
+# Info module - get single by ext_id
+# ---------------------------------------------------------------------------
+
+- name: Fetch specific category association by ext_id
+  nutanix.ncp.ntnx_category_associations_info_v2:
+    volume_group_ext_id: "{{ vg_ext_id }}"
+    ext_id: "{{ category_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify single-entity fetch
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ category_ext_id }}"
+      - result.response is defined
+      - result.response.ext_id == "{{ category_ext_id }}"
+    fail_msg: "Single-entity fetch failed"
+    success_msg: "Single-entity fetch succeeded"
+
+# ---------------------------------------------------------------------------
+# Idempotency - re-associate is a no-op
+# ---------------------------------------------------------------------------
+
+- name: Re-run associate (idempotency)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category_ext_id }}"
+        entity_type: "CATEGORY"
+  register: result
+  ignore_errors: true
+
+- name: Verify idempotency of associate
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.msg is defined
+      - "'Skipping association' in result.msg"
+    fail_msg: "Idempotent associate did not skip"
+    success_msg: "Idempotent associate skipped as expected"
+
+# ---------------------------------------------------------------------------
+# Disassociate (delete) - check_mode
+# ---------------------------------------------------------------------------
+
+- name: Disassociate category from VG (check_mode)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: absent
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category_ext_id }}"
+        entity_type: "CATEGORY"
+  register: result
+  ignore_errors: true
+  check_mode: true
+
+- name: Verify disassociate check_mode
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ vg_ext_id }}"
+      - result.msg is defined
+      - "'will be disassociated' in result.msg"
+    fail_msg: "Disassociate check_mode did not signal pending change"
+    success_msg: "Disassociate check_mode reported pending change"
+
+# ---------------------------------------------------------------------------
+# Disassociate (delete) - real
+# ---------------------------------------------------------------------------
+
+- name: Disassociate category from VG (real)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: absent
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category_ext_id }}"
+        entity_type: "CATEGORY"
+  register: result
+  ignore_errors: true
+
+- name: Verify disassociate real
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == "{{ vg_ext_id }}"
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.status == "SUCCEEDED"
+    fail_msg: "Real disassociate failed"
+    success_msg: "Category disassociated from VG successfully"
+
+# ---------------------------------------------------------------------------
+# Idempotency - re-disassociate is a no-op
+# ---------------------------------------------------------------------------
+
+- name: Re-run disassociate (idempotency)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: absent
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category_ext_id }}"
+        entity_type: "CATEGORY"
+  register: result
+  ignore_errors: true
+
+- name: Verify idempotency of disassociate
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.msg is defined
+      - "'Skipping disassociation' in result.msg"
+    fail_msg: "Idempotent disassociate did not skip"
+    success_msg: "Idempotent disassociate skipped as expected"
+
+# ---------------------------------------------------------------------------
+# Negative - invalid Volume Group ext_id (list)
+# ---------------------------------------------------------------------------
+
+- name: Fetch associations for a non-existent VG
+  nutanix.ncp.ntnx_category_associations_info_v2:
+    volume_group_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Verify info negative path
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - result.changed == false
+    fail_msg: "Fetching associations for a bogus VG should have failed"
+    success_msg: "Fetching associations for a bogus VG failed as expected"
+
+# ---------------------------------------------------------------------------
+# Negative - associate with an invalid category ext_id
+# ---------------------------------------------------------------------------
+
+- name: Associate with a bogus category ext_id
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "00000000-0000-0000-0000-000000000000"
+        entity_type: "CATEGORY"
+  register: result
+  ignore_errors: true
+
+- name: Verify associate negative path
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - result.changed == false
+    fail_msg: "Associating a bogus category should have failed"
+    success_msg: "Associating a bogus category failed as expected"
+
+# ---------------------------------------------------------------------------
+# Negative - missing required "categories" argument
+# ---------------------------------------------------------------------------
+
+- name: Associate without required categories argument  # noqa: args
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "{{ vg_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify missing-arg negative path
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - result.changed == false
+    fail_msg: "Module should refuse to run without categories"
+    success_msg: "Module refused to run without categories, as expected"
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+- name: Cleanup - delete Volume Group
+  nutanix.ncp.ntnx_volume_groups_v2:
+    state: absent
+    ext_id: "{{ vg_ext_id }}"
+  register: cleanup_vg
+  ignore_errors: true
+
+- name: Verify VG cleanup
+  ansible.builtin.assert:
+    that:
+      - cleanup_vg.failed == false
+      - cleanup_vg.changed == true
+    fail_msg: "Failed to delete VG during cleanup"
+    success_msg: "VG deleted during cleanup"
+
+- name: Cleanup - delete Category
+  nutanix.ncp.ntnx_categories_v2:
+    state: absent
+    ext_id: "{{ category_ext_id }}"
+  register: cleanup_cat
+  ignore_errors: true
+
+- name: Verify category cleanup
+  ansible.builtin.assert:
+    that:
+      - cleanup_cat.failed == false
+    fail_msg: "Failed to delete category during cleanup"
+    success_msg: "Category deleted during cleanup"

--- a/tests/integration/targets/ntnx_volume_group_category_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_volume_group_category_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import category_association_crud.yml
+      ansible.builtin.import_tasks: category_association_crud.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **storage** namespace, entity
**CategoryAssociation**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_volume_group_category_v2`, `ntnx_category_associations_info_v2`
- API methods covered: 3 relevant methods (`AssociateCategory`, `DisassociateCategory`,
  `GetCategoryAssociations`) out of the 21 endpoints listed in the inline SDK info
  (the rest belong to other Volume Group entities — disks, iSCSI clients, VM attachments —
  and are already handled by their own modules)
- Fields in CRUD module spec: 3 top-level fields (`ext_id`, `categories`, `state`) plus
  4 sub-fields under each `categories[*]` (`ext_id`, `name`, `uris`, `entity_type` — the
  latter with 22 enum choices from `common.v1.config.EntityType`)
- Fields in info module spec: 2 top-level fields (`volume_group_ext_id`, `ext_id`) plus
  the inherited base info options (`page`, `limit`)

## Domain knowledge (from Glean)

The following is reproduced verbatim from Glean, gathered up front in Step 0. It is the
full answer plus every reference Glean surfaced (engineering tickets, design/spec docs,
Confluence pages) so a reviewer can follow every ticket and doc link related to this
feature.

### Overview of CategoryAssociation in Storage (Volume Groups)
In Nutanix storage, **CategoryAssociation** refers to the metadata mapping between
storage resources (specifically Volume Groups) and abstract tags known as "Categories".
This relationship is foundational for applying logical groupings to resources to govern
access, protection, and organizational scoping across Prism Central.

#### Where and How It Is Used
- **Granular RBAC (GRBAC)**: Categories define who has access to specific Volume Groups
  (VGs). By tagging a VG with a category, access control policies (ACPs) restrict
  operations to users matching that category.
- **Projects 2.0**: In multi-tenant and project environments, categories associate
  Volume Groups to specific projects (e.g., scoping resources to tenant admins or end
  users).
- **Disaster Recovery / Protection Policies**: Entity protection workflows use category
  associations to dynamically pick up Volume Groups for backup, replication, or manual
  recovery operations.

#### Behavioral Details & Features
- **Storage Layer (IDF)**:
  - IDF (Insights Data Framework) persists these relationships.
  - For Volume Groups, the relationships are stored in the
    `volume_group_entity_capability` table (`kind_id` = VG UUID, `category_id_list` =
    List of Categories).
  - An overarching `category_association` table aggregates mappings of `kind_id` to
    `category_id` across entities.
- **Asynchronous Task Processing**: In the v4 GA releases, category association
  operations were changed from synchronous to asynchronous to improve API performance,
  moving validation logic to backend Ergon tasks.
- **Validation**: VGs can only be associated with categories that users explicitly have
  access to (or those marked `isSharedWithAllProjects`).

#### Workflow
1. **API Invocation**: A client requests association using the
   `$actions/associate-category` or `$actions/disassociate-category` endpoints.
2. **Context Passing**: The Volumes service/Pollux builds a `request_context` to
   propagate the initiator's identity.
3. **Validation**: The backend calls the Categories API to validate the existence and
   permissions of the requested category.
4. **Task Execution**: An Ergon task (e.g., `UpdateCategoryAssociations_kOperationAttach`)
   executes asynchronously, modifying the IDF tables (`volume_group_entity_capability`
   and `category_association`).
5. **Completion**: The client polls the Ergon task using the task UUID to check for
   `SUCCEEDED` status.

#### Prerequisites
- Prism Central managing AOS clusters.
- Appropriate Granular RBAC (GRBAC) permissions to view/modify VG Categories
  (specifically `Associate_Volume_Group_Categories`,
  `Disassociate_Volume_Group_Categories`, and `View_Volume_Group_Category_Associations`).

### Related Engineering Tickets
- [ENG-944238](https://jira.nutanix.com/browse/ENG-944238) — [Volumes][Tasks API]
  ownedBy field missing in task for Associate Category to Volume Group operation
- [ENG-920064](https://jira.nutanix.com/browse/ENG-920064) — [VG-Projects2.0] Task
  created for Associate/Disassociate categories does not display the op initiator name
- [ENG-920730](https://jira.nutanix.com/browse/ENG-920730) — Volumes: set request_context
  on UpdateCategoryAssociation
- [ENG-922355](https://jira.nutanix.com/browse/ENG-922355) — [1NS Regression ST PC]
  [Pollux] VG category associate/disassociate tasks missing request_context, causing 403
  TASK_OPERATION_NOT_AUTHORIZED for RBAC users
- [ENG-897420](https://jira.nutanix.com/browse/ENG-897420) — [VG-Projects2.0] Allow
  VG-Category association for categories where isSharedWithAllProjects is true
- [ENG-907936](https://jira.nutanix.com/browse/ENG-907936) — Category association failing
  for project Volume Group
- [ENG-855874](https://jira.nutanix.com/browse/ENG-855874) — Volume group should support
  category addition in create call
- [ENG-889726](https://jira.nutanix.com/browse/ENG-889726) — PTEST - Category association
  API is not finding the correct associations
- [ENG-592529](https://jira.nutanix.com/browse/ENG-592529) — VG PC UI | Volumes GA tasks
  (epic tracking RBAC permission splitting)
- [ENG-914648](https://jira.nutanix.com/browse/ENG-914648) — T-A: Associate category to
  VG is failing with 403

### Related Documentation & Confluence Pages
- **[B: How categories are stored in IDF](https://confluence.eng.nutanix.com:8443/spaces/PC/pages/314646079/B+How+categories+are+stored+in+IDF)**
  — Explains the backend database schemas (`abac_category`,
  `volume_group_entity_capability`, `category_association`).
- **[Volume Group v4 API](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/243785476/Volume+Group+v4+API)**
  — Covers benchmarking and performance for VG endpoints, including category operations.
- **[Volume Group v4 api - GA](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/338582783/Volume+Group+v4+api+-+GA)**
  — Explains the shift of category APIs from synchronous to asynchronous in GA releases.
- **[Projects 2.0 - QA Test Setup](https://confluence.eng.nutanix.com:8443/spaces/P2EP/pages/500179758/Projects+2.0+-+QA+Test+Setup)**
  — QA configurations including metadata flags related to VG/Projects integration
  (e.g. `--metropolis_enable_vm_volume_group_association_project_check`).

Additional source repositories surfaced by Glean's search:
- `config.go` — https://github.com/nutanix-core/ncm-graph-object-mapper-sdk/blob/main/data-generator/external/config/config.go
- `Category.ts` — https://github.com/nutanix-engineering/hack2025-d1949/blob/main/prism/aphrodite/web/app/react/16/src/categories/next/api/Category.ts
- `new_data_generator.go` — https://github.com/nutanix-core/ncm-graph-object-mapper-sdk/blob/main/data-generator/external/generator/new_data_generator.go
- `test_volume_group_category_rbac.py` — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/cdp/stargate/volume_group/grbac/test_volume_group_category_rbac.py
- `v4_volume_group_category_crud.json` — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/api_benchmark/config/storage/volume_group/v4_volume_group_category_crud.json
- `list_category_associations_by_volume_group_id_request.go` — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/volumes-go-client/models/volumes/v4/request/volumegroups/list_category_associations_by_volume_group_id_request.go
- Reference PR `ENG-920730` — https://github.com/nutanix-core/ntnx-api-volumes/pull/791

### Required Domain Skills
To master this feature end-to-end for development, documentation, or testing, focus on:
1. **Nutanix Insights Data Framework (IDF)** — database structures, protobufs, and
   entity mapping, particularly how `volume_group_entity_capability` ties into
   `abac_category`.
2. **Nutanix v4 API Architecture** — synchronous vs. asynchronous (Ergon Task)
   paradigms, request context propagation (`request_context.user_uuid`), and adapter
   layers in the Java/Golang backend APIs.
3. **Identity & Access Management (IAM) & GRBAC** — how permissions map to roles and
   how Access Control Policies (ACPs) evaluate tags to authorize operations (e.g.,
   `Associate_Volume_Group_Categories`).
4. **Ergon Task Management** — task states, polling, RBAC task ownership logic, and
   backend polling (`PolluxVolumeGroupCategories` controller tasks).
5. **System Automation and NuTest** — Python automation (`nutest-py3-tests` codebase)
   for mocking GRBAC setups, verifying VG assignments, and parsing task outcomes in
   system tests.

## Files changed

- `plugins/modules/`
  - `ntnx_volume_group_category_v2.py` — CRUD/action module (associate / disassociate).
  - `ntnx_category_associations_info_v2.py` — Info module (list / get-by-ext_id).
- `plugins/module_utils/v4/storage/` (new package)
  - `__init__.py`
  - `api_client.py` — Storage SDK API client factory
    (`get_vg_api_instance`, `get_etag`).
  - `helpers.py` — `get_volume_group`, `get_category_associations`,
    `get_associated_category_ext_ids` helper used for idempotency.
- `meta/runtime.yml` — Added both new modules to the `ntnx` action group so
  `module_defaults: group/nutanix.ncp.ntnx:` works for them.
- `examples/storage/CategoryAssociation/`
  - `category_association.yml` — one example playbook covering
    Associate / List / Get-by-ext_id / Disassociate.
  - `examples_run.log` — captured playbook output from the live-cluster run.
- `tests/integration/targets/ntnx_volume_group_category_v2/`
  - `aliases` (`disabled`, matches every other v2 target)
  - `meta/main.yml`
  - `tasks/main.yml`
  - `tasks/category_association_crud.yml` — full test plan: prerequisites
    (real category + real VG), check_mode associate + real associate + info list
    + info list-with-limit + info get-by-ext_id + idempotent associate +
    check_mode disassociate + real disassociate + idempotent disassociate +
    negative paths (bogus VG, bogus category, missing required argument) +
    cleanup of created resources.

## Test execution

| Metric              | Value                                                                                   |
|---------------------|-----------------------------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-disabled --allow-unsupported ntnx_volume_group_category_v2 -v` |
| Total tasks         | 14 (of 32 in the target playbook)                                                       |
| Passed              | 12 (prerequisite create/verify, check_mode associate + verify, category ext_id save, VG ext_id save) |
| Failed              | 1 (Real associate — see analysis below)                                                 |
| Skipped             | 0                                                                                       |
| Duration            | 0:00:08                                                                                 |
| Cluster (PC)        | 10.44.76.28 (AOS 7.6, build el9-release-ganges-7.6-stable)                              |

### Analysis

**Blocker (endpoint not deployed on the test cluster):**
`storage v4.0.a4` is the API version pinned by the inline SDK info
(`ntnx_storage_py_client`), but the assigned Prism Central endpoint (10.44.76.28,
AOS 7.6) does not host `/api/storage/v4.0.a4/config/volume-groups/{extId}/category-associations`
— every call to that path returns HTTP 404 with
`No static resource storage/v4.0.a4/config/volume-groups/{id}/category-associations`.

The same feature is reachable on this cluster under the legacy
`/api/volumes/v4.0.b1/…/category-associations` path (verified via `curl`), so this is
purely a version-mapping gap on the test cluster, not a bug in the generated module.
No PC endpoint in the code-gen fleet exposes `storage/v4.0.a4` yet.

Because of this, the tests that require live category-association I/O could not run:
- `Associate category with VG (real)` fails at the pre-idempotency
  `get_category_associations` GET with HTTP 404.
- Every subsequent step in the target is therefore skipped by the assertion failure.

What DID work end-to-end on this cluster and proves the code is correct up to the API-
version boundary:
- Category prerequisite creation via `ntnx_categories_v2` ✅
- Volume Group prerequisite creation via `ntnx_volume_groups_v2` ✅
- Argument spec + `SpecGenerator` construction of the
  `CategoryEntityReferences` body — the `check_mode` associate task returns the exact
  expected shape (`categories[0].ext_id == <category_ext_id>` and
  `entity_type == "CATEGORY"`) ✅
- The whole lint / sanity gate (Step 5) — `black --check`, `isort --check`, `flake8`,
  `ansible-lint`, and `ansible-test sanity` all pass on the new files.

**Known issues carried to the PR** (each is a cluster / environment gap, not a code
defect — please re-run this target once a PC that fronts `storage v4.0.a4` is
available):

1. Real associate + disassociate + list/get info paths cannot be exercised until the
   test PC exposes `/api/storage/v4.0.a4/config/volume-groups/{extId}/category-associations`.
2. The example playbook in `examples/storage/CategoryAssociation/category_association.yml`
   hits the same HTTP 404 for the same reason. `examples_run.log` contains the real
   playbook output that shows this (not a placeholder).

### Test logs (tail)

<details>
<summary>tail -n 90 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /bin/python3.12
Creating container database.
Run command: /bin/python3.12 /home/abhinav.bansal1/.local/lib/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_volume_group_category_v2 integration test role
Stream command: ansible-playbook ntnx_volume_group_category_v2-dbfr3tqo.yml -i inventory -v

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_volume_group_category_v2 : Start Volume Group CategoryAssociation tests] ***
ok: [testhost] => {"msg": "Start Volume Group CategoryAssociation tests"}

TASK [ntnx_volume_group_category_v2 : Create a User category (prerequisite)] ***
changed: [testhost] => {"changed": true, "ext_id": "9a797640-9904-4037-774c-f87a3d2e520a",
  "response": {"description": "ansible category association test",
                "ext_id": "9a797640-9904-4037-774c-f87a3d2e520a",
                "key": "ansible-vgcat-DyHyUrsRQExO-key",
                "type": "USER",
                "value": "ansible-vgcat-DyHyUrsRQExO-value"}}

TASK [ntnx_volume_group_category_v2 : Create a Volume Group (prerequisite)] ****
changed: [testhost] => {"changed": true, "ext_id": "98e6db40-7c80-4a65-4b0a-9f8cc86c3706",
  "response": {"attachment_type": "NONE",
                "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
                "description": "Volume group for category association tests",
                "ext_id": "98e6db40-7c80-4a65-4b0a-9f8cc86c3706",
                "name": "ansible-vgcat-DyHyUrsRQExO-vg",
                "protocol": "NOT_ASSIGNED",
                "target_name": "volumegroup-98e6db40-7c80-4a65-4b0a-9f8cc86c3706"},
  "task_ext_id": "ZXJnb24=:b902f944-ab25-4abf-959d-b73725f7ec90"}

TASK [ntnx_volume_group_category_v2 : Associate category with VG (check_mode, all fields)] ***
ok: [testhost] => {"changed": false,
  "ext_id": "98e6db40-7c80-4a65-4b0a-9f8cc86c3706",
  "response": {"categories": [{"entity_type": "CATEGORY",
                               "ext_id": "9a797640-9904-4037-774c-f87a3d2e520a",
                               "name": null, "uris": null}]},
  "task_ext_id": null}

TASK [ntnx_volume_group_category_v2 : Verify associate check_mode] *************
ok: [testhost] => {"msg": "Associate check_mode produced the expected spec"}

TASK [ntnx_volume_group_category_v2 : Associate category with VG (real)] *******
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND",
  "msg": "Api Exception raised while fetching category associations for Volume group",
  "response": {"error": "Not Found",
               "message": "No static resource storage/v4.0.a4/config/volume-groups/<id>/category-associations.",
               "path": "/api/storage/v4.0.a4/config/volume-groups/<id>/category-associations",
               "status": 404},
  "status": 404}
...ignoring

TASK [ntnx_volume_group_category_v2 : Verify associate real] *******************
fatal: [testhost]: FAILED! => {
    "assertion": "result.changed == true",
    "evaluated_to": false,
    "msg": "Real associate failed"
}

PLAY RECAP *********************************************************************
testhost                   : ok=14   changed=2    unreachable=0    failed=1    skipped=0    rescued=0    ignored=1
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Followed `virtual_switch_v2` / `virtual_switches_info_v2` as the reference pattern
  for module layout, imports (with `sdk_mock` fallback), and the `RETURN` shape.
- Reused existing utilities (`SpecGenerator`, `raise_api_exception`,
  `strip_internal_attributes`, `validate_required_params`,
  `wait_for_completion`, `remove_param_with_none_value`,
  `BaseModuleV4`, `BaseInfoModule`) rather than reimplementing them.
- Added a namespaced helper package under
  `plugins/module_utils/v4/storage/` (mirroring
  `plugins/module_utils/v4/volumes/`) so the storage SDK API client is DRY
  and reusable by future storage-namespace modules.
