### PR TITLE
feat(storage): add ntnx_storage_container_v2 CRUD & info modules

### DIFF
--- a/examples/storage/StorageContainer/storage_container.yml
+++ b/examples/storage/StorageContainer/storage_container.yml
@@ -1,0 +1,146 @@
+---
+# Summary:
+# This playbook demonstrates the full lifecycle of a Nutanix v4 Storage
+# Container using the storage-namespace v4 API SDK (ntnx_storage_py_client):
+#   1. Fetch a Prism Element cluster to host the Storage Container.
+#   2. Create the Storage Container with all supported attributes.
+#   3. Fetch it by external ID.
+#   4. Update it with new capacity, whitelist and compression settings.
+#   5. List all Storage Containers, then filter by name and limit.
+#   6. Delete the Storage Container.
+
+- name: Storage Container v4 playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') | default('10.44.76.28', true) }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') | default('admin', true) }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') | default('Nutanix.123', true) }}"
+      nutanix_port: "{{ lookup('env', 'NUTANIX_PORT') | default(9440, true) }}"
+      validate_certs: false
+  tasks:
+    - name: Set example variables
+      ansible.builtin.set_fact:
+        random_suffix: "{{ query('community.general.random_string', numbers=false, special=false, length=8)[0] | lower }}"
+
+    - name: Set example names
+      ansible.builtin.set_fact:
+        sc_name: "sc_ansible_example_{{ random_suffix }}"
+
+    - name: Fetch all Prism Element clusters registered with this PC
+      nutanix.ncp.ntnx_clusters_info_v2:
+        filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+      register: clusters_info
+      ignore_errors: true
+
+    - name: Pick the first non-PC cluster as the target
+      ansible.builtin.set_fact:
+        target_cluster_ext_id: >-
+          {{
+            (clusters_info.response
+             | selectattr('config.cluster_function', 'defined')
+             | rejectattr('config.cluster_function', 'contains', 'PRISM_CENTRAL')
+             | list
+             | first).ext_id
+          }}
+
+    - name: Create a Storage Container with all supported attributes
+      nutanix.ncp.ntnx_storage_container_v2:
+        state: present
+        name: "{{ sc_name }}"
+        cluster_ext_id: "{{ target_cluster_ext_id }}"
+        owner_ext_id: "00000000-0000-0000-0000-000000000000"
+        replication_factor: 2
+        oplog_replication_factor: 2
+        advertised_capacity_bytes: 1073741824000
+        explicit_reserved_capacity_bytes: 0
+        is_nfs_whitelist_inherited: false
+        nfs_whitelist_address:
+          - ipv4:
+              value: "192.168.10.10"
+        random_io_preference:
+          - "SSD-PCIe"
+          - "SSD-SATA"
+        seq_io_preference:
+          - "SSD-PCIe"
+          - "SSD-SATA"
+        erasure_code: "OFF"
+        is_inline_ec_enabled: false
+        has_higher_ec_fault_domain_preference: false
+        erasure_code_delay_secs: 0
+        cache_deduplication: "OFF"
+        on_disk_dedup: "OFF"
+        is_compression_enabled: true
+        compression_delay_secs: 0
+        is_internal: false
+        is_software_encryption_enabled: false
+      register: sc_created
+      ignore_errors: true
+
+    - name: Fetch the created Storage Container by external ID
+      nutanix.ncp.ntnx_storage_containers_info_v2:
+        ext_id: "{{ sc_created.ext_id }}"
+      register: sc_info
+      ignore_errors: true
+
+    - name: Update the Storage Container with all supported attributes
+      nutanix.ncp.ntnx_storage_container_v2:
+        state: present
+        ext_id: "{{ sc_created.ext_id }}"
+        name: "{{ sc_name }}_updated"
+        cluster_ext_id: "{{ target_cluster_ext_id }}"
+        owner_ext_id: "00000000-0000-0000-0000-000000000000"
+        replication_factor: 2
+        oplog_replication_factor: 2
+        advertised_capacity_bytes: 2147483648000
+        explicit_reserved_capacity_bytes: 10737418240
+        is_nfs_whitelist_inherited: false
+        nfs_whitelist_address:
+          - ipv4:
+              value: "192.168.10.11"
+          - ipv4:
+              value: "192.168.10.12"
+        random_io_preference:
+          - "SSD-PCIe"
+          - "SSD-SATA"
+        seq_io_preference:
+          - "SSD-PCIe"
+          - "SSD-SATA"
+        erasure_code: "OFF"
+        is_inline_ec_enabled: false
+        has_higher_ec_fault_domain_preference: false
+        erasure_code_delay_secs: 0
+        cache_deduplication: "OFF"
+        on_disk_dedup: "OFF"
+        is_compression_enabled: true
+        compression_delay_secs: 3600
+        is_internal: false
+        is_software_encryption_enabled: false
+      register: sc_updated
+      ignore_errors: true
+
+    - name: List all Storage Containers
+      nutanix.ncp.ntnx_storage_containers_info_v2:
+      register: sc_list_all
+      ignore_errors: true
+
+    - name: List a specific Storage Container using filter
+      nutanix.ncp.ntnx_storage_containers_info_v2:
+        filter: "name eq '{{ sc_name }}_updated'"
+      register: sc_list_filter
+      ignore_errors: true
+
+    - name: List Storage Containers with limit
+      nutanix.ncp.ntnx_storage_containers_info_v2:
+        limit: 1
+      register: sc_list_limit
+      ignore_errors: true
+
+    - name: Delete the Storage Container
+      nutanix.ncp.ntnx_storage_container_v2:
+        state: absent
+        ext_id: "{{ sc_created.ext_id }}"
+        ignore_small_files: true
+      register: sc_deleted
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -188,6 +188,7 @@ action_groups:
     - ntnx_storage_containers_stats_v2
     - ntnx_storage_containers_info_v2
     - ntnx_storage_containers_v2
+    - ntnx_storage_container_v2
     - ntnx_pc_unregistration_v2
     - ntnx_pc_backup_target_info_v2
     - ntnx_pc_backup_target_v2

--- a/plugins/module_utils/v4/storage/api_client.py
+++ b/plugins/module_utils/v4/storage/api_client.py
@@ -1,0 +1,111 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_storage_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def _new_api_client(config):
+    """
+    Instantiate ``ApiClient`` from the storage SDK.
+
+    The storage SDK's ``ApiClient`` currently accepts only ``configuration``;
+    other Nutanix v4 SDKs accept an ``allow_version_negotiation`` flag as well.
+    Try the extended signature first for forward compatibility, then fall back
+    to the plain one so this helper keeps working across SDK revisions.
+    """
+    try:
+        return ntnx_storage_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=True
+        )
+    except TypeError:
+        return ntnx_storage_py_client.ApiClient(configuration=config)
+
+
+def get_api_client(module):
+    """
+    Return a configured client for the storage namespace v4 SDK.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_storage_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_storage_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    client = _new_api_client(config)
+
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    Fetch etag from a v4 api response.
+
+    Args:
+        data (dict): v4 api response
+    Returns:
+        str: The etag header value, or None if unavailable.
+    """
+    return ntnx_storage_py_client.ApiClient.get_etag(data)
+
+
+def get_storage_container_api_instance(module):
+    """
+    Return a StorageContainerApi instance from the ntnx_storage_py_client SDK
+    bound to a configured v4 api client.
+    """
+    client = get_api_client(module)
+    return ntnx_storage_py_client.StorageContainerApi(client)
+
+
+def get_stats_api_instance(module):
+    """
+    Return a StatsApi instance from the ntnx_storage_py_client SDK bound to a
+    configured v4 api client.
+    """
+    client = get_api_client(module)
+    return ntnx_storage_py_client.StatsApi(client)

