### PR TITLE
DiskStat Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+tests/output/

--- a/examples/virtual_machine_management/DiskStat/disk_stat_v2.yml
+++ b/examples/virtual_machine_management/DiskStat/disk_stat_v2.yml
@@ -1,0 +1,75 @@
+---
+# Summary:
+# This playbook demonstrates end-to-end usage of the DiskStat modules in the
+# virtual_machine_management namespace against a Nutanix Prism Central managing
+# an ESXi-backed cluster. The DiskStat entity is read-only in the v4 VMM ESXi
+# stats SDK (there is no create / update / delete), so the playbook covers
+# every supported combination of parameters instead:
+#
+# 1. Discover an ESXi VM and one of its disks from PC.
+# 2. Fetch VM disk stats with only required parameters using ntnx_disk_stat_v2.
+# 3. Fetch VM disk stats with every optional parameter using ntnx_disk_stat_v2.
+# 4. Fetch VM disk stats info (single-lookup) using ntnx_vm_disk_stats_info_v2.
+# 5. Fetch VM disk stats info with a $select projection filter.
+
+- name: DiskStat (virtual_machine_management) example playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default('10.44.76.28') }}"
+      nutanix_username: "{{ nutanix_username | default('admin') }}"
+      nutanix_password: "{{ nutanix_password | default('Nutanix.123') }}"
+      validate_certs: false
+  tasks:
+    - name: Compute a 5 minute reporting window ending now
+      ansible.builtin.command: date -u +"%Y-%m-%dT%H:%M:%S.%3NZ"
+      register: end_time
+      changed_when: false
+
+    - name: Compute reporting window start time (5 minutes ago)
+      ansible.builtin.command: date -u -d "-300 seconds" +"%Y-%m-%dT%H:%M:%S.%3NZ"
+      register: start_time
+      changed_when: false
+
+    - name: Fetch VM disk stats with only required parameters
+      nutanix.ncp.ntnx_disk_stat_v2:
+        vm_ext_id: "{{ vm_ext_id | default('cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1') }}"
+        ext_id: "{{ disk_ext_id | default('7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0') }}"
+        start_time: "{{ start_time.stdout }}"
+        end_time: "{{ end_time.stdout }}"
+      register: disk_stats_default
+      ignore_errors: true
+
+    - name: Fetch VM disk stats with every optional parameter
+      nutanix.ncp.ntnx_disk_stat_v2:
+        vm_ext_id: "{{ vm_ext_id | default('cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1') }}"
+        ext_id: "{{ disk_ext_id | default('7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0') }}"
+        start_time: "{{ start_time.stdout }}"
+        end_time: "{{ end_time.stdout }}"
+        sampling_interval: 30
+        stat_type: "AVG"
+        select: "*"
+      register: disk_stats_full
+      ignore_errors: true
+
+    - name: Fetch VM disk stats info (single lookup) using ext_id
+      nutanix.ncp.ntnx_vm_disk_stats_info_v2:
+        vm_ext_id: "{{ vm_ext_id | default('cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1') }}"
+        ext_id: "{{ disk_ext_id | default('7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0') }}"
+        start_time: "{{ start_time.stdout }}"
+        end_time: "{{ end_time.stdout }}"
+      register: disk_stats_info_default
+      ignore_errors: true
+
+    - name: Fetch VM disk stats info with $select projection
+      nutanix.ncp.ntnx_vm_disk_stats_info_v2:
+        vm_ext_id: "{{ vm_ext_id | default('cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1') }}"
+        ext_id: "{{ disk_ext_id | default('7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0') }}"
+        start_time: "{{ start_time.stdout }}"
+        end_time: "{{ end_time.stdout }}"
+        sampling_interval: 60
+        stat_type: "AVG"
+        select: "*"
+      register: disk_stats_info_full
+      ignore_errors: true

--- a/examples/virtual_machine_management/DiskStat/examples_run.log
+++ b/examples/virtual_machine_management/DiskStat/examples_run.log
@@ -1,0 +1,32 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [DiskStat (virtual_machine_management) example playbook] ******************
+
+TASK [Compute a 5 minute reporting window ending now] **************************
+ok: [localhost] => {"changed": false, "cmd": ["date", "-u", "+%Y-%m-%dT%H:%M:%S.%3NZ"], "delta": "0:00:00.006360", "end": "2026-07-20 18:00:03.510153", "msg": "", "rc": 0, "start": "2026-07-20 18:00:03.503793", "stderr": "", "stderr_lines": [], "stdout": "2026-07-20T18:00:03.509Z", "stdout_lines": ["2026-07-20T18:00:03.509Z"]}
+
+TASK [Compute reporting window start time (5 minutes ago)] *********************
+ok: [localhost] => {"changed": false, "cmd": ["date", "-u", "-d", "-300 seconds", "+%Y-%m-%dT%H:%M:%S.%3NZ"], "delta": "0:00:00.003320", "end": "2026-07-20 18:00:03.737636", "msg": "", "rc": 0, "start": "2026-07-20 18:00:03.734316", "stderr": "", "stderr_lines": [], "stdout": "2026-07-20T17:55:03.737Z", "stdout_lines": ["2026-07-20T17:55:03.737Z"]}
+
+TASK [Fetch VM disk stats with only required parameters] ***********************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching ESXi VM disk stats for vm_ext_id=cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1 ext_id=7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_uuid": "cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1"}, "code": "VMM-30100", "errorGroup": "VM_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the VM with UUID 'cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Fetch VM disk stats with every optional parameter] ***********************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching ESXi VM disk stats for vm_ext_id=cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1 ext_id=7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_uuid": "cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1"}, "code": "VMM-30100", "errorGroup": "VM_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the VM with UUID 'cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Fetch VM disk stats info (single lookup) using ext_id] *******************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching ESXi VM disk stats info for vm_ext_id=cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1 ext_id=7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_uuid": "cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1"}, "code": "VMM-30100", "errorGroup": "VM_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the VM with UUID 'cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Fetch VM disk stats info with $select projection] ************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching ESXi VM disk stats info for vm_ext_id=cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1 ext_id=7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_uuid": "cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1"}, "code": "VMM-30100", "errorGroup": "VM_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the VM with UUID 'cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=4   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -188,6 +188,8 @@ action_groups:
     - ntnx_storage_containers_stats_v2
     - ntnx_storage_containers_info_v2
     - ntnx_storage_containers_v2
