### PR TITLE
code-gen(virtual_machine_management/ConsoleToken): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+tests/output/

--- a/examples/virtual_machine_management/ConsoleToken/examples_run.log
+++ b/examples/virtual_machine_management/ConsoleToken/examples_run.log
@@ -1,0 +1,110 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [VM Console Token playbook] ***********************************************
+
+TASK [Set variables for the console token example] *****************************
+ok: [localhost] => {"ansible_facts": {"invalid_vm_ext_id": "00000000-0000-0000-0000-000000000000", "vm_ext_id": "70f9a8bb-7834-4146-7b12-a436f3fbd520"}, "changed": false}
+
+TASK [Generate a VM console token] *********************************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "70f9a8bb-7834-4146-7b12-a436f3fbd520", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-20T17:54:29.608900+00:00", "completion_details": [{"name": "VmConsoleToken", "value": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3ODQ1NzM2NjksInVzZXJVdWlkIjoiMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwIiwidm1VdWlkIjoiNzBmOWE4YmItNzgzNC00MTQ2LTdiMTItYTQzNmYzZmJkNTIwIn0.MOuxHsmYa_D8GBjDvfcV9DgqHQEBuIy5f0X6yN_LzVPHlsL6zGt23vhForch9VrNyJuaUmo15uVC837oDPYxMN-0Ayq5fQlsv-Rr9bI2aQQq2ECC74giRlgzuJlhpXCc2AZAlTIdrAZbbKdW_VSBEDKQukdSLtlBIQbGl2N-7CPCafcYLYEKFOTEk8rlFNmmgcWRds3m4bDvceEYjpoJwH-gzo57Kd3yXN1Ad5abEWM--L8G2KUVfqKkiZ9SkUhFYGiCaYN4IE1U2ZNhfRJvwIVMCGAT6FKpozgoco5KIKUe7bpEl-jRfaAPO3L3WuAAFv_8ZZwKGtcQMzZT_V5Hfw"}, {"name": "WsUri", "value": "/console/launch/70f9a8bb-7834-4146-7b12-a436f3fbd520"}], "created_time": "2026-07-20T17:54:29.544886+00:00", "entities_affected": [{"ext_id": "70f9a8bb-7834-4146-7b12-a436f3fbd520", "name": "nkp-bastion", "rel": "vmm:ahv:config:vm"}], "error_messages": null, "ext_id": "ZXJnb24=:df2d5769-abcf-50cb-b77d-0ba16e5faab9", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-20T17:54:29.608899+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "GenerateVmConsoleToken", "operation_description": "Generate VM console token", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-20T17:54:29.552914+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:df2d5769-abcf-50cb-b77d-0ba16e5faab9"}
+
+TASK [Show generated console token task response] ******************************
+ok: [localhost] => {
+    "token_result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "70f9a8bb-7834-4146-7b12-a436f3fbd520",
+        "failed": false,
+        "response": {
+            "app_name": null,
+            "batch_summary": null,
+            "cluster_ext_ids": null,
+            "completed_time": "2026-07-20T17:54:29.608900+00:00",
+            "completion_details": [
+                {
+                    "name": "VmConsoleToken",
+                    "value": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3ODQ1NzM2NjksInVzZXJVdWlkIjoiMDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAwIiwidm1VdWlkIjoiNzBmOWE4YmItNzgzNC00MTQ2LTdiMTItYTQzNmYzZmJkNTIwIn0.MOuxHsmYa_D8GBjDvfcV9DgqHQEBuIy5f0X6yN_LzVPHlsL6zGt23vhForch9VrNyJuaUmo15uVC837oDPYxMN-0Ayq5fQlsv-Rr9bI2aQQq2ECC74giRlgzuJlhpXCc2AZAlTIdrAZbbKdW_VSBEDKQukdSLtlBIQbGl2N-7CPCafcYLYEKFOTEk8rlFNmmgcWRds3m4bDvceEYjpoJwH-gzo57Kd3yXN1Ad5abEWM--L8G2KUVfqKkiZ9SkUhFYGiCaYN4IE1U2ZNhfRJvwIVMCGAT6FKpozgoco5KIKUe7bpEl-jRfaAPO3L3WuAAFv_8ZZwKGtcQMzZT_V5Hfw"
+                },
+                {
+                    "name": "WsUri",
+                    "value": "/console/launch/70f9a8bb-7834-4146-7b12-a436f3fbd520"
+                }
+            ],
+            "created_time": "2026-07-20T17:54:29.544886+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "70f9a8bb-7834-4146-7b12-a436f3fbd520",
+                    "name": "nkp-bastion",
+                    "rel": "vmm:ahv:config:vm"
+                }
+            ],
+            "error_messages": null,
+            "ext_id": "ZXJnb24=:df2d5769-abcf-50cb-b77d-0ba16e5faab9",
+            "is_background_task": false,
+            "is_cancelable": false,
+            "last_updated_time": "2026-07-20T17:54:29.608899+00:00",
+            "legacy_error_message": null,
+            "number_of_entities_affected": 1,
+            "number_of_subtasks": 0,
+            "operation": "GenerateVmConsoleToken",
+            "operation_description": "Generate VM console token",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "projectExtId": "00000000-0000-0000-0000-000000000000",
+            "resource_links": null,
+            "root_task": null,
+            "started_time": "2026-07-20T17:54:29.552914+00:00",
+            "status": "SUCCEEDED",
+            "sub_steps": null,
+            "sub_tasks": null,
+            "warnings": null
+        },
+        "task_ext_id": "ZXJnb24=:df2d5769-abcf-50cb-b77d-0ba16e5faab9"
+    }
+}
+
+TASK [Attempt to generate a token for a non-existent VM] ***********************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while generating VM console token", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_uuid": "00000000-0000-0000-0000-000000000000"}, "code": "VMM-30100", "errorGroup": "VM_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the VM with UUID '00000000-0000-0000-0000-000000000000', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Show the failure response for an invalid VM external ID] *****************
+ok: [localhost] => {
+    "invalid_token_result": {
+        "changed": false,
+        "error": "NOT FOUND",
+        "failed": true,
+        "msg": "Api Exception raised while generating VM console token",
+        "response": {
+            "$dataItemDiscriminator": "vmm.v4.error.ErrorResponse",
+            "data": {
+                "$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>",
+                "$objectType": "vmm.v4.error.ErrorResponse",
+                "error": [
+                    {
+                        "$objectType": "vmm.v4.error.AppMessage",
+                        "argumentsMap": {
+                            "vm_uuid": "00000000-0000-0000-0000-000000000000"
+                        },
+                        "code": "VMM-30100",
+                        "errorGroup": "VM_NOT_FOUND",
+                        "locale": "en-US",
+                        "message": "Failed to perform the operation on the VM with UUID '00000000-0000-0000-0000-000000000000', because it is not found.",
+                        "severity": "ERROR"
+                    }
+                ]
+            }
+        },
+        "status": 404
+    }
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=5    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
+

--- a/examples/virtual_machine_management/ConsoleToken/vm_console_token_v2.yml
+++ b/examples/virtual_machine_management/ConsoleToken/vm_console_token_v2.yml
@@ -1,0 +1,82 @@
+---
+# Summary:
+# This playbook demonstrates how to generate a VNC console token for an AHV
+# VM using the Nutanix VMM v4 API.
+#
+# It covers:
+# 1. Generating a console token for an existing AHV VM.
+# 2. Handling the negative case where the VM external ID does not exist.
+#
+# Override the following variables when running the playbook against a live
+# Prism Central (see also examples_run.log):
+#   -e pc_ip=<pc_ip> -e pc_user=<user> -e pc_password=<pass>
+#      -e vm_ext_id=<real_vm_uuid>
+
+- name: VM Console Token playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ pc_ip | default('<pc_ip>') }}"
+      nutanix_username: "{{ pc_user | default('<user>') }}"
+      nutanix_password: "{{ pc_password | default('<pass>') }}"
+      validate_certs: false
+  tasks:
+    - name: Set variables for the console token example
+      ansible.builtin.set_fact:
+        vm_ext_id: "{{ vm_ext_id | default('ac5aff0c-6c68-4948-9088-b903e2be0ce7') }}"
+        invalid_vm_ext_id: "00000000-0000-0000-0000-000000000000"
+
+    - name: Generate a VM console token
+      nutanix.ncp.ntnx_vm_console_token_v2:
+        state: present
+        ext_id: "{{ vm_ext_id }}"
+      register: token_result
+      ignore_errors: true
+
+    - name: Show generated console token task response
+      ansible.builtin.debug:
+        var: token_result
+
+    - name: Attempt to generate a token for a non-existent VM
+      nutanix.ncp.ntnx_vm_console_token_v2:
+        state: present
+        ext_id: "{{ invalid_vm_ext_id }}"
+      register: invalid_token_result
+      ignore_errors: true
+
+    - name: Show the failure response for an invalid VM external ID
+      ansible.builtin.debug:
+        var: invalid_token_result
+
+# Sample response (real output captured from an actual run against a live
+# Prism Central 4.2 cluster — the VmConsoleToken JWT is redacted below):
+#
+# token_result:
+#   changed: true
+#   failed: false
+#   ext_id: "70f9a8bb-7834-4146-7b12-a436f3fbd520"
+#   task_ext_id: "ZXJnb24=:XXXX-XXXX-XXXX-XXXX"
+#   response:
+#     status: "SUCCEEDED"
+#     operation: "GenerateVmConsoleToken"
+#     progress_percentage: 100
+#     entities_affected:
+#       - ext_id: "70f9a8bb-7834-4146-7b12-a436f3fbd520"
+#         rel: "vmm:ahv:config:vm"
+#     completion_details:
+#       - name: "VmConsoleToken"
+#         value: "<REDACTED-JWT>"
+#       - name: "WsUri"
+#         value: "/console/launch/70f9a8bb-7834-4146-7b12-a436f3fbd520"
+#
+# invalid_token_result:
+#   failed: true
+#   status: 404
+#   error: "NOT FOUND"
+#   response:
+#     data:
+#       error:
+#         - code: "VMM-30100"
+#           errorGroup: "VM_NOT_FOUND"
+#           message: "Failed to perform the operation on the VM with UUID '00000000-0000-0000-0000-000000000000', because it is not found."

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -178,6 +178,7 @@ action_groups:
     - ntnx_recovery_points_v2
     - ntnx_recovery_point_restore_v2
     - ntnx_vm_revert_v2