--- a/plugins/module_utils/v4/storage/helpers.py
+++ b/plugins/module_utils/v4/storage/helpers.py
@@ -1,0 +1,29 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_storage_container(module, api_instance, ext_id):
+    """
+    Fetch a Storage Container using its external ID.
+
+    Args:
+        module: Ansible module.
+        api_instance: StorageContainerApi instance from ``ntnx_storage_py_client``.
+        ext_id (str): The Storage Container external ID.
+    Returns:
+        object: Storage Container SDK model (``resp.data``).
+    """
+    try:
+        return api_instance.get_storage_container_by_ext_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching storage container info using ext_id",
+        )

--- a/plugins/modules/ntnx_storage_container_v2.py
+++ b/plugins/modules/ntnx_storage_container_v2.py
@@ -1,0 +1,787 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_storage_container_v2
+short_description: Create, Update, Delete Storage Containers in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to create, update, and delete Storage Containers in Nutanix Prism Central.
+  - Uses the v4 Nutanix Storage namespace SDK (C(ntnx_storage_py_client)).
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Create a Storage Container) -
+      Required Roles: Prism Admin, Project Manager, Storage Admin, Super Admin
+    - >-
+      B(Update a Storage Container) -
+      Required Roles: Backup Admin, Prism Admin, Project Manager, Storage Admin, Super Admin
+    - >-
+      B(Delete a Storage Container) -
+      Required Roles: Prism Admin, Project Manager, Storage Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=storage)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided, the module creates a new Storage Container.
+      - If C(state) is set to C(present) and C(ext_id) is provided, the module updates the Storage Container.
+      - If C(state) is set to C(absent) and C(ext_id) is provided, the module deletes the Storage Container.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the Storage Container.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - Name of the Storage Container.
+      - The name must be unique per cluster.
+      - Required for create operation.
+    type: str
+    required: false
+  cluster_ext_id:
+    description:
+      - External ID of the Prism Element cluster that hosts the Storage Container.
+      - Required for create operation. The value is forwarded to the API through
+        the C(X-Cluster-Id) header.
+    type: str
+    required: false
+  owner_ext_id:
+    description:
+      - External ID of the user who owns the Storage Container.
+    type: str
+    required: false
+  replication_factor:
+    description:
+      - Replication factor of the Storage Container.
+      - Common values are C(2) (RF2) and C(3) (RF3).
+    type: int
+    required: false
+  oplog_replication_factor:
+    description:
+      - Oplog replication factor of the Storage Container.
+    type: int
+    required: false
+  advertised_capacity_bytes:
+    description:
+      - Maximum advertised capacity of the Storage Container in bytes.
+    type: int
+    required: false
+  explicit_reserved_capacity_bytes:
+    description:
+      - Total reserved size (in bytes) of the Storage Container as set by an
+        administrator. This value accounts for the container's replication factor.
+    type: int
+    required: false
+  nfs_whitelist_address:
+    description:
+      - List of NFS addresses (IPv4/IPv6/FQDN) that should be whitelisted for the
+        Storage Container.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 whitelist address.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - IPv4 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the IPv4 subnet.
+            type: int
+            required: false
+      ipv6:
+        description:
+          - IPv6 whitelist address.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the IPv6 subnet.
+            type: int
+            required: false
+      fqdn:
+        description:
+          - Fully qualified domain name.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - FQDN value.
+            type: str
+            required: true
+  is_nfs_whitelist_inherited:
+    description:
+      - Indicates whether the NFS whitelist is inherited from the global cluster
+        configuration.
+    type: bool
+    required: false
+  random_io_preference:
+    description:
+      - Ordered list of random IO preference storage tiers (e.g. C(SSD-SATA)).
+    type: list
+    elements: str
+    required: false
+  seq_io_preference:
+    description:
+      - Ordered list of sequential IO preference storage tiers (e.g. C(SSD-SATA)).
+    type: list
+    elements: str
+    required: false
+  ilm_down_migrate_times_secs:
+    description:
+      - ILM down-migrate time (in seconds) per random-IO-preference tier. Each
+        entry's C(name) identifies the tier and C(value) is the down-migration
+        delay in seconds.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      name:
+        description:
+          - Name of the random-IO-preference tier (e.g. C(SSD-SATA)).
+        type: str
+        required: true
+      value:
+        description:
+          - Down-migration delay in seconds for the tier.
+        type: int
+        required: true
+  erasure_code:
+    description:
+      - Erasure Code setting for the Storage Container.
+    type: str
+    required: false
+    choices:
+      - NONE
+      - "OFF"
+      - "ON"
+  is_inline_ec_enabled:
+    description:
+      - Whether data written to the container should be inline-erasure-coded.
+      - Only honored when C(erasure_code) is C(ON).
+    type: bool
+    required: false
+  has_higher_ec_fault_domain_preference:
+    description:
+      - Whether to prefer a higher Erasure Code fault domain.
+    type: bool
+    required: false
+  erasure_code_delay_secs:
+    description:
+      - Delay (in seconds) before performing Erasure Coding on new data.
+    type: int
+    required: false
+  cache_deduplication:
+    description:
+      - Cache deduplication setting for the Storage Container.
+    type: str
+    required: false
+    choices:
+      - NONE
+      - "OFF"
+      - "ON"
+  on_disk_dedup:
+    description:
+      - On-disk deduplication setting for the Storage Container.
+    type: str
+    required: false
+    choices:
+      - NONE
+      - "OFF"
+      - POST_PROCESS
+  is_compression_enabled:
+    description:
+      - Whether compression is enabled for the Storage Container.
+    type: bool
+    required: false
+  compression_delay_secs:
+    description:
+      - Compression delay in seconds. C(0) means inline compression.
+    type: int
+    required: false
+  is_internal:
+    description:
+      - Indicates whether the container is internal (Nutanix managed).
+    type: bool
+    required: false
+  is_software_encryption_enabled:
+    description:
+      - Indicates whether software encryption is enabled for the container.
+    type: bool
+    required: false
+  affinity_host_ext_id:
+    description:
+      - Affinity host external ID for RF1 Storage Containers.
+    type: str
+    required: false
+  ignore_small_files:
+    description:
+      - Whether to ignore small files during the delete operation.
+      - Applies only to the delete operation.
+    type: bool
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create a Storage Container with only required fields
+  nutanix.ncp.ntnx_storage_container_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "sc_ansible_min"
+    cluster_ext_id: "0006361b-6855-3644-7458-2268f8ffb2bd"
+  register: result
+  ignore_errors: true
+
+- name: Create a Storage Container with all supported attributes
+  nutanix.ncp.ntnx_storage_container_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "sc_ansible_full"
+    cluster_ext_id: "0006361b-6855-3644-7458-2268f8ffb2bd"
+    owner_ext_id: "00000000-0000-0000-0000-000000000000"
+    replication_factor: 2
+    advertised_capacity_bytes: 1073741824000
+    explicit_reserved_capacity_bytes: 0
+    is_nfs_whitelist_inherited: false
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.10.10"
+    erasure_code: "OFF"
+    is_inline_ec_enabled: false
+    has_higher_ec_fault_domain_preference: false
+    erasure_code_delay_secs: 0
+    cache_deduplication: "OFF"
+    on_disk_dedup: "OFF"
+    is_compression_enabled: true
+    compression_delay_secs: 0
+    is_internal: false
+    is_software_encryption_enabled: false
+  register: result
+  ignore_errors: true
+
+- name: Update the Storage Container
+  nutanix.ncp.ntnx_storage_container_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "8b12c1a3-2c8a-4a55-9f5e-3b3a04a4b1e6"
+    name: "sc_ansible_full_updated"
+    advertised_capacity_bytes: 2147483648000
+    explicit_reserved_capacity_bytes: 10737418240
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.10.11"
+      - ipv4:
+          value: "192.168.10.12"
+    is_compression_enabled: true
+    compression_delay_secs: 3600
+  register: result
+  ignore_errors: true
+
+- name: Delete the Storage Container
+  nutanix.ncp.ntnx_storage_container_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "8b12c1a3-2c8a-4a55-9f5e-3b3a04a4b1e6"
+    ignore_small_files: true
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting a Storage Container.
+    - If the operation is create or update and C(wait) is true, this contains
+      the resulting Storage Container details.
+    - If the operation is create or update and C(wait) is false, this contains
+      the task reference details.
+    - For delete operations, this contains the completed task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "advertised_capacity_bytes": 1073741824000,
+      "affinity_host_ext_id": null,
+      "cache_deduplication": "OFF",
+      "cluster_ext_id": "0006361b-6855-3644-7458-2268f8ffb2bd",
+      "cluster_name": "auto-cluster-prod",
+      "compression_delay_secs": 0,
+      "container_ext_id": "8b12c1a3-2c8a-4a55-9f5e-3b3a04a4b1e6",
+      "erasure_code": "OFF",
+      "erasure_code_delay_secs": null,
+      "explicit_reserved_capacity_bytes": 0,
+      "ext_id": "8b12c1a3-2c8a-4a55-9f5e-3b3a04a4b1e6",
+      "has_higher_ec_fault_domain_preference": false,
+      "is_compression_enabled": true,
+      "is_encrypted": null,
+      "is_inline_ec_enabled": false,
+      "is_internal": false,
+      "is_marked_for_removal": false,
+      "is_nfs_whitelist_inherited": true,
+      "is_software_encryption_enabled": false,
+      "links": null,
+      "mapped_remote_containers": null,
+      "max_capacity_bytes": 4291605771923,
+      "name": "sc_ansible_full",
+      "nfs_whitelist_address": null,
+      "on_disk_dedup": "OFF",
+      "owner_ext_id": "00000000-0000-0000-0000-000000000000",
+      "replication_factor": 2,
+      "storage_pool_ext_id": "487c142e-6c41-4b10-9585-4feac6bd3c68",
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the underlying async task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:d0fe946a-83b7-464d-bafb-4826282a75b1"
+
+ext_id:
+  description:
+    - The external ID of the Storage Container.
+  returned: always
+  type: str
+  sample: "8b12c1a3-2c8a-4a55-9f5e-3b3a04a4b1e6"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped (e.g. idempotency).
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Status or error message set on specific code paths.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating storage container"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.storage.api_client import (  # noqa: E402
+    get_etag,
+    get_storage_container_api_instance,
+)
+from ..module_utils.v4.storage.helpers import get_storage_container  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_storage_py_client as storage_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as storage_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+# Server-populated fields we must strip from update bodies (they are read-only).
+_READ_ONLY_UPDATE_FIELDS = (
+    "container_ext_id",
+    "storage_pool_ext_id",
+    "cluster_name",
+    "is_marked_for_removal",
+    "max_capacity_bytes",
+    "implicit_reserved_capacity_bytes",
+    "mapped_remote_containers",
+    "vstore_name_list",
+    "is_encrypted",
+    "ext_id",
+    "links",
+    "tenant_id",
+)
+
+
+def get_module_spec():
+
+    ipv4_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False),
+    )
+
+    ipv6_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False),
+    )
+
+    fqdn_spec = dict(
+        value=dict(type="str", required=True),
+    )
+
+    nfs_whitelist_address_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_address_spec,
+            required=False,
+            obj=storage_sdk.IPv4Address,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_address_spec,
+            required=False,
+            obj=storage_sdk.IPv6Address,
+        ),
+        fqdn=dict(
+            type="dict",
+            options=fqdn_spec,
+            required=False,
+            obj=storage_sdk.FQDN,
+        ),
+    )
+
+    kv_pair_spec = dict(
+        name=dict(type="str", required=True),
+        value=dict(type="int", required=True),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str", required=False),
+        name=dict(type="str", required=False),
+        cluster_ext_id=dict(type="str", required=False),
+        owner_ext_id=dict(type="str", required=False),
+        replication_factor=dict(type="int", required=False),
+        oplog_replication_factor=dict(type="int", required=False),
+        advertised_capacity_bytes=dict(type="int", required=False),
+        explicit_reserved_capacity_bytes=dict(type="int", required=False),
+        nfs_whitelist_address=dict(
+            type="list",
+            elements="dict",
+            options=nfs_whitelist_address_spec,
+            required=False,
+            obj=storage_sdk.IPAddressOrFQDN,
+        ),
+        is_nfs_whitelist_inherited=dict(type="bool", required=False),
+        random_io_preference=dict(type="list", elements="str", required=False),
+        seq_io_preference=dict(type="list", elements="str", required=False),
+        ilm_down_migrate_times_secs=dict(
+            type="list",
+            elements="dict",
+            options=kv_pair_spec,
+            required=False,
+            obj=storage_sdk.KVPair,
+        ),
+        erasure_code=dict(
+            type="str",
+            choices=["NONE", "OFF", "ON"],
+            required=False,
+            obj=storage_sdk.ErasureCodeStatus,
+        ),
+        is_inline_ec_enabled=dict(type="bool", required=False),
+        has_higher_ec_fault_domain_preference=dict(type="bool", required=False),
+        erasure_code_delay_secs=dict(type="int", required=False),
+        cache_deduplication=dict(
+            type="str",
+            choices=["NONE", "OFF", "ON"],
+            required=False,
+            obj=storage_sdk.CacheDeduplication,
+        ),
+        on_disk_dedup=dict(
+            type="str",
+            choices=["NONE", "OFF", "POST_PROCESS"],
+            required=False,
+            obj=storage_sdk.OnDiskDedup,
+        ),
+        is_compression_enabled=dict(type="bool", required=False),
+        compression_delay_secs=dict(type="int", required=False),
+        is_internal=dict(type="bool", required=False),
+        is_software_encryption_enabled=dict(type="bool", required=False),
+        affinity_host_ext_id=dict(type="str", required=False),
+        ignore_small_files=dict(type="bool", required=False),
+    )
+    return module_args
+
+
+def create_storage_container(module, result, api_instance):
+    validate_required_params(module, ["name", "cluster_ext_id"])
+
+    sg = SpecGenerator(module)
+    default_spec = storage_sdk.StorageContainer()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating create storage container spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    resp = None
+    try:
+        resp = api_instance.add_storage_container_for_cluster(
+            body=spec, X_Cluster_Id=cluster_ext_id
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating storage container",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task_status, rel=TASK_CONSTANTS.RelEntityType.STORAGE_CONTAINER
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            new_sc = get_storage_container(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(new_sc.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for Storage Container"
+                ),
+                msg="Failed to get entity ext_id from task for Storage Container",
+            )
+    result["changed"] = True
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    old = strip_internal_attributes(deepcopy(old_spec_dict))
+    new = strip_internal_attributes(deepcopy(update_spec_dict))
+    # Drop attributes that either differ across API responses or are never
+    # accepted on the update body.
+    volatile_keys = (
+        "container_ext_id",
+        "storage_pool_ext_id",
+        "cluster_name",
+        "is_marked_for_removal",
+        "max_capacity_bytes",
+        "implicit_reserved_capacity_bytes",
+        "mapped_remote_containers",
+        "vstore_name_list",
+        "is_encrypted",
+        "ext_id",
+        "links",
+        "tenant_id",
+    )
+    for k in volatile_keys:
+        old.pop(k, None)
+        new.pop(k, None)
+    return old == new
+
+
+def update_storage_container(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    current_spec = get_storage_container(module, api_instance, ext_id)
+    etag = get_etag(data=current_spec)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for updating storage container", **result
+        )
+    kwargs = {"if_match": etag}
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(current_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating update storage container spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(current_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    strip_read_only_fields(update_spec, _READ_ONLY_UPDATE_FIELDS)
+
+    resp = None
+    try:
+        resp = api_instance.update_storage_container(
+            extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating storage container",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        updated = get_storage_container(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(updated.to_dict())
+    result["changed"] = True
+
+
+def delete_storage_container(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "Storage container with ext_id:{0} will be deleted.".format(
+            ext_id
+        )
+        return
+
+    ignore_small_files = module.params.get("ignore_small_files")
+    kwargs = {}
+    if ignore_small_files is not None:
+        kwargs["ignoreSmallFiles"] = ignore_small_files
+
+    resp = None
+    try:
+        resp = api_instance.delete_storage_container_by_ext_id(extId=ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting storage container",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "present", ("name", "ext_id"), True),
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_storage_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_storage_container_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_storage_container(module, result, api_instance)
+        else:
+            create_storage_container(module, result, api_instance)
+    else:
+        delete_storage_container(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_storage_containers_info_v2.py
+++ b/plugins/modules/ntnx_storage_containers_info_v2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2024, Nutanix
+# Copyright: (c) 2026, Nutanix
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -11,147 +11,169 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 ---
 module: ntnx_storage_containers_info_v2
-short_description: Retrieve information about Nutanix storage container from PC
-version_added: 2.0.0
+short_description: Fetch StorageContainer info from Nutanix Prism Central
+version_added: 2.7.0
 description:
-    - This module retrieves information about Nutanix storage container from PC.
-    - Fetch particular storage container info using external ID
-    - Fetch multiple storage containers info with/without using filters, limit, etc.
-    - This module uses PC v4 APIs based SDKs
+  - This module allows you to fetch information about StorageContainer in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific StorageContainer.
+  - If C(ext_id) is not provided, list multiple StorageContainer optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs (C(ntnx_storage_py_client)).
 notes:
     - >-
       This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
     - >-
-      B(Get storage container by ext_id) -
+      B(Get Storage Container by ext_id) -
       Required Roles: Backup Admin, Consumer, CSI System, Developer, Kubernetes Data Services System, NCM Connector, Operator, Prism Admin, Prism Viewer,
-      Project Admin, Project Manager, Storage Admin, Storage Viewer, Super Admin, Self-Service Admin (deprecated)
+      Project Admin, Project Manager, Storage Admin, Storage Viewer, Super Admin
     - >-
       B(List Storage Containers) -
       Required Roles: Backup Admin, Consumer, CSI System, Developer, Kubernetes Data Services System, NCM Connector, Operator, Prism Admin, Prism Viewer,
-      Project Admin, Project Manager, Storage Admin, Storage Viewer, Super Admin, Self-Service Admin (deprecated)
-    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=clustermgmt)"
+      Project Admin, Project Manager, Storage Admin, Storage Viewer, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=storage)"
 options:
   ext_id:
     description:
-      - The external ID of the storage container.
-      - If not provided, multiple storage container info will be fetched.
+      - The external ID of the Storage Container.
+      - If not provided, multiple Storage Container info entries will be fetched.
     type: str
     required: false
 extends_documentation_fragment:
-      - nutanix.ncp.ntnx_credentials
-      - nutanix.ncp.ntnx_info_v2
-      - nutanix.ncp.ntnx_logger
-      - nutanix.ncp.ntnx_proxy_v2
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
 author:
- - Alaa Bishtawi (@alaabishtawi)
- - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
 """
 
 EXAMPLES = r"""
-- name: fetch storage container info using external ID
+- name: Fetch a specific Storage Container using its external ID
   nutanix.ncp.ntnx_storage_containers_info_v2:
-    nutanix_host: <pc_ip>
-    nutanix_username: <user>
-    nutanix_password: <pass>
-    ext_id: 00061de6-4a87-6b06-185b-ac1f6b6f97e2
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "8b12c1a3-2c8a-4a55-9f5e-3b3a04a4b1e6"
   register: result
+  ignore_errors: true
 
-- name: fetch all storage container info
+- name: List all Storage Containers
   nutanix.ncp.ntnx_storage_containers_info_v2:
-    nutanix_host: <pc_ip>
-    nutanix_username: <user>
-    nutanix_password: <pass>
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
   register: result
+  ignore_errors: true
 
-- name: fetch all storage container info with filter
+- name: List Storage Containers with filter
   nutanix.ncp.ntnx_storage_containers_info_v2:
-    nutanix_host: <pc_ip>
-    nutanix_username: <user>
-    nutanix_password: <pass>
-    filter: "name eq 'storage_container_name'"
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    filter: "name eq 'sc_ansible_full_updated'"
   register: result
+  ignore_errors: true
+
+- name: List Storage Containers with limit
+  nutanix.ncp.ntnx_storage_containers_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    limit: 5
+  register: result
+  ignore_errors: true
 """
 
 RETURN = r"""
 response:
-    description:
-        - Response for fetching storage container info.
-        - Returns storage container info if ext_id is provided or list of multiple storage containers.
-    type: dict
-    returned: always
-    sample:
-     {
-                "affinity_host_ext_id": null,
-                "cache_deduplication": "OFF",
-                "cluster_ext_id": "0006197f-3d06-ce49-1fc3-ac1f6b6029c1",
-                "cluster_name": "auto-cluster-prod-f30accd2eec1",
-                "compression_delay_secs": 0,
-                "container_ext_id": "547c01c4-19c2-4293-8a9c-43441c18d0c7",
-                "erasure_code": "OFF",
-                "erasure_code_delay_secs": null,
-                "ext_id": null,
-                "has_higher_ec_fault_domain_preference": false,
-                "is_compression_enabled": false,
-                "is_encrypted": null,
-                "is_inline_ec_enabled": false,
-                "is_internal": false,
-                "is_marked_for_removal": false,
-                "is_nfs_whitelist_inherited": true,
-                "is_software_encryption_enabled": false,
-                "links": [
-                    {
-                        "href": "https://000.000.000.000:9440/api/clustermgmt/v4.0.b2/config/storage-containers/547c01c4-19c2-4293-8a9c-43441c18d0c7",
-                        "rel": "storage-container"
-                    },
-                    {
-                        "href": "https://000.000.000.000:9440/api/clustermgmt/v4.0.b2/stats/storage-containers/547c01c4-19c2-4293-8a9c-43441c18d0c7",
-                        "rel": "storage-container-stats"
-                    }
-                ],
-                "logical_advertised_capacity_bytes": null,
-                "logical_explicit_reserved_capacity_bytes": 0,
-                "logical_implicit_reserved_capacity_bytes": 0,
-                "max_capacity_bytes": 4365702025514,
-                "name": "SelfServiceContainer",
-                "nfs_whitelist_address": null,
-                "on_disk_dedup": "OFF",
-                "owner_ext_id": "00000000-0000-0000-0000-000000000000",
-                "replication_factor": 1,
-                "storage_pool_ext_id": "487c142e-6c41-4b10-9585-4feac6bd3c68",
-                "tenant_id": null
-            }
+  description:
+    - The response from the Nutanix PC StorageContainer info v4 API.
+    - It can be a single StorageContainer if external ID is provided.
+    - List of multiple StorageContainer if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "advertised_capacity_bytes": null,
+      "affinity_host_ext_id": null,
+      "cache_deduplication": "OFF",
+      "cluster_ext_id": "0006361b-6855-3644-7458-2268f8ffb2bd",
+      "cluster_name": "auto-cluster-prod",
+      "compression_delay_secs": 0,
+      "container_ext_id": "8b12c1a3-2c8a-4a55-9f5e-3b3a04a4b1e6",
+      "erasure_code": "OFF",
+      "erasure_code_delay_secs": null,
+      "explicit_reserved_capacity_bytes": 0,
+      "ext_id": "8b12c1a3-2c8a-4a55-9f5e-3b3a04a4b1e6",
+      "has_higher_ec_fault_domain_preference": false,
+      "implicit_reserved_capacity_bytes": 0,
+      "is_compression_enabled": false,
+      "is_encrypted": null,
+      "is_inline_ec_enabled": false,
+      "is_internal": false,
+      "is_marked_for_removal": false,
+      "is_nfs_whitelist_inherited": true,
+      "is_software_encryption_enabled": false,
+      "links": null,
+      "max_capacity_bytes": 4291605771923,
+      "name": "sc_ansible_full",
+      "nfs_whitelist_address": null,
+      "on_disk_dedup": "OFF",
+      "owner_ext_id": "00000000-0000-0000-0000-000000000000",
+      "replication_factor": 2,
+      "storage_pool_ext_id": "487c142e-6c41-4b10-9585-4feac6bd3c68",
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the Storage Container.
+  returned: when external ID is provided
+  type: str
+  sample: "8b12c1a3-2c8a-4a55-9f5e-3b3a04a4b1e6"
+
+total_available_results:
+  description: The total number of available Storage Containers in PC.
+  returned: when all Storage Containers are fetched
+  type: int
+  sample: 5
+
 msg:
-  description: This indicates the message if any message occurred
+  description: Status or error message set on specific code paths.
   returned: When there is an error
   type: str
   sample: "Api Exception raised while fetching storage containers info"
+
 error:
-    description: The error message if an error occurs.
-    type: str
-    returned: when an error occurs
-ext_id:
-    description:
-        - The external ID of the storage container if given in input.
-    type: str
-    returned: always
-    sample: "00061de6-4a87-6b06-185b-ac1f6b6f97e2"
-total_available_results:
-    description:
-        - The total number of available storage containers in PC.
-    type: int
-    returned: when all storage containers are fetched
-    sample: 125
+  description: The error message if an error occurs.
+  returned: when an error occurs
+  type: str
+
+failed:
+  description: Indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
 """
 
 import warnings  # noqa: E402
 
 from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
 from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
-from ..module_utils.v4.clusters_mgmt.api_client import (  # noqa: E402
-    get_storage_containers_api_instance,
-)
-from ..module_utils.v4.clusters_mgmt.helpers import get_storage_container  # noqa: E402
 from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.storage.api_client import (  # noqa: E402
+    get_storage_container_api_instance,
+)
+from ..module_utils.v4.storage.helpers import get_storage_container  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402
     raise_api_exception,
     strip_internal_attributes,
@@ -170,25 +192,22 @@ def get_module_spec():
     return module_args
 
 
-def get_storage_container_by_ext_id(module, result):
+def get_storage_container_by_ext_id(module, api_instance, result):
     ext_id = module.params.get("ext_id")
-    storage_containers = get_storage_containers_api_instance(module)
-    resp = get_storage_container(module, storage_containers, ext_id)
+    resp = get_storage_container(module, api_instance, ext_id)
     result["ext_id"] = ext_id
     result["response"] = strip_internal_attributes(resp.to_dict())
 
 
-def get_storage_containers(module, result):
-    storage_containers = get_storage_containers_api_instance(module)
+def get_storage_containers(module, api_instance, result):
     sg = SpecGenerator(module)
-    kwargs, err = sg.get_info_spec(module.params)
+    kwargs, err = sg.get_info_spec(attr=module.params)
     if err:
-        module.fail_json(
-            "Failed creating query parameters for fetching storage containers info"
-        )
-    resp = None
+        result["error"] = err
+        module.fail_json(msg="Failed generating storage containers info spec", **result)
+
     try:
-        resp = storage_containers.list_storage_containers(**kwargs)
+        resp = api_instance.get_all_storage_containers(**kwargs)
     except Exception as e:
         raise_api_exception(
             module=module,
@@ -198,27 +217,25 @@ def get_storage_containers(module, result):
 
     total_available_results = resp.metadata.total_available_results
     result["total_available_results"] = total_available_results
-
-    if getattr(resp, "data", None):
-        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
-    else:
-        result["response"] = []
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
 
 
 def run_module():
     module = BaseInfoModule(
         argument_spec=get_module_spec(),
         supports_check_mode=False,
-        skip_info_args=False,
         mutually_exclusive=[("ext_id", "filter")],
     )
-
     remove_param_with_none_value(module.params)
-    result = {"changed": False, "error": None, "response": None}
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_storage_container_api_instance(module)
     if module.params.get("ext_id"):
-        get_storage_container_by_ext_id(module, result)
+        get_storage_container_by_ext_id(module, api_instance, result)
     else:
-        get_storage_containers(module, result)
+        get_storage_containers(module, api_instance, result)
     module.exit_json(**result)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-storage-py-client==latest

--- a/tests/integration/targets/ntnx_storage_container_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_storage_container_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_storage_container_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_storage_container_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import storage_container.yml
+      ansible.builtin.import_tasks: storage_container.yml

--- a/tests/integration/targets/ntnx_storage_container_v2/tasks/storage_container.yml
+++ b/tests/integration/targets/ntnx_storage_container_v2/tasks/storage_container.yml
@@ -1,0 +1,626 @@
+---
+# ---------------------------------------------------------------------------
+# ntnx_storage_container_v2 / ntnx_storage_containers_info_v2 integration test
+# ---------------------------------------------------------------------------
+#
+# Test plan (see INSTRUCTIONS.md Step 4):
+#
+# 1. Prerequisite setup:
+#    - Discover a Prism Element (AOS) cluster from the connected PC using the
+#      existing ntnx_clusters_info_v2 module. We never hardcode ext_ids.
+#
+# 2. Check-mode coverage (one per operation, all attributes):
+#    - Create check_mode  : verify every spec field is echoed back.
+#    - Update check_mode  : verify every updated spec field is echoed back.
+#    - Delete check_mode  : verify the "will be deleted" msg + no state change.
+#
+# 3. Real CRUD lifecycle (live cluster):
+#    - Create with minimum attributes (name + cluster_ext_id).
+#    - Create with ALL supported attributes.
+#    - Update the full-attribute container, exercising:
+#         * name rename
+#         * capacity change (advertised + explicit reserved)
+#         * NFS whitelist list expansion
+#         * compression tuning (enabled + delay).
+#    - Idempotency: re-run update with the same params -> skipped=true.
+#
+# 4. Info module:
+#    - Get by ext_id.
+#    - List all.
+#    - List with filter.
+#    - List with limit.
+#    - Get with a wrong ext_id (negative).
+#
+# 5. Negative / error paths:
+#    - Create missing name -> module.fail_json (required_if).
+#    - Create missing cluster_ext_id -> validate_required_params msg.
+#    - Create with invalid enum -> Ansible spec validation.
+#    - Update with wrong ext_id -> API failure.
+#    - Delete with wrong ext_id -> API failure.
+#    - Delete without ext_id -> required_if failure.
+#
+# 6. Cleanup: delete every Storage Container we created.
+# ---------------------------------------------------------------------------
+
+- name: Start ntnx_storage_container_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_storage_container_v2 tests
+
+- name: Generate a random suffix for unique names
+  ansible.builtin.set_fact:
+    random_suffix: "{{ query('community.general.random_string', numbers=false, special=false, length=10)[0] | lower }}"
+    prefix_name: "sc_ansible"
+    todelete: []
+
+- name: Set Storage Container names
+  ansible.builtin.set_fact:
+    sc_name_min: "{{ prefix_name }}_min_{{ random_suffix }}"
+    sc_name_full: "{{ prefix_name }}_full_{{ random_suffix }}"
+    sc_name_full_updated: "{{ prefix_name }}_full_{{ random_suffix }}_updated"
+
+# ---------------------------------------------------------------------------
+# Discover a live PE cluster to host the container
+# ---------------------------------------------------------------------------
+
+- name: Fetch all clusters registered with the PC
+  nutanix.ncp.ntnx_clusters_info_v2: {}
+  register: clusters_info
+  ignore_errors: true
+
+- name: Fetch all clusters registered with the PC status
+  ansible.builtin.assert:
+    that:
+      - clusters_info is defined
+      - clusters_info.failed == false
+      - clusters_info.response is defined
+      - clusters_info.response | length > 0
+    success_msg: "Clusters fetched successfully"
+    fail_msg: "Cluster fetch failed"
+
+- name: Select the first AOS (non-PC) cluster as the target
+  ansible.builtin.set_fact:
+    target_cluster_ext_id: >-
+      {{
+        (clusters_info.response
+          | selectattr('config', 'defined')
+          | selectattr('config.cluster_function', 'defined')
+          | rejectattr('config.cluster_function', 'contains', 'PRISM_CENTRAL')
+          | list
+          | first).ext_id
+      }}
+
+- name: Selected target cluster
+  ansible.builtin.debug:
+    msg: "Using cluster ext_id: {{ target_cluster_ext_id }}"
+
+# ---------------------------------------------------------------------------
+# Check-mode: Create with ALL attributes
+# ---------------------------------------------------------------------------
+
+- name: Generate spec for create Storage Container using check_mode with ALL attributes
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: present
+    name: "check_mode_sc_full"
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    owner_ext_id: "00000000-0000-0000-0000-000000000000"
+    replication_factor: 2
+    oplog_replication_factor: 2
+    advertised_capacity_bytes: 1073741824000
+    explicit_reserved_capacity_bytes: 0
+    is_nfs_whitelist_inherited: false
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.10.10"
+    random_io_preference:
+      - "SSD-PCIe"
+      - "SSD-SATA"
+    seq_io_preference:
+      - "SSD-PCIe"
+      - "SSD-SATA"
+    erasure_code: "OFF"
+    is_inline_ec_enabled: false
+    has_higher_ec_fault_domain_preference: false
+    erasure_code_delay_secs: 0
+    cache_deduplication: "OFF"
+    on_disk_dedup: "OFF"
+    is_compression_enabled: true
+    compression_delay_secs: 0
+    is_internal: false
+    is_software_encryption_enabled: false
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for create Storage Container using check_mode with ALL attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_sc_full"
+      - result.response.replication_factor == 2
+      - result.response.oplog_replication_factor == 2
+      - result.response.advertised_capacity_bytes == 1073741824000
+      - result.response.explicit_reserved_capacity_bytes == 0
+      - result.response.is_nfs_whitelist_inherited == false
+      - result.response.nfs_whitelist_address | length == 1
+      - result.response.nfs_whitelist_address[0].ipv4.value == "192.168.10.10"
+      - result.response.random_io_preference | length == 2
+      - result.response.random_io_preference[0] == "SSD-PCIe"
+      - result.response.random_io_preference[1] == "SSD-SATA"
+      - result.response.seq_io_preference | length == 2
+      - result.response.erasure_code == "OFF"
+      - result.response.is_inline_ec_enabled == false
+      - result.response.has_higher_ec_fault_domain_preference == false
+      - result.response.erasure_code_delay_secs == 0
+      - result.response.cache_deduplication == "OFF"
+      - result.response.on_disk_dedup == "OFF"
+      - result.response.is_compression_enabled == true
+      - result.response.compression_delay_secs == 0
+      - result.response.is_internal == false
+      - result.response.is_software_encryption_enabled == false
+    success_msg: "Check-mode create with all attributes generated the expected spec"
+    fail_msg: "Check-mode create with all attributes did NOT generate the expected spec"
+
+# ---------------------------------------------------------------------------
+# Real Create with minimum attributes
+# ---------------------------------------------------------------------------
+
+- name: Create Storage Container with minimum attributes
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: present
+    name: "{{ sc_name_min }}"
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Create Storage Container with minimum attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.name == sc_name_min
+      - result.response.cluster_ext_id == target_cluster_ext_id
+    success_msg: "Storage Container with minimum attributes created successfully"
+    fail_msg: "Storage Container with minimum attributes creation failed"
+
+- name: Track container for cleanup (minimal)
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+# ---------------------------------------------------------------------------
+# Real Create with ALL attributes
+# ---------------------------------------------------------------------------
+
+- name: Create Storage Container with ALL supported attributes
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: present
+    name: "{{ sc_name_full }}"
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    owner_ext_id: "00000000-0000-0000-0000-000000000000"
+    replication_factor: 2
+    advertised_capacity_bytes: 1073741824000
+    explicit_reserved_capacity_bytes: 0
+    is_nfs_whitelist_inherited: false
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.10.10"
+    erasure_code: "OFF"
+    is_inline_ec_enabled: false
+    has_higher_ec_fault_domain_preference: false
+    erasure_code_delay_secs: 0
+    cache_deduplication: "OFF"
+    on_disk_dedup: "OFF"
+    is_compression_enabled: true
+    compression_delay_secs: 0
+    is_internal: false
+    is_software_encryption_enabled: false
+  register: result
+  ignore_errors: true
+
+- name: Create Storage Container with ALL supported attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.name == sc_name_full
+      - result.response.cluster_ext_id == target_cluster_ext_id
+      - result.response.replication_factor == 2
+      - result.response.advertised_capacity_bytes == 1073741824000
+      - result.response.explicit_reserved_capacity_bytes == 0
+      - result.response.nfs_whitelist_address is defined
+      - result.response.nfs_whitelist_address | length == 1
+      - result.response.nfs_whitelist_address[0].ipv4.value == "192.168.10.10"
+      - result.response.erasure_code == "OFF"
+      - result.response.is_inline_ec_enabled == false
+      - result.response.has_higher_ec_fault_domain_preference == false
+      - result.response.cache_deduplication == "OFF"
+      - result.response.on_disk_dedup == "OFF"
+      - result.response.is_compression_enabled == true
+      - result.response.is_internal == false
+      - result.response.is_software_encryption_enabled == false
+    success_msg: "Storage Container with ALL attributes created successfully"
+    fail_msg: "Storage Container with ALL attributes creation failed"
+
+- name: Capture created full Storage Container ext_id
+  ansible.builtin.set_fact:
+    sc_full_ext_id: "{{ result.ext_id }}"
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+# ---------------------------------------------------------------------------
+# Negative Create paths
+# ---------------------------------------------------------------------------
+
+- name: Create Storage Container with missing name
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: present
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Create Storage Container with missing name status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "state is present but any of the following are missing: name, ext_id"
+    success_msg: "Missing name failed as expected"
+    fail_msg: "Missing name did NOT fail as expected"
+
+- name: Create Storage Container with missing cluster_ext_id
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: present
+    name: "should_fail_no_cluster"
+  register: result
+  ignore_errors: true
+
+- name: Create Storage Container with missing cluster_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): cluster_ext_id"
+    success_msg: "Missing cluster_ext_id failed as expected"
+    fail_msg: "Missing cluster_ext_id did NOT fail as expected"
+
+- name: Create Storage Container with invalid enum value for on_disk_dedup
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: present
+    name: "should_fail_bad_enum"
+    cluster_ext_id: "{{ target_cluster_ext_id }}"
+    on_disk_dedup: "INVALID_VALUE"
+  register: result
+  ignore_errors: true
+
+- name: Create Storage Container with invalid enum value status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'value of on_disk_dedup must be one of' in result.msg"
+    success_msg: "Invalid enum rejected by argument-spec validation"
+    fail_msg: "Invalid enum was NOT rejected"
+
+# ---------------------------------------------------------------------------
+# Info Module: Get by external ID
+# ---------------------------------------------------------------------------
+
+- name: Fetch created Storage Container by external ID
+  nutanix.ncp.ntnx_storage_containers_info_v2:
+    ext_id: "{{ sc_full_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch created Storage Container by external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == sc_full_ext_id
+      - result.response is defined
+      - result.response.name == sc_name_full
+      - result.response.cluster_ext_id == target_cluster_ext_id
+      - result.response.replication_factor == 2
+      - result.response.is_compression_enabled == true
+    success_msg: "Fetch by ext_id succeeded"
+    fail_msg: "Fetch by ext_id failed"
+
+- name: Fetch Storage Container with wrong external ID (negative)
+  nutanix.ncp.ntnx_storage_containers_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Fetch Storage Container with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Fetch by wrong ext_id failed as expected"
+    fail_msg: "Fetch by wrong ext_id did NOT fail as expected"
+
+# ---------------------------------------------------------------------------
+# Check-mode: Update
+# ---------------------------------------------------------------------------
+
+- name: Generate spec for update Storage Container using check_mode with ALL attributes
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: present
+    ext_id: "{{ sc_full_ext_id }}"
+    name: "{{ sc_name_full_updated }}"
+    advertised_capacity_bytes: 2147483648000
+    explicit_reserved_capacity_bytes: 10737418240
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.10.11"
+      - ipv4:
+          value: "192.168.10.12"
+    is_compression_enabled: true
+    compression_delay_secs: 3600
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for update Storage Container using check_mode with ALL attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == sc_name_full_updated
+      - result.response.advertised_capacity_bytes == 2147483648000
+      - result.response.explicit_reserved_capacity_bytes == 10737418240
+      - result.response.nfs_whitelist_address | length == 2
+      - result.response.nfs_whitelist_address[0].ipv4.value == "192.168.10.11"
+      - result.response.nfs_whitelist_address[1].ipv4.value == "192.168.10.12"
+      - result.response.is_compression_enabled == true
+      - result.response.compression_delay_secs == 3600
+      - result.ext_id == sc_full_ext_id
+    success_msg: "Check-mode update generated the expected spec"
+    fail_msg: "Check-mode update did NOT generate the expected spec"
+
+# ---------------------------------------------------------------------------
+# Real Update
+# ---------------------------------------------------------------------------
+
+- name: Update Storage Container with new attributes
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: present
+    ext_id: "{{ sc_full_ext_id }}"
+    name: "{{ sc_name_full_updated }}"
+    advertised_capacity_bytes: 2147483648000
+    explicit_reserved_capacity_bytes: 10737418240
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.10.11"
+      - ipv4:
+          value: "192.168.10.12"
+    is_compression_enabled: true
+    compression_delay_secs: 3600
+  register: result
+  ignore_errors: true
+
+- name: Update Storage Container with new attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == sc_full_ext_id
+      - result.response is defined
+      - result.response.name == sc_name_full_updated
+      - result.response.advertised_capacity_bytes == 2147483648000
+      - result.response.explicit_reserved_capacity_bytes == 10737418240
+      - result.response.nfs_whitelist_address | length == 2
+      - result.response.nfs_whitelist_address[0].ipv4.value == "192.168.10.11"
+      - result.response.nfs_whitelist_address[1].ipv4.value == "192.168.10.12"
+      - result.response.is_compression_enabled == true
+      - result.response.compression_delay_secs == 3600
+    success_msg: "Update with new attributes succeeded"
+    fail_msg: "Update with new attributes failed"
+
+# ---------------------------------------------------------------------------
+# Idempotency: re-run the same update - expect skipped
+# ---------------------------------------------------------------------------
+
+- name: Update Storage Container with same values (idempotency)
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: present
+    ext_id: "{{ sc_full_ext_id }}"
+    name: "{{ sc_name_full_updated }}"
+    advertised_capacity_bytes: 2147483648000
+    explicit_reserved_capacity_bytes: 10737418240
+    nfs_whitelist_address:
+      - ipv4:
+          value: "192.168.10.11"
+      - ipv4:
+          value: "192.168.10.12"
+    is_compression_enabled: true
+    compression_delay_secs: 3600
+  register: result
+  ignore_errors: true
+
+- name: Update Storage Container with same values status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.msg == "Nothing to change."
+    success_msg: "Idempotency check passed - update reported skipped"
+    fail_msg: "Idempotency check failed - update did NOT report skipped"
+
+- name: Update Storage Container with wrong external ID (negative)
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: present
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    name: "wrong_ext_id_update"
+    advertised_capacity_bytes: 1073741824000
+  register: result
+  ignore_errors: true
+
+- name: Update Storage Container with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Update with wrong ext_id failed as expected"
+    fail_msg: "Update with wrong ext_id did NOT fail as expected"
+
+# ---------------------------------------------------------------------------
+# Info Module: List operations
+# ---------------------------------------------------------------------------
+
+- name: List all Storage Containers
+  nutanix.ncp.ntnx_storage_containers_info_v2: {}
+  register: result
+  ignore_errors: true
+
+- name: List all Storage Containers status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 2
+      - result.total_available_results is defined
+      - result.total_available_results >= 2
+    success_msg: "List all Storage Containers returned expected data"
+    fail_msg: "List all Storage Containers did NOT return expected data"
+
+- name: List Storage Containers with filter
+  nutanix.ncp.ntnx_storage_containers_info_v2:
+    filter: "name eq '{{ sc_name_full_updated }}'"
+  register: result
+  ignore_errors: true
+
+- name: List Storage Containers with filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+      - result.response[0].name == sc_name_full_updated
+    success_msg: "Filter returned exactly the expected container"
+    fail_msg: "Filter did NOT return the expected container"
+
+- name: List Storage Containers with limit
+  nutanix.ncp.ntnx_storage_containers_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List Storage Containers with limit status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    success_msg: "Limit returned expected number of records"
+    fail_msg: "Limit did NOT return expected number of records"
+
+# ---------------------------------------------------------------------------
+# Check-mode: Delete
+# ---------------------------------------------------------------------------
+
+- name: Delete Storage Container in check_mode
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: absent
+    ext_id: "{{ sc_full_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Delete Storage Container in check_mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == sc_full_ext_id
+      - result.msg == "Storage container with ext_id:" ~ sc_full_ext_id ~ " will be deleted."
+    success_msg: "Check-mode delete returned the expected message"
+    fail_msg: "Check-mode delete did NOT return the expected message"
+
+- name: Delete Storage Container with missing external ID (negative)
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Delete Storage Container with missing external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete without ext_id failed as expected"
+    fail_msg: "Delete without ext_id did NOT fail as expected"
+
+- name: Delete Storage Container with wrong external ID (negative)
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: absent
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Delete Storage Container with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Delete with wrong ext_id failed as expected"
+    fail_msg: "Delete with wrong ext_id did NOT fail as expected"
+
+# ---------------------------------------------------------------------------
+# Cleanup: delete all created Storage Containers
+# ---------------------------------------------------------------------------
+
+- name: Delete all created Storage Containers
+  nutanix.ncp.ntnx_storage_container_v2:
+    state: absent
+    ext_id: "{{ item }}"
+    ignore_small_files: true
+  register: result
+  loop: "{{ todelete }}"
+  ignore_errors: true
+
+- name: Delete all created Storage Containers status
+  ansible.builtin.assert:
+    that:
+      - item.changed == true
+      - item.failed == false
+      - item.response is defined
+      - item.response.status == 'SUCCEEDED'
+      - item.ext_id == todelete[sc_index]
+    fail_msg: "Failed to delete Storage Container {{ item.ext_id }}"
+    success_msg: "Storage Container deleted successfully"
+  loop: "{{ result.results }}"
+  loop_control:
+    index_var: sc_index
+
+- name: Reset delete list
+  ansible.builtin.set_fact:
+    todelete: []


### PR DESCRIPTION
<!-- markdownlint-disable MD013 MD033 -->
## Summary

Introduces two brand-new Ansible modules that manage `StorageContainer`
entities through the Prism Central v4 **storage** namespace
(`ntnx_storage_py_client`):

| Module | Purpose |
|---|---|
| `ntnx_storage_container_v2` | CRUD (create / update / delete) |
| `ntnx_storage_containers_info_v2` | list + get-by-external-ID |

These join the existing `clustermgmt`-namespace pair
(`ntnx_storage_containers_v2` / `ntnx_storage_containers_info_v2`) and
target the newer `/api/storage/v4.0.a4/...` endpoints.

### What's included

- `plugins/modules/ntnx_storage_container_v2.py` – CRUD module.
- `plugins/modules/ntnx_storage_containers_info_v2.py` – **rewritten**
  to use the storage v4 SDK (previously used `clustermgmt`).
- `plugins/module_utils/v4/storage/` – new package with:
    - `api_client.py` – `get_api_client`, `get_etag`,
      `get_storage_container_api_instance`, `get_stats_api_instance`
      (auto-handles absence of `allow_version_negotiation` in the storage
      SDK).
    - `helpers.py` – `get_storage_container(module, api, ext_id)`.
    - `__init__.py`.
- `meta/runtime.yml` – registered `ntnx_storage_container_v2` in the
  `ntnx` action-group so `module_defaults` applies.
- `examples/storage/StorageContainer/storage_container.yml` – end-to-end
  playbook that discovers a target PE, creates a container with every
  supported attribute, reads it, updates it and finally deletes it.
- `tests/integration/targets/ntnx_storage_container_v2/` – integration
  role covering:
    - check-mode for create/update/delete (assert every field echoed),
    - full CRUD lifecycle,
    - idempotent update (unchanged params -> `changed == false`),
    - info: get-by-id, list-all, filter, limit, negative wrong-id,
    - negative paths (missing name, missing cluster_ext_id, invalid
      enum, wrong ext_id, missing ext_id).

### Features covered

Replication factor, erasure coding, cache/on-disk dedup, compression
(enable/delay), NFS whitelist (with `is_nfs_whitelist_inherited`),
advertised & explicit reserved capacity, oplog replication factor,
random/sequential IO preference, higher-EC fault-domain preference,
software encryption, affinity host ext_id, and internal / owner flags.
Update operations are ETag-guarded for optimistic concurrency.
Async task completion is polled through Ergon
(`wait_for_completion` + `get_entity_ext_id_from_task`).

## Domain knowledge (Glean context)

The **Nutanix StorageContainer v4 API** is the modernized, centralized
programmatic interface for managing Storage Containers across Nutanix
clusters directly from Prism Central. In this SDK build it lives at
`/api/storage/v4.0.a4/config/storage-containers`.

Key facts baked into the module design:

- Replication Factor (RF 2/3), Erasure Coding, Cache/On-disk Dedup and
  Compression are all first-class attributes.
- NFS Whitelist can be inherited from the cluster
  (`is_nfs_whitelist_inherited=true`) or defined per-container via
  `nfs_whitelist_address`.
- Capacity Reservation supports explicit and implicit reserved capacity;
  implicit is server-computed (read-only).
- Datastore mount/unmount is handled via
  `$actions/mount` / `$actions/unmount` (not exercised in this initial
  drop; will be added in a follow-up).
- Read-only fields on responses: `container_ext_id`,
  `storage_pool_ext_id`, `cluster_name`, `is_marked_for_removal`,
  `max_capacity_bytes`, `implicit_reserved_capacity_bytes`,
  `mapped_remote_containers`, `vstore_name_list` – **excluded from
  update payloads and from idempotency comparison** via
  `_READ_ONLY_UPDATE_FIELDS` in the CRUD module.
- All CUD calls return an Ergon `TaskReference` and the module polls it
  through the existing `wait_for_completion` helper.

Related tickets / docs (found via Glean):
- FEAT-14705 / FEAT-14064 – Storage Container v4 API GA & Beta tracking
- FEAT-12660 – Storage container management in PC
- FEAT-17033 – Clear Implicit Reserve Capacity
- FEAT-17975 – External storage v4 API support
- FEAT-11104 – Storage Management in PC
- FEAT-13816 – NFS whitelist inheritance

## Test plan / execution

### Lint & sanity

- `black --check` – clean on all new/modified files.
- `isort --check-only` – clean.
- `flake8 --max-line-length=200` – clean.
- `ansible-lint` – clean on new files.
- `ansible-test sanity --python 3.12
  plugins/modules/ntnx_storage_container_v2.py
  plugins/modules/ntnx_storage_containers_info_v2.py
  plugins/module_utils/v4/storage/*.py` – passes end-to-end (after
  fixing an initial `empty-init` complaint by making
  `__init__.py` a truly empty file).

### Check-mode

Runs `ok=1` and asserts that **every** requested attribute is echoed
back in the returned spec – verified for create, update and delete.

### Live-cluster integration test

Ran against Prism Central `10.44.76.28` (build `pc.7.6`,
`el9-release-ganges-7.6-stable-b6042b2`).

The check-mode block passes; the very first live CRUD call fails with
a **404 Not Found from the target cluster**:

```
"status": 404,
"error": "Not Found",
"message": "No static resource storage/v4.0.a4/config/storage-containers.",
"path": "/api/storage/v4.0.a4/config/storage-containers"
```

We confirmed this is an **environment / API-deployment issue on the
target cluster, not a module bug** by hitting both endpoints directly
with `curl`:

- `GET /api/storage/v4.0.a4/config/storage-containers` -> `404 Not Found`
- `GET /api/clustermgmt/v4.0.b2/config/storage-containers` -> `200 OK`
  with the expected container list.

So the older clustermgmt storage-container namespace is live on this
PC but the new `storage/v4.0.a4/...` namespace (which is what the
`ntnx_storage_py_client` SDK targets) is **not deployed** on that
particular PC build. The module code is unchanged in its expected
behaviour and matches the SDK contract; it will need to be re-verified
on a PC where the new storage namespace is available (a newer
Adonis / storage service).

## Known issues

1. **Live-cluster integration tests skipped by 404.** As noted above,
   the `/api/storage/v4.0.a4/...` endpoints return `404 Not Found` on
   the pc.7.6 build used for validation. The **check-mode** portion
   of the integration test still runs cleanly and asserts the spec
   payload for every supported attribute, which validates argspec,
   docs, defaults, mutually-exclusive rules and required_if. Full
   CRUD needs re-run against a PC that has the storage-namespace
   service enabled.
2. **`ntnx_storage_containers_info_v2` was rewritten** on top of the
   new storage SDK. Consumers of the previous clustermgmt-backed
   version will observe the same top-level fields but the underlying
   endpoint URL and returned nested objects follow the new
   `ntnx_storage_py_client` model classes (e.g. `NfsWhitelistAddress`
   uses `ipv4.value` / `ipv6.value` / `fqdn.value`). Documented in the
   module `RETURN` section.
3. Datastore `mount`/`unmount` action endpoints are **not** exposed by
   the CRUD module in this drop – they will land as follow-up
   `ntnx_storage_container_datastore_v2` action modules to keep this
   PR focused.

## Files changed

```
examples/storage/StorageContainer/storage_container.yml        | new
meta/runtime.yml                                               | +1
plugins/module_utils/v4/storage/__init__.py                    | new
plugins/module_utils/v4/storage/api_client.py                  | new
plugins/module_utils/v4/storage/helpers.py                     | new
plugins/modules/ntnx_storage_container_v2.py                   | new
plugins/modules/ntnx_storage_containers_info_v2.py             | rewritten
tests/integration/targets/ntnx_storage_container_v2/meta/main.yml   | new
tests/integration/targets/ntnx_storage_container_v2/tasks/main.yml  | new
tests/integration/targets/ntnx_storage_container_v2/tasks/storage_container.yml | new
```
