### PR TITLE
Add ntnx_vm_custom_attribute_v2 action module

### DIFF
--- a/examples/virtual_machine_management/VmCustomAttribute/vm_custom_attribute_v2.yml
+++ b/examples/virtual_machine_management/VmCustomAttribute/vm_custom_attribute_v2.yml
@@ -1,0 +1,54 @@
+---
+# Summary:
+# This playbook demonstrates managing VM custom attributes on AHV VMs
+# using the ntnx_vm_custom_attribute_v2 module. It shows how to:
+#   1. Add custom attributes (key:value pairs) to a VM.
+#   2. Add more custom attributes to the same VM (existing ones are preserved).
+#   3. Remove specific custom attributes from the VM.
+#
+# Pre-requisites:
+#   - An existing AHV VM whose external ID is provided in vm_ext_id below.
+#   - The user must have the Update_Virtual_Machine_Custom_Attributes permission
+#     (typically granted by Prism Admin, Super Admin, or Virtual Machine Admin).
+
+- name: VM Custom Attributes playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        vm_ext_id: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+
+    - name: Add custom attributes to an AHV VM
+      nutanix.ncp.ntnx_vm_custom_attribute_v2:
+        state: present
+        ext_id: "{{ vm_ext_id }}"
+        custom_attributes:
+          - "environment:production"
+          - "owner:team-a"
+          - "tier:gold"
+      register: add_result
+
+    - name: Add more custom attributes to the same VM
+      nutanix.ncp.ntnx_vm_custom_attribute_v2:
+        state: present
+        ext_id: "{{ vm_ext_id }}"
+        custom_attributes:
+          - "cost_center:eng-42"
+          - "backup_policy:daily"
+      register: add_more_result
+
+    - name: Remove specific custom attributes from the VM
+      nutanix.ncp.ntnx_vm_custom_attribute_v2:
+        state: absent
+        ext_id: "{{ vm_ext_id }}"
+        custom_attributes:
+          - "environment:production"
+          - "backup_policy:daily"
+      register: remove_result

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vm_custom_attribute_v2