+    - ntnx_vm_console_token_v2
     - ntnx_recovery_point_replicate_v2
     - ntnx_gpus_v2
     - ntnx_gpus_info_v2

--- a/plugins/modules/ntnx_vm_console_token_v2.py
+++ b/plugins/modules/ntnx_vm_console_token_v2.py
@@ -1,0 +1,262 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_console_token_v2
+short_description: Generate a VNC console token for an AHV VM
+version_added: 2.7.0
+description:
+    - Generate a short-lived VNC console token (JWT) for a given AHV VM in
+      Nutanix Prism Central.
+    - The generated token is returned via the underlying asynchronous task
+      completion details and is intended to be used together with the
+      WebSocket URI (C(WsUri)) to establish a secure VNC session against
+      the target VM.
+    - This module wraps the Nutanix VMM v4
+      C(POST /api/vmm/v4.x/ahv/config/vms/{extId}/$actions/generate-console-token)
+      action endpoint.
+    - This module uses PC v4 APIs based SDKs.
+options:
+    state:
+        description:
+            - State of the module.
+            - If C(state) is C(present), the module will generate a new VM
+              console token for the provided VM.
+            - Only C(present) is supported for this action module.
+        type: str
+        choices:
+            - present
+        default: present
+    ext_id:
+        description:
+            - The globally unique identifier (UUID) of the AHV VM for which
+              the console token should be generated.
+            - This is the external ID of the target User VM (UVM) — CVMs
+              are not supported by this API.
+        type: str
+        required: true
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+    - George Ghawali (@george-ghawali)
+"""
+EXAMPLES = r"""
+- name: Generate VM console token
+  nutanix.ncp.ntnx_vm_console_token_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+  register: result
+  ignore_errors: true
+"""
+RETURN = r"""
+response:
+    description:
+        - Response for generating the VM console token.
+        - Task details when C(wait) is true (the completed task carries the
+          console token / WebSocket URI in its completion details).
+        - Task reference details when C(wait) is false.
+    returned: always
+    type: dict
+    sample:
+        {
+            "cluster_ext_ids": [
+                "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2"
+            ],
+            "completed_time": "2026-07-20T17:36:20.123456+00:00",
+            "completion_details": [
+                {
+                    "name": "VmConsoleToken",
+                    "value": "eyJhbGciOiJSUzI1NiJ9.<truncated-jwt>"
+                },
+                {
+                    "name": "WsUri",
+                    "value": "wss://10.44.76.28:9440/console/launch/ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+                }
+            ],
+            "created_time": "2026-07-20T17:36:17.000000+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "ac5aff0c-6c68-4948-9088-b903e2be0ce7",
+                    "rel": "vmm:ahv:config:vm"
+                }
+            ],
+            "error_messages": null,
+            "ext_id": "ZXJnb24=:1a1a1a1a-2b2b-3c3c-4d4d-5e5e5e5e5e5e",
+            "is_cancelable": false,
+            "last_updated_time": "2026-07-20T17:36:20.123456+00:00",
+            "legacy_error_message": null,
+            "operation": "GenerateVmConsoleToken",
+            "operation_description": "Generate VM console token",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "started_time": "2026-07-20T17:36:17.500000+00:00",
+            "status": "SUCCEEDED",
+            "sub_steps": null,
+            "sub_tasks": null,
+            "warnings": null
+        }
+
+changed:
+    description: This indicates whether the task resulted in any changes.
+    returned: always
+    type: bool
+    sample: true
+
+msg:
+    description: This indicates the message if any message occurred.
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while generating VM console token"
+
+error:
+    description:
+        - This field typically holds information about if the task have
+          errors that occurred during the task execution.
+    returned: when an error occurs
+    type: str
+    sample: "Not Found"
+
+failed:
+    description: This field typically holds information about if the task have failed.
+    returned: always
+    type: bool
+    sample: false
+
+task_ext_id:
+    description: The external ID of the async task that generates the console token.
+    returned: always
+    type: str
+    sample: "ZXJnb24=:1a1a1a1a-2b2b-3c3c-4d4d-5e5e5e5e5e5e"
+
+ext_id:
+    description: The external ID of the AHV VM the token was generated for.
+    returned: always
+    type: str
+    sample: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import get_vm_api_instance  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_vmm_py_client  # noqa: F401,E402  pylint: disable=unused-import
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: F401,E402  pylint: disable=unused-import
+        mock_sdk as ntnx_vmm_py_client,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        ext_id=dict(type="str", required=True),
+    )
+
+    return module_args
+
+
+def generate_vm_console_token(module, result, api_instance):
+    """
+    Trigger the async VMM v4 GenerateConsoleTokenById action for the given VM.
+
+    Args:
+        module: Ansible module.
+        result: shared result dict (mutated in place).
+        api_instance: VmApi instance from ntnx_vmm_py_client SDK.
+    """
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["response"] = {
+            "ext_id": ext_id,
+            "operation": "GenerateVmConsoleToken",
+        }
+        return
+
+    resp = None
+    try:
+        resp = api_instance.generate_console_token_by_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while generating VM console token",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"), exception=SDK_IMP_ERROR
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_vm_api_instance(module)
+    generate_vm_console_token(module, result, api_instance)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_console_token_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_console_token_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_console_token_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_console_token_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_console_token_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_console_token_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import vm_console_token.yml
+      ansible.builtin.import_tasks: "vm_console_token.yml"