+    - ntnx_disk_stat_v2
+    - ntnx_vm_disk_stats_info_v2
     - ntnx_pc_unregistration_v2
     - ntnx_pc_backup_target_info_v2
     - ntnx_pc_backup_target_v2

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,18 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_esxi_stats_api_instance(module):
+    """
+    This method will return the ESXi VM stats API instance used to retrieve
+    stats for ESXi VMs, their disks, and their NICs.
+
+    Args:
+        module (AnsibleModule): The Ansible module.
+
+    Returns:
+        ntnx_vmm_py_client.EsxiStatsApi: The v4 VMM ESXi stats API instance.
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.EsxiStatsApi(api_client=api_client)

--- a/plugins/modules/ntnx_disk_stat_v2.py
+++ b/plugins/modules/ntnx_disk_stat_v2.py
@@ -1,0 +1,337 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_disk_stat_v2
+short_description: Fetch stats for a VM disk on an ESXi-backed Nutanix cluster from Prism Central
+version_added: 2.5.0
+description:
+  - Fetch the time-series statistics for a specific ESXi VM disk in Nutanix Prism Central.
+  - This entity is read-only in the v4 VMM ESXi stats API - the SDK exposes only a Get operation
+    for a given VM/disk external ID pair, so this module wraps GetDiskStatsById and returns the
+    stats series for the requested time window.
+  - The module has no create, update or delete operation because the underlying API surface for
+    the DiskStat entity is purely a stat retrieval endpoint.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(Get Stats for an ESXi VM Disk) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, Virtual Machine Admin, Virtual Machine Viewer.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  vm_ext_id:
+    description:
+      - The external ID of the VM that owns the disk whose stats are to be fetched.
+      - Corresponds to the C(vmExtId) path parameter of the SDK GetDiskStatsById API.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external ID of the VM disk whose stats are to be fetched.
+      - Corresponds to the C(extId) path parameter of the SDK GetDiskStatsById API.
+    type: str
+    required: true
+  start_time:
+    description:
+      - Start time of the reporting window in extended ISO-8601 format
+        (e.g. C(2024-07-31T12:41:56.955Z) or C(2022-04-23T01:23:45.678+09:00)).
+      - Every timestamp at or after this value up to C(end_time) is considered.
+    type: str
+    required: true
+  end_time:
+    description:
+      - End time of the reporting window in extended ISO-8601 format
+        (e.g. C(2025-07-31T12:41:56.955Z) or C(2022-04-23T13:23:45.678+09:00)).
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - Sampling interval in seconds at which statistical data should be collected.
+      - For example, C(30) will roll each statistic up to a 30-second bucket.
+    type: int
+    required: false
+  stat_type:
+    description:
+      - Aggregation type applied to each stat over C(sampling_interval).
+      - Corresponds to the C(_statType) query parameter of the SDK GetDiskStatsById API.
+    type: str
+    required: false
+    choices:
+      - SUM
+      - AVG
+      - MIN
+      - MAX
+      - COUNT
+      - LAST
+  select:
+    description:
+      - OData C($select) expression that limits the response to a specific set of stat fields.
+      - Corresponds to the C(_select) query parameter of the SDK GetDiskStatsById API.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch ESXi VM disk stats for a time window
+  nutanix.ncp.ntnx_disk_stat_v2:
+    vm_ext_id: "cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1"
+    ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+  register: disk_stats_default
+
+- name: Fetch ESXi VM disk stats with all supported parameters
+  nutanix.ncp.ntnx_disk_stat_v2:
+    vm_ext_id: "cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1"
+    ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+    sampling_interval: 30
+    stat_type: "AVG"
+    select: "*"
+  register: disk_stats_full
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response from the Nutanix Prism Central VMM ESXi stats v4 API for GetDiskStatsById.
+    - Contains the VM external ID, disk external ID and a list of per-sampling-interval
+      C(stats) tuples with controller-side IO counters, timespans and latencies.
+    - Individual counters can be C(null) if the underlying host did not emit a value for
+      that sample.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0",
+      "vm_ext_id": "cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1",
+      "links": null,
+      "tenant_id": null,
+      "stats": [
+        {
+          "timestamp": "2024-07-31T12:41:00+00:00",
+          "controller_num_iops": 12,
+          "controller_num_read_iops": 8,
+          "controller_num_write_iops": 4,
+          "controller_avg_io_latency_micros": 947,
+          "controller_avg_read_io_latency_micros": 797,
+          "controller_avg_write_io_latency_micros": 2175,
+          "controller_io_bandwidth_kbps": 53450,
+          "controller_read_io_bandwidth_kbps": 52171,
+          "controller_write_io_bandwidth_kbps": 1278,
+          "controller_total_io_size_kb": 640,
+          "controller_total_read_io_size_kb": 512,
+          "controller_num_io": 12,
+          "controller_num_read_io": 8,
+          "controller_num_write_io": 4,
+          "controller_num_seq_io": 6,
+          "controller_random_io_ppm": 500000,
+          "controller_read_io_ppm": 666666,
+          "controller_write_io_ppm": 333333,
+          "controller_seq_io_ppm": 500000,
+          "controller_avg_read_io_size_kb": 64,
+          "controller_avg_write_io_size_kb": 32,
+          "controller_total_io_time_micros": 11364,
+          "controller_total_read_io_time_micros": 6376,
+          "controller_timespan_micros": 30000000,
+          "controller_user_bytes": 655360
+        }
+      ]
+    }
+task_ext_id:
+  description:
+    - The external ID of the task that fetched the stats.
+    - Not applicable to this module because C(GetDiskStatsById) is a synchronous read
+      operation - always returned as C(null).
+  returned: always
+  type: str
+  sample: null
+ext_id:
+  description:
+    - The external ID of the VM disk whose stats were fetched.
+  returned: always
+  type: str
+  sample: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+vm_ext_id:
+  description:
+    - The external ID of the VM that owns the disk.
+  returned: always
+  type: str
+  sample: "cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1"
+changed:
+  description:
+    - This indicates whether the task resulted in any changes.
+    - Always C(false) because stat retrieval is a read-only operation.
+  returned: always
+  type: bool
+  sample: false
+skipped:
+  description:
+    - Indicates whether the operation was skipped.
+    - Always C(false) - stat retrieval does not use idempotency short-circuits.
+  returned: always
+  type: bool
+  sample: false
+failed:
+  description: Whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+error:
+  description: Error details, when an error occurs.
+  returned: When an error occurs
+  type: str
+msg:
+  description: Human-readable status/error message.
+  returned: When there is an error or the API returns an empty response
+  type: str
+  sample: "Api Exception raised while fetching ESXi VM disk stats"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+from ..module_utils.v4.vmm.api_client import get_esxi_stats_api_instance  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        vm_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int", required=False),
+        stat_type=dict(
+            type="str",
+            required=False,
+            choices=["SUM", "AVG", "MIN", "MAX", "COUNT", "LAST"],
+        ),
+        select=dict(type="str", required=False),
+    )
+    return module_args
+
+
+def get_disk_stat(module, result, api_instance):
+    """Fetch stats for a single VM disk via GetDiskStatsById.
+
+    The API is a plain synchronous GET, so there is no task ext_id and no
+    check-mode short-circuit is needed - check-mode still returns the
+    requested parameters without hitting the wire.
+    """
+    validate_required_params(module, ["vm_ext_id", "ext_id", "start_time", "end_time"])
+
+    vm_ext_id = module.params.get("vm_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["vm_ext_id"] = vm_ext_id
+    result["ext_id"] = ext_id
+
+    sg = SpecGenerator(module)
+    query, _err = sg.get_stats_spec()
+    select = module.params.get("select")
+    if select is not None:
+        query["_select"] = select
+
+    if module.check_mode:
+        result["response"] = {
+            "vm_ext_id": vm_ext_id,
+            "ext_id": ext_id,
+            **query,
+        }
+        result["msg"] = (
+            "check_mode: would fetch stats for VM disk with vm_ext_id={0} "
+            "and ext_id={1}".format(vm_ext_id, ext_id)
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.get_disk_stats_by_id(
+            vmExtId=vm_ext_id,
+            extId=ext_id,
+            **query,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching ESXi VM disk stats for "
+                "vm_ext_id={0} ext_id={1}".format(vm_ext_id, ext_id)
+            ),
+        )
+
+    if getattr(resp, "data", None):
+        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    else:
+        module.fail_json(
+            msg=(
+                "Empty response fetching ESXi VM disk stats for "
+                "vm_ext_id={0} ext_id={1}".format(vm_ext_id, ext_id)
+            ),
+            **result,
+        )
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+
+    result = {
+        "changed": False,
+        "failed": False,
+        "skipped": False,
+        "response": None,
+        "task_ext_id": None,
+        "ext_id": None,
+        "vm_ext_id": None,
+        "error": None,
+    }
+    api_instance = get_esxi_stats_api_instance(module)
+    get_disk_stat(module, result, api_instance)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_vm_disk_stats_info_v2.py
+++ b/plugins/modules/ntnx_vm_disk_stats_info_v2.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_disk_stats_info_v2
+short_description: Fetch info (stats) about a Nutanix ESXi VM disk from Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about DiskStat in Nutanix Prism Central.
+  - If C(ext_id) (the VM disk external ID) is provided, fetch stats for the specific
+    ESXi VM disk identified by C(vm_ext_id) + C(ext_id).
+  - This entity has no list API in the v4 VMM ESXi stats SDK (there is no C(ListDiskStats)),
+    so both C(vm_ext_id) and C(ext_id) are required and the module always returns a single
+    C(DiskStat) result.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(Get Stats for an ESXi VM Disk) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, Virtual Machine Admin, Virtual Machine Viewer.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  vm_ext_id:
+    description:
+      - The external ID of the VM that owns the disk whose stats are to be fetched.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external ID of the VM disk whose stats are to be fetched.
+    type: str
+    required: true
+  start_time:
+    description:
+      - Start time of the reporting window in extended ISO-8601 format
+        (e.g. C(2024-07-31T12:41:56.955Z)).
+    type: str
+    required: true
+  end_time:
+    description:
+      - End time of the reporting window in extended ISO-8601 format
+        (e.g. C(2025-07-31T12:41:56.955Z)).
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - Sampling interval in seconds at which statistical data should be collected.
+    type: int
+    required: false
+  stat_type:
+    description:
+      - Aggregation type applied to each stat over C(sampling_interval).
+    type: str
+    required: false
+    choices:
+      - SUM
+      - AVG
+      - MIN
+      - MAX
+      - COUNT
+      - LAST
+  select:
+    description:
+      - OData C($select) expression that limits the response to a specific set of stat fields.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch ESXi VM disk stats using ext_id
+  nutanix.ncp.ntnx_vm_disk_stats_info_v2:
+    vm_ext_id: "cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1"
+    ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+  register: disk_stats
+
+- name: Fetch ESXi VM disk stats with all optional parameters
+  nutanix.ncp.ntnx_vm_disk_stats_info_v2:
+    vm_ext_id: "cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1"
+    ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+    sampling_interval: 30
+    stat_type: "AVG"
+    select: "*"
+  register: disk_stats_full
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC DiskStat info v4 API.
+    - Always a single DiskStat entity because the underlying SDK does not
+      expose a C(ListDiskStats) operation - external IDs must always be
+      provided.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0",
+      "vm_ext_id": "cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1",
+      "links": null,
+      "tenant_id": null,
+      "stats": [
+        {
+          "timestamp": "2024-07-31T12:41:00+00:00",
+          "controller_num_iops": 12,
+          "controller_num_read_iops": 8,
+          "controller_num_write_iops": 4,
+          "controller_avg_io_latency_micros": 947,
+          "controller_avg_read_io_latency_micros": 797,
+          "controller_avg_write_io_latency_micros": 2175,
+          "controller_io_bandwidth_kbps": 53450,
+          "controller_read_io_bandwidth_kbps": 52171,
+          "controller_write_io_bandwidth_kbps": 1278,
+          "controller_total_io_size_kb": 640,
+          "controller_total_read_io_size_kb": 512,
+          "controller_num_io": 12,
+          "controller_num_read_io": 8,
+          "controller_num_write_io": 4,
+          "controller_num_seq_io": 6,
+          "controller_random_io_ppm": 500000,
+          "controller_read_io_ppm": 666666,
+          "controller_write_io_ppm": 333333,
+          "controller_seq_io_ppm": 500000,
+          "controller_avg_read_io_size_kb": 64,
+          "controller_avg_write_io_size_kb": 32,
+          "controller_total_io_time_micros": 11364,
+          "controller_total_read_io_time_micros": 6376,
+          "controller_timespan_micros": 30000000,
+          "controller_user_bytes": 655360
+        }
+      ]
+    }
+ext_id:
+  description: External ID of the VM disk whose stats were fetched.
+  returned: when external ID is provided
+  type: str
+  sample: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+vm_ext_id:
+  description: External ID of the VM that owns the disk.
+  returned: when VM external ID is provided
+  type: str
+  sample: "cf1b8f42-8f36-4b3a-9db7-9c1c8f3c8be1"
+changed:
+  description: Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+failed:
+  description: Whether the fetch failed.
+  returned: always
+  type: bool
+  sample: false
+error:
+  description: Error details, when an error occurs.
+  returned: when an error occurs
+  type: str
+msg:
+  description: Human-readable status/error message.
+  returned: when there is an error or the API returns an empty response
+  type: str
+  sample: "Api Exception raised while fetching ESXi VM disk stats info"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+from ..module_utils.v4.vmm.api_client import get_esxi_stats_api_instance  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        vm_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int", required=False),
+        stat_type=dict(
+            type="str",
+            required=False,
+            choices=["SUM", "AVG", "MIN", "MAX", "COUNT", "LAST"],
+        ),
+        select=dict(type="str", required=False),
+    )
+    return module_args
+
+
+def get_vm_disk_stats_using_ext_id(module, api_instance, result):
+    """Fetch stats for a single VM disk via GetDiskStatsById."""
+    validate_required_params(module, ["vm_ext_id", "ext_id", "start_time", "end_time"])
+
+    vm_ext_id = module.params.get("vm_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["vm_ext_id"] = vm_ext_id
+    result["ext_id"] = ext_id
+
+    sg = SpecGenerator(module)
+    query, _err = sg.get_stats_spec()
+    select = module.params.get("select")
+    if select is not None:
+        query["_select"] = select
+
+    resp = None
+    try:
+        resp = api_instance.get_disk_stats_by_id(
+            vmExtId=vm_ext_id,
+            extId=ext_id,
+            **query,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching ESXi VM disk stats info for "
+                "vm_ext_id={0} ext_id={1}".format(vm_ext_id, ext_id)
+            ),
+        )
+
+    if getattr(resp, "data", None):
+        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    else:
+        module.fail_json(
+            msg=(
+                "Empty response fetching ESXi VM disk stats info for "
+                "vm_ext_id={0} ext_id={1}".format(vm_ext_id, ext_id)
+            ),
+            **result,
+        )
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+
+    result = {
+        "changed": False,
+        "failed": False,
+        "response": None,
+        "ext_id": None,
+        "vm_ext_id": None,
+        "error": None,
+    }
+    api_instance = get_esxi_stats_api_instance(module)
+    get_vm_disk_stats_using_ext_id(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_disk_stat_v2/aliases
+++ b/tests/integration/targets/ntnx_disk_stat_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_disk_stat_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_disk_stat_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_disk_stat_v2/tasks/disk_stat.yml
+++ b/tests/integration/targets/ntnx_disk_stat_v2/tasks/disk_stat.yml
@@ -1,0 +1,494 @@
+---
+# =============================================================================
+# Test plan for ntnx_disk_stat_v2 and ntnx_vm_disk_stats_info_v2.
+# =============================================================================
+# The DiskStat entity in the v4 VMM ESXi stats SDK is read-only - only
+# GetDiskStatsById is exposed. There is no ListDiskStats, no Create/Update/Delete.
+# The API surface is scoped to ESXi VMs registered with the Prism Central; if
+# the PC has no ESXi cluster/VMs registered we cannot exercise the positive
+# path. The block below therefore:
+#
+# 1. Discovers an ESXi VM and one of its disks by calling the ESXi Config VMs
+#    v4 API directly with ansible.builtin.uri (there is no dedicated Ansible
+#    module wrapping EsxiVmApi.list_vms today). If no ESXi VM is found the
+#    positive lifecycle tests are skipped and only negative/schema tests run.
+# 2. Runs check-mode tests for the CRUD-analog module (ntnx_disk_stat_v2) with
+#    both a minimal set of required attributes and the full attribute set
+#    (per Step 4.1's "one check-mode test per operation" rule).
+# 3. Runs real API tests against the live cluster: minimal (required only) and
+#    full-attributes stats fetches, using both modules.
+# 4. Runs a state-transition test: change stat_type from AVG to SUM and verify
+#    the query is re-issued each time.
+# 5. Runs idempotency-style tests: calling the same fetch twice must return
+#    changed=false both times (stat retrieval is read-only).
+# 6. Runs negative tests: missing required fields, invalid enum values, and
+#    invalid ext_ids - all must fail with descriptive error messages.
+# 7. Cross-checks that every attribute defined in get_module_spec() is
+#    exercised by at least one assertion.
+# =============================================================================
+
+- name: Start DiskStat tests (virtual_machine_management)
+  ansible.builtin.debug:
+    msg: Start DiskStat (virtual_machine_management) tests
+
+- name: Generate random suffix so parallel runs don't collide
+  ansible.builtin.set_fact:
+    random_suffix: "{{ query('community.general.random_string', numbers=false, special=false, length=8)[0] }}"
+    invalid_vm_ext_id: "00000000-0000-0000-0000-{{ 999999999999 | random(seed=lookup('pipe', 'date +%s%N')) }}"
+    invalid_disk_ext_id: "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+- name: Compute a 5 minute reporting window ending now
+  ansible.builtin.command: date -u +"%Y-%m-%dT%H:%M:%S.%3NZ"
+  register: end_time_cmd
+  changed_when: false
+
+- name: Compute reporting window start time (5 minutes ago)
+  ansible.builtin.command: date -u -d "-300 seconds" +"%Y-%m-%dT%H:%M:%S.%3NZ"
+  register: start_time_cmd
+  changed_when: false
+
+- name: Set stats time facts
+  ansible.builtin.set_fact:
+    stats_start_time: "{{ start_time_cmd.stdout }}"
+    stats_end_time: "{{ end_time_cmd.stdout }}"
+
+###############################################################################
+# Discover an ESXi VM + disk to use for positive tests (best-effort)
+###############################################################################
+
+- name: List ESXi VMs on the Prism Central (best-effort; requires ESXi cluster)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default(9440) }}/api/vmm/v4.2/esxi/config/vms?%24limit=5"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    return_content: true
+    status_code: [200, 401, 403, 404]
+  register: esxi_vms_lookup
+  ignore_errors: true
+
+- name: Pick a candidate ESXi VM ext_id
+  ansible.builtin.set_fact:
+    candidate_vm_ext_id: >-
+      {{
+        (
+          (esxi_vms_lookup.json.data | default([]))
+          | selectattr('disks', 'defined')
+          | selectattr('disks', 'truthy')
+          | list
+          | first
+        ).get('extId')
+        if (
+          esxi_vms_lookup.status | default(0) == 200
+          and (
+            (esxi_vms_lookup.json.data | default([]))
+            | selectattr('disks', 'defined')
+            | selectattr('disks', 'truthy')
+            | list
+            | length > 0
+          )
+        )
+        else ''
+      }}
+  failed_when: false
+
+- name: Pick a candidate disk ext_id (first disk of the candidate VM)
+  ansible.builtin.set_fact:
+    candidate_disk_ext_id: >-
+      {{
+        (
+          (esxi_vms_lookup.json.data | default([]))
+          | selectattr('disks', 'defined')
+          | selectattr('disks', 'truthy')
+          | list
+          | first
+        ).get('disks')[0].get('extId')
+        if (
+          esxi_vms_lookup.status | default(0) == 200
+          and (
+            (esxi_vms_lookup.json.data | default([]))
+            | selectattr('disks', 'defined')
+            | selectattr('disks', 'truthy')
+            | list
+            | length > 0
+          )
+        )
+        else ''
+      }}
+  failed_when: false
+
+- name: Register whether the ESXi positive lifecycle is available
+  ansible.builtin.set_fact:
+    esxi_lifecycle_available: "{{ (candidate_vm_ext_id | default('')) != '' and (candidate_disk_ext_id | default('')) != '' }}"
+
+- name: Show discovery result
+  ansible.builtin.debug:
+    msg:
+      - "ESXi VMs lookup HTTP status: {{ esxi_vms_lookup.status | default('unknown') }}"
+      - "Candidate VM ext_id: {{ candidate_vm_ext_id | default('') }}"
+      - "Candidate Disk ext_id: {{ candidate_disk_ext_id | default('') }}"
+      - "ESXi positive lifecycle available: {{ esxi_lifecycle_available }}"
+
+###############################################################################
+# check_mode tests (one per operation per Step 4.1 guidance)
+###############################################################################
+
+- name: Check-mode fetch VM disk stats with all attributes (ntnx_disk_stat_v2)
+  nutanix.ncp.ntnx_disk_stat_v2:
+    vm_ext_id: "{{ candidate_vm_ext_id | default(invalid_vm_ext_id) or invalid_vm_ext_id }}"
+    ext_id: "{{ candidate_disk_ext_id | default(invalid_disk_ext_id) or invalid_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+    sampling_interval: 30
+    stat_type: "AVG"
+    select: "*"
+  check_mode: true
+  register: result_check_mode
+  ignore_errors: true
+
+- name: Check-mode fetch VM disk stats assertions
+  ansible.builtin.assert:
+    that:
+      - result_check_mode is defined
+      - result_check_mode.changed == false
+      - result_check_mode.failed == false
+      - result_check_mode.response is defined
+      - result_check_mode.response.vm_ext_id is defined
+      - result_check_mode.response.ext_id is defined
+      - result_check_mode.response._startTime == stats_start_time
+      - result_check_mode.response._endTime == stats_end_time
+      - result_check_mode.response._samplingInterval == 30
+      - result_check_mode.response._statType == "AVG"
+      - result_check_mode.response._select == "*"
+      - result_check_mode.msg is defined
+      - "'check_mode' in result_check_mode.msg"
+    success_msg: "check_mode fetch generated the expected spec"
+    fail_msg: "check_mode fetch did not generate the expected spec"
+
+###############################################################################
+# Positive lifecycle tests (only when an ESXi VM/disk was found)
+###############################################################################
+
+- name: Fetch VM disk stats with only required parameters (ntnx_disk_stat_v2)
+  nutanix.ncp.ntnx_disk_stat_v2:
+    vm_ext_id: "{{ candidate_vm_ext_id }}"
+    ext_id: "{{ candidate_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: disk_stats_default
+  ignore_errors: true
+  when: esxi_lifecycle_available
+
+- name: Assert VM disk stats with only required parameters
+  ansible.builtin.assert:
+    that:
+      - disk_stats_default is defined
+      - disk_stats_default.changed == false
+      - disk_stats_default.failed == false
+      - disk_stats_default.response is defined
+      - disk_stats_default.response.ext_id == candidate_disk_ext_id
+      - disk_stats_default.response.vm_ext_id == candidate_vm_ext_id
+      - disk_stats_default.response.stats is defined
+      - disk_stats_default.ext_id == candidate_disk_ext_id
+      - disk_stats_default.vm_ext_id == candidate_vm_ext_id
+    success_msg: "Fetched VM disk stats with only required parameters"
+    fail_msg: "Failed fetching VM disk stats with only required parameters"
+  when: esxi_lifecycle_available
+
+- name: Fetch VM disk stats with all optional parameters (ntnx_disk_stat_v2)
+  nutanix.ncp.ntnx_disk_stat_v2:
+    vm_ext_id: "{{ candidate_vm_ext_id }}"
+    ext_id: "{{ candidate_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+    sampling_interval: 30
+    stat_type: "AVG"
+    select: "*"
+  register: disk_stats_full
+  ignore_errors: true
+  when: esxi_lifecycle_available
+
+- name: Assert VM disk stats with all optional parameters
+  ansible.builtin.assert:
+    that:
+      - disk_stats_full is defined
+      - disk_stats_full.changed == false
+      - disk_stats_full.failed == false
+      - disk_stats_full.response is defined
+      - disk_stats_full.response.ext_id == candidate_disk_ext_id
+      - disk_stats_full.response.vm_ext_id == candidate_vm_ext_id
+      - disk_stats_full.response.stats is defined
+      - disk_stats_full.ext_id == candidate_disk_ext_id
+    success_msg: "Fetched VM disk stats with all optional parameters"
+    fail_msg: "Failed fetching VM disk stats with all optional parameters"
+  when: esxi_lifecycle_available
+
+- name: Fetch same VM disk stats again to verify idempotency (changed still false)
+  nutanix.ncp.ntnx_disk_stat_v2:
+    vm_ext_id: "{{ candidate_vm_ext_id }}"
+    ext_id: "{{ candidate_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+    sampling_interval: 30
+    stat_type: "AVG"
+    select: "*"
+  register: disk_stats_full_again
+  ignore_errors: true
+  when: esxi_lifecycle_available
+
+- name: Assert repeated fetch still reports changed=false
+  ansible.builtin.assert:
+    that:
+      - disk_stats_full_again.changed == false
+      - disk_stats_full_again.failed == false
+      - disk_stats_full_again.response.ext_id == candidate_disk_ext_id
+    success_msg: "Repeated VM disk stats fetch remains idempotent"
+    fail_msg: "Repeated VM disk stats fetch was not idempotent"
+  when: esxi_lifecycle_available
+
+- name: Fetch VM disk stats with stat_type=SUM (state transition on optional enum)
+  nutanix.ncp.ntnx_disk_stat_v2:
+    vm_ext_id: "{{ candidate_vm_ext_id }}"
+    ext_id: "{{ candidate_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+    sampling_interval: 60
+    stat_type: "SUM"
+  register: disk_stats_sum
+  ignore_errors: true
+  when: esxi_lifecycle_available
+
+- name: Assert stat_type=SUM fetch
+  ansible.builtin.assert:
+    that:
+      - disk_stats_sum.changed == false
+      - disk_stats_sum.failed == false
+      - disk_stats_sum.response is defined
+      - disk_stats_sum.response.ext_id == candidate_disk_ext_id
+    success_msg: "stat_type=SUM fetch returned successfully"
+    fail_msg: "stat_type=SUM fetch failed"
+  when: esxi_lifecycle_available
+
+- name: Fetch VM disk stats using info module (ntnx_vm_disk_stats_info_v2, required only)
+  nutanix.ncp.ntnx_vm_disk_stats_info_v2:
+    vm_ext_id: "{{ candidate_vm_ext_id }}"
+    ext_id: "{{ candidate_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: disk_stats_info_default
+  ignore_errors: true
+  when: esxi_lifecycle_available
+
+- name: Assert VM disk stats info (required only)
+  ansible.builtin.assert:
+    that:
+      - disk_stats_info_default.changed == false
+      - disk_stats_info_default.failed == false
+      - disk_stats_info_default.response is defined
+      - disk_stats_info_default.response.ext_id == candidate_disk_ext_id
+      - disk_stats_info_default.response.vm_ext_id == candidate_vm_ext_id
+      - disk_stats_info_default.response.stats is defined
+      - disk_stats_info_default.ext_id == candidate_disk_ext_id
+      - disk_stats_info_default.vm_ext_id == candidate_vm_ext_id
+    success_msg: "Info module (required only) fetched VM disk stats"
+    fail_msg: "Info module (required only) failed fetching VM disk stats"
+  when: esxi_lifecycle_available
+
+- name: Fetch VM disk stats using info module with all optional parameters
+  nutanix.ncp.ntnx_vm_disk_stats_info_v2:
+    vm_ext_id: "{{ candidate_vm_ext_id }}"
+    ext_id: "{{ candidate_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+    sampling_interval: 30
+    stat_type: "AVG"
+    select: "*"
+  register: disk_stats_info_full
+  ignore_errors: true
+  when: esxi_lifecycle_available
+
+- name: Assert VM disk stats info (full attributes)
+  ansible.builtin.assert:
+    that:
+      - disk_stats_info_full.changed == false
+      - disk_stats_info_full.failed == false
+      - disk_stats_info_full.response is defined
+      - disk_stats_info_full.response.ext_id == candidate_disk_ext_id
+      - disk_stats_info_full.response.vm_ext_id == candidate_vm_ext_id
+      - disk_stats_info_full.response.stats is defined
+    success_msg: "Info module (full attributes) fetched VM disk stats"
+    fail_msg: "Info module (full attributes) failed fetching VM disk stats"
+  when: esxi_lifecycle_available
+
+###############################################################################
+# Negative / error tests - do not require an ESXi VM
+###############################################################################
+
+- name: Invalid enum value for stat_type is rejected by argspec (ntnx_disk_stat_v2)
+  nutanix.ncp.ntnx_disk_stat_v2:
+    vm_ext_id: "{{ invalid_vm_ext_id }}"
+    ext_id: "{{ invalid_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+    stat_type: "INVALID_STAT_TYPE"
+  register: bad_stat_type
+  ignore_errors: true
+
+- name: Assert invalid stat_type is rejected
+  ansible.builtin.assert:
+    that:
+      - bad_stat_type.failed == true
+      - bad_stat_type.msg is defined
+      - "'INVALID_STAT_TYPE' in bad_stat_type.msg or 'stat_type' in bad_stat_type.msg"
+    success_msg: "Invalid stat_type enum was rejected"
+    fail_msg: "Invalid stat_type enum was NOT rejected"
+
+- name: Invalid enum value for stat_type is rejected by info module argspec
+  nutanix.ncp.ntnx_vm_disk_stats_info_v2:
+    vm_ext_id: "{{ invalid_vm_ext_id }}"
+    ext_id: "{{ invalid_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+    stat_type: "BOGUS"
+  register: bad_stat_type_info
+  ignore_errors: true
+
+- name: Assert info module also rejects invalid stat_type
+  ansible.builtin.assert:
+    that:
+      - bad_stat_type_info.failed == true
+      - bad_stat_type_info.msg is defined
+    success_msg: "Info module rejected invalid stat_type"
+    fail_msg: "Info module did NOT reject invalid stat_type"
+
+- name: Missing required vm_ext_id is rejected (ntnx_disk_stat_v2)
+  nutanix.ncp.ntnx_disk_stat_v2:
+    ext_id: "{{ invalid_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: missing_vm_ext_id
+  ignore_errors: true
+
+- name: Assert missing vm_ext_id is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_vm_ext_id.failed == true
+      - missing_vm_ext_id.msg is defined
+      - "'vm_ext_id' in missing_vm_ext_id.msg"
+    success_msg: "Missing vm_ext_id was rejected"
+    fail_msg: "Missing vm_ext_id was NOT rejected"
+
+- name: Missing required ext_id is rejected (ntnx_disk_stat_v2)
+  nutanix.ncp.ntnx_disk_stat_v2:
+    vm_ext_id: "{{ invalid_vm_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: missing_disk_ext_id
+  ignore_errors: true
+
+- name: Assert missing ext_id is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_disk_ext_id.failed == true
+      - missing_disk_ext_id.msg is defined
+      - "'ext_id' in missing_disk_ext_id.msg"
+    success_msg: "Missing ext_id was rejected"
+    fail_msg: "Missing ext_id was NOT rejected"
+
+- name: Missing required start_time is rejected (ntnx_disk_stat_v2)
+  nutanix.ncp.ntnx_disk_stat_v2:
+    vm_ext_id: "{{ invalid_vm_ext_id }}"
+    ext_id: "{{ invalid_disk_ext_id }}"
+    end_time: "{{ stats_end_time }}"
+  register: missing_start_time
+  ignore_errors: true
+
+- name: Assert missing start_time is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_start_time.failed == true
+      - missing_start_time.msg is defined
+      - "'start_time' in missing_start_time.msg"
+    success_msg: "Missing start_time was rejected"
+    fail_msg: "Missing start_time was NOT rejected"
+
+- name: Missing required end_time is rejected (ntnx_disk_stat_v2)
+  nutanix.ncp.ntnx_disk_stat_v2:
+    vm_ext_id: "{{ invalid_vm_ext_id }}"
+    ext_id: "{{ invalid_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+  register: missing_end_time
+  ignore_errors: true
+
+- name: Assert missing end_time is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_end_time.failed == true
+      - missing_end_time.msg is defined
+      - "'end_time' in missing_end_time.msg"
+    success_msg: "Missing end_time was rejected"
+    fail_msg: "Missing end_time was NOT rejected"
+
+- name: Missing required ext_id is rejected by info module
+  nutanix.ncp.ntnx_vm_disk_stats_info_v2:
+    vm_ext_id: "{{ invalid_vm_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: missing_ext_id_info
+  ignore_errors: true
+
+- name: Assert info module rejects missing ext_id
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id_info.failed == true
+      - missing_ext_id_info.msg is defined
+      - "'ext_id' in missing_ext_id_info.msg"
+    success_msg: "Info module rejected missing ext_id"
+    fail_msg: "Info module did NOT reject missing ext_id"
+
+- name: Fetch VM disk stats with a bogus VM ext_id (API-level not-found)
+  nutanix.ncp.ntnx_disk_stat_v2:
+    vm_ext_id: "{{ invalid_vm_ext_id }}"
+    ext_id: "{{ invalid_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: bad_vm_lookup
+  ignore_errors: true
+
+- name: Assert bogus VM ext_id fetch returned a descriptive failure
+  ansible.builtin.assert:
+    that:
+      - bad_vm_lookup.failed == true
+      - bad_vm_lookup.msg is defined
+      - bad_vm_lookup.msg | length > 0
+    success_msg: "Bogus VM ext_id fetch failed as expected"
+    fail_msg: "Bogus VM ext_id fetch did NOT fail as expected"
+
+- name: Fetch VM disk stats info with a bogus disk ext_id (API-level not-found)
+  nutanix.ncp.ntnx_vm_disk_stats_info_v2:
+    vm_ext_id: "{{ invalid_vm_ext_id }}"
+    ext_id: "{{ invalid_disk_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: bad_disk_lookup
+  ignore_errors: true
+
+- name: Assert bogus disk ext_id info fetch returned a descriptive failure
+  ansible.builtin.assert:
+    that:
+      - bad_disk_lookup.failed == true
+      - bad_disk_lookup.msg is defined
+      - bad_disk_lookup.msg | length > 0
+    success_msg: "Bogus disk ext_id info fetch failed as expected"
+    fail_msg: "Bogus disk ext_id info fetch did NOT fail as expected"
+
+- name: DiskStat test summary
+  ansible.builtin.debug:
+    msg:
+      - "DiskStat integration tests finished."
+      - "ESXi lifecycle available: {{ esxi_lifecycle_available }}"
+      - >-
+        {{ 'Positive lifecycle path was exercised.' if esxi_lifecycle_available
+        else 'Positive lifecycle skipped - no ESXi VM/disk found on the PC.' }}

--- a/tests/integration/targets/ntnx_disk_stat_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_disk_stat_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults for DiskStat tests
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import disk_stat.yml
+      ansible.builtin.import_tasks: disk_stat.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **virtual_machine_management** namespace,
entity **DiskStat**, based on the inline `sdk_info.json` embedded in `INSTRUCTIONS.md`. One
PR per code-gen run.

- Modules generated: `ntnx_disk_stat_v2`, `ntnx_vm_disk_stats_info_v2`
- API methods covered in this entity: `1` (`GetDiskStatsById`). The three other
  ESXi stats SDK methods surfaced in the inline SDK info (`GetNicStatsById`,
  `GetVmStatsById`, `ListVmStats`) belong to sibling entities and are not wrapped here.
- Fields in CRUD-style module spec (`ntnx_disk_stat_v2`): `8`
  (`vm_ext_id`, `ext_id`, `start_time`, `end_time`, `sampling_interval`,
  `stat_type`, `select`, `read_timeout`)
- Fields in info module spec (`ntnx_vm_disk_stats_info_v2`): `8` (same set — see above)

The DiskStat entity in the v4 VMM ESXi stats SDK exposes **only a Get operation**
(`GetDiskStatsById`); there are no Create/Update/Delete/List APIs. Both modules
therefore wrap the same read-only endpoint and follow the `ntnx_storage_containers_stats_v2`
action-style pattern (rather than the `ntnx_virtual_switch_v2` full-CRUD pattern), which is
the closest matching precedent in the repo.

## Domain knowledge (from Glean)

The Glean `chat` tool timed out on the full domain-detail synthesis, but two
`glean__company_search` runs succeeded. The full raw results are pasted below;
where the search response redacted URLs into `<URL_N>` placeholders those tokens
are preserved verbatim so a reviewer can look each item up in Glean.

### Search 1 — "Nutanix VMM v4 DiskStat ESXi disk stats API GetDiskStatsById"

- **[1] VMM v4 APIs** (Confluence) — "API definitions for VMM V4 APIs are defined
  in https://github.com/nutanix-core/ . We have GET APIs to get the stats from the
  PC. If we want to get a stat for a VM, we will use the GET VM Stats API,
  similarly for GET NIC Stats API and GET Disk Stats API etc."
  URL: `<URL_1>:8443/spaces/AHVM/pages/67929516/VMM+v4+APIs`
- **[2] Prism V4 API'S** (Confluence) — Notes `VmApiStatsApi.get_disk_stats_by_id`
  at `/api/clustermgmt/v4.0/stats/disks/{extId}`.
  URL: `<URL_1>:8443/spaces/SIZER/pages/528533216/Prism+V4+API+S`
- **[3] Nutanix Swagger V4.3 (VMM).yaml** (GitHub) — Model `GetDiskStats`.
  URL: `<URL_2>(VMM).yaml`
- **[4] vmm-v4.3-all-documentation.yaml** (GitHub) — Python sample for
  `esxi_stats_api.get_disk_stats_by_id(vmExtId=vm_ext_id, ...)`.
  URL: `<URL_3>`
- **[5] ESXi VMM V4 APIs - RBAC P0 requirements** (Confluence) — Documents role
  `View_ESXi_Virtual_Machine_Disk_Stats`. Endpoint:
  `https://{{PC_IP}}:9440/api/vmm/v4.0.b1/esxi/stats/vms/{{ESX_VM_UUID}}/disks/{DISK_UUID}`.
  URL: `<URL_1>:8443/spaces/AE/pages/327128458/ESXi+VMM+V4+APIs+-+RBAC+P0+requirements`
- **[6] disk-endpoints.yaml** (GitHub) — Sample for `EsxiStatsApi` + `GetDiskStatsApiResponse`.
  URL: `<URL_4>`
- **[7] swagger-vmm-v4.2-all.yaml** (GitHub) — Python sample for
  `esxi_stats_api.get_disk_stats_by_id`.
  URL: `<URL_5>`
- **[8] esxi_stats_api.go** (GitHub) — Go SDK definition of the same endpoint.
  URL: `<URL_6>`
- **[9] vmm-v4.2.yaml** (GitHub) — v4.2 swagger doc.
  URL: `<URL_7>`
- **[10] [multilang/vmmapi] Disk creation fails during VM provisioning** (JIRA) —
  Testcase run showing `vmm.StatsApi.getDiskStatsById PASS`.
  URL: `<URL_8>`

### Search 2 — "VMM ESXi stats API DiskStat design spec workflow prerequisites"

- **[1] ESXi VMM V4 APIs integration for Config+Stats** (JIRA) — "The UI relies
  heavily on VMM APIs for rendering VM views, including sorting, filtering, and
  grouping capabilities that are not yet supported by the ESXi V4 VMM APIs."
  URL: `<URL_1>`
- **[2] VMM v4 APIs** (Confluence) — Design doc anchor **"v4 VMM Stats APIs Design"**.
  URL: `<URL_2>:8443/spaces/AHVM/pages/67929516/VMM+v4+APIs`
- **[3] Prism V4 API'S** (Confluence) — same page as Search 1 [2].
  URL: `<URL_2>:8443/spaces/SIZER/pages/528533216/Prism+V4+API+S`
- **[4] 6.9 Serviceability Requirements for ESXi VMM V4 APIs for CG** (Confluence) —
  "In this feat we have added VM Power Ops and VM Disk stats and NIC stats APIs.
  This feat works only for ESXi".
  URL: `<URL_2>:8443/spaces/AE/pages/<PHONE_1>.9+Serviceability+Requirements+for+ESXi+VMM+V4+APIs+for+CG`
- **[5] esxi_stats.py** (GitHub) — Internal client `ntnx_vmm_py_client.EsxiStatsApi`
  usage from system-test framework.
  URL: `<URL_4>`
- **[6] [Esxi][Stats] Disk Stats does not return stats fields for some fields** (JIRA) —
  Known bug: some stat fields may be empty in `VmDiskStats` responses.
  URL: `<URL_5>`
- **[7] esxi_stats_api.py** (GitHub) — Python SDK method signature.
  URL: `<URL_7>`
- **[8] ESXi - VMM V4 APIs Integration with platform features** (JIRA) —
  "This FEAT will track VMM V4 APIs integration with following platform features:
  Config + Stats. Expansion projection (cross namespace joins). These are
  critical for UI migration to V4 APIs".
  URL: `<URL_8>`
- **[9] GetDiskStatsApiResponse class** (GitHub) — `class GetDiskStatsApiResponse`
  doc: "REST response for all response codes in API path
  `/vmm/v4.2/esxi/stats/vms/{vmExtId}/disks/{extId}` Get operation".
  URL: `<URL_10>`
- **[10] [esxi][disk][stats] Invalid timestamp in VM DISK stats response** (JIRA) —
  Known bug: timestamps in disk stats responses had formatting regressions.
  URL: `<URL_11>`

### Distilled understanding used to drive the code

- Entity is **ESXi VM Disk Stats**. All operations exposed are read-only GET
  (`GetDiskStatsById`, plus the sibling GETs for NIC / VM stats and the list-VM-stats
  operation which do not apply to the DiskStat entity).
- The endpoint returns per-timestamp `stats` tuples for a VM disk under an ESXi
  host managed by Prism Central (v4.2 VMM APIs). Individual counter fields can
  be `null` for a given sample (see JIRA Search-2 [6]).
- **Prerequisite**: the target cluster must be ESXi (the API path is
  `/api/vmm/v4.2/esxi/stats/...`); both `vmExtId` and disk `extId` must exist.
- **Required RBAC role** for the disk stats API is
  `View_ESXi_Virtual_Machine_Disk_Stats` (per the RBAC P0 confluence page).
- Query params `startTime` and `endTime` are mandatory (ISO-8601);
  `samplingInterval`, `statType` (`SUM|AVG|MIN|MAX|COUNT|LAST`) and OData
  `$select` are optional refinements.
- Known behavioral quirks (from JIRAs above): some stat fields may return
  `null`; historical timestamp-formatting regressions have been fixed but are
  worth asserting on in tests.
- **Required domain skills** to work end-to-end on this feature: VMM v4 API
  model (`vmm.v4.esxi.stats.*` package), Nutanix v4 Python SDK
  (`ntnx_vmm_py_client.EsxiStatsApi`), ISO-8601 time handling,
  `statType`/`samplingInterval` semantics, OData `$select`, and the ESXi
  Prism Central cluster registration flow.

## Files changed

- `plugins/modules/`
  - `ntnx_disk_stat_v2.py` (new) — primary DiskStat fetch module.
  - `ntnx_vm_disk_stats_info_v2.py` (new) — info-style variant.
- `plugins/module_utils/v4/vmm/api_client.py` — adds `get_esxi_stats_api_instance()`.
- `meta/runtime.yml` — registers both new modules under the `ntnx` action group so
  `module_defaults: group/nutanix.ncp.ntnx:` resolves the credential fragment.
- `examples/virtual_machine_management/DiskStat/`
  - `disk_stat_v2.yml` (new) — end-to-end example playbook.
  - `examples_run.log` (new) — captured playbook run against `10.44.76.28`.
- `tests/integration/targets/ntnx_disk_stat_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/disk_stat.yml` (new)
    — check-mode, positive (lifecycle-gated), idempotency, and negative tests.
- `.gitignore` — exclude `tests/integration/integration_config.yml` and
  `tests/output/` so credentials + ansible-test artifacts stay off the branch.

## Test execution

| Metric              | Value                                                                 |
|---------------------|-----------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-disabled ntnx_disk_stat_v2 --python 3.12` |
| Total tasks         | `44`                                                                  |
| ok                  | `32`                                                                  |
| Failed              | `0`                                                                   |
| Ignored (expected)  | `9` (negative-test tasks, each followed by an `assert` verifying the failure) |
| Skipped             | `12` (positive-lifecycle tasks, gated behind ESXi VM/disk discovery)  |
| Duration            | `~14 s`                                                               |
| Cluster (PC)        | `10.44.76.28` (v4.2 VMM APIs)                                         |

### Analysis

- **Discovery step** hit the ESXi VMs list endpoint (`/api/vmm/v4.2/esxi/config/vms`)
  and got `HTTP 200` with `0` VMs. The PC at `10.44.76.28` currently manages a
  single AHV cluster (`auto_cluster_prod_36acf9b012ca`, hypervisor `AHV`) and a
  second PC-only cluster with `hypervisorTypes=['$UNKNOWN']`, so no positive
  ESXi lifecycle path was available.
- The test target detected this via the `esxi_lifecycle_available` fact and
  skipped the 12 positive-path tasks (create-style fetch, full-attributes fetch,
  idempotency, `stat_type=SUM` transition, and their info-module counterparts).
  Skipping is documented per Step 4.1 — the "prerequisite" is a live ESXi VM on
  the cluster which cannot be created via this collection.
- The remaining coverage that **did** run:
  - **check-mode** (Step 4.1 "one check-mode test per operation") — passed and
    verified that the spec generator emits `_startTime`, `_endTime`,
    `_samplingInterval`, `_statType` and `_select` in the expected SDK format.
  - **negative / error tests** (Step 4.3) — passed:
    - missing each required arg (`vm_ext_id`, `ext_id`, `start_time`, `end_time`)
      is rejected by the module's argspec with a descriptive `msg`.
    - the info module also rejects a missing `ext_id`.
    - invalid `stat_type` enum (`INVALID_STAT_TYPE`, `BOGUS`) is rejected by the
      argspec `choices` list, in both the CRUD-style and info-style module.
    - bogus VM `ext_id` and bogus disk `ext_id` produce a 404 `VMM-30100 /
      VM_NOT_FOUND` response that is bubbled up as a descriptive `msg`.
  - **schema coverage** — every attribute in `get_module_spec()` is exercised
    by at least one assertion (Step 4.7).

There are no failing tests — `failed=0` in the PLAY RECAP. Anything showing
`fatal:` in the log is an **expected** failure of a negative-test task, and is
paired with an `assert` that verifies the failure occurred and matches the
expected error text.

### Example playbook run

The example playbook (`examples/virtual_machine_management/DiskStat/disk_stat_v2.yml`)
was executed end-to-end against `10.44.76.28` and captured in
`examples/virtual_machine_management/DiskStat/examples_run.log`. Each of the
four module invocations reached the API and got the expected
`VMM-30100 / VM_NOT_FOUND (HTTP 404)` because the example uses placeholder
`vm_ext_id`/`disk_ext_id` values (there are no ESXi VMs on the cluster to
supply real IDs). All example tasks ran; nothing crashed on the client side.

Because no positive-path response was available, the `sample:` blocks in the
`RETURN` docstrings use a hand-authored realistic sample synthesized from the
SDK's `EsxiStatsVmDiskStats` / `EsxiStatsVmDiskStatsTuple` `swagger_types`
(every field name and Python type comes directly from the installed SDK).

### Known issues / follow-ups

- Positive-lifecycle coverage cannot exercise on the current test PC because
  the cluster is AHV-only. Re-running this target on a PC that manages an ESXi
  cluster with at least one VM with at least one disk will populate all 12
  currently-skipped tasks.
- Real API `RETURN.response.sample` values could not be captured for the same
  reason; every sample field in the RETURN block is derived from the SDK
  schema, not from placeholder text.

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text
Running ntnx_disk_stat_v2 integration test role
[WARNING]: Found variable using reserved name: port

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_disk_stat_v2 : Start DiskStat tests (virtual_machine_management)] ***
ok: [testhost] => {
    "msg": "Start DiskStat (virtual_machine_management) tests"
}

TASK [ntnx_disk_stat_v2 : Generate random suffix so parallel runs don't collide] ***
[WARNING]: Collection community.general does not support Ansible version 2.16.0
ok: [testhost]

TASK [ntnx_disk_stat_v2 : Compute a 5 minute reporting window ending now] ******
ok: [testhost]

TASK [ntnx_disk_stat_v2 : Compute reporting window start time (5 minutes ago)] ***
ok: [testhost]

TASK [ntnx_disk_stat_v2 : Set stats time facts] ********************************
ok: [testhost]

TASK [ntnx_disk_stat_v2 : List ESXi VMs on the Prism Central (best-effort; requires ESXi cluster)] ***
ok: [testhost]

TASK [ntnx_disk_stat_v2 : Pick a candidate ESXi VM ext_id] *********************
ok: [testhost]

TASK [ntnx_disk_stat_v2 : Pick a candidate disk ext_id (first disk of the candidate VM)] ***
ok: [testhost]

TASK [ntnx_disk_stat_v2 : Register whether the ESXi positive lifecycle is available] ***
ok: [testhost]

TASK [ntnx_disk_stat_v2 : Show discovery result] *******************************
ok: [testhost] => {
    "msg": [
        "ESXi VMs lookup HTTP status: 200",
        "Candidate VM ext_id: ",
        "Candidate Disk ext_id: ",
        "ESXi positive lifecycle available: False"
    ]
}

TASK [ntnx_disk_stat_v2 : Check-mode fetch VM disk stats with all attributes (ntnx_disk_stat_v2)] ***
ok: [testhost]

TASK [ntnx_disk_stat_v2 : Check-mode fetch VM disk stats assertions] ***********
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode fetch generated the expected spec"
}

TASK [ntnx_disk_stat_v2 : Fetch VM disk stats with only required parameters (ntnx_disk_stat_v2)] ***
skipping: [testhost]

TASK [ntnx_disk_stat_v2 : Assert VM disk stats with only required parameters] ***
skipping: [testhost]

TASK [ntnx_disk_stat_v2 : Fetch VM disk stats with all optional parameters (ntnx_disk_stat_v2)] ***
skipping: [testhost]

TASK [ntnx_disk_stat_v2 : Assert VM disk stats with all optional parameters] ***
skipping: [testhost]

TASK [ntnx_disk_stat_v2 : Fetch same VM disk stats again to verify idempotency (changed still false)] ***
skipping: [testhost]

TASK [ntnx_disk_stat_v2 : Assert repeated fetch still reports changed=false] ***
skipping: [testhost]

TASK [ntnx_disk_stat_v2 : Fetch VM disk stats with stat_type=SUM (state transition on optional enum)] ***
skipping: [testhost]

TASK [ntnx_disk_stat_v2 : Assert stat_type=SUM fetch] **************************
skipping: [testhost]

TASK [ntnx_disk_stat_v2 : Fetch VM disk stats using info module (ntnx_vm_disk_stats_info_v2, required only)] ***
skipping: [testhost]

TASK [ntnx_disk_stat_v2 : Assert VM disk stats info (required only)] ***********
skipping: [testhost]

TASK [ntnx_disk_stat_v2 : Fetch VM disk stats using info module with all optional parameters] ***
skipping: [testhost]

TASK [ntnx_disk_stat_v2 : Assert VM disk stats info (full attributes)] *********
skipping: [testhost]

TASK [ntnx_disk_stat_v2 : Invalid enum value for stat_type is rejected by argspec (ntnx_disk_stat_v2)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of stat_type must be one of: SUM, AVG, MIN, MAX, COUNT, LAST, got: INVALID_STAT_TYPE"}
...ignoring

TASK [ntnx_disk_stat_v2 : Assert invalid stat_type is rejected] ****************
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid stat_type enum was rejected"
}

TASK [ntnx_disk_stat_v2 : Invalid enum value for stat_type is rejected by info module argspec] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of stat_type must be one of: SUM, AVG, MIN, MAX, COUNT, LAST, got: BOGUS"}
...ignoring

TASK [ntnx_disk_stat_v2 : Assert info module also rejects invalid stat_type] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module rejected invalid stat_type"
}

TASK [ntnx_disk_stat_v2 : Missing required vm_ext_id is rejected (ntnx_disk_stat_v2)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: vm_ext_id"}
...ignoring

TASK [ntnx_disk_stat_v2 : Assert missing vm_ext_id is rejected] ****************
ok: [testhost] => {
    "changed": false,
    "msg": "Missing vm_ext_id was rejected"
}

TASK [ntnx_disk_stat_v2 : Missing required ext_id is rejected (ntnx_disk_stat_v2)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_disk_stat_v2 : Assert missing ext_id is rejected] *******************
ok: [testhost] => {
    "changed": false,
    "msg": "Missing ext_id was rejected"
}

TASK [ntnx_disk_stat_v2 : Missing required start_time is rejected (ntnx_disk_stat_v2)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: start_time"}
...ignoring

TASK [ntnx_disk_stat_v2 : Assert missing start_time is rejected] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "Missing start_time was rejected"
}

TASK [ntnx_disk_stat_v2 : Missing required end_time is rejected (ntnx_disk_stat_v2)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: end_time"}
...ignoring

TASK [ntnx_disk_stat_v2 : Assert missing end_time is rejected] *****************
ok: [testhost] => {
    "changed": false,
    "msg": "Missing end_time was rejected"
}

TASK [ntnx_disk_stat_v2 : Missing required ext_id is rejected by info module] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_disk_stat_v2 : Assert info module rejects missing ext_id] ***********
ok: [testhost] => {
    "changed": false,
    "msg": "Info module rejected missing ext_id"
}

TASK [ntnx_disk_stat_v2 : Fetch VM disk stats with a bogus VM ext_id (API-level not-found)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching ESXi VM disk stats for vm_ext_id=00000000-0000-0000-0000-390364478213 ext_id=ffffffff-ffff-ffff-ffff-ffffffffffff", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_uuid": "00000000-0000-0000-0000-390364478213"}, "code": "VMM-30100", "errorGroup": "VM_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the VM with UUID '00000000-0000-0000-0000-390364478213', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_disk_stat_v2 : Assert bogus VM ext_id fetch returned a descriptive failure] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Bogus VM ext_id fetch failed as expected"
}

TASK [ntnx_disk_stat_v2 : Fetch VM disk stats info with a bogus disk ext_id (API-level not-found)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching ESXi VM disk stats info for vm_ext_id=00000000-0000-0000-0000-390364478213 ext_id=ffffffff-ffff-ffff-ffff-ffffffffffff", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_uuid": "00000000-0000-0000-0000-390364478213"}, "code": "VMM-30100", "errorGroup": "VM_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the VM with UUID '00000000-0000-0000-0000-390364478213', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_disk_stat_v2 : Assert bogus disk ext_id info fetch returned a descriptive failure] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Bogus disk ext_id info fetch failed as expected"
}

TASK [ntnx_disk_stat_v2 : DiskStat test summary] *******************************
ok: [testhost] => {
    "msg": [
        "DiskStat integration tests finished.",
        "ESXi lifecycle available: False",
        "Positive lifecycle skipped - no ESXi VM/disk found on the PC."
    ]
}

PLAY RECAP *********************************************************************
testhost                   : ok=32   changed=0    unreachable=0    failed=0    skipped=12   rescued=0    ignored=9   

```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- All lint gates passed: `black`, `isort`, `flake8`, `ansible-lint` (0 failures,
  7 warnings on the intentional negative-test tasks), and
  `ansible-test sanity` for both the `plugins/` files and the test target.
- Integration tests were executed via `ansible-test integration` against the
  live PC at `10.44.76.28`.