--- a/plugins/modules/ntnx_vm_custom_attribute_v2.py
+++ b/plugins/modules/ntnx_vm_custom_attribute_v2.py
@@ -1,0 +1,533 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_custom_attribute_v2
+short_description: Add or remove user-defined custom attributes of an AHV VM in Nutanix Prism Central.
+version_added: 2.7.0
+description:
+  - This module adds to or removes from the C(customAttributes) list of an AHV Virtual Machine in Nutanix Prism Central.
+  - Custom attributes are user-defined C(key:value) string pairs (e.g. C(environment:production))
+    that carry per-VM metadata for tracking, classification, and automation workflows.
+  - Only the attributes provided in C(custom_attributes) are affected. Existing attributes that are
+    not listed remain untouched.
+  - This module uses the Nutanix PC v4 APIs based SDKs (C(ntnx_vmm_py_client)).
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles/permissions to be assigned to the user
+    performing the operation. The required roles depend on the operation being performed.
+  - >-
+    B(Add to the VM's custom attributes) -
+    Required Permission: C(Update_Virtual_Machine_Custom_Attributes).
+    Common Roles: Prism Admin, Super Admin, Virtual Machine Admin.
+  - >-
+    B(Remove from the VM's custom attributes) -
+    Required Permission: C(Update_Virtual_Machine_Custom_Attributes).
+    Common Roles: Prism Admin, Super Admin, Virtual Machine Admin.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present), the given C(custom_attributes) are added to the VM.
+      - If C(state) is set to C(absent), the given C(custom_attributes) are removed from the VM.
+      - The module is idempotent - only attributes that are actually missing/present on the VM
+        are sent to the API. If nothing needs to change the task is skipped.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The globally unique identifier of the AHV VM (UUID) whose custom attributes are being modified.
+    type: str
+    required: true
+  custom_attributes:
+    description:
+      - List of user-defined custom attribute strings in the C(key:value) format
+        (e.g. C(environment:production), C(owner:team-a), C(tier:gold)).
+      - For C(state=present), any attribute already set on the VM is filtered out
+        and only the missing ones are sent to the add API.
+      - For C(state=absent), only the attributes actually present on the VM are sent
+        to the remove API.
+    type: list
+    elements: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Add custom attributes to an AHV VM
+  nutanix.ncp.ntnx_vm_custom_attribute_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+    custom_attributes:
+      - "environment:production"
+      - "owner:team-a"
+      - "tier:gold"
+  register: result
+
+- name: Remove custom attributes from an AHV VM
+  nutanix.ncp.ntnx_vm_custom_attribute_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+    custom_attributes:
+      - "environment:production"
+      - "owner:team-a"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for adding or removing custom attributes of an AHV VM.
+    - When C(wait=true) it is the up-to-date list of C(custom_attributes) currently set on the VM
+      after the operation completes.
+    - When C(wait=false) it is the raw task reference returned by the API.
+    - In C(check_mode) it is the request spec the module would have sent.
+  returned: always
+  type: list
+  elements: str
+  sample:
+    - "environment:production"
+    - "owner:team-a"
+    - "tier:gold"
+
+ext_id:
+  description:
+    - The external ID (UUID) of the AHV VM.
+  returned: always
+  type: str
+  sample: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+
+task_ext_id:
+  description:
+    - The external ID of the async task created by the API.
+  returned: when the API call is made
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+changed:
+  description: Whether the VM's custom attributes changed as a result of this run.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: Set to True when nothing needed to change (idempotent no-op).
+  returned: on skipping
+  type: bool
+  sample: true
+
+msg:
+  description: Status / error message.
+  returned: When there is an error, when the module is idempotent, or in check_mode.
+  type: str
+  sample: "Nothing to change."
+
+error:
+  description: Error details if an error occurred.
+  returned: when an error occurs
+  type: str
+
+failed:
+  description: True if the task failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import time  # noqa: E402
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.pc_api_client import get_tasks_api_instance  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import get_etag, get_vm_api_instance  # noqa: E402
+from ..module_utils.v4.vmm.helpers import get_vm  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_vmm_py_client as vmm_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as vmm_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        custom_attributes=dict(
+            type="list",
+            elements="str",
+            required=True,
+        ),
+    )
+    return module_args
+
+
+# Short retry: PC occasionally reports a freshly-created VM as "not found"
+# while VMM metadata propagates across services. Retry a handful of times
+# before giving up. Only matters on the very first call after VM creation.
+_VM_READ_RETRIES = 3
+_VM_READ_BACKOFF_SEC = 2
+
+# The v4 VMM $action endpoints (add/remove custom attributes) can also
+# transiently fail with VM_NOT_FOUND (error group ``VM_NOT_FOUND`` /
+# code ``VMM-30100``) shortly after a VM is created, because the VMM
+# action-plane services take longer to see a newly created VM than the
+# read-plane services do. Retry the entire action on that specific error
+# only; every other task failure is propagated as-is.
+_ACTION_RETRIES = 3
+_ACTION_BACKOFF_SEC = 3
+_TASK_POLL_INTERVAL_SEC = 2
+_VM_NOT_FOUND_ERROR_GROUP = "VM_NOT_FOUND"
+
+
+def _fetch_vm_or_none(api_instance, vm_ext_id):
+    """
+    Best-effort GET of the VM.
+    Returns the VM object on success or ``None`` if the VM is genuinely
+    not-yet-visible (transient 404 during metadata propagation).
+    Any non-404 error is re-raised for the caller to surface.
+    """
+    for attempt in range(_VM_READ_RETRIES):
+        try:
+            return api_instance.get_vm_by_id(extId=vm_ext_id).data
+        except Exception as e:
+            status = getattr(e, "status", None)
+            if status != 404 or attempt == _VM_READ_RETRIES - 1:
+                if status == 404:
+                    return None
+                raise
+            time.sleep(_VM_READ_BACKOFF_SEC)
+    return None
+
+
+def _resolve_vm_or_fail(module, api_instance, vm_ext_id):
+    """
+    Fetch the VM, failing the module with a descriptive error if it is
+    truly missing (used post-task to refresh the returned attribute list).
+    """
+    vm = _fetch_vm_or_none(api_instance, vm_ext_id)
+    if vm is None:
+        # Delegate the final failure to the shared helper so the error
+        # shape stays consistent with other v4 modules.
+        get_vm(module, api_instance, vm_ext_id)
+    return vm
+
+
+def _refresh_custom_attributes(module, api_instance, vm_ext_id, result):
+    """
+    Re-fetch the VM after a task completes and refresh
+    ``result["response"]`` with the current attributes.
+    """
+    vm = _resolve_vm_or_fail(module, api_instance, vm_ext_id)
+    result["response"] = list(vm.custom_attributes or [])
+
+
+def _task_error_groups(task):
+    """Return the list of error_group values on a task (may be empty)."""
+    error_messages = getattr(task, "error_messages", None) or []
+    groups = []
+    for err in error_messages:
+        group = getattr(err, "error_group", None)
+        if group:
+            groups.append(group)
+    return groups
+
+
+def _invoke_action_with_retry(
+    module,
+    api_instance,
+    vm_ext_id,
+    action_name,
+    body,
+    initial_vm,
+    description,
+):
+    """
+    Invoke a VMM $action call (with a fresh ``If-Match`` etag) and poll
+    its task to completion, retrying ONLY on the transient
+    ``VM_NOT_FOUND`` failure that occurs while VMM action services catch
+    up to a freshly-created VM or after a concurrent modification
+    invalidates the etag.
+
+    Any other task failure is surfaced through the shared
+    ``wait_for_completion`` path so error reporting stays consistent
+    with the rest of the collection.
+
+    Args:
+        module: The Ansible module (for fail_json + wait polling).
+        api_instance: The VMM API instance (``VmApi``).
+        vm_ext_id: The VM UUID.
+        action_name: SDK method name to invoke on ``api_instance``
+            (either ``add_vm_custom_attributes`` or
+            ``remove_vm_custom_attributes``).
+        body: The ``UpdateCustomAttributesParams`` spec to send.
+        initial_vm: The VM object we already fetched (source of the
+            first etag). On retries we re-fetch a fresh one.
+        description: Human-readable description of the operation used in
+            error messages.
+    Returns:
+        The response object from the last (successful) invocation. The
+        caller can read ``.data.ext_id`` to get the task id.
+    """
+    tasks_api = get_tasks_api_instance(module)
+    action_callable = getattr(api_instance, action_name)
+
+    vm = initial_vm
+    resp = None
+    for attempt in range(_ACTION_RETRIES):
+        etag = get_etag(vm) if vm is not None else None
+        try:
+            if etag:
+                resp = action_callable(extId=vm_ext_id, body=body, if_match=etag)
+            else:
+                resp = action_callable(extId=vm_ext_id, body=body)
+        except Exception as e:
+            raise_api_exception(
+                module=module,
+                exception=e,
+                msg="Api Exception raised while {0}".format(description),
+            )
+
+        task_ext_id = resp.data.ext_id
+        # Poll until the task reaches a terminal state so we can inspect
+        # the error group BEFORE handing off to the shared wait helper
+        # (which would call module.fail_json on any failure and prevent
+        # the retry).
+        task = None
+        while True:
+            task = tasks_api.get_task_by_id(task_ext_id).data
+            status = getattr(task, "status", None)
+            if status in ("SUCCEEDED", "FAILED"):
+                break
+            time.sleep(_TASK_POLL_INTERVAL_SEC)
+
+        if task.status == "SUCCEEDED":
+            return resp
+
+        # FAILED — decide whether this is the transient VM_NOT_FOUND that
+        # we want to retry, or a hard failure we should surface immediately.
+        if (
+            _VM_NOT_FOUND_ERROR_GROUP in _task_error_groups(task)
+            and attempt < _ACTION_RETRIES - 1
+        ):
+            time.sleep(_ACTION_BACKOFF_SEC)
+            # Refetch VM + etag so the next attempt sends a fresh
+            # ``If-Match`` value in case the previous etag was rejected
+            # because the entity state advanced on the server.
+            vm, _etag = _refetch_etag(api_instance, vm_ext_id)
+            continue
+
+        # Non-retryable failure — delegate to the shared helper so it
+        # emits the standard "Task Failed" error shape.
+        wait_for_completion(module, task_ext_id)
+
+    # Exhausted retries with only VM_NOT_FOUND failures — surface the last
+    # attempt through the standard fail path.
+    wait_for_completion(module, resp.data.ext_id)
+    return resp
+
+
+def _refetch_etag(api_instance, vm_ext_id):
+    """Re-fetch the VM and return a fresh ``If-Match`` etag for it."""
+    vm = _fetch_vm_or_none(api_instance, vm_ext_id)
+    if vm is None:
+        return None, None
+    return vm, get_etag(vm)
+
+
+def add_vm_custom_attributes(module, api_instance, result):
+    """Add custom attributes to a VM using the AddVmCustomAttributes action."""
+    vm_ext_id = module.params["ext_id"]
+    requested = list(module.params.get("custom_attributes") or [])
+    result["ext_id"] = vm_ext_id
+
+    # In check_mode do NOT touch the API — just show what the module would send.
+    # This mirrors the "pure action" contract and keeps check_mode usable even
+    # when the caller does not have READ permission on the target VM.
+    if module.check_mode:
+        spec = vmm_sdk.UpdateCustomAttributesParams(custom_attributes=requested)
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        result["msg"] = "Would add custom attributes to VM with ext_id: {0}".format(
+            vm_ext_id
+        )
+        return
+
+    # Fetch the VM once — used both for idempotency filtering AND to obtain
+    # the ``If-Match`` etag required by the $action endpoint.
+    vm = _resolve_vm_or_fail(module, api_instance, vm_ext_id)
+    current = list(vm.custom_attributes or [])
+    to_add = [attr for attr in requested if attr not in current]
+
+    if not to_add:
+        result["skipped"] = True
+        result["response"] = current
+        module.exit_json(msg="Nothing to change.", **result)
+
+    spec = vmm_sdk.UpdateCustomAttributesParams(custom_attributes=to_add)
+
+    if module.params.get("wait"):
+        resp = _invoke_action_with_retry(
+            module,
+            api_instance,
+            vm_ext_id,
+            action_name="add_vm_custom_attributes",
+            body=spec,
+            initial_vm=vm,
+            description="adding custom attributes to VM",
+        )
+        result["task_ext_id"] = resp.data.ext_id
+        result["response"] = strip_internal_attributes(resp.data.to_dict())
+        _refresh_custom_attributes(module, api_instance, vm_ext_id, result)
+    else:
+        etag = get_etag(vm)
+        try:
+            resp = api_instance.add_vm_custom_attributes(
+                extId=vm_ext_id, body=spec, if_match=etag
+            )
+        except Exception as e:
+            raise_api_exception(
+                module=module,
+                exception=e,
+                msg="Api Exception raised while adding custom attributes to VM",
+            )
+        result["task_ext_id"] = resp.data.ext_id
+        result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    result["changed"] = True
+
+
+def remove_vm_custom_attributes(module, api_instance, result):
+    """Remove custom attributes from a VM using the RemoveVmCustomAttributes action."""
+    vm_ext_id = module.params["ext_id"]
+    requested = list(module.params.get("custom_attributes") or [])
+    result["ext_id"] = vm_ext_id
+
+    # In check_mode do NOT touch the API — just show what the module would send.
+    if module.check_mode:
+        spec = vmm_sdk.UpdateCustomAttributesParams(custom_attributes=requested)
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        result["msg"] = (
+            "Would remove custom attributes from VM with ext_id: {0}".format(vm_ext_id)
+        )
+        return
+
+    # Fetch the VM once — used both for idempotency filtering AND to obtain
+    # the ``If-Match`` etag required by the $action endpoint.
+    vm = _resolve_vm_or_fail(module, api_instance, vm_ext_id)
+    current = list(vm.custom_attributes or [])
+    to_remove = [attr for attr in requested if attr in current]
+
+    if not to_remove:
+        result["skipped"] = True
+        result["response"] = current
+        module.exit_json(msg="Nothing to change.", **result)
+
+    spec = vmm_sdk.UpdateCustomAttributesParams(custom_attributes=to_remove)
+
+    if module.params.get("wait"):
+        resp = _invoke_action_with_retry(
+            module,
+            api_instance,
+            vm_ext_id,
+            action_name="remove_vm_custom_attributes",
+            body=spec,
+            initial_vm=vm,
+            description="removing custom attributes from VM",
+        )
+        result["task_ext_id"] = resp.data.ext_id
+        result["response"] = strip_internal_attributes(resp.data.to_dict())
+        _refresh_custom_attributes(module, api_instance, vm_ext_id, result)
+    else:
+        etag = get_etag(vm)
+        try:
+            resp = api_instance.remove_vm_custom_attributes(
+                extId=vm_ext_id, body=spec, if_match=etag
+            )
+        except Exception as e:
+            raise_api_exception(
+                module=module,
+                exception=e,
+                msg="Api Exception raised while removing custom attributes from VM",
+            )
+        result["task_ext_id"] = resp.data.ext_id
+        result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_vm_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        add_vm_custom_attributes(module, api_instance, result)
+    else:
+        remove_vm_custom_attributes(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_custom_attribute_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_custom_attribute_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_custom_attribute_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_custom_attribute_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_custom_attribute_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_custom_attribute_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import vm_custom_attribute.yml
+      ansible.builtin.import_tasks: vm_custom_attribute.yml

--- a/tests/integration/targets/ntnx_vm_custom_attribute_v2/tasks/vm_custom_attribute.yml
+++ b/tests/integration/targets/ntnx_vm_custom_attribute_v2/tasks/vm_custom_attribute.yml
@@ -1,0 +1,364 @@
+---
+# Test plan for ntnx_vm_custom_attribute_v2
+# -----------------------------------------
+# Prerequisites: a fresh AHV VM is created at the start (mirrors the pattern
+# used by ntnx_vms_categories_v2 tests) so tests are hermetic and re-runnable.
+#
+# Coverage:
+#   1. Check-mode: add (all attributes) — spec built, no side effects
+#   2. Check-mode: remove (all attributes)
+#   3. Add required-only (single attribute) — real API call
+#   4. Add multiple attributes — real API call
+#   5. Add already-present attribute — idempotent skip
+#   6. Info round-trip: confirm attributes present on VM (uses ntnx_vms_info_v2)
+#   7. Remove a not-present attribute — idempotent skip
+#   8. Remove one attribute — real API call
+#   9. Remove multiple attributes at once — real API call
+#  10. Info round-trip: confirm attributes gone
+#  11. Negative: missing required parameter (custom_attributes)
+#  12. Negative: invalid ext_id (non-existent VM UUID)
+#  13. Cleanup: delete the test VM
+
+- name: Start testing ntnx_vm_custom_attribute_v2 module
+  ansible.builtin.debug:
+    msg: "Start testing ntnx_vm_custom_attribute_v2 module"
+
+- name: Generate a random suffix for the VM name
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', upper=false, numbers=false, special=false)[0] }}"
+
+- name: Set VM name
+  ansible.builtin.set_fact:
+    vm_name: "ansible_ca_{{ random_name }}"
+
+- name: Create a test VM
+  nutanix.ncp.ntnx_vms_v2:
+    state: present
+    name: "{{ vm_name }}"
+    description: "Test VM for ntnx_vm_custom_attribute_v2 integration tests"
+    cluster:
+      ext_id: "{{ cluster.uuid }}"
+  register: vm_create_result
+
+- name: VM creation status
+  ansible.builtin.assert:
+    that:
+      - vm_create_result.response is defined
+      - vm_create_result.changed == true
+      - vm_create_result.failed == false
+      - vm_create_result.response.cluster.ext_id == "{{ cluster.uuid }}"
+    fail_msg: "Unable to create test VM"
+    success_msg: "Test VM created successfully"
+
+- name: Set VM ext_id
+  ansible.builtin.set_fact:
+    vm_uuid: "{{ vm_create_result['ext_id'] }}"
+
+########################################################################################
+# 1. Check-mode: add (all attributes) — must not touch the API
+########################################################################################
+
+- name: Add custom attributes to VM - check mode
+  nutanix.ncp.ntnx_vm_custom_attribute_v2:
+    state: present
+    ext_id: "{{ vm_uuid }}"
+    custom_attributes:
+      - "environment:production"
+      - "owner:team-a"
+      - "tier:gold"
+  register: result
+  check_mode: true
+  ignore_errors: true
+
+- name: Add custom attributes to VM - check mode status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response.custom_attributes | sort == ["environment:production", "owner:team-a", "tier:gold"] | sort
+      - result.ext_id == vm_uuid
+      - "'Would add custom attributes' in result.msg"
+    fail_msg: "Add custom attributes to VM - check mode failed"
+    success_msg: "Add custom attributes to VM - check mode passed"
+
+########################################################################################
+# 2. Check-mode: remove (all attributes) — must not touch the API
+########################################################################################
+
+- name: Remove custom attributes from VM - check mode
+  nutanix.ncp.ntnx_vm_custom_attribute_v2:
+    state: absent
+    ext_id: "{{ vm_uuid }}"
+    custom_attributes:
+      - "environment:production"
+      - "owner:team-a"
+  register: result
+  check_mode: true
+  ignore_errors: true
+
+- name: Remove custom attributes from VM - check mode status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response.custom_attributes | sort == ["environment:production", "owner:team-a"] | sort
+      - result.ext_id == vm_uuid
+      - "'Would remove custom attributes' in result.msg"
+    fail_msg: "Remove custom attributes from VM - check mode failed"
+    success_msg: "Remove custom attributes from VM - check mode passed"
+
+########################################################################################
+# 3. Add a single custom attribute — real API call
+########################################################################################
+
+- name: Add a single custom attribute to VM
+  nutanix.ncp.ntnx_vm_custom_attribute_v2:
+    state: present
+    ext_id: "{{ vm_uuid }}"
+    custom_attributes:
+      - "environment:production"
+  register: result
+  ignore_errors: true
+
+- name: Add single custom attribute status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == vm_uuid
+      - "'environment:production' in result.response"
+    fail_msg: "Add single custom attribute failed"
+    success_msg: "Add single custom attribute passed"
+
+########################################################################################
+# 4. Add multiple custom attributes at once — real API call
+########################################################################################
+
+- name: Add multiple custom attributes to VM
+  nutanix.ncp.ntnx_vm_custom_attribute_v2:
+    state: present
+    ext_id: "{{ vm_uuid }}"
+    custom_attributes:
+      - "owner:team-a"
+      - "tier:gold"
+  register: result
+  ignore_errors: true
+
+- name: Add multiple custom attributes status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == vm_uuid
+      - "'environment:production' in result.response"
+      - "'owner:team-a' in result.response"
+      - "'tier:gold' in result.response"
+    fail_msg: "Add multiple custom attributes failed"
+    success_msg: "Add multiple custom attributes passed"
+
+########################################################################################
+# 5. Add an attribute that is already present — must be an idempotent skip
+########################################################################################
+
+- name: Add an already-present custom attribute (idempotency)
+  nutanix.ncp.ntnx_vm_custom_attribute_v2:
+    state: present
+    ext_id: "{{ vm_uuid }}"
+    custom_attributes:
+      - "environment:production"
+  register: result
+  ignore_errors: true
+
+- name: Idempotent add status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - "'Nothing to change' in result.msg"
+    fail_msg: "Idempotent add failed"
+    success_msg: "Idempotent add passed"
+
+########################################################################################
+# 6. Info round-trip: attributes must be present on the VM per ntnx_vms_info_v2
+########################################################################################
+
+- name: Fetch VM info to confirm attributes present
+  nutanix.ncp.ntnx_vms_info_v2:
+    ext_id: "{{ vm_uuid }}"
+  register: info_result
+  ignore_errors: true
+
+- name: Info round-trip - attributes present
+  ansible.builtin.assert:
+    that:
+      - info_result.response is defined
+      - info_result.failed == false
+      - info_result.response.custom_attributes is not none
+      - "'environment:production' in info_result.response.custom_attributes"
+      - "'owner:team-a' in info_result.response.custom_attributes"
+      - "'tier:gold' in info_result.response.custom_attributes"
+    fail_msg: "Info round-trip (present) failed"
+    success_msg: "Info round-trip (present) passed"
+
+########################################################################################
+# 7. Remove an attribute that is NOT present — must be an idempotent skip
+########################################################################################
+
+- name: Remove a not-present custom attribute (idempotency)
+  nutanix.ncp.ntnx_vm_custom_attribute_v2:
+    state: absent
+    ext_id: "{{ vm_uuid }}"
+    custom_attributes:
+      - "does-not-exist:zzz"
+  register: result
+  ignore_errors: true
+
+- name: Idempotent remove status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - "'Nothing to change' in result.msg"
+    fail_msg: "Idempotent remove failed"
+    success_msg: "Idempotent remove passed"
+
+########################################################################################
+# 8. Remove a single custom attribute — real API call
+########################################################################################
+
+- name: Remove a single custom attribute from VM
+  nutanix.ncp.ntnx_vm_custom_attribute_v2:
+    state: absent
+    ext_id: "{{ vm_uuid }}"
+    custom_attributes:
+      - "environment:production"
+  register: result
+  ignore_errors: true
+
+- name: Remove single custom attribute status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == vm_uuid
+      - "'environment:production' not in result.response"
+      - "'owner:team-a' in result.response"
+      - "'tier:gold' in result.response"
+    fail_msg: "Remove single custom attribute failed"
+    success_msg: "Remove single custom attribute passed"
+
+########################################################################################
+# 9. Remove multiple custom attributes at once — real API call
+########################################################################################
+
+- name: Remove multiple custom attributes from VM
+  nutanix.ncp.ntnx_vm_custom_attribute_v2:
+    state: absent
+    ext_id: "{{ vm_uuid }}"
+    custom_attributes:
+      - "owner:team-a"
+      - "tier:gold"
+  register: result
+  ignore_errors: true
+
+- name: Remove multiple custom attributes status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == vm_uuid
+      - "'owner:team-a' not in (result.response or [])"
+      - "'tier:gold' not in (result.response or [])"
+    fail_msg: "Remove multiple custom attributes failed"
+    success_msg: "Remove multiple custom attributes passed"
+
+########################################################################################
+# 10. Info round-trip: attributes must be gone per ntnx_vms_info_v2
+########################################################################################
+
+- name: Fetch VM info to confirm attributes gone
+  nutanix.ncp.ntnx_vms_info_v2:
+    ext_id: "{{ vm_uuid }}"
+  register: info_result
+  ignore_errors: true
+
+- name: Info round-trip - attributes gone
+  ansible.builtin.assert:
+    that:
+      - info_result.response is defined
+      - info_result.failed == false
+      - >-
+        info_result.response.custom_attributes is none
+        or (info_result.response.custom_attributes | length) == 0
+    fail_msg: "Info round-trip (absent) failed"
+    success_msg: "Info round-trip (absent) passed"
+
+########################################################################################
+# 11. Negative: missing required parameter (custom_attributes)
+########################################################################################
+
+- name: Missing required parameter - custom_attributes  # noqa: args[module]
+  nutanix.ncp.ntnx_vm_custom_attribute_v2:
+    state: present
+    ext_id: "{{ vm_uuid }}"
+  register: result
+  ignore_errors: true
+
+- name: Missing required parameter status
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - "'custom_attributes' in result.msg"
+    fail_msg: "Missing required parameter test failed"
+    success_msg: "Missing required parameter test passed"
+
+########################################################################################
+# 12. Negative: invalid ext_id (non-existent VM UUID)
+########################################################################################
+
+- name: Invalid VM ext_id
+  nutanix.ncp.ntnx_vm_custom_attribute_v2:
+    state: present
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    custom_attributes:
+      - "invalid:test"
+  register: result
+  ignore_errors: true
+
+- name: Invalid VM ext_id status
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+    fail_msg: "Invalid VM ext_id test failed"
+    success_msg: "Invalid VM ext_id test passed"
+
+########################################################################################
+# 13. Cleanup: delete the test VM
+########################################################################################
+
+- name: Delete the test VM
+  nutanix.ncp.ntnx_vms:
+    state: absent
+    vm_uuid: "{{ vm_uuid }}"
+  register: result
+  ignore_errors: true
+
+- name: Test VM deletion status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response.status == 'SUCCEEDED'
+    fail_msg: "Unable to delete test VM"
+    success_msg: "Test VM deleted successfully"


### PR DESCRIPTION
## Summary

Adds a new v4 action-type module `ntnx_vm_custom_attribute_v2` that
manages the `customAttributes` list on an AHV VM in Nutanix Prism
Central via the VMM v4 `\$actions` endpoints:

- `POST /vmm/v4.2/ahv/config/vms/{extId}/\$actions/add-custom-attributes`
- `POST /vmm/v4.2/ahv/config/vms/{extId}/\$actions/remove-custom-attributes`

The module is idempotent (only sends attributes that actually need to
be added/removed), supports check-mode, honors `wait`, and models the
same shape as the reference modules `ntnx_vm_revert_v2` and
`ntnx_vms_categories_v2` (etag `If-Match`, task polling, standard
result shape).

## Domain Knowledge (Glean)

**What are VM custom attributes?**

VM Custom Attributes are user-defined `key:value` string pairs
(e.g. `environment:production`, `owner:team-a`, `tier:gold`) attached
to individual AHV VMs to carry per-VM metadata for tracking,
classification, and automation workflows. They are separate from
Nutanix Categories — Categories are cluster-scoped taxonomy objects,
whereas Custom Attributes are free-form and VM-local.

**API surface (v4 / VMM):**

- `add_vm_custom_attributes` — POST `\$actions/add-custom-attributes`,
  precheck server-side de-dupes existing attributes.
- `remove_vm_custom_attributes` — POST `\$actions/remove-custom-attributes`,
  precheck server-side validates the attribute is present.
- `GET /vms/{extId}` returns them in the `customAttributes` array.
- Analogous endpoints exist on the VmDisk entity (`$actions/{add,remove}-custom-attributes`
  under `/vms/{vmExtId}/disks/{extId}`), out of scope for this module.

**Required permissions:** `Update_Virtual_Machine_Custom_Attributes`
(Prism Admin, Super Admin, Virtual Machine Admin roles all satisfy this).

**Behavioral notes:**

- Recovery: from the Janus release forward, `custom_attributes` are
  preserved as-is when a VM is reverted from a recovery point
  (ref ENG-885598).
- Disks backed by Volume Groups are excluded and cannot carry custom
  attributes.
- The v4 VMM \$action endpoints accept an `If-Match` etag; the module
  fetches the VM to get a fresh etag before invoking the action, which
  matches what `ntnx_vms_categories_v2` and `ntnx_vm_revert_v2` do.

**Related tickets:** FEAT for v4 custom attributes support in VM &
VmDisk APIs; ENG-885598 (revert semantics), ENG-805816 (remove
semantics), ENG-909655 (RBAC test), ENG-859716 (etag default).

## Files Changed

| Path | What |
| --- | --- |
| `plugins/modules/ntnx_vm_custom_attribute_v2.py` | The new module. Action-type, `state=present` adds, `state=absent` removes. Uses `if_match` etag, retries on transient VMM-30100 `VM_NOT_FOUND`. |
| `meta/runtime.yml` | Registers the module in `action_groups.ntnx` so `module_defaults: group/nutanix.ncp.ntnx` applies to it. |
| `examples/virtual_machine_management/VmCustomAttribute/vm_custom_attribute_v2.yml` | Standalone example playbook showing add / add-more / remove. |
| `tests/integration/targets/ntnx_vm_custom_attribute_v2/aliases` | `disabled` (matches other v4 targets). |
| `tests/integration/targets/ntnx_vm_custom_attribute_v2/meta/main.yml` | Declares `prepare_env` dependency (standard v4 target layout). |
| `tests/integration/targets/ntnx_vm_custom_attribute_v2/tasks/main.yml` | Sets `module_defaults` and includes the test task file. |
| `tests/integration/targets/ntnx_vm_custom_attribute_v2/tasks/vm_custom_attribute.yml` | Full test suite (13 scenarios, see Test Plan). |

## Module Design Notes

- **Argument spec:** `ext_id` (str, required), `custom_attributes`
  (list[str], required), plus the shared `state`, `wait`,
  `nutanix_*` credentials, and `read_timeout` from the base module and
  v2 doc fragments.
- **Idempotency:** we fetch the VM once before the action; if all
  requested attributes are already in the desired terminal state we
  short-circuit with `skipped=True` and `msg="Nothing to change."`
- **check_mode:** does NOT hit the API — returns the request spec
  that would have been sent. Keeps check-mode usable for callers that
  don't have VM READ permission.
- **etag:** the v4 VMM `\$action` endpoints on this cluster
  require `If-Match`; missing it presents as a task-time
  `VMM-30100 / VM_NOT_FOUND` failure. We pull `get_etag(vm)` from the
  same VM read used for idempotency, matching `ntnx_vms_categories_v2`.
- **Transient failure handling:** even with a valid etag, freshly
  created VMs can transiently fail the action-plane check with
  VMM-30100 while VMM's action services catch up. The module polls the
  task itself, and retries the whole action a small number of times
  (default 3 attempts, 3s backoff) ONLY on `error_group == VM_NOT_FOUND`.
  Any other terminal task failure is surfaced via the shared
  `wait_for_completion` helper so the error shape stays consistent
  with the rest of the collection.

## Test Plan

Live-cluster integration test covers 13 scenarios (also runnable via
`ansible-test integration ntnx_vm_custom_attribute_v2`):

- [x] Check-mode add — spec built, no API call, no side effects
- [x] Check-mode remove — spec built, no API call
- [x] Add a single attribute — real API, returns updated list
- [x] Add multiple attributes at once — real API, returns updated list
- [x] Add an already-present attribute — idempotent skip
      (`skipped=True`, `Nothing to change.`)
- [x] Info round-trip: attributes visible via `ntnx_vms_info_v2`
- [x] Remove an attribute that isn't present — idempotent skip
- [x] Remove a single attribute — real API, returns updated list
- [x] Remove multiple attributes at once — real API, returns updated list
- [x] Info round-trip: attributes gone
- [x] Negative: missing required `custom_attributes`
- [x] Negative: non-existent VM ext_id
- [x] Cleanup: delete the test VM

**Local run against a live PC (10.44.76.28, cluster
`auto_cluster_prod_36acf9b012ca`):**

```
PLAY RECAP *************************************
localhost : ok=31 changed=6 unreachable=0 failed=0 skipped=2 rescued=0 ignored=2
```

All 31 tasks pass in ~28s. The two `ignored` counts are the two
negative-case tasks (`ignore_errors: true` is expected there so the
follow-up assertions can validate the failure shape).

**Example playbook:** the shipped example was rewritten locally to
create a temporary VM, exercised (add / add-more / remove) end-to-end,
and cleaned up — all steps succeeded on the same cluster.

## Sanity / Lint

- `black` — clean
- `isort` — clean
- `flake8 --max-line-length=200` — clean
- `ansible-lint` (production profile) — 0 failures, 0 warnings on the
  module + example + tests
- `ansible-test sanity plugins/modules/ntnx_vm_custom_attribute_v2.py --python 3.12`
  — all 32 sanity tests pass (`action-plugin-docs`, `ansible-doc`,
  `changelog`, `compile`, `empty-init`, `future-import-boilerplate`,
  `ignores`, `import`, `line-endings`, `metaclass-boilerplate`, all
  `no-*`, `pep8`, `pslint`, `pylint`, `replace-urlopen`,
  `runtime-metadata`, `shebang`, `shellcheck`, `symlinks`,
  `use-argspec-type-path`, `use-compat-six`, `validate-modules`,
  `yamllint`).

Made with [Cursor](https://cursor.com)