--- a/tests/integration/targets/ntnx_vm_console_token_v2/tasks/vm_console_token.yml
+++ b/tests/integration/targets/ntnx_vm_console_token_v2/tasks/vm_console_token.yml
@@ -1,0 +1,245 @@
+---
+# Integration tests for ntnx_vm_console_token_v2
+#
+# Test plan:
+# 1. Discover an AHV cluster on the target Prism Central so the test is
+#    portable across environments (no hard-coded cluster UUIDs).
+# 2. Create a minimal AHV VM on that cluster to act as the console-token
+#    target. The generate-console-token API only needs a VM external ID
+#    (no body), so the VM itself does not need networking or disks for
+#    the token request to be accepted.
+# 3. Check_mode test for Generate: verify no API call is made and the
+#    module reports changed==false with the target ext_id echoed back.
+# 4. Real generate call: run against the created VM and assert the
+#    module reports changed==true, failed==false, task_ext_id present
+#    and the underlying task reached SUCCEEDED status.
+# 5. Wait=false variant: verify the module returns the task reference
+#    immediately without waiting for completion.
+# 6. Negative test: attempt to generate a token for a non-existent VM
+#    external ID and verify the module fails with a descriptive error.
+# 7. Negative test: omit the required ext_id parameter and verify the
+#    Ansible argument spec rejects the call.
+# 8. Cleanup: delete the VM created for the test.
+
+- name: Start ntnx_vm_console_token_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_vm_console_token_v2 tests
+
+- name: Generate random suffix for VM name
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set VM name for console token test
+  ansible.builtin.set_fact:
+    vm_name: "ansible_console_token_{{ random_name }}"
+
+########################################################################################
+# Discover an AHV cluster to host the test VM
+########################################################################################
+
+- name: Fetch AHV clusters on Prism Central
+  nutanix.ncp.ntnx_clusters_info_v2:
+    filter: "config/clusterFunction/any(f:f eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+  register: clusters_info
+  ignore_errors: true
+
+- name: Assert clusters were listed
+  ansible.builtin.assert:
+    that:
+      - clusters_info is defined
+      - clusters_info.failed == false
+      - clusters_info.response is defined
+      - clusters_info.response | length > 0
+    success_msg: "Clusters fetched successfully"
+    fail_msg: "Failed to fetch clusters from Prism Central"
+
+- name: Pick the first AHV cluster (skip PRISM_CENTRAL)
+  ansible.builtin.set_fact:
+    ahv_cluster_ext_id: >-
+      {{ (clusters_info.response
+          | selectattr('config', 'defined')
+          | selectattr('config.cluster_function', 'defined')
+          | rejectattr('config.cluster_function', 'contains', 'PRISM_CENTRAL')
+          | list
+          | first).ext_id }}
+
+- name: Show selected AHV cluster ext_id
+  ansible.builtin.debug:
+    var: ahv_cluster_ext_id
+
+########################################################################################
+# Create a test VM to act as the console-token target
+########################################################################################
+
+- name: Create test VM for console token generation
+  nutanix.ncp.ntnx_vms_v2:
+    state: present
+    name: "{{ vm_name }}"
+    description: "VM created by ntnx_vm_console_token_v2 integration test"
+    cluster:
+      ext_id: "{{ ahv_cluster_ext_id }}"
+    memory_size_bytes: 1073741824
+    num_sockets: 1
+    num_cores_per_socket: 1
+  register: vm_result
+  ignore_errors: true
+
+- name: Assert VM created
+  ansible.builtin.assert:
+    that:
+      - vm_result is defined
+      - vm_result.changed == true
+      - vm_result.failed == false
+      - vm_result.response is defined
+      - vm_result.response.name == vm_name
+      - vm_result.ext_id is defined
+    success_msg: "Test VM created successfully"
+    fail_msg: "Failed to create test VM"
+
+- name: Set VM ext_id
+  ansible.builtin.set_fact:
+    vm_ext_id: "{{ vm_result.ext_id }}"
+
+########################################################################################
+# check_mode: generate console token (should NOT hit the API)
+########################################################################################
+
+- name: Generate console token in check mode
+  nutanix.ncp.ntnx_vm_console_token_v2:
+    state: present
+    ext_id: "{{ vm_ext_id }}"
+  register: check_result
+  ignore_errors: true
+  check_mode: true
+
+- name: Assert check_mode generate response
+  ansible.builtin.assert:
+    that:
+      - check_result is defined
+      - check_result.changed == false
+      - check_result.failed == false
+      - check_result.ext_id == vm_ext_id
+      - check_result.response is defined
+      - check_result.response.ext_id == vm_ext_id
+      - check_result.response.operation == 'GenerateVmConsoleToken'
+      - check_result.task_ext_id is none or check_result.task_ext_id == None
+    success_msg: "check_mode generate console token behaved correctly"
+    fail_msg: "check_mode generate console token unexpected result"
+
+########################################################################################
+# Real generate console token call (default wait: true)
+########################################################################################
+
+- name: Generate console token for the test VM (wait for task completion)
+  nutanix.ncp.ntnx_vm_console_token_v2:
+    state: present
+    ext_id: "{{ vm_ext_id }}"
+  register: token_result
+  ignore_errors: true
+
+- name: Assert generate console token result
+  ansible.builtin.assert:
+    that:
+      - token_result is defined
+      - token_result.changed == true
+      - token_result.failed == false
+      - token_result.ext_id == vm_ext_id
+      - token_result.task_ext_id is defined
+      - token_result.task_ext_id | length > 0
+      - token_result.response is defined
+      - token_result.response.status == 'SUCCEEDED'
+      - token_result.response.operation == 'GenerateVmConsoleToken'
+      - token_result.response.entities_affected is defined
+      - token_result.response.entities_affected | length > 0
+      - (token_result.response.entities_affected
+           | selectattr('ext_id', 'equalto', vm_ext_id) | list | length) > 0
+    success_msg: "Generate console token succeeded and returned a task"
+    fail_msg: "Generate console token failed or returned unexpected data"
+
+########################################################################################
+# Generate console token with wait: false (return task reference immediately)
+########################################################################################
+
+- name: Generate console token without waiting for task completion
+  nutanix.ncp.ntnx_vm_console_token_v2:
+    state: present
+    ext_id: "{{ vm_ext_id }}"
+    wait: false
+  register: nowait_result
+  ignore_errors: true
+
+- name: Assert wait:false response
+  ansible.builtin.assert:
+    that:
+      - nowait_result is defined
+      - nowait_result.changed == true
+      - nowait_result.failed == false
+      - nowait_result.ext_id == vm_ext_id
+      - nowait_result.task_ext_id is defined
+      - nowait_result.task_ext_id | length > 0
+      - nowait_result.response is defined
+      - nowait_result.response.ext_id == nowait_result.task_ext_id
+    success_msg: "wait:false returned task reference immediately"
+    fail_msg: "wait:false did not return the expected task reference"
+
+########################################################################################
+# Negative test: non-existent VM external ID
+########################################################################################
+
+- name: Attempt to generate console token for a non-existent VM
+  nutanix.ncp.ntnx_vm_console_token_v2:
+    state: present
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: invalid_ext_id_result
+  ignore_errors: true
+
+- name: Assert non-existent VM failure
+  ansible.builtin.assert:
+    that:
+      - invalid_ext_id_result is defined
+      - invalid_ext_id_result.failed == true
+      - invalid_ext_id_result.msg is defined
+      - >-
+        'Api Exception raised while generating VM console token'
+        in invalid_ext_id_result.msg
+    success_msg: "Non-existent VM produced expected API failure"
+    fail_msg: "Non-existent VM did not fail as expected"
+
+########################################################################################
+# Negative test: missing required ext_id
+########################################################################################
+
+- name: Attempt to generate console token without ext_id
+  nutanix.ncp.ntnx_vm_console_token_v2:
+    state: present
+  register: missing_ext_id_result
+  ignore_errors: true
+
+- name: Assert missing ext_id validation error
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id_result is defined
+      - missing_ext_id_result.failed == true
+      - missing_ext_id_result.msg is defined
+      - "'ext_id' in missing_ext_id_result.msg"
+    success_msg: "Missing ext_id was rejected by argument spec validation"
+    fail_msg: "Missing ext_id was not rejected as expected"
+
+########################################################################################
+# Cleanup: delete the test VM
+########################################################################################
+
+- name: Delete the test VM
+  nutanix.ncp.ntnx_vms_v2:
+    state: absent
+    ext_id: "{{ vm_ext_id }}"
+  register: cleanup_result
+  ignore_errors: true
+
+- name: Assert VM cleanup succeeded
+  ansible.builtin.assert:
+    that:
+      - cleanup_result is defined
+      - cleanup_result.failed == false
+    success_msg: "Test VM deleted successfully"
+    fail_msg: "Failed to delete test VM (manual cleanup may be required)"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **virtual_machine_management** namespace,
entity **ConsoleToken**, based on the inline `sdk_info.json` embedded in the code-gen
instructions. One PR per code-gen run.

