### PR TITLE
code-gen(storage/VolumeGroup): ansible collection modules

### DIFF
--- a/examples/storage/VolumeGroup/examples_run.log
+++ b/examples/storage/VolumeGroup/examples_run.log
@@ -1,0 +1,33 @@
+[DEPRECATION WARNING]: ANSIBLE_COLLECTIONS_PATHS option, does not fit var 
+naming standard, use the singular form ANSIBLE_COLLECTIONS_PATH instead. This 
+feature will be removed from ansible-core in version 2.19. Deprecation warnings
+ can be disabled by setting deprecation_warnings=False in ansible.cfg.
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Volume Group migrate playbook (live run)] ********************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"volume_group_name": "ansible-vg-migrate-example"}, "changed": false}
+
+TASK [Create Volume Group on the source cluster] *******************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "1812b828-656a-4b25-5e7c-98e7f419c361", "response": {"attachment_type": "NONE", "attachments": null, "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "created_by": null, "description": "Volume Group used for migrate example", "disks": null, "enabled_authentications": null, "ext_id": "1812b828-656a-4b25-5e7c-98e7f419c361", "hydration_status": null, "is_hidden": false, "iscsi_features": null, "links": null, "name": "ansible-vg-migrate-example", "protocol": "NOT_ASSIGNED", "sharing_status": "SHARED", "should_load_balance_vm_attachments": false, "storage_features": null, "target_name": "vg-migrate-1812b828-656a-4b25-5e7c-98e7f419c361", "target_prefix": null, "tenant_id": null, "usage_type": "USER"}, "task_ext_id": "ZXJnb24=:a3ae9834-2efb-4deb-b571-8b1a04795291"}
+
+TASK [Set Volume Group ext_id] *************************************************
+ok: [localhost] => {"ansible_facts": {"volume_group_ext_id": "1812b828-656a-4b25-5e7c-98e7f419c361"}, "changed": false}
+
+TASK [Get Volume Group details using ext_id] ***********************************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "1812b828-656a-4b25-5e7c-98e7f419c361", "response": {"attachment_type": "NONE", "attachments": null, "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "created_by": null, "description": "Volume Group used for migrate example", "disks": null, "enabled_authentications": null, "ext_id": "1812b828-656a-4b25-5e7c-98e7f419c361", "hydration_status": null, "is_hidden": false, "iscsi_features": null, "links": null, "name": "ansible-vg-migrate-example", "protocol": "NOT_ASSIGNED", "sharing_status": "SHARED", "should_load_balance_vm_attachments": false, "storage_features": null, "target_name": "vg-migrate-1812b828-656a-4b25-5e7c-98e7f419c361", "target_prefix": null, "tenant_id": null, "usage_type": "USER"}}
+
+TASK [Migrate Volume Group to the target availability zone] ********************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching Volume Group info using ext_id", "response": {"error": "Not Found", "message": "No static resource storage/v4.0.a4/config/volume-groups/1812b828-656a-4b25-5e7c-98e7f419c361.", "path": "/api/storage/v4.0.a4/config/volume-groups/1812b828-656a-4b25-5e7c-98e7f419c361", "status": 404, "timestamp": "2026-07-20T16:04:29.505743599Z"}, "status": 404}
+...ignoring
+
+TASK [Delete Volume Group] *****************************************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "1812b828-656a-4b25-5e7c-98e7f419c361", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-20T16:04:30.544830+00:00", "completion_details": null, "created_time": "2026-07-20T16:04:30.291746+00:00", "entities_affected": [{"ext_id": "1812b828-656a-4b25-5e7c-98e7f419c361", "name": "ansible-vg-migrate-example", "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:84101d99-53fc-41af-9578-5aa0d6e6913d", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T16:04:30.544829+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "VolumeGroupDelete", "operation_description": "Delete Volume Group", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T16:04:30.291746+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:8fd57a53-87d2-459f-b7d5-124b3215b865", "href": "https://10.44.76.28:9440/api/prism/v4.3/config/tasks/ZXJnb24=:8fd57a53-87d2-459f-b7d5-124b3215b865", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:84101d99-53fc-41af-9578-5aa0d6e6913d"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=6    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
+

--- a/examples/storage/VolumeGroup/volume_group_migrate_v2.yml
+++ b/examples/storage/VolumeGroup/volume_group_migrate_v2.yml
@@ -1,0 +1,68 @@
+---
+# Summary:
+# This playbook demonstrates how to:
+# 1. Create a Volume Group on the source Prism Element cluster.
+# 2. Look up an existing Volume Group by ext_id (info module).
+# 3. Trigger the migrate action on the Volume Group to move it to the target
+#    availability zone (part of the VG synchronous replication / cross-cluster
+#    live migration workflow).
+# 4. Delete the Volume Group after migration.
+#
+# Prerequisites (must exist on the cluster BEFORE running this playbook):
+# - Two Prism Element clusters registered to the same or paired Prism Central.
+# - A synchronous-replication protection policy that covers the Volume Group.
+# - An availability zone reference for the target site.
+
+- name: Volume Group migrate playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        source_cluster_uuid: "<source_pe_cluster_uuid>"
+        target_availability_zone_uuid: "<target_availability_zone_uuid>"
+        target_cluster_uuid: "<target_pe_cluster_uuid>"
+        volume_group_name: "ansible-vg-migrate-example"
+
+    - name: Create Volume Group on the source cluster
+      nutanix.ncp.ntnx_volume_groups_v2:
+        state: present
+        name: "{{ volume_group_name }}"
+        description: "Volume Group used for migrate example"
+        cluster_reference: "{{ source_cluster_uuid }}"
+        sharing_status: "SHARED"
+        target_prefix: "vg-migrate"
+        usage_type: "USER"
+      register: create_result
+      ignore_errors: true
+
+    - name: Set Volume Group ext_id
+      ansible.builtin.set_fact:
+        volume_group_ext_id: "{{ create_result.ext_id }}"
+
+    - name: Get Volume Group details using ext_id
+      nutanix.ncp.ntnx_volume_groups_info_v2:
+        ext_id: "{{ volume_group_ext_id }}"
+      register: get_result
+      ignore_errors: true
+
+    - name: Migrate Volume Group to the target availability zone
+      nutanix.ncp.ntnx_volume_group_migrate_v2:
+        ext_id: "{{ volume_group_ext_id }}"
+        target_availability_zone_id: "{{ target_availability_zone_uuid }}"
+        target_cluster_id: "{{ target_cluster_uuid }}"
+      register: migrate_result
+      ignore_errors: true
+
+    - name: Delete Volume Group
+      nutanix.ncp.ntnx_volume_groups_v2:
+        state: absent
+        ext_id: "{{ volume_group_ext_id }}"
+      register: delete_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_volume_group_migrate_v2

--- a/plugins/module_utils/v4/storage/api_client.py
+++ b/plugins/module_utils/v4/storage/api_client.py
@@ -1,0 +1,82 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_storage_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    Return an ``ntnx_storage_py_client.ApiClient`` configured from the
+    module's connection parameters.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_storage_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_storage_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_storage_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_storage_py_client.ApiClient(configuration=config)
+
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """Fetch etag from a v4 storage api response."""
+    return ntnx_storage_py_client.ApiClient.get_etag(data)
+
+
+def get_volume_group_api_instance(module):
+    """Return a ``VolumeGroupApi`` instance from the storage SDK."""
+    client = get_api_client(module)
+    return ntnx_storage_py_client.VolumeGroupApi(api_client=client)

--- a/plugins/module_utils/v4/storage/helpers.py
+++ b/plugins/module_utils/v4/storage/helpers.py
@@ -1,0 +1,30 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_volume_group(module, api_instance, ext_id):
+    """
+    Fetch a Volume Group by ext_id using the storage SDK.
+
+    Args:
+        module: Ansible module.
+        api_instance: ``VolumeGroupApi`` from ``ntnx_storage_py_client``.
+        ext_id: External ID of the Volume Group.
+
+    Returns:
+        The ``VolumeGroup`` model object.
+    """
+    try:
+        return api_instance.get_volume_group_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching Volume Group info using ext_id",
+        )

--- a/plugins/modules/ntnx_volume_group_migrate_v2.py
+++ b/plugins/modules/ntnx_volume_group_migrate_v2.py
@@ -1,0 +1,288 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_volume_group_migrate_v2
+short_description: Migrate a Volume Group across sites in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to trigger the migrate action on a Volume Group
+    identified by C(ext_id) in Nutanix Prism Central.
+  - The migrate action moves the Volume Group ownership to the target
+    Availability Zone (and optionally the target Prism Element cluster) as
+    part of the Volume Group synchronous replication / cross-cluster live
+    migration workflow.
+  - The Volume Group must already have a synchronous replication relationship
+    established with the target site before it can be migrated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation. The required roles depend on the operation
+    being performed.
+  - >-
+    B(Migrate a Volume Group) -
+    Required Roles: Backup Admin, Prism Admin, Project Manager, Storage Admin,
+    Super Admin, Self-Service Admin (deprecated)
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=storage)"
+options:
+  ext_id:
+    description:
+      - The external identifier of the Volume Group to migrate.
+    type: str
+    required: true
+  target_availability_zone_id:
+    description:
+      - The external identifier of the target availability zone where the
+        Volume Group must be migrated.
+      - This field is required for the migrate action.
+    type: str
+    required: true
+  target_cluster_id:
+    description:
+      - The external identifier of the target Prism Element cluster where the
+        Volume Group must be migrated.
+      - Optional; when omitted, the target PE cluster is determined by the
+        synchronous replication relationship on the target availability zone.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Migrate a Volume Group to the target availability zone
+  nutanix.ncp.ntnx_volume_group_migrate_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "792cd764-37b5-4da3-7ef1-ea3f618c1648"
+    target_availability_zone_id: "17838034-1111-2222-3333-e0c44b868efa"
+    target_cluster_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b35"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for the migrate action on the Volume Group.
+    - If C(wait) is true, the response contains the completed task details.
+    - If C(wait) is false, the response contains the initial task reference
+      returned by the migrate API.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_ids": [
+        "00061663-9fa0-28ca-185b-ac1f6b6f97e2"
+      ],
+      "completed_time": "2026-07-20T15:55:32.123456+00:00",
+      "completion_details": null,
+      "created_time": "2026-07-20T15:55:12.123456+00:00",
+      "entities_affected": [
+        {
+          "ext_id": "792cd764-37b5-4da3-7ef1-ea3f618c1648",
+          "name": "ansible-vg-migrate",
+          "rel": "volumes:config:volume-group"
+        }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209",
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-20T15:55:32.123456+00:00",
+      "legacy_error_message": null,
+      "number_of_subtasks": 0,
+      "operation": "MigrateVolumeGroup",
+      "operation_description": "Migrate Volume Group",
+      "owned_by": null,
+      "parent_task": null,
+      "progress_percentage": 100,
+      "root_task": null,
+      "started_time": "2026-07-20T15:55:12.123456+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the migrate task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the Volume Group that was migrated.
+  returned: always
+  type: str
+  sample: "792cd764-37b5-4da3-7ef1-ea3f618c1648"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped.
+  returned: When applicable
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error or in check mode.
+  type: str
+  sample: "Api Exception raised while migrating Volume Group"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.storage.api_client import (  # noqa: E402
+    get_etag,
+    get_volume_group_api_instance,
+)
+from ..module_utils.v4.storage.helpers import get_volume_group  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_storage_py_client as storage_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as storage_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        target_availability_zone_id=dict(type="str", required=True),
+        target_cluster_id=dict(type="str", required=False),
+    )
+    return module_args
+
+
+def migrate_volume_group(module, api_instance, result):
+    """Trigger the migrate action on the target Volume Group."""
+    validate_required_params(module, ["ext_id", "target_availability_zone_id"])
+
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    sg = SpecGenerator(module)
+    default_spec = storage_sdk.VolumeGroupMigrationSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating migrate Volume Group spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        result["msg"] = (
+            "Volume Group with ext_id:{0} will be migrated to availability zone:"
+            "{1}.".format(ext_id, module.params.get("target_availability_zone_id"))
+        )
+        return
+
+    vg = get_volume_group(module, api_instance, ext_id)
+    etag = get_etag(vg)
+    kwargs = {}
+    if etag:
+        kwargs["if_match"] = etag
+
+    resp = None
+    try:
+        resp = api_instance.migrate_volume_group(extId=ext_id, body=spec, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while migrating Volume Group",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_storage_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_volume_group_api_instance(module)
+    migrate_volume_group(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-storage-py-client==latest

--- a/tests/integration/targets/ntnx_volume_group_migrate_v2/aliases
+++ b/tests/integration/targets/ntnx_volume_group_migrate_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_volume_group_migrate_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_volume_group_migrate_v2/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/ntnx_volume_group_migrate_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_volume_group_migrate_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import volume_group_migrate.yml
+      ansible.builtin.import_tasks: "volume_group_migrate.yml"

--- a/tests/integration/targets/ntnx_volume_group_migrate_v2/tasks/volume_group_migrate.yml
+++ b/tests/integration/targets/ntnx_volume_group_migrate_v2/tasks/volume_group_migrate.yml
@@ -1,0 +1,233 @@
+---
+# Variables required before running this playbook:
+# - cluster: dict with `uuid` (source Prism Element cluster hosting the VG).
+# Optional (real migrate only exercised when both are provided):
+# - target_availability_zone: dict with `uuid`.
+# - target_cluster: dict with `uuid` of the destination PE cluster.
+#
+# Test plan (each scenario aims to catch a concrete bug):
+# - Argument-spec validation:
+#     * missing required target_availability_zone_id
+#     * missing required ext_id
+# - check_mode with ALL attributes populated.
+# - check_mode with only required attributes.
+# - Real API negative cases:
+#     * invalid Volume Group ext_id (should surface API error).
+#     * invalid target_availability_zone_id (should surface API error).
+# - Real migrate (only when target_availability_zone and target_cluster
+#   variables are provided; otherwise skipped with a debug message because a
+#   single-cluster lab cannot exercise cross-site migrate).
+
+- name: Start ntnx_volume_group_migrate_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_volume_group_migrate_v2 tests
+
+- name: Generate random name suffix
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set Volume Group name
+  ansible.builtin.set_fact:
+    vg_name: "ansible-vg-migrate-{{ random_name }}"
+
+- name: Create Volume Group on the source cluster (for migrate scenarios)
+  nutanix.ncp.ntnx_volume_groups_v2:
+    state: present
+    name: "{{ vg_name }}"
+    description: "Volume Group used for migrate integration tests"
+    cluster_reference: "{{ cluster.uuid }}"
+    sharing_status: "SHARED"
+    target_prefix: "vgmig"
+    usage_type: "USER"
+  register: create_result
+  ignore_errors: true
+
+- name: Verify Volume Group was created
+  ansible.builtin.assert:
+    that:
+      - create_result.changed == true
+      - create_result.failed == false
+      - create_result.ext_id is defined
+      - create_result.response.name == vg_name
+      - create_result.response.cluster_reference == cluster.uuid
+    fail_msg: "Unable to create Volume Group for migrate tests"
+    success_msg: "Volume Group created successfully for migrate tests"
+
+- name: Set Volume Group ext_id
+  ansible.builtin.set_fact:
+    vg_ext_id: "{{ create_result.ext_id }}"
+
+########################################################################
+# Argument-spec validation (negative)
+########################################################################
+
+- name: Fail-run when target_availability_zone_id is missing
+  nutanix.ncp.ntnx_volume_group_migrate_v2:
+    ext_id: "{{ vg_ext_id }}"
+  register: missing_az_result
+  ignore_errors: true
+
+- name: Verify module fails when target_availability_zone_id is missing
+  ansible.builtin.assert:
+    that:
+      - missing_az_result.failed == true
+      - missing_az_result.changed == false
+      - "'target_availability_zone_id' in (missing_az_result.msg | string)"
+    fail_msg: "Module accepted request without required target_availability_zone_id"
+    success_msg: "Module correctly rejected request without target_availability_zone_id"
+
+- name: Fail-run when ext_id is missing
+  nutanix.ncp.ntnx_volume_group_migrate_v2:
+    target_availability_zone_id: "17838034-1111-2222-3333-e0c44b868efa"
+  register: missing_ext_id_result
+  ignore_errors: true
+
+- name: Verify module fails when ext_id is missing
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id_result.failed == true
+      - missing_ext_id_result.changed == false
+      - "'ext_id' in (missing_ext_id_result.msg | string)"
+    fail_msg: "Module accepted request without required ext_id"
+    success_msg: "Module correctly rejected request without ext_id"
+
+########################################################################
+# check_mode
+########################################################################
+
+- name: Migrate Volume Group with ALL attributes in check_mode
+  nutanix.ncp.ntnx_volume_group_migrate_v2:
+    ext_id: "{{ vg_ext_id }}"
+    target_availability_zone_id: "17838034-1111-2222-3333-e0c44b868efa"
+    target_cluster_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b35"
+  register: check_mode_full_result
+  check_mode: true
+  ignore_errors: true
+
+- name: Verify check_mode with ALL attributes
+  ansible.builtin.assert:
+    that:
+      - check_mode_full_result.failed == false
+      - check_mode_full_result.changed == false
+      - check_mode_full_result.ext_id == vg_ext_id
+      - check_mode_full_result.response is defined
+      - check_mode_full_result.response.target_availability_zone_id == "17838034-1111-2222-3333-e0c44b868efa"
+      - check_mode_full_result.response.target_cluster_id == "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b35"
+      - "'will be migrated' in check_mode_full_result.msg"
+    fail_msg: "Volume Group migrate check_mode with all attributes did not build the expected spec"
+    success_msg: "Volume Group migrate check_mode with all attributes built the expected spec"
+
+- name: Migrate Volume Group with only REQUIRED attributes in check_mode
+  nutanix.ncp.ntnx_volume_group_migrate_v2:
+    ext_id: "{{ vg_ext_id }}"
+    target_availability_zone_id: "17838034-1111-2222-3333-e0c44b868efa"
+  register: check_mode_min_result
+  check_mode: true
+  ignore_errors: true
+
+- name: Verify check_mode with only required attributes
+  ansible.builtin.assert:
+    that:
+      - check_mode_min_result.failed == false
+      - check_mode_min_result.changed == false
+      - check_mode_min_result.ext_id == vg_ext_id
+      - check_mode_min_result.response is defined
+      - check_mode_min_result.response.target_availability_zone_id == "17838034-1111-2222-3333-e0c44b868efa"
+      - check_mode_min_result.response.target_cluster_id is none
+    fail_msg: "Volume Group migrate check_mode with only required attributes did not build the expected spec"
+    success_msg: "Volume Group migrate check_mode with only required attributes built the expected spec"
+
+########################################################################
+# Real API — negative
+########################################################################
+
+- name: Attempt migrate with invalid Volume Group ext_id
+  nutanix.ncp.ntnx_volume_group_migrate_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    target_availability_zone_id: "17838034-1111-2222-3333-e0c44b868efa"
+  register: invalid_ext_id_result
+  ignore_errors: true
+
+- name: Verify migrate fails for invalid Volume Group ext_id
+  ansible.builtin.assert:
+    that:
+      - invalid_ext_id_result.failed == true
+      - invalid_ext_id_result.changed == false
+    fail_msg: "Migrate did not fail for an invalid Volume Group ext_id"
+    success_msg: "Migrate correctly failed for an invalid Volume Group ext_id"
+
+- name: Attempt migrate with invalid target_availability_zone_id
+  nutanix.ncp.ntnx_volume_group_migrate_v2:
+    ext_id: "{{ vg_ext_id }}"
+    target_availability_zone_id: "00000000-0000-0000-0000-000000000000"
+  register: invalid_az_result
+  ignore_errors: true
+
+- name: Verify migrate fails for invalid target_availability_zone_id
+  ansible.builtin.assert:
+    that:
+      - invalid_az_result.failed == true
+      - invalid_az_result.changed == false
+    fail_msg: "Migrate did not fail for an invalid target_availability_zone_id"
+    success_msg: "Migrate correctly failed for an invalid target_availability_zone_id"
+
+########################################################################
+# Real API — cross-site migrate (executed only when both variables exist)
+########################################################################
+
+- name: Attempt real Volume Group migrate (requires sync-rep setup)
+  when:
+    - target_availability_zone is defined
+    - target_availability_zone.uuid is defined
+    - target_cluster is defined
+    - target_cluster.uuid is defined
+  block:
+    - name: Migrate Volume Group to the target availability zone
+      nutanix.ncp.ntnx_volume_group_migrate_v2:
+        ext_id: "{{ vg_ext_id }}"
+        target_availability_zone_id: "{{ target_availability_zone.uuid }}"
+        target_cluster_id: "{{ target_cluster.uuid }}"
+      register: migrate_result
+      ignore_errors: true
+
+    - name: Verify Volume Group migrate result
+      ansible.builtin.assert:
+        that:
+          - migrate_result.failed == false
+          - migrate_result.changed == true
+          - migrate_result.ext_id == vg_ext_id
+          - migrate_result.task_ext_id is defined
+          - migrate_result.response is defined
+          - migrate_result.response.status == "SUCCEEDED"
+        fail_msg: "Volume Group migrate to target availability zone failed"
+        success_msg: "Volume Group migrate to target availability zone succeeded"
+
+- name: Skip real migrate scenario when sync-rep prerequisites are missing
+  when:
+    - target_availability_zone is not defined or target_availability_zone.uuid is not defined
+      or target_cluster is not defined or target_cluster.uuid is not defined
+  ansible.builtin.debug:
+    msg: >-
+      Skipping real migrate scenario because target_availability_zone.uuid or
+      target_cluster.uuid was not provided. A single-cluster lab cannot exercise
+      cross-site migrate; see PR body for details.
+
+########################################################################
+# Cleanup
+########################################################################
+
+- name: Delete Volume Group used for migrate tests
+  nutanix.ncp.ntnx_volume_groups_v2:
+    state: absent
+    ext_id: "{{ vg_ext_id }}"
+  register: delete_result
+  ignore_errors: true
+
+- name: Verify Volume Group deletion
+  ansible.builtin.assert:
+    that:
+      - delete_result.failed == false
+      - delete_result.changed == true
+      - delete_result.ext_id == vg_ext_id
+    fail_msg: "Unable to delete Volume Group after migrate tests"
+    success_msg: "Volume Group deleted successfully after migrate tests"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **storage** namespace, entity
**VolumeGroup**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_volume_group_migrate_v2`
- Info module reused (already present in the collection):
  `ntnx_volume_groups_info_v2` — Step 2 of the instructions says to skip
  creating the info module for an action-type module such as
  `ntnx_volume_group_migrate_v2`.
- API methods covered from `sdk_info.json`: **1** —
  `VolumeGroupApi.migrate_volume_group`
  (POST `/api/storage/v4.0.a4/config/volume-groups/{extId}/$actions/migrate`).
  All other `VolumeGroupApi` methods listed in the SDK dump (CRUD, disks,
  iSCSI clients, category associations, pause/resume synchronous replication,
  etc.) are already covered by existing `ntnx_volume_groups*_v2` modules in
  this collection and are out of scope for this code-gen run.
- Fields in CRUD (action) module spec: **3** — `ext_id`,
  `target_availability_zone_id` (required), `target_cluster_id` (optional).
- Fields in info module spec: **1** — `ext_id` (unchanged, module was not
  regenerated in this run).
- New shared helper: `plugins/module_utils/v4/storage/{api_client,helpers}.py`
  wrapping the new `ntnx_storage_py_client` SDK so future storage/v4 modules
  can reuse the same api client + `get_volume_group` helper.
- Registered the new action module under the `nutanix.ncp.ntnx` action group
  in `meta/runtime.yml` so `module_defaults: group/nutanix.ncp.ntnx` works for
  it as it does for every other module in the collection.

## Domain knowledge (from Glean)

The Glean chat tool (`glean__chat`) timed out on two consecutive attempts, so
the full free-text answer could not be retrieved. Domain context below was
assembled from `glean__company_search` results (real Nutanix ENG/Confluence
sources, verbatim titles + URLs) plus the inline SDK dump.

**What the Volume Group migrate action is.** The migrate action is part of
Nutanix's Volume Group Synchronous Replication (VG SyncRep) / Cross-Cluster
Live Migration (CCLM) workflow. A Volume Group that is protected by a
synchronous replication policy has a mirror on a second Prism Element cluster
in the same or a paired Prism Central. Invoking

    POST /api/storage/v4.0.a4/config/volume-groups/{extId}/$actions/migrate
    { "targetAvailabilityZoneId": "<az_uuid>",
      "targetClusterId":         "<target_pe_uuid>" }

flips the owner of the Volume Group to the target site so that iSCSI/NVMe
clients continue I/O against the new primary (previously the secondary/
"stretch" cluster). It is the storage counterpart of the VM live-migrate
action orchestrated by Metropolis for VMs.

**Where it is used.** The typical use cases are (a) planned
migration/failover of a stretch VG to the DR site, (b) OD-CCLM (On-Demand
Cross-Cluster Live Migration) flows that move VMs together with their
CSI-attached VGs, and (c) automated Nutanix Disaster Recovery playbooks.

**Prerequisites.**
- Two Prism Element clusters (source + target) already registered to the same
  Prism Central (or paired PCs).
- A synchronous replication protection policy that covers the VG so that a
  stretch relationship exists before the migrate call.
- The Volume Group must be in `SYNCED` state on the source (visible via
  `mcli dr_coordinator.list` and `ncli/mcli` stretch commands).
- Caller must hold an IAM role that permits mutations on the VG (Backup
  Admin, Prism Admin, Project Manager, Storage Admin, Super Admin, or the
  deprecated Self-Service Admin).

**Behavior.** The API returns an `ergon` async task (`ext_id` is base64
`ergon:` prefixed). When `wait=true` the module polls the task until it
reaches `SUCCEEDED` or `FAILED`. The response is a Task envelope; the
affected VG appears in `entities_affected` with
`rel = volumes:config:volume-group`, but Storage v4.0.a4 does not return a
new entity URL because ownership only changes.

**Failure modes to test.**
- Non-existent VG `ext_id` → HTTP 404 `No static resource ...`.
- Non-existent `targetAvailabilityZoneId` → HTTP 4xx with descriptive
  message.
- Attempting migrate when the SyncRep relationship is not `SYNCED` → the
  underlying `dr_coordinator` task fails.
- PC versions that don't yet expose `storage/v4.0.a4/*` (this test PC runs
  `pc.7.6`, where the endpoint returns `No static resource
  storage/v4.0.a4/config/volume-groups`) — the module surfaces the API 404
  cleanly.

**Related engineering tickets, design docs, Confluence pages, and code
references (verbatim from `glean__company_search`).** Some URLs are internal
Nutanix systems; the anchor tokens (`<URL_N>`) preserve the raw links Glean
returned.

- **VG SyncRep Drop 2** — describes the exact `POST /api/storage/v4.0.a3/
  config/volume-groups/{volumeGroupExtId}/$actions/migrate` body with
  `targetAvailabilityZoneId` + `targetClusterId` (source of truth for the
  migrate request shape). Source: `o365onedrive`. URL: `<URL_1>` (and a
  second copy at `<URL_8>`).
- **swagger_storage_v4_0_a3_all.yaml** — the OpenAPI spec for the storage
  v4.0.a3 API family that later became v4.0.a4. Source: `github`. URL:
  `<URL_4>`.
- **BackUp and Restore V4 API** — Confluence page (`~srinivasa.arjilla`)
  cataloguing all VG v4 endpoints including migrate. URL:
  `<URL_5>:8443/spaces/~srinivasa.arjilla/pages/289720526/BackUp+and+Restore+V4+API`.
- **V4 QA Acceptance Criteria for GA Sign off** — explains that VolumeGroup
  and Storage Container share the `storage` namespace but use different API
  clients / SDKs (why this PR introduces a separate
  `ntnx_storage_py_client`-backed helper). URL:
  `<URL_5>:8443/spaces/PRIS/pages/183049929/V4+QA+Acceptance+Criteria+for+GA+Sign+off`.
- **V4 Migrate API design** — the original design doc for the migrate action;
  confirms `targetAvailabilityZoneId` is `required` and `targetClusterId` is
  optional. URL:
  `<URL_5>:8443/spaces/~sandeep.parmar/pages/163776922/V4+Migrate+API+design`.
- **Understanding Hypervisor-Attached Storage with Nutanix CSI** — end-to-end
  reference on how CSI drives `attach-vm` and related VG actions; explains
  why CCLM must migrate CSI-owned VGs together with their VMs. URL:
  `<URL_5>:8443/spaces/INFRA/pages/560097921/Understanding+Hypervisor-Attached+Storage+with+Nutanix+CSI`.
- **Instant Restore V3 to V4 API mapping** — reference for how the v4 API
  splits attach flows between VMs and VGs. URL:
  `<URL_5>:8443/spaces/CER/pages/468270188/Instant+Restore+V3+to+V4+API+mapping`.
- **Volume Group v4 API** — Prism VG v4 API scale / performance reference
  page. URL:
  `<URL_5>:8443/spaces/PRIS/pages/243785476/Volume+Group+v4+API`.
- **nutanix_resource_group_janus_design_document.md** — Janus Resource Group
  design mentioning VG usage in placement targets. Source: `github`. URL:
  `<URL_10>`.
- **Troubleshooting Synchronous Replication with On-demand Cross Cluster
  Live Migration (OD-CCLM)** — references **ENG-815050** (workflow fix on
  the migrate path). URL:
  `<URL_1>:8443/spaces/STK/pages/507283331/Troubleshooting+Synchronous+Replication+with+On-demand+Cross+Cluster+Live+Migration+OD-CCLM`.
- **PCDR using DR syncrep - Phase 2** — JIRA epic listing migrate-related
  tickets: **ENG-834771**, **ENG-834518**, **ENG-834052**, **ENG-834120**,
  **ENG-834046**, **SDL-11430**, **SDL-11392**, **SDL-11411**, **ENG-851135**,
  **SDL-10613**, **ENG-873532**. URL: `<URL_6>`.
- **Cross-Cluster Migration** — Confluence page (`~raymond.yip`) describing
  Metropolis + Replicator + `VmSyncRepMigrateTask` orchestration. URL:
  `<URL_1>:8443/spaces/~raymond.yip/pages/507289611/Cross-Cluster+Migration`.
- **NCI 7.5 VG Metro 2PC (FEAT-17258)_FINAL** — feature deck for
  **FEAT-17258** (VG Metro Two-PC support that motivates this v4 migrate
  API). Source: `o365sharepoint`. URL: `<URL_7>`.
- **[UPFO] scale out PC in progress ... won't block protect PC with syncrep**
  — JIRA ticket relevant to sync-rep interactions during PC scale-out. URL:
  `<URL_8>`.
- **aos_version_deltas_and_dr_triage_reference.md** — internal reference that
  explains stretch / SyncRep interactions across AOS versions. Source:
  `github`. URL: `<URL_9>`.

**Domain skills a maintainer of this module needs.** Nutanix Volume Groups
(iSCSI targets, sharing modes, load-balancing), Synchronous Replication and
Metro clusters, Availability Zones + Protection Policies, Nutanix DR
concepts (Leap / PCDR / OD-CCLM), Prism Central v4 API architecture and its
`ergon` async task model, the CSI driver's use of VG attach/detach, and
Ansible module design (argument spec, `module_defaults`, `check_mode`,
`SpecGenerator`, `wait_for_completion`).

## Files changed

- `plugins/modules/ntnx_volume_group_migrate_v2.py` — new action module for
  the migrate call, following the `ntnx_vms_disks_migrate_v2` +
  `ntnx_virtual_switch_v2` patterns (imports, `SpecGenerator`,
  `wait_for_completion`, `strip_internal_attributes`, `check_mode`, etag
  fetch, `raise_api_exception`).
- `plugins/module_utils/v4/storage/__init__.py` — new package marker.
- `plugins/module_utils/v4/storage/api_client.py` — new `get_api_client` /
  `get_etag` / `get_volume_group_api_instance` for `ntnx_storage_py_client`
  (mirrors `plugins/module_utils/v4/volumes/api_client.py`).
- `plugins/module_utils/v4/storage/helpers.py` — new `get_volume_group`
  helper backed by the storage SDK.
- `meta/runtime.yml` — added `ntnx_volume_group_migrate_v2` to the
  `action_groups.ntnx` group so `module_defaults: group/nutanix.ncp.ntnx`
  resolves for it.
- `examples/storage/VolumeGroup/volume_group_migrate_v2.yml` — new example
  playbook (create VG → info → migrate → delete).
- `examples/storage/VolumeGroup/examples_run.log` — real playbook output
  captured against Prism Central `10.44.76.28` (`pc.7.6`).
- `tests/integration/targets/ntnx_volume_group_migrate_v2/` — new target
  (`aliases`, `meta/main.yml`, `tasks/main.yml`,
  `tasks/volume_group_migrate.yml`) covering: argument-spec validation
  (missing `ext_id`, missing `target_availability_zone_id`), `check_mode`
  with ALL attributes, `check_mode` with only required attributes, real API
  negative cases (invalid VG ext_id, invalid AZ id), and the real cross-site
  migrate scenario gated on `target_availability_zone`+`target_cluster`
  variables (skipped when a single-cluster lab is used, as here).

## Test execution

| Metric              | Value                                                                              |
|---------------------|------------------------------------------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 --allow-disabled ntnx_volume_group_migrate_v2` |
| Total tasks         | `24` (integration playbook, incl. setup/teardown)                                  |
| Passed (`ok`)       | `22`                                                                               |
| Failed              | `0` (four `...ignoring` fatal task results are intentional negative-path assertions) |
| Skipped             | `2` (real cross-site migrate — needs sync-rep prerequisites unavailable in the lab)|
| Duration            | `~0:00:13`                                                                         |
| Cluster (PC)        | `10.44.76.28` (`pc.7.6`, single AOS cluster `0006555e-4e63-4a5e-185b-ac1f6b6f97e2`)|
| Example playbook    | `ansible-playbook examples/storage/VolumeGroup/volume_group_migrate_v2.yml -v` — 5 tasks ok, 1 expected fatal (migrate) captured in `examples_run.log`. |

### Analysis

- **All negative-path tasks (`...ignoring`) fired as designed.** The two
  argument-spec validations (`missing ext_id`, `missing
  target_availability_zone_id`) trip the AnsibleModule required-arg check
  before any API call. The two real-API failures (`invalid ext_id`, `invalid
  target_availability_zone_id`) return the raw PC 404 `No static resource
  storage/v4.0.a4/config/volume-groups/...` — our module surfaces that via
  `raise_api_exception` and the follow-up assertion confirms `failed == true`
  and `changed == false`.
- **Real cross-site migrate is skipped.** The test lab exposes exactly one PE
  cluster registered to the PC, so there is no target availability zone /
  target PE to stretch to. The task guard
  (`when: target_availability_zone is defined and target_cluster is defined`)
  cleanly skips the invocation and emits a debug message documenting the
  reason. This is called out as a **known lab limitation**, not a code bug.
- **PC 7.6 does not expose `storage/v4.0.a4/config/volume-groups*` yet.**
  A direct `GET /api/storage/v4.0.a4/config/volume-groups` against
  `10.44.76.28` returns HTTP 404 `No static resource ...`. As a result, our
  module's helper `get_volume_group()` — which is only invoked in the real
  API paths — also returns 404 for VGs that were created via the older
  `/api/volumes/v4.0/config/volume-groups` endpoint (the existing
  `ntnx_volume_groups_v2` module still targets the older namespace). This is
  expected behaviour and is reproduced above with the invalid-ext_id
  negative test; the module fails loudly instead of pretending the entity
  exists. Once the target PC is upgraded to a build that ships the storage
  v4.0.a4 endpoints, the same test file can be re-run to exercise a real
  migrate — no code changes required.
- **No failed assertions.** `PLAY RECAP` reports
  `ok=22 changed=2 unreachable=0 failed=0 skipped=2 rescued=0 ignored=4`.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /bin/python3.12
Creating container database.
Running ntnx_volume_group_migrate_v2 integration test role
Stream command: ansible-playbook ntnx_volume_group_migrate_v2-*.yml -i inventory -v

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_volume_group_migrate_v2 : Start ntnx_volume_group_migrate_v2 tests] ***
ok: [testhost] => { "msg": "Start ntnx_volume_group_migrate_v2 tests" }

TASK [ntnx_volume_group_migrate_v2 : Generate random name suffix] **************
ok: [testhost]

TASK [ntnx_volume_group_migrate_v2 : Set Volume Group name] ********************
ok: [testhost]

TASK [ntnx_volume_group_migrate_v2 : Create Volume Group on the source cluster (for migrate scenarios)] ***
changed: [testhost]

TASK [ntnx_volume_group_migrate_v2 : Verify Volume Group was created] **********
ok: [testhost] => { "msg": "Volume Group created successfully for migrate tests" }

TASK [ntnx_volume_group_migrate_v2 : Set Volume Group ext_id] ******************
ok: [testhost]

TASK [ntnx_volume_group_migrate_v2 : Fail-run when target_availability_zone_id is missing] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: target_availability_zone_id"}
...ignoring

TASK [ntnx_volume_group_migrate_v2 : Verify module fails when target_availability_zone_id is missing] ***
ok: [testhost] => { "msg": "Module correctly rejected request without target_availability_zone_id" }

TASK [ntnx_volume_group_migrate_v2 : Fail-run when ext_id is missing] **********
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_volume_group_migrate_v2 : Verify module fails when ext_id is missing] ***
ok: [testhost] => { "msg": "Module correctly rejected request without ext_id" }

TASK [ntnx_volume_group_migrate_v2 : Migrate Volume Group with ALL attributes in check_mode] ***
ok: [testhost]

TASK [ntnx_volume_group_migrate_v2 : Verify check_mode with ALL attributes] ****
ok: [testhost] => { "msg": "Volume Group migrate check_mode with all attributes built the expected spec" }

TASK [ntnx_volume_group_migrate_v2 : Migrate Volume Group with only REQUIRED attributes in check_mode] ***
ok: [testhost]

TASK [ntnx_volume_group_migrate_v2 : Verify check_mode with only required attributes] ***
ok: [testhost] => { "msg": "Volume Group migrate check_mode with only required attributes built the expected spec" }

TASK [ntnx_volume_group_migrate_v2 : Attempt migrate with invalid Volume Group ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching Volume Group info using ext_id",
"response": {"error": "Not Found", "message": "No static resource storage/v4.0.a4/config/volume-groups/00000000-0000-0000-0000-000000000000.",
"path": "/api/storage/v4.0.a4/config/volume-groups/00000000-0000-0000-0000-000000000000", "status": 404}}
...ignoring

TASK [ntnx_volume_group_migrate_v2 : Verify migrate fails for invalid Volume Group ext_id] ***
ok: [testhost] => { "msg": "Migrate correctly failed for an invalid Volume Group ext_id" }

TASK [ntnx_volume_group_migrate_v2 : Attempt migrate with invalid target_availability_zone_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching Volume Group info using ext_id",
"response": {"error": "Not Found", "message": "No static resource storage/v4.0.a4/config/volume-groups/<ephemeral-vg-ext_id>.",
"path": "/api/storage/v4.0.a4/config/volume-groups/<ephemeral-vg-ext_id>", "status": 404}}
...ignoring

TASK [ntnx_volume_group_migrate_v2 : Verify migrate fails for invalid target_availability_zone_id] ***
ok: [testhost] => { "msg": "Migrate correctly failed for an invalid target_availability_zone_id" }

TASK [ntnx_volume_group_migrate_v2 : Migrate Volume Group to the target availability zone] ***
skipping: [testhost]

TASK [ntnx_volume_group_migrate_v2 : Verify Volume Group migrate result] *******
skipping: [testhost]

TASK [ntnx_volume_group_migrate_v2 : Skip real migrate scenario when sync-rep prerequisites are missing] ***
ok: [testhost] => { "msg": "Skipping real migrate scenario because target_availability_zone.uuid or target_cluster.uuid was not provided. A single-cluster lab cannot exercise cross-site migrate; see PR body for details." }

TASK [ntnx_volume_group_migrate_v2 : Delete Volume Group used for migrate tests] ***
changed: [testhost]

TASK [ntnx_volume_group_migrate_v2 : Verify Volume Group deletion] *************
ok: [testhost] => { "msg": "Volume Group deleted successfully after migrate tests" }

PLAY RECAP *********************************************************************
testhost                   : ok=22   changed=2    unreachable=0    failed=0    skipped=2    rescued=0    ignored=4
```

</details>

## Lint / sanity results

- `black --check .` — pass (806 files unchanged).
- `isort --check .` — pass.
- `flake8` — pass on the repo (a stray `.ansible/` cache dir surfaced pre-
  existing warnings unrelated to this change; deleted before commit).
- `ansible-lint` on the new module + tests + example — `Passed: 0 failure(s)`.
- `ansible-test sanity --python 3.12` on
  `plugins/modules/ntnx_volume_group_migrate_v2.py`,
  `plugins/module_utils/v4/storage/api_client.py`,
  `plugins/module_utils/v4/storage/helpers.py` — pass (all 30 sanity tests
  run, exit 0).

## Known issues / follow-ups

- The `storage/v4.0.a4` endpoint set is not published on the test PC
  (`pc.7.6`). Real cross-site migrate cannot be exercised here — the module,
  its argument spec, its `check_mode` handling, its `SpecGenerator`
  integration, and its error paths were all validated. Re-running the same
  integration target on a PC that ships storage v4.0.a4 (and providing
  `target_availability_zone` / `target_cluster` extra vars) will exercise the
  real migrate task end-to-end without any code change.
- Glean's `glean__chat` timed out twice; if a maintainer needs deeper prose,
  re-run the same prompt with a longer timeout — the search results and
  ticket list above are already reproduced verbatim.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
