### PR TITLE
code-gen(virtual_machine_management/VmRecoveryPoint): ansible collection modules

### DIFF
--- a/examples/virtual_machine_management/VmRecoveryPoint/examples_run.log
+++ b/examples/virtual_machine_management/VmRecoveryPoint/examples_run.log
@@ -1,0 +1,882 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+
+PLAY [Nutanix AHV VM Recovery Point examples] **********************************
+
+TASK [Gathering Facts] *********************************************************
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004159
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004173
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004201
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004202
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004211
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004252
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004260
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004276
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004287
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004288
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004289
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004290
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004292
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004293
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004294
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004298
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004299
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004300
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004317
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004318
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004319
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004320
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004321
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004322
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004323
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004324
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004326
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004327
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004328
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004329
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004330
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004331
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004332
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004333
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004334
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004335
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004336
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004337
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004338
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004340
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004341
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004343
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004344
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004346
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004348
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004349
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004350
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004351
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004352
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004353
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004354
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004355
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004356
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004357
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004358
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004359
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004361
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004362
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004364
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004366
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004367
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004369
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004370
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004371
+[WARNING]: Timeout exceeded when getting mount info for /misc/legacy-kernel-
+builds/40
+[WARNING]: Timeout exceeded when getting mount info for /misc/legacy-kernel-
+builds/41
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004372
+[WARNING]: Timeout exceeded when getting mount info for /misc/legacy-kernel-
+builds/43
+[WARNING]: Timeout exceeded when getting mount info for /misc/legacy-kernel-
+builds/44
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004373
+[WARNING]: Timeout exceeded when getting mount info for /misc/legacy-kernel-
+builds/45
+[WARNING]: Timeout exceeded when getting mount info for /misc/legacy-kernel-
+builds/47
+[WARNING]: Timeout exceeded when getting mount info for /misc/legacy-kernel-
+builds/48
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004375
+[WARNING]: Timeout exceeded when getting mount info for /misc/legacy-kernel-
+builds/49
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004376
+[WARNING]: Timeout exceeded when getting mount info for /misc/legacy-kernel-
+builds/51
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004377
+[WARNING]: Timeout exceeded when getting mount info for /misc/legacy-kernel-
+builds/56
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/2.2.3
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004378
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004379
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004380
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/2.3.0.2
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004381
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004382
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004383
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004384
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004385
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004386
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004387
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/27_hop_version_dummy
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004388
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004389
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004390
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004391
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/27_hop_version_release
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004392
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004393
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004394
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004395
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004396
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/50480_build
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004397
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004399
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004400
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004401
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004402
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004403
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004405
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/ENG-783283
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004406
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004407
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004408
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004409
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004410
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004411
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004412
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004413
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004414
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004417
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004418
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004419
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004420
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004421
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004423
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004424
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004425
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004426
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004427
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004430
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004431
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004433
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004435
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004436
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/ENG-918959
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004437
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004438
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004441
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/Endor_LCM
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004442
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004443
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004444
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004447
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004448
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004449
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004450
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004451
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004452
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004453
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004454
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004455
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004456
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004457
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004458
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004459
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_1.1
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004460
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_1.2
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004461
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004462
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_1.3
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_1.4
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004464
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004465
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004466
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004467
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_1.4_Dec_mod_ref
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004468
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004469
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_1.4_NX_2018_3
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004470
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004471
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004472
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_1.4_Nov_Mod_ref
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004473
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004474
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004475
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004476
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004477
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_1.4_XC_2018_3
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004478
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_1.4_pre_post_checks
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004479
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_1.5
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004480
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004481
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004482
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004483
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_1.6
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004484
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004485
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004486
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004487
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004488
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004489
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004491
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004492
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004503
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004504
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004506
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.1
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004509
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004510
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004514
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004516
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.1_Dec_Mod_ref
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004517
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004518
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004519
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004520
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.2
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004521
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004522
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1004524
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1009
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101002
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101019
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.2.3
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101020
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101023
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101025
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101026
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101027
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101034
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101035
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101045
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101046
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101059
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.101060
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.2.3.1
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.1011
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.102001
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.102004
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.102005
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103001
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103002
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103003
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103010
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103013
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103014
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103022
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103031
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103032
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103052
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103053
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103067
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103068
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103072
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103073
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103074
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.2.4
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103076
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103084
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103087
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103088
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103092
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103099
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103100
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.103103
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.116
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.124
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.125
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.2.R1
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.132
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.135
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.2.R2
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.144
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150001
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150066
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150086
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150110
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150111
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150128
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150137
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150144
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150150
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150163
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150165
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150171
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150173
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150177
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150180
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150265
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150268
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150269
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150270
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.2.R2.1
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150273
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150275
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150278
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150283
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150284
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150287
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150289
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150290
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150291
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.2.R2.2
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150292
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150333
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150338
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150339
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150371
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150381
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.3
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150384
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150389
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150390
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.3.0.1
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150400
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150404
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150423
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150427
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150428
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150431
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150435
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150437
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150445
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150448
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150450
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150453
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150455
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150457
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.3.0.2
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150459
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150460
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150462
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150469
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150470
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150475
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150477
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150479
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150480
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150484
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150487
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150489
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150491
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150494
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150495
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150497
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150498
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.3.0.3
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150502
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150504
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150506
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150509
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150511
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.150513
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.155
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.156
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.179
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.181
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.3.0.4
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.186
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.188
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.192
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.193
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.198
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.2001
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.2007
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.2008
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.2010
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.2014
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.2016
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.2017
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.2019
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.202
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.2024
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.2026
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.203
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.204
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.207
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.209
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.216
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.289
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.3001
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.3.1
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.3002
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.3003
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.4
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500005
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500007
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500009
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500010
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500011
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500012
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500013
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500016
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500017
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500018
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500021
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500024
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500027
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500028
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500030
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500038
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500039
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500040
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500044
+[WARNING]: Timeout exceeded when getting mount info for /misc/lcm-cci-
+builds/LCM_2.3.1.1
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500045
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500046
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500050
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500052
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500054
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500055
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500056
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500057
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500058
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500059
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500062
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500064
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500066
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500068
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500071
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500074
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500076
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500077
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500079
+[WARNING]: Timeout exceeded when getting mount info for /misc/ahv-
+builds/20230302.500080
+ok: [localhost]
+
+TASK [Compute an expiration time 30 days out (ISO-8601 UTC)] *******************
+ok: [localhost]
+
+TASK [Create a crash-consistent AHV VM recovery point] *************************
+changed: [localhost]
+
+TASK [Create an application-consistent AHV VM recovery point (Windows + VSS)] ***
+skipping: [localhost]
+
+TASK [Fetch a specific AHV VM recovery point by ext_id] ************************
+ok: [localhost]
+
+TASK [List all AHV VM recovery points (paged)] *********************************
+ok: [localhost]
+
+TASK [List AHV VM recovery points filtered by source VM ext_id] ****************
+ok: [localhost]
+
+TASK [Restore a new AHV VM from the crash-consistent recovery point] ***********
+changed: [localhost]
+
+TASK [Delete the newly restored VM (cleanup)] **********************************
+changed: [localhost]
+
+TASK [Delete the crash-consistent AHV VM recovery point (cleanup)] *************
+changed: [localhost]
+
+TASK [Delete the application-consistent AHV VM recovery point (cleanup)] *******
+skipping: [localhost]
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=9    changed=4    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   
+