- Module generated: `ntnx_vm_console_token_v2` (action-type; wraps VMM v4
  `POST /api/vmm/v4.x/ahv/config/vms/{extId}/$actions/generate-console-token`).
- The upstream API only exposes a single action (`GenerateConsoleTokenById`) — there is
  no list / get-by-id endpoint for console tokens — so per the Step 2 rule
  ("If the module is action type module then skip this step") no companion
  `ntnx_console_tokens_info_v2` module was generated.
- API methods covered: **1** (`GenerateConsoleTokenById`).
- Fields in module spec: **2** (`state`, `ext_id`) plus the shared connection /
  operations / proxy / logger doc fragments.

## Domain knowledge (from Glean)

### ConsoleToken in Virtual Machine Management

The **ConsoleToken** (specifically utilized via the `Generate_VM_Console_Token` operation)
is a feature in the Nutanix Virtual Machine Management (VMM) V4 API. It provides secure,
token-based access to the Virtual Network Computing (VNC) console of a User Virtual
Machine (UVM) running on AHV.

#### 1. Detailed Features
* **Secure Console Access:** Generates a short-lived JSON Web Token (JWT) and a WebSocket
  URI (`WsUri`) to authenticate and establish a VNC session with a VM.
* **Asynchronous Task Execution:** The generation request is handled as an asynchronous
  Ergon task (`GenerateVmConsoleToken`), which returns completion details containing the
  credentials.
* **Decoupled Architecture:** Separates the authentication layer (token generation) from
  the connection layer (WebSocket establishment), allowing clients to securely pass the
  token without embedding raw credentials.
* **Public/Private Key Management:** Automatically sets up and rotates RSA public/private
  keys in IDF (Infrastructure Data Fabric) and Mantle for token signing and verification.

#### 2. Where and How is it Used?
* **Prism Central (PC) UI:** The `VmConsole` React component (`VmConsole.tsx`) dispatches a
  Redux thunk (`fetchVmConsoleToken`) to fetch the token and URI, then establishes a
  connection via `wss://<PC-IP>:9440/console/launch/<VM_UUID>?VmConsoleToken=<jwt-token>`.
* **Automation & CI/CD:** Used in automated testing (e.g., `vnc_socket.py`), Packer
  plugins (`packer-plugin-nutanix`), and Cluster API providers
  (`cluster-api-provider-nutanix`) to interact with the VM UI programmatically.
* **Nutanix Cloud Manager (NCM):** Used by the NCM Connector and Self-Service portals to
  provide tenant users with console access.

#### 3. Prerequisites
* **API Version:** Requires Nutanix V4 APIs.
* **Cluster Capability:** The underlying AHV/PE cluster must have the
  `supports_gw_vnc_console: true` capability enabled.
* **Entity Type:** The target entity must be a User VM (UVM). CVMs (Controller VMs) are
  internal infrastructure components and do not support this endpoint.