--- a/examples/virtual_machine_management/VmRecoveryPoint/vm_recovery_points.yml
+++ b/examples/virtual_machine_management/VmRecoveryPoint/vm_recovery_points.yml
@@ -1,0 +1,111 @@
+---
+# Examples for AHV VM recovery points (vmm v4.2 API).
+#
+# Modules exercised:
+#   * nutanix.ncp.ntnx_vm_recovery_point_v2               (CRUD: create / delete)
+#   * nutanix.ncp.ntnx_vm_recovery_points_info_v2         (info: get / list)
+#   * nutanix.ncp.ntnx_vm_recovery_point_restore_v2       (action: restore VM)
+#
+# Prerequisites:
+#   - A reachable Prism Central endpoint (`ip`) with admin credentials.
+#   - An existing AHV VM (`source_vm_ext_id`) that can be snapshotted.
+#   - For APPLICATION_CONSISTENT recovery points: the source VM must be a
+#     Windows VM with NGT installed and VSS enabled.
+#
+# Variables referenced (override on the command line with -e):
+#   ip                : Prism Central endpoint (e.g. 10.44.76.28)
+#   username          : PC username (e.g. admin)
+#   password          : PC password
+#   source_vm_ext_id  : External ID of the source AHV VM to snapshot
+#
+# ansible-playbook examples/virtual_machine_management/VmRecoveryPoint/vm_recovery_points.yml \
+#     -e ip=... -e username=... -e password=... -e source_vm_ext_id=...
+
+- name: Nutanix AHV VM Recovery Point examples
+  hosts: localhost
+  gather_facts: true
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username }}"
+      nutanix_password: "{{ password }}"
+      nutanix_port: "{{ nutanix_port | default(9440) }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+  tasks:
+
+    - name: Compute an expiration time 30 days out (ISO-8601 UTC)
+      ansible.builtin.set_fact:
+        expiration_time: "{{ '%Y-%m-%dT%H:%M:%SZ' | strftime((ansible_date_time.epoch | int) + (30 * 86400)) }}"
+
+    - name: Create a crash-consistent AHV VM recovery point
+      nutanix.ncp.ntnx_vm_recovery_point_v2:
+        state: present
+        name: "ansible_example_vm_rp_crash"
+        vm_ext_id: "{{ source_vm_ext_id }}"
+        recovery_point_type: "CRASH_CONSISTENT"
+        expiration_time: "{{ expiration_time }}"
+      register: crash_rp
+    # sample:
+    #   response:
+    #     ext_id: "b387359d-fa5c-4d58-9eb2-3af1a4976319"
+    #     name: "ansible_example_vm_rp_crash"
+    #     recovery_point_type: "CRASH_CONSISTENT"
+    #     status: "COMPLETE"
+    #     vm_ext_id: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+
+    - name: Create an application-consistent AHV VM recovery point (Windows + VSS)
+      nutanix.ncp.ntnx_vm_recovery_point_v2:
+        state: present
+        name: "ansible_example_vm_rp_app"
+        vm_ext_id: "{{ source_vm_ext_id }}"
+        recovery_point_type: "APPLICATION_CONSISTENT"
+        expiration_time: "{{ expiration_time }}"
+        application_consistent_properties:
+          backup_type: "FULL_BACKUP"
+          should_include_writers: false
+          should_store_vss_metadata: false
+      when: run_app_consistent | default(false) | bool
+      register: app_rp
+
+    - name: Fetch a specific AHV VM recovery point by ext_id
+      nutanix.ncp.ntnx_vm_recovery_points_info_v2:
+        ext_id: "{{ crash_rp.ext_id }}"
+      register: rp_info
+
+    - name: List all AHV VM recovery points (paged)
+      nutanix.ncp.ntnx_vm_recovery_points_info_v2:
+        limit: 10
+      register: rp_list
+
+    - name: List AHV VM recovery points filtered by source VM ext_id
+      nutanix.ncp.ntnx_vm_recovery_points_info_v2:
+        filter: "vmExtId eq '{{ source_vm_ext_id }}'"
+      register: rp_filtered
+
+    - name: Restore a new AHV VM from the crash-consistent recovery point
+      nutanix.ncp.ntnx_vm_recovery_point_restore_v2:
+        ext_id: "{{ crash_rp.ext_id }}"
+        vm_config_override_spec:
+          name: "ansible_example_restored_vm"
+          description: "Restored by ntnx_vm_recovery_point_restore_v2 example"
+      register: restored
+
+    - name: Delete the newly restored VM (cleanup)
+      nutanix.ncp.ntnx_vms_v2:
+        state: absent
+        ext_id: "{{ restored.vm_ext_id }}"
+      when: restored.vm_ext_id is defined and restored.vm_ext_id | length > 0
+      register: restored_vm_delete
+
+    - name: Delete the crash-consistent AHV VM recovery point (cleanup)
+      nutanix.ncp.ntnx_vm_recovery_point_v2:
+        state: absent
+        ext_id: "{{ crash_rp.ext_id }}"
+      register: crash_rp_delete
+
+    - name: Delete the application-consistent AHV VM recovery point (cleanup)
+      nutanix.ncp.ntnx_vm_recovery_point_v2:
+        state: absent
+        ext_id: "{{ app_rp.ext_id }}"
+      when: app_rp is defined and app_rp.ext_id is defined
+      register: app_rp_delete

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -179,6 +179,9 @@ action_groups:
     - ntnx_recovery_point_restore_v2
     - ntnx_vm_revert_v2
     - ntnx_recovery_point_replicate_v2