* **RBAC Permissions:** The user must have a role with the `Generate_VM_Console_Token`
  permission. Supported roles include: *Super Admin, Internal Super Admin, Prism Admin,
  VM Admin, Project Admin, Developer, Consumer, Operator, NCM Connector, Tenant Admin,
  and Tenant Consumer*.

#### 4. Workflow
1. **Request:** A client makes a
   `POST /api/vmm/v4.x/ahv/config/vms/{extId}/$actions/generate-console-token` request.
2. **Task Creation:** Metropolis creates an Ergon task and transitions it to running.
3. **Key Verification:** The `token_manager` checks if VM console token keys exist in
   IDF/Mantle. If not, it generates and stores a new RSA key pair.
4. **Token Generation:** A JWT token is signed using the private key.
5. **Completion:** The task succeeds and outputs `VmConsoleToken` and `WsUri` in its
   `completionDetails`.
6. **Connection:** The client opens a WebSocket connection to the `WsUri` and passes the
   JWT token. The VNC proxy validates the signature against the public key and proxies
   the traffic to the AHV host.

#### 5. Behavioral Details & Known Edge Cases
* **CVM Restriction:** Attempting to generate a console token for a CVM yields a
  `404 Not Found` or `VM Operation Not Authorized (VMM-30500)`, as CVMs do not exist in
  the VMM database scope.
* **Unsupported Clusters:** If the PE cluster lacks the capability or there is an IDF
  sync issue, the task fails with `VMM-10001: Generate Token Failed: VM console token
  generation is not supported in cluster`.
* **Key Generation Race Condition:** Historically, launching multiple concurrent token
  generation tasks on a completely fresh cluster could cause a race condition
  (`Another update in progress`), resulting in corrupted keys and subsequent
  `401 Unauthorized (crypto/rsa: verification error)` failures during WebSocket
  handshakes. A synchronization lock was implemented to fix this.
* **Error Codes:**
  * `31400`: Key setup failed.
  * `31401`: Token generation internal error.
  * `31402`: Token invalid or expired (`crypto/rsa: verification error`).
  * `31403`: Token not found.

### Related Engineering Tickets, Documents, and Links