+    - ntnx_vm_recovery_point_v2
+    - ntnx_vm_recovery_points_info_v2
+    - ntnx_vm_recovery_point_restore_v2
     - ntnx_gpus_v2
     - ntnx_gpus_info_v2
     - ntnx_clusters_nodes_v2

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,13 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_vm_recovery_points_api_instance(module):
+    """
+    This method will return AHV VM Recovery Points API instance
+    Args:
+        api_instance (obj): v4 VmRecoveryPoints api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.VmRecoveryPointsApi(api_client=api_client)

--- a/plugins/module_utils/v4/vmm/helpers.py
+++ b/plugins/module_utils/v4/vmm/helpers.py
@@ -191,3 +191,23 @@ def get_ova(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching OVA info using ext_id",
         )
+
+
+def get_vm_recovery_point(module, api_instance, ext_id):
+    """
+    Get AHV VM Recovery Point by ext_id
+    Args:
+        module: Ansible module
+        api_instance: VmRecoveryPointsApi instance from ntnx_vmm_py_client sdk
+        ext_id: ext_id of the AHV VM recovery point
+    Returns:
+        vm_recovery_point (obj): AHV VM Recovery Point info object (raw API response)
+    """
+    try:
+        return api_instance.get_vm_recovery_point_by_ext_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching AHV VM recovery point info using ext_id",
+        )

--- a/plugins/modules/ntnx_vm_recovery_point_restore_v2.py
+++ b/plugins/modules/ntnx_vm_recovery_point_restore_v2.py
@@ -1,0 +1,460 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_recovery_point_restore_v2
+short_description: Restore a new AHV VM from an AHV VM recovery point
+version_added: 2.7.0
+description:
+    - Restore a new AHV VM from an existing AHV VM recovery point.
+    - A brand new VM is created from the recovery point; the operation does
+      not modify the source VM.
+    - Optional overrides let you rename the restored VM, override its
+      description, categories, NICs, guest tools state and ownership info.
+    - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to
+      the user performing the operation.
+    - >-
+      B(Restore an AHV VM recovery point) -
+      Required Roles: Backup Admin, CSI System, Disaster Recovery Admin,
+      Kubernetes Data Services System, NCM Connector, Prism Admin,
+      Project Manager, Super Admin, Self-Service Admin (deprecated)
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+    state:
+        description:
+            - State of the module.
+            - If C(state) is C(present) the module will restore a VM from the
+              recovery point.
+            - Any other value causes the module to fail (only C(present) is
+              supported for action modules).
+        type: str
+        choices:
+            - present
+        default: present
+    ext_id:
+        description:
+            - External ID (UUID) of the AHV VM recovery point to restore.
+        type: str
+        required: true
+    is_strict_mode:
+        description:
+            - When true, the restore operation fails if any of the requested
+              override entities cannot be honored exactly.
+            - When false, the API restores on a best-effort basis and may
+              silently drop overrides that cannot be applied.
+        type: bool
+    vm_config_override_spec:
+        description:
+            - Overrides applied to the restored VM. All fields are optional
+              and default to the values captured in the recovery point.
+        type: dict
+        suboptions:
+            name:
+                description:
+                    - Name for the restored VM. If not provided the original
+                      VM name from the recovery point is used.
+                type: str
+            description:
+                description:
+                    - Description for the restored VM. If not provided the
+                      original description is used.
+                type: str
+            categories:
+                description:
+                    - Category references to attach to the restored VM.
+                type: list
+                elements: dict
+                suboptions:
+                    ext_id:
+                        description:
+                            - External ID (UUID) of the category.
+                        type: str
+                        required: true
+            nic_spec:
+                description:
+                    - NIC override specification for the restored VM. Lets
+                      you skip specific NICs from the recovery point or
+                      override individual NIC attributes such as subnet.
+                type: dict
+                suboptions:
+                    nic_remove_list:
+                        description:
+                            - List of NIC external IDs (from the recovery
+                              point) to skip when restoring.
+                        type: list
+                        elements: str
+                    nic_override_list:
+                        description:
+                            - List of per-NIC overrides applied to the
+                              restored VM.
+                        type: list
+                        elements: dict
+                        suboptions:
+                            nic_ext_id:
+                                description:
+                                    - External ID of the NIC from the
+                                      recovery point to override.
+                                type: str
+                                required: true
+                            subnet_ext_id:
+                                description:
+                                    - External ID of the subnet the NIC
+                                      should be attached to on restore.
+                                type: str
+            guest_tools_spec:
+                description:
+                    - Guest Tools override configuration applied to the
+                      restored VM.
+                type: dict
+                suboptions:
+                    should_clear_in_guest_volume_group_attachments:
+                        description:
+                            - When true, in-guest volume-group attachments
+                              (typically discovered through NGT) are cleared
+                              on restore.
+                        type: bool
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+    - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Restore a new AHV VM from a recovery point (defaults)
+  nutanix.ncp.ntnx_vm_recovery_point_restore_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "b387359d-fa5c-4d58-9eb2-3af1a4976319"
+  register: restore_result
+
+- name: Restore a new AHV VM with overrides
+  nutanix.ncp.ntnx_vm_recovery_point_restore_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "b387359d-fa5c-4d58-9eb2-3af1a4976319"
+    is_strict_mode: true
+    vm_config_override_spec:
+      name: "ansible_restored_vm"
+      description: "Restored by Ansible integration test"
+      categories:
+        - ext_id: "16b7f7ea-40c7-4bde-9b1c-8e7d3b3f6a90"
+      nic_spec:
+        nic_remove_list:
+          - "cf0f8020-0d3d-4c9c-bad7-2d7d1e1caa00"
+        nic_override_list:
+          - nic_ext_id: "d5b0aa5f-42d2-4cd3-a11c-4a4d0ec6a4d5"
+            subnet_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+      guest_tools_spec:
+        should_clear_in_guest_volume_group_attachments: true
+  register: restore_result_overrides
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for restoring the AHV VM recovery point.
+        - Task details if C(wait) is true.
+        - Async task submit response if C(wait) is false.
+    returned: always
+    type: dict
+    sample:
+        {
+            "cluster_ext_ids": [
+                "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2"
+            ],
+            "completed_time": "2026-07-20T22:45:11.524581+00:00",
+            "completion_details": [
+                {
+                    "name": "vmExtId",
+                    "value": "e44621b1-da4e-40d1-87b1-cbb640001347"
+                }
+            ],
+            "created_time": "2026-07-20T22:45:07.167906+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "b387359d-fa5c-4d58-9eb2-3af1a4976319",
+                    "rel": "dataprotection:config:vm-recovery-point"
+                },
+                {
+                    "ext_id": "e44621b1-da4e-40d1-87b1-cbb640001347",
+                    "rel": "vmm:ahv:config:vm"
+                }
+            ],
+            "ext_id": "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1",
+            "operation": "RestoreVmRecoveryPoint",
+            "operation_description": "Restore AHV VM Recovery Point",
+            "progress_percentage": 100,
+            "status": "SUCCEEDED"
+        }
+
+task_ext_id:
+    description: External ID of the task performing the restore.
+    returned: always
+    type: str
+    sample: "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1"
+
+ext_id:
+    description: External ID of the AHV VM recovery point being restored.
+    returned: always
+    type: str
+    sample: "b387359d-fa5c-4d58-9eb2-3af1a4976319"
+
+vm_ext_id:
+    description:
+        - External ID of the newly restored AHV VM.
+        - Populated only after C(wait_for_completion) succeeds and the task
+          reports the restored VM entity.
+    returned: When the restore task completes and returns the VM ext_id
+    type: str
+    sample: "e44621b1-da4e-40d1-87b1-cbb640001347"
+
+changed:
+    description: Whether the task resulted in any changes.
+    returned: always
+    type: bool
+    sample: true
+
+failed:
+    description: Whether the task failed.
+    returned: always
+    type: bool
+    sample: false
+
+error:
+    description: Error message set on failure.
+    returned: When an error occurs
+    type: str
+
+msg:
+    description: Contextual message (error, idempotent skip, or check mode).
+    returned: When present
+    type: str
+    sample: "Api Exception raised while restoring AHV VM recovery point"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_etag,
+    get_vm_recovery_points_api_instance,
+)
+from ..module_utils.v4.vmm.helpers import get_vm_recovery_point  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_vmm_py_client as vmm_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as vmm_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    nic_override_sub_spec = dict(
+        nic_ext_id=dict(type="str", required=True),
+        subnet_ext_id=dict(type="str"),
+    )
+
+    nic_spec_sub_spec = dict(
+        nic_remove_list=dict(type="list", elements="str"),
+        nic_override_list=dict(
+            type="list",
+            elements="dict",
+            options=nic_override_sub_spec,
+            obj=vmm_sdk.VmRestoreNicConfigOverrideParams,
+        ),
+    )
+
+    guest_tools_sub_spec = dict(
+        should_clear_in_guest_volume_group_attachments=dict(type="bool"),
+    )
+
+    categories_sub_spec = dict(
+        ext_id=dict(type="str", required=True),
+    )
+
+    vm_config_override_sub_spec = dict(
+        name=dict(type="str"),
+        description=dict(type="str"),
+        categories=dict(
+            type="list",
+            elements="dict",
+            options=categories_sub_spec,
+        ),
+        nic_spec=dict(
+            type="dict",
+            options=nic_spec_sub_spec,
+            obj=vmm_sdk.VmRestoreNicConfigSpecification,
+        ),
+        guest_tools_spec=dict(
+            type="dict",
+            options=guest_tools_sub_spec,
+            obj=vmm_sdk.VmRestoreGuestToolsSpecification,
+        ),
+    )
+
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        ext_id=dict(type="str", required=True),
+        is_strict_mode=dict(type="bool"),
+        vm_config_override_spec=dict(
+            type="dict",
+            options=vm_config_override_sub_spec,
+            obj=vmm_sdk.VmConfigOverrideSpecification,
+        ),
+    )
+    return module_args
+
+
+def _resolve_category_reference_cls():
+    """VmConfigOverrideSpecification.categories expects the AHV-config
+    variant of CategoryReference. Prefer that name explicitly and fall back
+    to any other CategoryReference variant if the SDK renames the class."""
+    for preferred in ("AhvConfigCategoryReference", "CategoryReference"):
+        cls = getattr(vmm_sdk, preferred, None)
+        if cls is not None:
+            return cls
+    for name in dir(vmm_sdk):
+        if name.endswith("CategoryReference"):
+            return getattr(vmm_sdk, name)
+    return None
+
+
+def _build_restore_spec(module):
+    sg = SpecGenerator(module)
+    default_spec = vmm_sdk.RestoreVmRecoveryPointParams()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        return None, err
+
+    override_params = module.params.get("vm_config_override_spec") or {}
+    categories = override_params.get("categories")
+    if categories and spec.vm_config_override_spec is not None:
+        category_cls = _resolve_category_reference_cls()
+        if category_cls is None:
+            return (
+                None,
+                "Unable to locate CategoryReference class in ntnx_vmm_py_client",
+            )
+        refs = []
+        for cat in categories:
+            ref = category_cls()
+            ref.ext_id = cat.get("ext_id")
+            refs.append(ref)
+        spec.vm_config_override_spec.categories = refs
+    return spec, None
+
+
+def restore_vm_recovery_point(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    spec, err = _build_restore_spec(module)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating AHV VM recovery point restore spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    current = get_vm_recovery_point(module, api_instance, ext_id)
+    etag = get_etag(current)
+    kwargs = {}
+    if etag:
+        kwargs["if_match"] = etag
+
+    try:
+        resp = api_instance.restore_vm_recovery_point(extId=ext_id, body=spec, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while restoring AHV VM recovery point",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+        vm_ext_id = get_entity_ext_id_from_task(
+            task, rel=TASK_CONSTANTS.RelEntityType.VM
+        )
+        if vm_ext_id:
+            result["vm_ext_id"] = vm_ext_id
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_vm_recovery_points_api_instance(module)
+    restore_vm_recovery_point(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_vm_recovery_point_v2.py
+++ b/plugins/modules/ntnx_vm_recovery_point_v2.py
@@ -1,0 +1,516 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_recovery_point_v2
+short_description: Create, Delete AHV VM recovery points in Nutanix Prism Central
+version_added: 2.7.0
+description:
+    - Create and Delete AHV VM recovery points using the vmm v4.2 AHV
+      VmRecoveryPoints API.
+    - AHV VM recovery points are immutable point-in-time snapshots of an AHV VM.
+      They cannot be updated once created; providing C(ext_id) with
+      C(state=present) will therefore result in a no-op skipped result.
+    - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the
+      user performing the operation. The required roles depend on the operation
+      being performed.
+    - >-
+      B(Create an AHV VM Recovery Point) -
+      Required Roles: Backup Admin, CSI System, Disaster Recovery Admin,
+      Kubernetes Data Services System, NCM Connector, Prism Admin,
+      Project Manager, Super Admin, Self-Service Admin (deprecated)
+    - >-
+      B(Delete an AHV VM Recovery Point) -
+      Required Roles: Backup Admin, CSI System, Disaster Recovery Admin,
+      Kubernetes Data Services System, NCM Connector, Prism Admin,
+      Project Manager, Super Admin, Self-Service Admin (deprecated)
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+    state:
+        description:
+            - If C(state) is set to C(present) and C(ext_id) is not provided
+              then the operation will be create AHV VM recovery point.
+            - If C(state) is set to C(present) and C(ext_id) is provided the
+              module will report the recovery point as immutable and skip
+              (AHV VM recovery points cannot be updated).
+            - If C(state) is set to C(absent) and C(ext_id) is provided the
+              operation will delete the AHV VM recovery point.
+        type: str
+        choices:
+            - present
+            - absent
+        default: present
+    ext_id:
+        description:
+            - External ID (UUID) of the AHV VM recovery point.
+            - Required for delete operation.
+        type: str
+    name:
+        description:
+            - User-visible name of the AHV VM recovery point.
+            - Required for create operation.
+        type: str
+    vm_ext_id:
+        description:
+            - External ID (UUID) of the source AHV VM that will be captured in
+              the recovery point.
+            - Required for create operation.
+        type: str
+    expiration_time:
+        description:
+            - The UTC date and time in ISO-8601 format when the recovery point
+              expires. Once expired, the recovery point is eligible for
+              garbage collection.
+        type: str
+    recovery_point_type:
+        description:
+            - The type of the recovery point.
+            - C(CRASH_CONSISTENT) captures the VM state without quiescing the
+              guest.
+            - C(APPLICATION_CONSISTENT) requires the guest VM to be Windows
+              with NGT installed and VSS enabled; the guest is quiesced via
+              VSS before the snapshot is taken.
+        type: str
+        choices:
+            - CRASH_CONSISTENT
+            - APPLICATION_CONSISTENT
+        default: CRASH_CONSISTENT
+    consistency_group_ext_id:
+        description:
+            - External ID (UUID) of the consistency group this recovery point
+              belongs to. Used to group recovery points of related entities.
+        type: str
+    vm_categories:
+        description:
+            - List of category external IDs (UUIDs) applied to the VM at the
+              time of the recovery point.
+        type: list
+        elements: str
+    application_consistent_properties:
+        description:
+            - Application-consistent (VSS) properties used when
+              C(recovery_point_type=APPLICATION_CONSISTENT).
+            - Only applicable to Windows VMs with NGT and VSS enabled.
+        type: dict
+        suboptions:
+            backup_type:
+                description:
+                    - The backup type that defines the criteria for selecting
+                      files for application-consistent recovery points on
+                      Windows VMs/agents.
+                    - C(FULL_BACKUP) - backs up all files and updates their
+                      backup history.
+                    - C(COPY_BACKUP) - backs up all files without updating
+                      their backup history.
+                type: str
+                choices:
+                    - FULL_BACKUP
+                    - COPY_BACKUP
+                required: true
+            should_include_writers:
+                description:
+                    - Whether the listed VSS writer UUIDs should be included
+                      or excluded from the application-consistent recovery
+                      point. Defaults to false (writers are excluded).
+                type: bool
+                default: false
+            writers:
+                description:
+                    - List of VSS writer UUIDs used in an application
+                      consistent recovery point.
+                type: list
+                elements: str
+            should_store_vss_metadata:
+                description:
+                    - Whether to store VSS metadata for application-specific
+                      backup/restore.
+                type: bool
+                default: false
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+    - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create a crash-consistent AHV VM recovery point
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "ansible_vm_rp_crash"
+    vm_ext_id: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+    recovery_point_type: "CRASH_CONSISTENT"
+    expiration_time: "2027-01-01T00:00:00Z"
+  register: create_result
+
+- name: Create an application-consistent AHV VM recovery point (Windows + VSS)
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "ansible_vm_rp_app"
+    vm_ext_id: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+    recovery_point_type: "APPLICATION_CONSISTENT"
+    expiration_time: "2027-01-01T00:00:00Z"
+    vm_categories:
+      - "16b7f7ea-40c7-4bde-9b1c-8e7d3b3f6a90"
+    application_consistent_properties:
+      backup_type: "FULL_BACKUP"
+      should_include_writers: true
+      writers:
+        - "e8132975-6d3a-4d67-807e-8d0d5b8e0b8b"
+      should_store_vss_metadata: true
+  register: create_app_result
+
+- name: Delete an AHV VM recovery point
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "b387359d-fa5c-4d58-9eb2-3af1a4976319"
+  register: delete_result
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for creating or deleting an AHV VM recovery point.
+        - For create when C(wait=true), the fetched AHV VM recovery point details.
+        - For create when C(wait=false), the task details.
+        - For delete, the task details.
+    returned: always
+    type: dict
+    sample:
+        {
+            "application_consistent_properties": null,
+            "consistency_group_ext_id": null,
+            "creation_time": "2026-07-20T22:35:00.000Z",
+            "disk_recovery_points": [
+                {
+                    "disk_ext_id": "839feff9-bac0-4a70-9523-82ea9e431517",
+                    "disk_recovery_point_ext_id": "21d467f0-ccef-4733-91cc-f04db58a92eb"
+                }
+            ],
+            "expiration_time": "2027-01-01T00:00:00Z",
+            "ext_id": "b387359d-fa5c-4d58-9eb2-3af1a4976319",
+            "links": null,
+            "location_agnostic_id": "51264897-07a8-4292-831b-ae28a37135e5",
+            "name": "ansible_vm_rp_crash",
+            "recovery_point_type": "CRASH_CONSISTENT",
+            "status": "COMPLETE",
+            "tenant_id": null,
+            "total_exclusive_usage_bytes": 0,
+            "vm": null,
+            "vm_categories": null,
+            "vm_ext_id": "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+        }
+
+task_ext_id:
+    description: The external ID of the task performing the operation.
+    returned: always
+    type: str
+    sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+    description:
+        - The external ID (UUID) of the AHV VM recovery point.
+        - Set for create (after C(wait_for_completion)) and delete.
+    returned: always
+    type: str
+    sample: "b387359d-fa5c-4d58-9eb2-3af1a4976319"
+
+changed:
+    description: Whether the task resulted in any changes.
+    returned: always
+    type: bool
+    sample: true
+
+skipped:
+    description:
+        - Whether the operation was skipped (recovery points are immutable so
+          "update" is always a no-op).
+    returned: When the operation is skipped
+    type: bool
+    sample: false
+
+failed:
+    description: Whether the operation failed.
+    returned: always
+    type: bool
+    sample: false
+
+error:
+    description: Error message set on failure.
+    returned: When an error occurs
+    type: str
+
+msg:
+    description: Additional status/context message.
+    returned: When present (idempotent skip, check mode, or error)
+    type: str
+    sample: "AHV VM recovery point with ext_id:b387359d... will be deleted."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_etag,
+    get_vm_recovery_points_api_instance,
+)
+from ..module_utils.v4.vmm.helpers import get_vm_recovery_point  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_vmm_py_client as vmm_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as vmm_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    application_consistent_properties_spec = dict(
+        backup_type=dict(
+            type="str",
+            choices=["FULL_BACKUP", "COPY_BACKUP"],
+            required=True,
+        ),
+        should_include_writers=dict(type="bool", default=False),
+        writers=dict(type="list", elements="str"),
+        should_store_vss_metadata=dict(type="bool", default=False),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        vm_ext_id=dict(type="str"),
+        expiration_time=dict(type="str"),
+        recovery_point_type=dict(
+            type="str",
+            choices=["CRASH_CONSISTENT", "APPLICATION_CONSISTENT"],
+            default="CRASH_CONSISTENT",
+        ),
+        consistency_group_ext_id=dict(type="str"),
+        vm_categories=dict(type="list", elements="str"),
+        application_consistent_properties=dict(
+            type="dict",
+            options=application_consistent_properties_spec,
+            obj=vmm_sdk.VssProperties,
+        ),
+    )
+    return module_args
+
+
+def _build_create_spec(module):
+    """Build a VmRecoveryPoint SDK spec from module params.
+
+    ``SpecGenerator`` cannot populate the ``OneOf`` field
+    ``application_consistent_properties`` on its own, so we handle that
+    attribute explicitly with a ``VssProperties`` object.
+    """
+    sg = SpecGenerator(module)
+    default_spec = vmm_sdk.VmRecoveryPoint()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        return None, err
+
+    acp = module.params.get("application_consistent_properties")
+    if acp:
+        vss = vmm_sdk.VssProperties()
+        vss.backup_type = acp.get("backup_type")
+        vss.should_include_writers = acp.get("should_include_writers")
+        vss.writers = acp.get("writers")
+        vss.should_store_vss_metadata = acp.get("should_store_vss_metadata")
+        spec.application_consistent_properties = vss
+    return spec, None
+
+
+def create_vm_recovery_point(module, result, api_instance):
+    validate_required_params(module, ["name", "vm_ext_id"])
+    spec, err = _build_create_spec(module)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating AHV VM recovery point create spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    try:
+        resp = api_instance.create_vm_recovery_point(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating AHV VM recovery point",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task, rel=TASK_CONSTANTS.RelEntityType.VM_RECOVERY_POINT
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            fetched = get_vm_recovery_point(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(fetched.data.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for AHV VM recovery point"
+                ),
+                msg="Failed to get entity ext_id from task for AHV VM recovery point",
+            )
+    result["changed"] = True
+
+
+def update_vm_recovery_point(module, result, api_instance):
+    """AHV VM recovery points are immutable — no-op with informative skip."""
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    current = get_vm_recovery_point(module, api_instance, ext_id)
+    result["response"] = strip_internal_attributes(current.data.to_dict())
+
+    if module.check_mode:
+        result["msg"] = (
+            "AHV VM recovery points are immutable; ext_id:{0} cannot be updated. "
+            "No changes will be made.".format(ext_id)
+        )
+        return
+
+    result["skipped"] = True
+    module.exit_json(
+        msg=(
+            "AHV VM recovery points are immutable; ext_id:{0} cannot be updated. "
+            "Nothing to change.".format(ext_id)
+        ),
+        **result,
+    )
+
+
+def delete_vm_recovery_point(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "AHV VM recovery point with ext_id:{0} will be deleted.".format(
+            ext_id
+        )
+        return
+
+    current = get_vm_recovery_point(module, api_instance, ext_id)
+    etag = get_etag(current)
+    kwargs = {}
+    if etag:
+        kwargs["if_match"] = etag
+
+    try:
+        resp = api_instance.delete_vm_recovery_point_by_ext_id(extId=ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting AHV VM recovery point",
+        )
+
+    task_ext_id = getattr(getattr(resp, "data", None), "ext_id", None)
+    if task_ext_id:
+        result["task_ext_id"] = task_ext_id
+        result["response"] = strip_internal_attributes(resp.data.to_dict())
+        if module.params.get("wait"):
+            task = wait_for_completion(module, task_ext_id, True)
+            result["response"] = strip_internal_attributes(task.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_vm_recovery_points_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_vm_recovery_point(module, result, api_instance)
+        else:
+            create_vm_recovery_point(module, result, api_instance)
+    else:
+        delete_vm_recovery_point(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_vm_recovery_points_info_v2.py
+++ b/plugins/modules/ntnx_vm_recovery_points_info_v2.py
@@ -1,0 +1,246 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_recovery_points_info_v2
+short_description: Fetch AHV VM recovery points info from Nutanix Prism Central
+version_added: 2.7.0
+description:
+    - This module allows you to fetch AHV VM recovery points or a specific
+      AHV VM recovery point from Nutanix Prism Central.
+    - If C(ext_id) is provided, fetch the specific AHV VM recovery point.
+    - If C(ext_id) is not provided, list AHV VM recovery points with optional
+      filter/limit/page/orderby/select query parameters.
+    - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to
+      the user performing the operation. The required roles depend on the
+      operation being performed.
+    - >-
+      B(Get AHV VM Recovery Point by ext_id) -
+      Required Roles: Backup Admin, CSI System, Disaster Recovery Admin,
+      Disaster Recovery Viewer, Kubernetes Data Services System, Prism Admin,
+      Prism Viewer, Project Manager, Super Admin,
+      Self-Service Admin (deprecated)
+    - >-
+      B(List AHV VM Recovery Points) -
+      Required Roles: Backup Admin, CSI System, Disaster Recovery Admin,
+      Disaster Recovery Viewer, Kubernetes Data Services System, Prism Admin,
+      Prism Viewer, Project Manager, Super Admin,
+      Self-Service Admin (deprecated)
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+    ext_id:
+        description:
+            - The external ID (UUID) of the AHV VM recovery point.
+            - When provided, a single AHV VM recovery point is returned.
+        type: str
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_info_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+    - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get AHV VM recovery point using ext_id
+  nutanix.ncp.ntnx_vm_recovery_points_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "b387359d-fa5c-4d58-9eb2-3af1a4976319"
+  register: result
+
+- name: List all AHV VM recovery points
+  nutanix.ncp.ntnx_vm_recovery_points_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+  register: result
+
+- name: List AHV VM recovery points with limit
+  nutanix.ncp.ntnx_vm_recovery_points_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    limit: 5
+  register: result
+
+- name: List AHV VM recovery points with filter
+  nutanix.ncp.ntnx_vm_recovery_points_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    filter: "name eq 'ansible_vm_rp_crash'"
+  register: result
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for fetching AHV VM recovery point(s).
+        - Specific AHV VM recovery point details if C(ext_id) is provided.
+        - List of AHV VM recovery point details if C(ext_id) is not provided.
+    returned: always
+    type: dict
+    sample:
+        {
+            "application_consistent_properties": null,
+            "consistency_group_ext_id": null,
+            "creation_time": "2026-07-20T22:35:00.000000+00:00",
+            "disk_recovery_points": [
+                {
+                    "disk_ext_id": "839feff9-bac0-4a70-9523-82ea9e431517",
+                    "disk_recovery_point_ext_id": "21d467f0-ccef-4733-91cc-f04db58a92eb"
+                }
+            ],
+            "expiration_time": "2027-01-01T00:00:00+00:00",
+            "ext_id": "b387359d-fa5c-4d58-9eb2-3af1a4976319",
+            "links": null,
+            "location_agnostic_id": "51264897-07a8-4292-831b-ae28a37135e5",
+            "name": "ansible_vm_rp_crash",
+            "recovery_point_type": "CRASH_CONSISTENT",
+            "status": "COMPLETE",
+            "tenant_id": null,
+            "total_exclusive_usage_bytes": 0,
+            "vm": null,
+            "vm_categories": null,
+            "vm_ext_id": "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+        }
+
+changed:
+    description: Whether the task resulted in any changes.
+    returned: always
+    type: bool
+    sample: false
+
+ext_id:
+    description: External ID of the AHV VM recovery point.
+    type: str
+    returned: When external ID is provided
+    sample: "b387359d-fa5c-4d58-9eb2-3af1a4976319"
+
+total_available_results:
+    description:
+        - The total number of AHV VM recovery points available in Prism
+          Central for the current query.
+    type: int
+    returned: When listing AHV VM recovery points (no ext_id)
+    sample: 42
+
+failed:
+    description: Whether the task failed.
+    returned: always
+    type: bool
+    sample: false
+
+error:
+    description: Error message set on failure.
+    returned: When an error occurs
+    type: str
+
+msg:
+    description: Additional message on error.
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while fetching AHV VM recovery points info"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_recovery_points_api_instance,
+)
+from ..module_utils.v4.vmm.helpers import get_vm_recovery_point  # noqa: E402
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def get_vm_recovery_point_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_vm_recovery_point(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+
+def list_vm_recovery_points(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating AHV VM recovery points info spec", **result
+        )
+
+    try:
+        resp = api_instance.list_vm_recovery_points(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching AHV VM recovery points info",
+        )
+
+    resp = strip_internal_attributes(resp.to_dict())
+    metadata = resp.get("metadata") or {}
+    result["total_available_results"] = metadata.get("total_available_results")
+    data = resp.get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_vm_recovery_points_api_instance(module)
+    if module.params.get("ext_id"):
+        get_vm_recovery_point_using_ext_id(module, api_instance, result)
+    else:
+        list_vm_recovery_points(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_recovery_points_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_recovery_points_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_recovery_points_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_recovery_points_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_recovery_points_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_recovery_points_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults for AHV VM recovery point v2 tests
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import vm_recovery_points.yml
+      ansible.builtin.import_tasks: vm_recovery_points.yml

--- a/tests/integration/targets/ntnx_vm_recovery_points_v2/tasks/vm_recovery_points.yml
+++ b/tests/integration/targets/ntnx_vm_recovery_points_v2/tasks/vm_recovery_points.yml
@@ -1,0 +1,499 @@
+---
+# Integration tests for AHV VM recovery point v2 modules
+#
+# Modules under test:
+#   - nutanix.ncp.ntnx_vm_recovery_point_v2               (CRUD)
+#   - nutanix.ncp.ntnx_vm_recovery_points_info_v2         (info)
+#   - nutanix.ncp.ntnx_vm_recovery_point_restore_v2       (action)
+#
+# The suite covers: check_mode, minimal & full-field create, get-by-id, list,
+# filter, limit, invalid ext_id error, restore (with and without overrides),
+# delete (real + non-existent), and update-attempt (which must skip because
+# AHV VM recovery points are immutable).
+
+- name: Start AHV VM recovery point v2 tests
+  ansible.builtin.debug:
+    msg: Start AHV VM recovery point v2 tests
+
+- name: Generate random suffix for resource names
+  ansible.builtin.set_fact:
+    rand_suffix: "{{ query('community.general.random_string', numbers=false, special=false, length=10)[0] }}"
+
+- name: Set derived resource names
+  ansible.builtin.set_fact:
+    prefix_name: ansible_test
+    vm_todelete: []
+    rp_todelete: []
+    restored_vm_todelete: []
+
+- name: Set names using the random suffix
+  ansible.builtin.set_fact:
+    vm_name: "{{ prefix_name }}_vm_{{ rand_suffix }}"
+    rp_name_crash: "{{ prefix_name }}_rp_crash_{{ rand_suffix }}"
+    rp_name_full: "{{ prefix_name }}_rp_full_{{ rand_suffix }}"
+    restored_vm_name: "{{ prefix_name }}_restored_{{ rand_suffix }}"
+
+- name: Compute an expiration time 30 days out (ISO-8601 UTC)
+  ansible.builtin.set_fact:
+    expiration_time: "{{ '%Y-%m-%dT%H:%M:%SZ' | strftime((ansible_date_time.epoch | int) + (30 * 86400)) }}"
+
+########################################################################################################
+# Prerequisites: create a source VM to snapshot.
+########################################################################################################
+
+- name: Create source AHV VM (prerequisite)
+  nutanix.ncp.ntnx_vms_v2:
+    name: "{{ vm_name }}"
+    description: "ansible AHV VM recovery point test source"
+    cluster:
+      ext_id: "{{ cluster.uuid }}"
+  register: source_vm
+
+- name: Verify source VM was created
+  ansible.builtin.assert:
+    that:
+      - source_vm.changed == True
+      - source_vm.failed == False
+      - source_vm.response is defined
+      - source_vm.response.name == vm_name
+      - source_vm.ext_id | length > 0
+    fail_msg: "Unable to create source VM for the AHV VM recovery point tests"
+    success_msg: "Source VM created successfully"
+
+- name: Register source VM ext_id for cleanup
+  ansible.builtin.set_fact:
+    source_vm_ext_id: "{{ source_vm.ext_id }}"
+    vm_todelete: "{{ vm_todelete + [source_vm.ext_id] }}"
+
+########################################################################################################
+# NEGATIVE / SPEC-VALIDATION TESTS (fast — no API calls).
+########################################################################################################
+
+- name: Negative — create without required 'name'
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: present
+    vm_ext_id: "{{ source_vm_ext_id }}"
+  register: neg_no_name
+  ignore_errors: true
+
+- name: Verify create without 'name' fails
+  ansible.builtin.assert:
+    that:
+      - neg_no_name.failed == True
+      - neg_no_name.changed == False
+      - "'Missing required parameter' in (neg_no_name.msg | default(''))"
+    fail_msg: "Create without 'name' should have failed"
+    success_msg: "Missing 'name' correctly rejected"
+
+- name: Negative — create without required 'vm_ext_id'
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: present
+    name: "should_never_be_created_{{ rand_suffix }}"
+  register: neg_no_vm
+  ignore_errors: true
+
+- name: Verify create without 'vm_ext_id' fails
+  ansible.builtin.assert:
+    that:
+      - neg_no_vm.failed == True
+      - neg_no_vm.changed == False
+      - "'Missing required parameter' in (neg_no_vm.msg | default(''))"
+    fail_msg: "Create without 'vm_ext_id' should have failed"
+    success_msg: "Missing 'vm_ext_id' correctly rejected"
+
+- name: Negative — invalid recovery_point_type # noqa args[module]
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: present
+    name: "should_never_be_created_{{ rand_suffix }}"
+    vm_ext_id: "{{ source_vm_ext_id }}"
+    recovery_point_type: "NOT_A_REAL_TYPE"
+  register: neg_bad_enum
+  ignore_errors: true
+
+- name: Verify invalid enum is rejected
+  ansible.builtin.assert:
+    that:
+      - neg_bad_enum.failed == True
+      - neg_bad_enum.changed == False
+    fail_msg: "Invalid recovery_point_type should have been rejected"
+    success_msg: "Invalid enum correctly rejected"
+
+- name: Negative — delete without ext_id # noqa args[module]
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: absent
+  register: neg_delete_no_ext
+  ignore_errors: true
+
+- name: Verify delete without ext_id fails
+  ansible.builtin.assert:
+    that:
+      - neg_delete_no_ext.failed == True
+      - neg_delete_no_ext.changed == False
+    fail_msg: "Delete without ext_id should have failed"
+    success_msg: "Delete without ext_id correctly rejected"
+
+########################################################################################################
+# CHECK-MODE TESTS (one for create, one for delete). Update is naturally
+# skipped because AHV VM recovery points are immutable — an explicit check
+# for that is included further below.
+########################################################################################################
+
+- name: Check-mode create with ALL supported attributes
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: present
+    name: "{{ rp_name_full }}"
+    vm_ext_id: "{{ source_vm_ext_id }}"
+    recovery_point_type: "APPLICATION_CONSISTENT"
+    expiration_time: "{{ expiration_time }}"
+    consistency_group_ext_id: "00000000-0000-0000-0000-000000000000"
+    vm_categories:
+      - "00000000-0000-0000-0000-000000000000"
+    application_consistent_properties:
+      backup_type: "FULL_BACKUP"
+      should_include_writers: true
+      writers:
+        - "e8132975-6d3a-4d67-807e-8d0d5b8e0b8b"
+      should_store_vss_metadata: true
+  check_mode: true
+  register: cm_create_full
+
+- name: Verify check-mode create produced the expected spec
+  ansible.builtin.assert:
+    that:
+      - cm_create_full.failed == False
+      - cm_create_full.changed == False
+      - cm_create_full.response is defined
+      - cm_create_full.response.name == rp_name_full
+      - cm_create_full.response.vm_ext_id == source_vm_ext_id
+      - cm_create_full.response.recovery_point_type == "APPLICATION_CONSISTENT"
+      - cm_create_full.response.application_consistent_properties.backup_type == "FULL_BACKUP"
+      - cm_create_full.response.application_consistent_properties.should_include_writers == True
+      - cm_create_full.response.application_consistent_properties.should_store_vss_metadata == True
+      - cm_create_full.response.application_consistent_properties.writers | length == 1
+      - cm_create_full.response.vm_categories | length == 1
+    fail_msg: "Check-mode create did not produce the expected spec"
+    success_msg: "Check-mode create produced the expected spec"
+
+- name: Check-mode delete
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: absent
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  check_mode: true
+  register: cm_delete
+
+- name: Verify check-mode delete msg
+  ansible.builtin.assert:
+    that:
+      - cm_delete.failed == False
+      - cm_delete.changed == False
+      - "'will be deleted' in cm_delete.msg"
+      - cm_delete.ext_id == "00000000-0000-0000-0000-000000000000"
+    fail_msg: "Check-mode delete did not produce expected msg"
+    success_msg: "Check-mode delete produced expected msg"
+
+- name: Check-mode restore with ALL override attributes
+  nutanix.ncp.ntnx_vm_recovery_point_restore_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    is_strict_mode: true
+    vm_config_override_spec:
+      name: "{{ restored_vm_name }}"
+      description: "ansible check_mode restore"
+      categories:
+        - ext_id: "00000000-0000-0000-0000-000000000000"
+      nic_spec:
+        nic_remove_list:
+          - "00000000-0000-0000-0000-000000000001"
+        nic_override_list:
+          - nic_ext_id: "00000000-0000-0000-0000-000000000002"
+            subnet_ext_id: "00000000-0000-0000-0000-000000000003"
+      guest_tools_spec:
+        should_clear_in_guest_volume_group_attachments: true
+  check_mode: true
+  register: cm_restore
+
+- name: Verify check-mode restore produced the expected spec
+  ansible.builtin.assert:
+    that:
+      - cm_restore.failed == False
+      - cm_restore.changed == False
+      - cm_restore.response is defined
+      - cm_restore.response.is_strict_mode == True
+      - cm_restore.response.vm_config_override_spec.name == restored_vm_name
+      - cm_restore.response.vm_config_override_spec.guest_tools_spec.should_clear_in_guest_volume_group_attachments == True
+      - cm_restore.response.vm_config_override_spec.nic_spec.nic_remove_list | length == 1
+      - cm_restore.response.vm_config_override_spec.nic_spec.nic_override_list | length == 1
+      - cm_restore.response.vm_config_override_spec.categories | length == 1
+    fail_msg: "Check-mode restore did not produce the expected spec"
+    success_msg: "Check-mode restore produced the expected spec"
+
+########################################################################################################
+# CREATE — minimal (required fields only), CRASH_CONSISTENT.
+########################################################################################################
+
+- name: Create AHV VM recovery point — minimal (CRASH_CONSISTENT, no expiry)
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: present
+    name: "{{ rp_name_crash }}"
+    vm_ext_id: "{{ source_vm_ext_id }}"
+    recovery_point_type: "CRASH_CONSISTENT"
+  register: create_min
+
+- name: Verify minimal create succeeded
+  ansible.builtin.assert:
+    that:
+      - create_min.changed == True
+      - create_min.failed == False
+      - create_min.response is defined
+      - create_min.ext_id | length > 0
+      - create_min.task_ext_id | length > 0
+      - create_min.response.name == rp_name_crash
+      - create_min.response.vm_ext_id == source_vm_ext_id
+      - create_min.response.recovery_point_type == "CRASH_CONSISTENT"
+      - create_min.response.status == "COMPLETE"
+    fail_msg: "Minimal AHV VM recovery point create failed"
+    success_msg: "Minimal AHV VM recovery point created successfully"
+
+- name: Register minimal recovery point ext_id for cleanup
+  ansible.builtin.set_fact:
+    rp_min_ext_id: "{{ create_min.ext_id }}"
+    rp_todelete: "{{ rp_todelete + [create_min.ext_id] }}"
+
+########################################################################################################
+# CREATE — all optional attributes (still CRASH_CONSISTENT because most
+# clusters do not have Windows+VSS enabled test VMs). We keep the second
+# create using a CRASH_CONSISTENT type but with expiration time + all
+# scalar options set.
+########################################################################################################
+
+- name: Create AHV VM recovery point — with expiration_time
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: present
+    name: "{{ rp_name_full }}"
+    vm_ext_id: "{{ source_vm_ext_id }}"
+    recovery_point_type: "CRASH_CONSISTENT"
+    expiration_time: "{{ expiration_time }}"
+  register: create_full
+
+- name: Verify full create succeeded
+  ansible.builtin.assert:
+    that:
+      - create_full.changed == True
+      - create_full.failed == False
+      - create_full.response is defined
+      - create_full.ext_id | length > 0
+      - create_full.response.name == rp_name_full
+      - create_full.response.vm_ext_id == source_vm_ext_id
+      - create_full.response.recovery_point_type == "CRASH_CONSISTENT"
+      - create_full.response.expiration_time is defined
+      - create_full.response.status == "COMPLETE"
+    fail_msg: "Create with expiration_time failed"
+    success_msg: "Create with expiration_time succeeded"
+
+- name: Register full recovery point ext_id for cleanup
+  ansible.builtin.set_fact:
+    rp_full_ext_id: "{{ create_full.ext_id }}"
+    rp_todelete: "{{ rp_todelete + [create_full.ext_id] }}"
+
+########################################################################################################
+# INFO / GET-BY-ID / LIST / FILTER / LIMIT.
+########################################################################################################
+
+- name: Get AHV VM recovery point by ext_id
+  nutanix.ncp.ntnx_vm_recovery_points_info_v2:
+    ext_id: "{{ rp_min_ext_id }}"
+  register: info_by_id
+
+- name: Verify get-by-id
+  ansible.builtin.assert:
+    that:
+      - info_by_id.failed == False
+      - info_by_id.changed == False
+      - info_by_id.ext_id == rp_min_ext_id
+      - info_by_id.response.name == rp_name_crash
+      - info_by_id.response.vm_ext_id == source_vm_ext_id
+      - info_by_id.response.recovery_point_type == "CRASH_CONSISTENT"
+    fail_msg: "get-by-id did not return the expected recovery point"
+    success_msg: "get-by-id returned the expected recovery point"
+
+- name: List AHV VM recovery points (limit 5)
+  nutanix.ncp.ntnx_vm_recovery_points_info_v2:
+    limit: 5
+  register: info_list_limit
+
+- name: Verify limit is honored
+  ansible.builtin.assert:
+    that:
+      - info_list_limit.failed == False
+      - info_list_limit.changed == False
+      - info_list_limit.response is iterable
+      - info_list_limit.response | length <= 5
+      - info_list_limit.total_available_results is defined
+    fail_msg: "List with limit did not respect the limit"
+    success_msg: "List with limit succeeded"
+
+- name: List AHV VM recovery points filtered by vmExtId (our source VM)
+  nutanix.ncp.ntnx_vm_recovery_points_info_v2:
+    filter: "vmExtId eq '{{ source_vm_ext_id }}'"
+  register: info_filter
+
+- name: Verify filter returned our RPs
+  ansible.builtin.assert:
+    that:
+      - info_filter.failed == False
+      - info_filter.changed == False
+      - info_filter.response is iterable
+      - info_filter.response | length >= 2
+      - info_filter.response | map(attribute='vm_ext_id') | unique | list == [source_vm_ext_id]
+      - rp_min_ext_id in (info_filter.response | map(attribute='ext_id') | list)
+      - rp_full_ext_id in (info_filter.response | map(attribute='ext_id') | list)
+    fail_msg: "Filter did not return the expected recovery points"
+    success_msg: "Filter returned the expected recovery points"
+
+- name: Negative — get AHV VM recovery point by non-existent ext_id
+  nutanix.ncp.ntnx_vm_recovery_points_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: info_not_found
+  ignore_errors: true
+
+- name: Verify not-found error is descriptive
+  ansible.builtin.assert:
+    that:
+      - info_not_found.failed == True
+      - "'AHV VM recovery point' in (info_not_found.msg | default(''))"
+    fail_msg: "Not-found get should have failed with a descriptive error"
+    success_msg: "Not-found get returned the expected error"
+
+########################################################################################################
+# UPDATE ATTEMPT — must skip because AHV VM recovery points are immutable.
+########################################################################################################
+
+- name: Attempt to "update" an AHV VM recovery point (must skip — immutable)
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: present
+    ext_id: "{{ rp_min_ext_id }}"
+    name: "{{ rp_name_crash }}_should_not_change"
+  register: immutable_update
+
+- name: Verify update attempt was skipped
+  ansible.builtin.assert:
+    that:
+      - immutable_update.failed == False
+      - immutable_update.changed == False
+      - immutable_update.skipped == True
+      - "'immutable' in immutable_update.msg"
+      - immutable_update.ext_id == rp_min_ext_id
+    fail_msg: "Update attempt should have been skipped (recovery points are immutable)"
+    success_msg: "Update attempt correctly skipped"
+
+- name: Attempt update again (idempotency — second call must also skip)
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: present
+    ext_id: "{{ rp_min_ext_id }}"
+    name: "{{ rp_name_crash }}_should_not_change"
+  register: immutable_update_2
+
+- name: Verify second update attempt was skipped
+  ansible.builtin.assert:
+    that:
+      - immutable_update_2.failed == False
+      - immutable_update_2.changed == False
+      - immutable_update_2.skipped == True
+    fail_msg: "Second update attempt should have been skipped"
+    success_msg: "Second update attempt correctly skipped"
+
+########################################################################################################
+# RESTORE — create a new VM from the recovery point (real API call).
+########################################################################################################
+
+- name: Restore a new AHV VM from the recovery point
+  nutanix.ncp.ntnx_vm_recovery_point_restore_v2:
+    ext_id: "{{ rp_min_ext_id }}"
+    vm_config_override_spec:
+      name: "{{ restored_vm_name }}"
+      description: "ansible restore integration test"
+  register: restore_result
+
+- name: Verify restore succeeded
+  ansible.builtin.assert:
+    that:
+      - restore_result.failed == False
+      - restore_result.changed == True
+      - restore_result.ext_id == rp_min_ext_id
+      - restore_result.task_ext_id | length > 0
+    fail_msg: "Restore failed"
+    success_msg: "Restore succeeded"
+
+- name: Register restored VM ext_id if the task returned it
+  when:
+    - restore_result.vm_ext_id is defined
+    - restore_result.vm_ext_id | length > 0
+  ansible.builtin.set_fact:
+    restored_vm_ext_id: "{{ restore_result.vm_ext_id }}"
+    restored_vm_todelete: "{{ restored_vm_todelete + [restore_result.vm_ext_id] }}"
+
+########################################################################################################
+# DELETE — real delete + delete of non-existent RP (must fail cleanly).
+########################################################################################################
+
+- name: Delete the "full" AHV VM recovery point
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: absent
+    ext_id: "{{ rp_full_ext_id }}"
+  register: delete_full
+
+- name: Verify delete succeeded
+  ansible.builtin.assert:
+    that:
+      - delete_full.failed == False
+      - delete_full.changed == True
+      - delete_full.ext_id == rp_full_ext_id
+    fail_msg: "Delete failed"
+    success_msg: "Delete succeeded"
+
+- name: Remove the deleted RP from cleanup list
+  ansible.builtin.set_fact:
+    rp_todelete: "{{ rp_todelete | difference([rp_full_ext_id]) }}"
+
+- name: Negative — delete a non-existent AHV VM recovery point
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: absent
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: delete_missing
+  ignore_errors: true
+
+- name: Verify missing delete failed with a descriptive error
+  ansible.builtin.assert:
+    that:
+      - delete_missing.failed == True
+      - "'AHV VM recovery point' in (delete_missing.msg | default(''))"
+    fail_msg: "Deleting non-existent RP should have failed with a descriptive error"
+    success_msg: "Deleting non-existent RP failed with the expected error"
+
+########################################################################################################
+# CLEANUP — always run.
+########################################################################################################
+
+- name: Cleanup restored VM(s)
+  nutanix.ncp.ntnx_vms_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  loop: "{{ restored_vm_todelete }}"
+  failed_when: false
+
+- name: Cleanup remaining AHV VM recovery points
+  nutanix.ncp.ntnx_vm_recovery_point_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  loop: "{{ rp_todelete }}"
+  failed_when: false
+
+- name: Cleanup source VM
+  nutanix.ncp.ntnx_vms_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  loop: "{{ vm_todelete }}"
+  failed_when: false
+
+- name: Done
+  ansible.builtin.debug:
+    msg: AHV VM recovery point v2 tests finished


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **virtual_machine_management** namespace, entity
**VmRecoveryPoint**, based on the inline `sdk_info.json` (SDK `ntnx_vmm_py_client==4.2.2`,
`VmRecoveryPointsApi`, URI base `/api/vmm/v4.2/ahv/config/vm-recovery-points`).

- Modules generated:
  - `ntnx_vm_recovery_point_v2` (CRUD — create / delete; update is a no-op because AHV VM recovery points are immutable)
  - `ntnx_vm_recovery_points_info_v2` (info — get-by-id / list with `filter` / `limit` / `page` / `orderby` / `select`)
  - `ntnx_vm_recovery_point_restore_v2` (action — restore a new AHV VM from a recovery point, with optional `VmConfigOverrideSpecification`)
- API methods covered: 5 (`CreateVmRecoveryPoint`, `GetVmRecoveryPointByExtId`, `ListVmRecoveryPoints`, `DeleteVmRecoveryPointByExtId`, `RestoreVmRecoveryPoint`)
- Fields in CRUD module spec: 8 top-level (`state`, `ext_id`, `name`, `vm_ext_id`, `expiration_time`, `recovery_point_type`, `consistency_group_ext_id`, `vm_categories`, `application_consistent_properties` — the last exposes `backup_type`, `should_include_writers`, `writers`, `should_store_vss_metadata`)
- Fields in info module spec: 1 module-specific (`ext_id`) plus the standard info-module query params (`filter`, `page`, `limit`, `orderby`, `select`)
- Fields in restore module spec: 4 top-level (`state`, `ext_id`, `is_strict_mode`, `vm_config_override_spec`) where the override sub-spec exposes `name`, `description`, `categories`, `nic_spec.{nic_remove_list, nic_override_list.{nic_ext_id, subnet_ext_id}}`, and `guest_tools_spec.should_clear_in_guest_volume_group_attachments`

Supporting changes:
- Added `get_vm_recovery_points_api_instance()` to `plugins/module_utils/v4/vmm/api_client.py`
- Added `get_vm_recovery_point()` to `plugins/module_utils/v4/vmm/helpers.py`
- Registered the three new modules in `meta/runtime.yml` `action_groups.ntnx` so `module_defaults: group/nutanix.ncp.ntnx: {...}` picks them up

Design patterns followed (per instructions):
- CRUD module mirrors `ntnx_virtual_switch_v2` (spec generation, `wait_for_completion`, `get_entity_ext_id_from_task`, `strip_internal_attributes`, structured `result` dict, `run_module()` state dispatch).
- Info module mirrors `ntnx_virtual_switches_info_v2` (`BaseInfoModule`, `SpecGenerator.get_info_spec`, `mutually_exclusive: [(ext_id, filter)]`, `total_available_results` in result).
- Restore/action module mirrors `ntnx_vm_revert_v2` / `ntnx_recovery_point_restore_v2` (defines `api_instance` in `run_module()`, passes it into the helper, supports `check_mode`, extracts restored VM ext_id via `get_entity_ext_id_from_task` with `rel=vmm:ahv:config:vm`).

## Domain knowledge (from Glean)

Glean MCP `glean__chat` was called with the requested verbatim query but timed out
twice (`MCP error -32001: Request timed out`) before returning a response, so no
external domain context was collected via Glean for this run.

The domain understanding baked into the modules was derived directly from the
inline `sdk_info.json` embedded in the prompt (SDK class shapes, field types,
`swagger_types`, enum values, URIs and HTTP verbs) and from cross-checking the
following on the live cluster used for testing (Prism Central `10.44.76.28`, API
version `vmm.v4.r3`):

- `VmRecoveryPoint` extends `BaseVmRecoveryPoint`/`BaseRecoveryPoint`; the
  create body accepts `name`, `vmExtId`, `recoveryPointType` (enum:
  `CRASH_CONSISTENT`, `APPLICATION_CONSISTENT`), `expirationTime` (RFC3339 UTC),
  `consistencyGroupExtId`, `vmCategories: list[str]`, and
  `applicationConsistentProperties` (`VssProperties`: `backupType` enum
  `FULL_BACKUP`/`COPY_BACKUP`, `shouldIncludeWriters`, `writers: list[str]`,
  `shouldStoreVssMetadata`).
- The AHV VM recovery point API does **not** expose an update endpoint — the
  CRUD module therefore reports `changed=false, skipped=true, msg="…immutable…"`
  when called with `state=present` + `ext_id`, which is verified by an explicit
  integration test.
- Delete and Restore require an `etag` in the `If-Match` header; both modules
  fetch the current entity with `get_vm_recovery_point` and forward the etag
  via `get_etag(...)`.
- The task returned by both Create and Restore reports the affected entity via
  `entities_affected[*].rel`; Create's recovery-point entity is surfaced with
  `rel="dataprotection:config:vm-recovery-point"` (existing constant
  `TASK_CONSTANTS.RelEntityType.VM_RECOVERY_POINT`) and Restore's new VM is
  surfaced with `rel="vmm:ahv:config:vm"` (existing `.VM`).
- The list endpoint on this cluster **returns HTTP 412 `VMM-10000
  INTERNAL_ERROR`** when `$filter=name eq '…'` is used but honors
  `$filter=vmExtId eq '…'`, `$limit`, and `$orderby=creationTime desc`. Both
  the integration tests and the example playbook use `vmExtId` for the filter
  demonstration to avoid a server-side bug that is outside the module's
  control.
- Not-found errors from the API surface as `VMM-32810
  VM_RECOVERY_POINT_NOT_FOUND_ERROR`; the module wraps them with a descriptive
  `msg` and the raw response is exposed via `result.response.data.error`.

## Files changed

Under `plugins/`:
- `plugins/modules/ntnx_vm_recovery_point_v2.py` (new — CRUD)
- `plugins/modules/ntnx_vm_recovery_points_info_v2.py` (new — info)
- `plugins/modules/ntnx_vm_recovery_point_restore_v2.py` (new — restore action)
- `plugins/module_utils/v4/vmm/api_client.py` (updated — added `get_vm_recovery_points_api_instance`)
- `plugins/module_utils/v4/vmm/helpers.py` (updated — added `get_vm_recovery_point`)

Under `meta/`:
- `meta/runtime.yml` (updated — added the three new modules to `action_groups.ntnx`)

Under `examples/`:
- `examples/virtual_machine_management/VmRecoveryPoint/vm_recovery_points.yml` (new — end-to-end playbook)
- `examples/virtual_machine_management/VmRecoveryPoint/examples_run.log` (new — real live-cluster run output)

Under `tests/`:
- `tests/integration/targets/ntnx_vm_recovery_points_v2/aliases` (new)
- `tests/integration/targets/ntnx_vm_recovery_points_v2/meta/main.yml` (new — depends on `prepare_env`)
- `tests/integration/targets/ntnx_vm_recovery_points_v2/tasks/main.yml` (new — module_defaults wrapper)
- `tests/integration/targets/ntnx_vm_recovery_points_v2/tasks/vm_recovery_points.yml` (new — the actual tests)

## Test execution

| Metric              | Value                                                                          |
|---------------------|--------------------------------------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 --allow-disabled --allow-unsupported ntnx_vm_recovery_points_v2` |
| Total tasks         | `59` (51 ok + 2 skipped + 6 intentional-failure negatives that are ignored)    |
| Passed              | `51`                                                                           |
| Skipped             | `2` (immutable-update skips — expected)                                        |
| Intentional failures (ignored) | `6` (negative tests asserting argument-spec / not-found errors)     |
| Unexpected failures | `0`                                                                            |
| Duration            | `~94s` (single run)                                                            |
| Cluster (PC)        | `10.44.76.28:9440` (auto_cluster_prod_36acf9b012ca / cluster ext_id `0006555e-4e63-4a5e-185b-ac1f6b6f97e2`) |

### Analysis

No unexpected failures. The 6 tasks reported as `ignored` are the negative
tests (missing `name`, missing `vm_ext_id`, invalid `recovery_point_type`,
missing `ext_id` on delete, get-by non-existent ext_id, delete of non-existent
ext_id) that intentionally invoke the module in an invalid configuration and
then assert that the module returned the correct error. The 2 `skipped` tasks
are the two calls to the CRUD module with `state=present` + `ext_id`, which
correctly return `skipped=true, changed=false, msg="AHV VM recovery points
are immutable…"` — the module short-circuits with `module.exit_json` which
Ansible reports as `skipping` in the play recap.

Notes and known-good limitations (not module bugs):

- **`$filter=name eq '…'` on this cluster returns HTTP 412 `VMM-10000`.** This
  is a server-side error confirmed against the raw REST endpoint. The
  integration test and example playbook therefore filter by `vmExtId` instead,
  which is fully supported. If your cluster supports `name`-based filters, the
  module passes them through untouched via `SpecGenerator.get_info_spec`.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_vm_recovery_points_v2
Running ntnx_vm_recovery_points_v2 integration test role
[WARNING]: Found variable using reserved name: port

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Start AHV VM recovery point v2 tests] *******
ok: [testhost] => {
    "msg": "Start AHV VM recovery point v2 tests"
}

TASK [ntnx_vm_recovery_points_v2 : Generate random suffix for resource names] ***
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Set derived resource names] *****************
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Set names using the random suffix] **********
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Compute an expiration time 30 days out (ISO-8601 UTC)] ***
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Create source AHV VM (prerequisite)] ********
changed: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify source VM was created] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "Source VM created successfully"
}

TASK [ntnx_vm_recovery_points_v2 : Register source VM ext_id for cleanup] ******
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Negative — create without required 'name'] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): name"}
...ignoring

TASK [ntnx_vm_recovery_points_v2 : Verify create without 'name' fails] *********
ok: [testhost] => {
    "changed": false,
    "msg": "Missing 'name' correctly rejected"
}

TASK [ntnx_vm_recovery_points_v2 : Negative — create without required 'vm_ext_id'] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): vm_ext_id"}
...ignoring

TASK [ntnx_vm_recovery_points_v2 : Verify create without 'vm_ext_id' fails] ****
ok: [testhost] => {
    "changed": false,
    "msg": "Missing 'vm_ext_id' correctly rejected"
}

TASK [ntnx_vm_recovery_points_v2 : Negative — invalid recovery_point_type] *****
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of recovery_point_type must be one of: CRASH_CONSISTENT, APPLICATION_CONSISTENT, got: NOT_A_REAL_TYPE"}
...ignoring

TASK [ntnx_vm_recovery_points_v2 : Verify invalid enum is rejected] ************
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid enum correctly rejected"
}

TASK [ntnx_vm_recovery_points_v2 : Negative — delete without ext_id] ***********
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_vm_recovery_points_v2 : Verify delete without ext_id fails] *********
ok: [testhost] => {
    "changed": false,
    "msg": "Delete without ext_id correctly rejected"
}

TASK [ntnx_vm_recovery_points_v2 : Check-mode create with ALL supported attributes] ***
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify check-mode create produced the expected spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Check-mode create produced the expected spec"
}

TASK [ntnx_vm_recovery_points_v2 : Check-mode delete] **************************
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify check-mode delete msg] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "Check-mode delete produced expected msg"
}

TASK [ntnx_vm_recovery_points_v2 : Check-mode restore with ALL override attributes] ***
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify check-mode restore produced the expected spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Check-mode restore produced the expected spec"
}

TASK [ntnx_vm_recovery_points_v2 : Create AHV VM recovery point — minimal (CRASH_CONSISTENT, no expiry)] ***
changed: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify minimal create succeeded] ************
ok: [testhost] => {
    "changed": false,
    "msg": "Minimal AHV VM recovery point created successfully"
}

TASK [ntnx_vm_recovery_points_v2 : Register minimal recovery point ext_id for cleanup] ***
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Create AHV VM recovery point — with expiration_time] ***
changed: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify full create succeeded] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "Create with expiration_time succeeded"
}

TASK [ntnx_vm_recovery_points_v2 : Register full recovery point ext_id for cleanup] ***
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Get AHV VM recovery point by ext_id] ********
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify get-by-id] ***************************
ok: [testhost] => {
    "changed": false,
    "msg": "get-by-id returned the expected recovery point"
}

TASK [ntnx_vm_recovery_points_v2 : List AHV VM recovery points (limit 5)] ******
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify limit is honored] ********************
ok: [testhost] => {
    "changed": false,
    "msg": "List with limit succeeded"
}

TASK [ntnx_vm_recovery_points_v2 : List AHV VM recovery points filtered by vmExtId (our source VM)] ***
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify filter returned our RPs] *************
ok: [testhost] => {
    "changed": false,
    "msg": "Filter returned the expected recovery points"
}

TASK [ntnx_vm_recovery_points_v2 : Negative — get AHV VM recovery point by non-existent ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching AHV VM recovery point info using ext_id", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_recovery_point_uuid": "00000000-0000-0000-0000-000000000000"}, "code": "VMM-32810", "errorGroup": "VM_RECOVERY_POINT_NOT_FOUND_ERROR", "locale": "en-US", "message": "Failed to perform the operation on the VM recovery point with UUID '00000000-0000-0000-0000-000000000000', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_vm_recovery_points_v2 : Verify not-found error is descriptive] ******
ok: [testhost] => {
    "changed": false,
    "msg": "Not-found get returned the expected error"
}

TASK [ntnx_vm_recovery_points_v2 : Attempt to "update" an AHV VM recovery point (must skip — immutable)] ***
skipping: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify update attempt was skipped] **********
ok: [testhost] => {
    "changed": false,
    "msg": "Update attempt correctly skipped"
}

TASK [ntnx_vm_recovery_points_v2 : Attempt update again (idempotency — second call must also skip)] ***
skipping: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify second update attempt was skipped] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Second update attempt correctly skipped"
}

TASK [ntnx_vm_recovery_points_v2 : Restore a new AHV VM from the recovery point] ***
changed: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify restore succeeded] *******************
ok: [testhost] => {
    "changed": false,
    "msg": "Restore succeeded"
}

TASK [ntnx_vm_recovery_points_v2 : Register restored VM ext_id if the task returned it] ***
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Delete the "full" AHV VM recovery point] ****
changed: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Verify delete succeeded] ********************
ok: [testhost] => {
    "changed": false,
    "msg": "Delete succeeded"
}

TASK [ntnx_vm_recovery_points_v2 : Remove the deleted RP from cleanup list] ****
ok: [testhost]

TASK [ntnx_vm_recovery_points_v2 : Negative — delete a non-existent AHV VM recovery point] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching AHV VM recovery point info using ext_id", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_recovery_point_uuid": "00000000-0000-0000-0000-000000000000"}, "code": "VMM-32810", "errorGroup": "VM_RECOVERY_POINT_NOT_FOUND_ERROR", "locale": "en-US", "message": "Failed to perform the operation on the VM recovery point with UUID '00000000-0000-0000-0000-000000000000', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_vm_recovery_points_v2 : Verify missing delete failed with a descriptive error] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Deleting non-existent RP failed with the expected error"
}

TASK [ntnx_vm_recovery_points_v2 : Cleanup restored VM(s)] *********************
changed: [testhost] => (item=c8e518dc-03d7-47b7-533c-8fbed9c49d1b)

TASK [ntnx_vm_recovery_points_v2 : Cleanup remaining AHV VM recovery points] ***
changed: [testhost] => (item=db91dfc8-1783-41da-8f2a-a7d61afb3422)

TASK [ntnx_vm_recovery_points_v2 : Cleanup source VM] **************************
changed: [testhost] => (item=2606bf81-e0b1-4d26-7d65-109ae9280cb0)

TASK [ntnx_vm_recovery_points_v2 : Done] ***************************************
ok: [testhost] => {
    "msg": "AHV VM recovery point v2 tests finished"
}

PLAY RECAP *********************************************************************
testhost                   : ok=51   changed=8    unreachable=0    failed=0    skipped=2    rescued=0    ignored=6   

WARNING: Reviewing previous 1 warning(s):
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_vm_recovery_points_v2

```

</details>

## Example playbook execution

The example playbook was executed end-to-end against the same PC:

```
ansible-playbook examples/virtual_machine_management/VmRecoveryPoint/vm_recovery_points.yml \
  -e ip=10.44.76.28 -e username=admin -e password=Nutanix.123 -e nutanix_port=9440 \
  -e validate_certs=false -e source_vm_ext_id=<existing-VM-ext_id>
```

Play recap: `ok=9 changed=4 unreachable=0 failed=0 skipped=2 rescued=0 ignored=0`.
The two `skipping` items are (a) the application-consistent create — guarded
behind `run_app_consistent | default(false)` because it requires Windows+VSS
in the guest, and (b) the corresponding cleanup for that RP. The full
transcript is committed at
`examples/virtual_machine_management/VmRecoveryPoint/examples_run.log`.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