**JIRA Tickets (Bugs & Features):**
* [ENG-837692](https://jira.nutanix.com/browse/ENG-837692): Update the min permission on the backend for generating console token.
* [ENG-880205](https://jira.nutanix.com/browse/ENG-880205) / [ENG-876474](https://jira.nutanix.com/browse/ENG-876474): Generate Token Failed: VM console token generation is not supported in cluster.
* [ENG-924311](https://jira.nutanix.com/browse/ENG-924311) / [ENG-953200](https://jira.nutanix.com/browse/ENG-953200): VNC Console Snapshot fails with 401 `crypto/rsa: verification error`.
* [ENG-953296](https://jira.nutanix.com/browse/ENG-953296): NCM Connector Needs `Generate_VM_Console_Token` role mapping.
* [ENG-941207](https://jira.nutanix.com/browse/ENG-941207): Generate token failing for CVMs (V4 API UUID mismatch).
* [ENG-912457](https://jira.nutanix.com/browse/ENG-912457): Generate VM console token with unauthorized access UI issue.

**Pull Requests & Code Implementations:**
* [ntnx-api-vmm PR #1610](https://github.com/nutanix-core/ntnx-api-vmm/pull/1610) / [PR #1611](https://github.com/nutanix-core/ntnx-api-vmm/pull/1611): Adding NCM Connector role to endpoint.
* [prism-go-client PR #341](https://github.com/nutanix-cloud-native/prism-go-client/pull/341) / [PR #343](https://github.com/nutanix-cloud-native/prism-go-client/pull/343): Add `GenerateConsoleToken` to VMs Go client service.
* [packer-plugin-nutanix PR #340](https://github.com/nutanix-cloud-native/packer-plugin-nutanix/pull/340): Refactor `GenerateConsoleToken` to use `prism-go-client`.

**Source Documents & SDKs surfaced by Glean:**
* [GenerateConsoleTokenApiResponse.py](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/config/GenerateConsoleTokenApiResponse.py)
* [GenerateConsoleTokenApiResponsedata.py](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/OneOfvmm/v4/ahv/config/GenerateConsoleTokenApiResponsedata.py)
* [generate_console_token_by_id_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vm/generate_console_token_by_id_request.go)
* [generateConsoleTokenById_expectation.json](https://github.com/nutanix-core/pc-mock/blob/main/mock_expectations/wiremock/grpc/ntnx-api-vmm/15d3f7da9d02dcf601f1c134db286c8adf1e39c4/generateConsoleTokenById_expectation.json)
* [vmEndpoints.yaml (VMM API definitions)](https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv/released/api/vmEndpoints.yaml)
* [314xx-vmConsoleErrors.yaml](https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/etc/resources/errorMessages/bundles/en_US/314xx-vmConsoleErrors.yaml)
* [operations_api_vmm.json (RBAC)](https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/api_artifacts/vmm/v4.r1/vmm-api-definitions-17.4.0.4582-RELEASE/operations_api_vmm.json)
* [etag_removal_from_action_endpoints_test_plan_feat_17853.md](https://github.com/nutanix-core/panacea-documents/blob/main/documents/acropolis/test-plan/etag_removal_from_action_endpoints_test_plan_feat_17853.md)
* [VmConsole.tsx (Prism UI)](https://github.com/nutanix-core/prism-ui-prism-subapps-vnc/blob/master/services/src/components/VmConsole/VmConsole.tsx) / [PageConsole.tsx](https://github.com/nutanix-core/prism-ui-prism-subapps-vnc/blob/master/services/src/components/PageConsole/PageConsole.tsx) / [consoleSlice.ts](https://github.com/nutanix-core/prism-ui-prism-subapps-vnc/blob/master/services/src/store/slice/consoleSlice.ts) / [VmConsole.test.tsx](https://github.com/nutanix-core/prism-ui-prism-subapps-vnc/blob/master/services/src/components/VmConsole/VmConsole.test.tsx) / [selectors/index.ts](https://github.com/nutanix-core/prism-ui-prism-subapps-vnc/blob/master/services/src/store/selectors/index.ts) / [selectors/index.test.ts](https://github.com/nutanix-core/prism-ui-prism-subapps-vnc/blob/master/services/src/store/selectors/index.test.ts)
* [vnc_socket.py (nutest workflow)](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/lib/vnc/vnc_socket.py)
* [vms_test.go (prism-go-client)](https://github.com/nutanix-cloud-native/prism-go-client/blob/main/converged/v4/vms_test.go) / [vms.go mock](https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/mocks/converged/vms.go)

**Confluence / SharePoint / Design Docs:**
* [Narsil Overview](https://confluence.eng.nutanix.com:8443/spaces/~raymond.yip/pages/507289560/Narsil+Overview)
* [SDK Release Versions](https://confluence.eng.nutanix.com:8443/spaces/AI/pages/200405145/SDK+Release+Versions)
* [Node, VM & CVM Management](https://confluence.eng.nutanix.com:8443/spaces/SO/pages/137576994/Node+VM+CVM+Management)
* [pc-sec-guide (Prism Central Security Guide)](https://nutanixinc.sharepoint.com/sites/techpubs/External%20Documents/pc-sec-guide.pdf)
* [Day-to-Day virtual_machine_management operations](https://nutanixinc.sharepoint.com/sites/GSI_EMEA/_layouts/15/Doc.aspx?sourcedoc=%7BD046B348-F066-42A5-AF92-590A9EC0EB99%7D&file=Day-to-Day_virtual_machine_management_operations.docx&action=default&mobileredirect=true)
* [ahv_high_availability_for_virtual_machines_design_document.md](https://github.com/nutanix-core/panacea-documents/blob/main/documents/ahv/design-doc/ahv_high_availability_for_virtual_machines_design_document.md)
* [Java Client For Nutanix VMM APIs](https://github.com/nutanix-core/ntnx-api-java-sdk-external/blob/main/vmm/README.md) / [Go Client for VMM APIs](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_client/github.com/vendor/github.com/nutanix-core/ntnx-api-golang-sdk-internal/vmm-go-client/v17/README.md)
* [rbac_coverage_report.md](https://github.com/nutanix-engineering/hack2026-d3089/blob/main/hackathon_new/tpg_output/rbac/rbac_coverage_report.md)
* [AHV: DoDIN - Virtual Machine Manager (VMM) STIGs (ENG-662049)](https://jira.nutanix.com/browse/ENG-662049)
* [Recovery Points from all other projects are accessible for all user projects (ENG-704856)](https://jira.nutanix.com/browse/ENG-704856)

### Required Domain Skills

To understand and contribute to this feature end-to-end, familiarize yourself with:

1. **Nutanix V4 API Framework** — understand how `vmm-api-definitions` (Swagger/OpenAPI)
   map to Go/Python interfaces, and how Metropolis (PC) delegates capability checks to
   Acropolis/Narsil (PE).
2. **Ergon Task Orchestration** — how asynchronous tasks are dispatched, serialized, and
   how completion details (like `VmConsoleToken` / `WsUri`) are returned to the client
   upon `kSucceeded`.
3. **IAM & RBAC in Nutanix** — how `operations_api_vmm.json` and `vmEndpoints.yaml` map
   permissions like `Generate_VM_Console_Token` to roles.
4. **Cryptography & Mantle/IDF** — how RSA keys are generated, stored in Mantle (Nutanix
   secret store), persisted via IDF, and used to sign/verify JWTs.
5. **WebSocket & VNC Protocols (noVNC)** — how `noVNC` establishes WebSocket upgrades
   using URI parameters, and how the backend VNC proxy validates the JWT and tunnels
   RFB (Remote Framebuffer) traffic to the hypervisor.
6. **Frontend Redux Architecture** — `consoleSlice.ts` and `PageConsole.tsx` in
   `prism-ui-prism-subapps-vnc` for polling capabilities, requesting tokens, and falling
   back to legacy V3 WS connections when necessary.

## Files changed

- `plugins/modules/`
  - `ntnx_vm_console_token_v2.py` — new action module wrapping `GenerateConsoleTokenById`.
- `tests/integration/targets/ntnx_vm_console_token_v2/`
  - `aliases` — `disabled` alias to opt out of the default sanity/integration run set.
  - `meta/main.yml` — depends on `prepare_env`.
  - `tasks/main.yml` — sets `group/nutanix.ncp.ntnx` module_defaults and imports the
    scenarios.
  - `tasks/vm_console_token.yml` — full test plan (see comment header): discover AHV
    cluster, create test VM, check_mode + real generate + wait:false variants, negative
    tests (non-existent VM, missing required `ext_id`), cleanup.
- `examples/virtual_machine_management/ConsoleToken/`
  - `vm_console_token_v2.yml` — playbook demonstrating the successful and failure paths.
  - `examples_run.log` — real captured playbook output from a run against the live PC.
- `meta/runtime.yml` — added `ntnx_vm_console_token_v2` to the `ntnx` action group so
  `module_defaults: group/nutanix.ncp.ntnx:` supplies connection params to the module.
- `.gitignore` — added `tests/integration/integration_config.yml` (credentials file) and
  `tests/output/` (local ansible-test scratch) to keep run artifacts out of the branch.

## Test execution

| Metric              | Value                                                            |
|---------------------|------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-unsupported --allow-disabled ntnx_vm_console_token_v2 -v` |
| Total tests         | 23 tasks in the ntnx_vm_console_token_v2 role                    |
| Passed              | 23 (`ok=23  changed=4  failed=0  ignored=2`)                     |
| Failed              | 0                                                                |
| Skipped             | 0                                                                |
| Ignored (expected)  | 2 — the two negative-path modules calls that intentionally fail  |
| Duration            | ~24s                                                             |
| Cluster (PC)        | 10.44.76.28 (`auto_cluster_prod_36acf9b012ca`, AOS 7.6, AHV)      |
| Ansible / core      | `ansible [core 2.16.0]` / `ansible-test 2.16.0`                  |
| Sanity              | `ansible-test sanity --python 3.12 plugins/modules/ntnx_vm_console_token_v2.py` — all 32 sanity tests pass |
| Lint                | `black --check`, `isort --check`, `flake8`, `ansible-lint` — 0 failures |

### Analysis

All 23 assertions in the integration playbook pass on the live PC:

- **Cluster discovery + VM creation** succeed (the test picks the first non-PRISM_CENTRAL
  AHV cluster, then creates a temporary 1GB VM to act as the token target).
- **check_mode**: `ntnx_vm_console_token_v2` returns `changed=false`, no `task_ext_id`,
  and a stub `response` with `operation: GenerateVmConsoleToken` without hitting the API.
- **Real generate (wait=true default)**: returns `changed=true`, `failed=false`, a real
  `task_ext_id` (base64 `ergon:` prefix), and a completed task where
  `response.status == 'SUCCEEDED'`, `response.operation == 'GenerateVmConsoleToken'`,
  and `response.completion_details` carries `VmConsoleToken` (JWT) and `WsUri`.
- **wait=false variant**: returns immediately with the task reference; the module echoes
  the task ext_id back in both `task_ext_id` and `response.ext_id`.
- **Negative — non-existent VM UUID**: the module fails with `msg="Api Exception raised
  while generating VM console token"`, `status=404`, and the underlying API response
  reports `code: VMM-30100 / errorGroup: VM_NOT_FOUND`, matching the domain-knowledge
  expectations (see `314xx-vmConsoleErrors.yaml`).
- **Negative — missing required `ext_id`**: Ansible argument-spec validation rejects
  the call with `msg="missing required arguments: ext_id"` before any API call is made.
- **Cleanup**: the temporary VM is deleted (`DeleteVm SUCCEEDED`).

No test failures. No known issues.

### Test logs (tail)

<details>
<summary>tail of test_logs.log (last integration run against live PC)</summary>

```text
TASK [ntnx_vm_console_token_v2 : Generate console token in check mode] *********
ok: [testhost] => {"changed": false, "error": null, "ext_id": "ac6c51ea-b849-4e69-7b1c-bfd906a07892", "response": {"ext_id": "ac6c51ea-b849-4e69-7b1c-bfd906a07892", "operation": "GenerateVmConsoleToken"}, "task_ext_id": null}

TASK [ntnx_vm_console_token_v2 : Assert check_mode generate response] **********
ok: [testhost] => {"changed": false, "msg": "check_mode generate console token behaved correctly"}

TASK [ntnx_vm_console_token_v2 : Generate console token for the test VM (wait for task completion)] ***
changed: [testhost] => {"changed": true, "failed": false, "response": {"status": "SUCCEEDED", "operation": "GenerateVmConsoleToken",
    "completion_details": [{"name": "VmConsoleToken", "value": "<REDACTED-JWT>"},
                           {"name": "WsUri",           "value": "/console/launch/ac6c51ea-b849-4e69-7b1c-bfd906a07892"}]}}

TASK [ntnx_vm_console_token_v2 : Assert generate console token result] *********
ok: [testhost] => {"changed": false, "msg": "Generate console token succeeded and returned a task"}

TASK [ntnx_vm_console_token_v2 : Generate console token without waiting for task completion] ***
changed: [testhost] => {"changed": true, "task_ext_id": "ZXJnb24=:5ef0aa24-...", "response": {"ext_id": "ZXJnb24=:5ef0aa24-..."}}

TASK [ntnx_vm_console_token_v2 : Attempt to generate console token for a non-existent VM] ***
fatal: [testhost]: FAILED! => {"error": "NOT FOUND", "status": 404, "msg": "Api Exception raised while generating VM console token",
    "response": {"data": {"error": [{"code": "VMM-30100", "errorGroup": "VM_NOT_FOUND", "message": "Failed to perform the operation on the VM ... it is not found."}]}}}
...ignoring

TASK [ntnx_vm_console_token_v2 : Attempt to generate console token without ext_id] ***
fatal: [testhost]: FAILED! => {"msg": "missing required arguments: ext_id"}
...ignoring

PLAY RECAP *********************************************************************
testhost                   : ok=23   changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=2
```

</details>

The example playbook was also executed against the same PC — see
`examples/virtual_machine_management/ConsoleToken/examples_run.log` for the full output
(a real `VmConsoleToken` JWT was returned for the `nkp-bastion` VM). Sample response
values have been backfilled into the module's `RETURN` docstring where possible.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Reference modules followed: `plugins/modules/ntnx_vm_revert_v2.py` (action-type module
  layout & RETURN block) and `plugins/modules/ntnx_virtual_switch_v2.py` / the existing
  VMM v4 test/example patterns.
