### PR TITLE
code-gen(virtual_machine_management/FileByImageId): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+plugins/modules/__pycache__/

--- a/examples/virtual_machine_management/FileByImageId/examples_run.log
+++ b/examples/virtual_machine_management/FileByImageId/examples_run.log
@@ -1,0 +1,37 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [FileByImageId (virtual_machine_management) playbook] *********************
+
+TASK [List DISK_IMAGE images on the cluster (ordered by size ascending)] *******
+ok: [localhost] => {"changed": false, "error": null, "response": [{"category_ext_ids": null, "checksum": null, "cluster_location_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "create_time": "2026-07-02T11:06:09.743896+00:00", "description": "5.3.2", "ext_id": "9ba33498-2b99-4adb-90e6-23a93dc02180", "isSharedWithAllProjects": true, "last_update_time": "2026-07-02T11:06:15.514882+00:00", "links": null, "name": "predeployment_port_vm", "owner_ext_id": "00000000-0000-0000-0000-000000000000", "owner_name": "admin", "placement_policy_status": null, "projectExtId": "00000000-0000-0000-0000-000000000000", "size_bytes": 64487424, "source": null, "tenant_id": null, "type": "DISK_IMAGE"}, {"category_ext_ids": null, "checksum": null, "cluster_location_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "create_time": "2026-07-20T17:59:08.533991+00:00", "description": "Image used to exercise ntnx_file_image_v2", "ext_id": "089d72aa-db93-4cf0-96a3-2de40eec04e4", "isSharedWithAllProjects": true, "last_update_time": "2026-07-20T17:59:08.533991+00:00", "links": null, "name": "LSREhNdwLYTK_file_by_image_id_disk", "owner_ext_id": "00000000-0000-0000-0000-000000000000", "owner_name": "admin", "placement_policy_status": null, "projectExtId": "00000000-0000-0000-0000-000000000000", "size_bytes": 117440512, "source": null, "tenant_id": null, "type": "DISK_IMAGE"}, {"category_ext_ids": null, "checksum": null, "cluster_location_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "create_time": "2026-07-20T18:02:39.903508+00:00", "description": "PE-only image seeded by ntnx_import_image_v2 integration test", "ext_id": "42baad51-20df-4627-8436-26392cdf5f1f", "isSharedWithAllProjects": true, "last_update_time": "2026-07-20T18:02:39.903508+00:00", "links": null, "name": "peonly_ansible_1_HDcxAydVubMg", "owner_ext_id": "00000000-0000-0000-0000-000000000000", "owner_name": "admin", "placement_policy_status": null, "projectExtId": "00000000-0000-0000-0000-000000000000", "size_bytes": 117440512, "source": null, "tenant_id": null, "type": "DISK_IMAGE"}, {"category_ext_ids": null, "checksum": null, "cluster_location_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "create_time": "2026-07-20T18:01:15.953816+00:00", "description": "Image used to exercise ntnx_file_image_v2", "ext_id": "55ac03d9-e272-4fb1-9068-e71851246fa8", "isSharedWithAllProjects": true, "last_update_time": "2026-07-20T18:01:15.953816+00:00", "links": null, "name": "ynJKaNmxmXcA_file_by_image_id_disk", "owner_ext_id": "00000000-0000-0000-0000-000000000000", "owner_name": "admin", "placement_policy_status": null, "projectExtId": "00000000-0000-0000-0000-000000000000", "size_bytes": 117440512, "source": null, "tenant_id": null, "type": "DISK_IMAGE"}, {"category_ext_ids": null, "checksum": null, "cluster_location_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "create_time": "2026-07-20T17:59:27.074387+00:00", "description": "PE-only image seeded by ntnx_import_image_v2 integration test", "ext_id": "81253673-ea07-497f-b8da-1a1bc62ed33d", "isSharedWithAllProjects": true, "last_update_time": "2026-07-20T17:59:27.074387+00:00", "links": null, "name": "peonly_ansible_1_cjeWXuLQVdxI", "owner_ext_id": "00000000-0000-0000-0000-000000000000", "owner_name": "admin", "placement_policy_status": null, "projectExtId": "00000000-0000-0000-0000-000000000000", "size_bytes": 117440512, "source": null, "tenant_id": null, "type": "DISK_IMAGE"}], "total_available_results": 16}
+
+TASK [Pick the smallest image ext_id (to keep the demo download cheap)] ********
+ok: [localhost] => {"ansible_facts": {"image_ext_id": "9ba33498-2b99-4adb-90e6-23a93dc02180", "image_name": "predeployment_port_vm", "image_size_bytes": "64487424"}, "changed": false}
+
+TASK [Show which image we will download] ***************************************
+ok: [localhost] => {
+    "msg": "Using image ext_id=9ba33498-2b99-4adb-90e6-23a93dc02180 name=predeployment_port_vm size_bytes=64487424"
+}
+
+TASK [Download the image file using ntnx_image_download_v2] ********************
+changed: [localhost] => {"changed": true, "ext_id": "9ba33498-2b99-4adb-90e6-23a93dc02180", "response": {"path": "/tmp/codegen/014e15a08bd74ad1943e11c9a3a4e499/repo/examples/virtual_machine_management/FileByImageId/predeployment_port_vm_2026-07-21T04:50:22.727"}}
+
+TASK [Show downloaded file path] ***********************************************
+ok: [localhost] => {
+    "msg": "Downloaded to: /tmp/codegen/014e15a08bd74ad1943e11c9a3a4e499/repo/examples/virtual_machine_management/FileByImageId/predeployment_port_vm_2026-07-21T04:50:22.727"
+}
+
+TASK [Fetch the image file info using ntnx_file_by_image_ids_info_v2] **********
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "9ba33498-2b99-4adb-90e6-23a93dc02180", "response": {"path": "/tmp/codegen/014e15a08bd74ad1943e11c9a3a4e499/repo/examples/virtual_machine_management/FileByImageId/predeployment_port_vm_2026-07-21T04:50:24.069"}}
+
+TASK [Show fetched file info] **************************************************
+ok: [localhost] => {
+    "msg": "File info: {'path': '/tmp/codegen/014e15a08bd74ad1943e11c9a3a4e499/repo/examples/virtual_machine_management/FileByImageId/predeployment_port_vm_2026-07-21T04:50:24.069'}"
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=7    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/virtual_machine_management/FileByImageId/file_by_image_id.yml
+++ b/examples/virtual_machine_management/FileByImageId/file_by_image_id.yml
@@ -1,0 +1,54 @@
+---
+# Summary:
+# This playbook exercises the FileByImageId (virtual_machine_management) modules:
+#   1. Pick the smallest existing DISK_IMAGE on the cluster so we do NOT need
+#      to seed a large image just for the demo (image bytes are streamed to
+#      the Ansible controller's temp dir — a small image keeps the run cheap
+#      and portable to environments with limited local disk).
+#   2. Download the image file using ntnx_image_download_v2.
+#   3. Fetch the image file information using ntnx_file_by_image_ids_info_v2.
+
+- name: FileByImageId (virtual_machine_management) playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') | default('10.44.76.28', true) }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') | default('admin', true) }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') | default('Nutanix.123', true) }}"
+      validate_certs: false
+  tasks:
+    - name: List DISK_IMAGE images on the cluster (ordered by size ascending)
+      nutanix.ncp.ntnx_images_info_v2:
+        filter: "type eq Vmm.Content.ImageType'DISK_IMAGE'"
+        orderby: "sizeBytes asc"
+        limit: 5
+      register: images_list
+
+    - name: Pick the smallest image ext_id (to keep the demo download cheap)
+      ansible.builtin.set_fact:
+        image_ext_id: "{{ images_list.response[0].ext_id }}"
+        image_name: "{{ images_list.response[0].name }}"
+        image_size_bytes: "{{ images_list.response[0].size_bytes }}"
+
+    - name: Show which image we will download
+      ansible.builtin.debug:
+        msg: "Using image ext_id={{ image_ext_id }} name={{ image_name }} size_bytes={{ image_size_bytes }}"
+
+    - name: Download the image file using ntnx_image_download_v2
+      nutanix.ncp.ntnx_image_download_v2:
+        image_ext_id: "{{ image_ext_id }}"
+      register: download_result
+
+    - name: Show downloaded file path
+      ansible.builtin.debug:
+        msg: "Downloaded to: {{ download_result.response.path }}"
+
+    - name: Fetch the image file info using ntnx_file_by_image_ids_info_v2
+      nutanix.ncp.ntnx_file_by_image_ids_info_v2:
+        ext_id: "{{ image_ext_id }}"
+      register: file_info_result
+
+    - name: Show fetched file info
+      ansible.builtin.debug:
+        msg: "File info: {{ file_info_result.response }}"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_image_download_v2
+    - ntnx_file_by_image_ids_info_v2

--- a/plugins/modules/ntnx_file_by_image_ids_info_v2.py
+++ b/plugins/modules/ntnx_file_by_image_ids_info_v2.py
@@ -1,0 +1,164 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_file_by_image_ids_info_v2
+short_description: Fetch image file information for a Nutanix Prism Central image
+version_added: 2.5.0
+description:
+    - This module allows you to fetch information about the file associated
+      with a Nutanix Prism Central image (the C(FileByImageId) resource in
+      C(virtual_machine_management)).
+    - Wraps the VMM v4.2 C(GetFileByImageId) API
+      (C(GET /api/vmm/v4.2/content/images/{imageExtId}/file)).
+    - The v4.2 SDK returns the downloaded file path as the response C(data)
+      for a given image; this module surfaces that path as informational
+      output without setting C(changed=True).
+    - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get file by image ext_id) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+    ext_id:
+        description:
+            - The external ID of the image whose file information should be
+              fetched.
+            - Required to fetch file information for a specific image.
+        type: str
+        required: true
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_info_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Get file information for an image using ext_id
+  nutanix.ncp.ntnx_file_by_image_ids_info_v2:
+    ext_id: "12345678-1234-1234-1234-123456789012"
+  register: result
+"""
+
+RETURN = r"""
+response:
+    description:
+        - The response from the Nutanix PC C(GetFileByImageId) v4 API for the
+          given image external ID.
+        - Contains the local C(path) at which the SDK persisted the streamed
+          file bytes.
+    type: dict
+    returned: always
+    sample:
+        {
+            "path": "/tmp/tmpabc123/image_file.qcow2"
+        }
+ext_id:
+    description:
+        - The external ID of the image whose file information was fetched.
+    type: str
+    returned: always
+    sample: "12345678-1234-1234-1234-123456789012"
+changed:
+    description:
+        - This indicates whether the task resulted in any changes.
+        - Always C(False) for an info module.
+    type: bool
+    returned: always
+    sample: false
+msg:
+    description: This indicates the message if any message occurred.
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while fetching image file info"
+error:
+    description: The error message if an error occurred.
+    type: str
+    returned: When an error occurs
+failed:
+    description: Indicates whether the module execution failed.
+    type: bool
+    returned: always
+    sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.utils import raise_api_exception  # noqa: E402
+from ..module_utils.v4.vmm.api_client import get_image_api_instance  # noqa: E402
+
+SDK_IMP_ERROR = None
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_file_by_image_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    try:
+        resp = api_instance.get_file_by_image_id(imageExtId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching image file info",
+        )
+
+    path = resp.to_dict().get("data", {}).get("path")
+    result["response"] = {
+        "path": path,
+    }
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"), exception=SDK_IMP_ERROR
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "error": None, "response": None, "ext_id": None}
+    api_instance = get_image_api_instance(module)
+    get_file_by_image_id(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_image_download_v2.py
+++ b/plugins/modules/ntnx_image_download_v2.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_image_download_v2
+short_description: Download an image file from Nutanix Prism Central
+version_added: 2.5.0
+description:
+    - Download an image file from Nutanix Prism Central using its external ID.
+    - Wraps the VMM v4.2 C(GetFileByImageId) API
+      (C(GET /api/vmm/v4.2/content/images/{imageExtId}/file)).
+    - The image bytes are streamed by Prism Central from the hosting Prism
+      Element cluster; the module returns the local path where the SDK
+      persisted the downloaded file.
+    - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Download an Image) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+    image_ext_id:
+        description:
+            - External ID of the image whose file should be downloaded.
+        type: str
+        required: true
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Download image using ext_id
+  nutanix.ncp.ntnx_image_download_v2:
+    image_ext_id: "12345678-1234-1234-1234-123456789012"
+  register: result
+"""
+
+RETURN = r"""
+response:
+    description:
+        - The path where the image file has been downloaded on the Ansible
+          controller host.
+        - Populated on a successful download.
+    type: dict
+    returned: always
+    sample:
+        {
+            "path": "/tmp/tmpabc123/image_file.qcow2"
+        }
+ext_id:
+    description:
+        - The external ID of the image that was downloaded.
+    type: str
+    returned: always
+    sample: "12345678-1234-1234-1234-123456789012"
+changed:
+    description:
+        - Indicates whether the download action was performed.
+        - Always C(True) after a real (non check_mode) download because a new
+          file is written to disk.
+    type: bool
+    returned: always
+    sample: true
+msg:
+    description:
+        - This indicates the message if any message occurred.
+        - Populated on error or in check_mode.
+    type: str
+    returned: When there is an error or in check_mode operation
+    sample: "Api Exception raised while downloading image"
+error:
+    description: The error message if an error occurred.
+    type: str
+    returned: When an error occurs
+failed:
+    description: Indicates whether the module execution failed.
+    type: bool
+    returned: always
+    sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.utils import raise_api_exception  # noqa: E402
+from ..module_utils.v4.vmm.api_client import get_image_api_instance  # noqa: E402
+
+SDK_IMP_ERROR = None
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        image_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def download_image(module, api_instance, result):
+    image_ext_id = module.params.get("image_ext_id")
+    result["ext_id"] = image_ext_id
+
+    if module.check_mode:
+        result["msg"] = "Image with ext_id:{0} will be downloaded.".format(image_ext_id)
+        return
+
+    try:
+        resp = api_instance.get_file_by_image_id(imageExtId=image_ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while downloading image",
+        )
+
+    path = resp.to_dict().get("data", {}).get("path")
+    result["response"] = {
+        "path": path,
+    }
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"), exception=SDK_IMP_ERROR
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "response": None,
+        "ext_id": None,
+        "changed": False,
+    }
+    api_instance = get_image_api_instance(module)
+    download_image(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_image_download_v2/aliases
+++ b/tests/integration/targets/ntnx_image_download_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_image_download_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_image_download_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_image_download_v2/tasks/file_by_image_id_operations.yml
+++ b/tests/integration/targets/ntnx_image_download_v2/tasks/file_by_image_id_operations.yml
@@ -1,0 +1,243 @@
+---
+# =============================================================================
+# Integration tests for the virtual_machine_management / FileByImageId entity
+# -----------------------------------------------------------------------------
+# Modules under test:
+#   - ntnx_image_download_v2            (action / download)
+#   - ntnx_file_by_image_ids_info_v2    (info / GetFileByImageId)
+#
+# Test plan (why each test exists):
+#   1.  Prerequisite discovery: pick an existing DISK_IMAGE from Prism Central
+#       so we have a valid image_ext_id to download / query. This deliberately
+#       reuses ntnx_images_info_v2 (an existing v2 info module) so we do not
+#       hardcode any ext_id and do not depend on the very slow image-create
+#       lifecycle for a test that is only about the download endpoint.
+#   2.  Argument-spec validation on the DOWNLOAD module (missing required
+#       image_ext_id) — proves the module's own spec catches bad input
+#       BEFORE any API call.
+#   3.  check_mode on the DOWNLOAD module — MUST return changed=False /
+#       failed=False and MUST emit the exact "will be downloaded." msg. Runs
+#       exactly ONE check_mode task per the code-gen reviewer's guidance.
+#   4.  Real download via valid ext_id — MUST return changed=True,
+#       failed=False, and response.path defined.
+#   5.  Repeat download: calling download again must still succeed — proves
+#       the module has no hidden state that would break repeat invocations.
+#   6.  Negative: download with an invalid / non-existent image ext_id —
+#       MUST return changed=False, failed=True, and the exact
+#       "Api Exception raised while downloading image" msg.
+#   7.  Argument-spec validation on the INFO module (missing required
+#       ext_id).
+#   8.  Info fetch with valid ext_id — MUST return changed=False,
+#       failed=False, response.path defined, and the ext_id echoed back.
+#   9.  Negative: info fetch with a non-existent ext_id — MUST return
+#       changed=False, failed=True, and the exact
+#       "Api Exception raised while fetching image file info" msg.
+#  10.  Domain guardrail: the DOWNLOAD module's response.path MUST refer
+#       to a file the SDK actually wrote (we don't check byte content
+#       because the SDK writes to an ephemeral tmp file, but we DO check
+#       the path is a non-empty string that starts with a "/", which is
+#       what pathlib.Path.__str__ returns on Linux and matches what the
+#       OVA download tests assert about their own path).
+# =============================================================================
+
+- name: Start ntnx_image_download_v2 / ntnx_file_by_image_ids_info_v2 tests
+  ansible.builtin.debug:
+    msg: Start FileByImageId (virtual_machine_management) tests
+
+- name: Set fixture variables
+  ansible.builtin.set_fact:
+    invalid_ext_id: "123e4567-e89b-12d3-a456-426614174000"
+    image_ext_id: ""
+
+##############################################################################
+# Prerequisite discovery: pick an existing DISK_IMAGE on the cluster.        #
+##############################################################################
+
+- name: Discover an existing DISK_IMAGE on the cluster to test against
+  nutanix.ncp.ntnx_images_info_v2:
+    filter: "type eq Vmm.Content.ImageType'DISK_IMAGE'"
+  register: images_list_result
+  ignore_errors: true
+
+- name: Assert we found at least one image on the cluster
+  ansible.builtin.assert:
+    that:
+      - images_list_result.failed == false
+      - images_list_result.response is defined
+      - images_list_result.response | length > 0
+      - images_list_result.response[0].ext_id is defined
+    fail_msg: "Prerequisite failed: could not discover a DISK_IMAGE on the cluster. Create one via ntnx_images_v2 first."
+    success_msg: "Prerequisite met: found {{ images_list_result.response | length }} DISK_IMAGE(s) on the cluster"
+
+- name: Save the target image ext_id (first DISK_IMAGE returned)
+  ansible.builtin.set_fact:
+    image_ext_id: "{{ images_list_result.response[0].ext_id }}"
+
+- name: Log the target image ext_id
+  ansible.builtin.debug:
+    msg: "Using image_ext_id = {{ image_ext_id }} (name={{ images_list_result.response[0].name }})"
+
+##############################################################################
+# 2. Argument-spec validation on the DOWNLOAD module (missing image_ext_id) #
+##############################################################################
+
+- name: Negative — call ntnx_image_download_v2 without required image_ext_id
+  nutanix.ncp.ntnx_image_download_v2: {}
+  register: no_ext_id_download
+  ignore_errors: true
+
+- name: Assert download module rejects missing image_ext_id
+  ansible.builtin.assert:
+    that:
+      - no_ext_id_download.failed == true
+      - no_ext_id_download.changed == false
+      - '"image_ext_id" in no_ext_id_download.msg'
+    fail_msg: "Download module did NOT reject missing image_ext_id"
+    success_msg: "Download module correctly rejected missing image_ext_id"
+
+##############################################################################
+# 3. check_mode on the DOWNLOAD module (exactly one check_mode test)         #
+##############################################################################
+
+- name: Download image in check_mode
+  nutanix.ncp.ntnx_image_download_v2:
+    image_ext_id: "{{ image_ext_id }}"
+  register: download_check_mode
+  ignore_errors: true
+  check_mode: true
+
+- name: Assert download check_mode behavior
+  ansible.builtin.assert:
+    that:
+      - download_check_mode.failed == false
+      - download_check_mode.changed == false
+      - download_check_mode.ext_id == image_ext_id
+      - download_check_mode.msg == "Image with ext_id:" ~ image_ext_id ~ " will be downloaded."
+    fail_msg: "Download check_mode did not behave as expected"
+    success_msg: "Download check_mode behaved as expected"
+
+##############################################################################
+# 4. Real download via valid ext_id                                          #
+##############################################################################
+
+- name: Download image using valid ext_id
+  nutanix.ncp.ntnx_image_download_v2:
+    image_ext_id: "{{ image_ext_id }}"
+  register: download_result
+  ignore_errors: true
+
+- name: Assert real download succeeded and populated all return fields
+  ansible.builtin.assert:
+    that:
+      - download_result.failed == false
+      - download_result.changed == true
+      - download_result.ext_id == image_ext_id
+      - download_result.response is defined
+      - download_result.response.path is defined
+      - download_result.response.path | length > 0
+      - download_result.response.path is string
+      - download_result.response.path.startswith("/")
+    fail_msg: "Real image download failed or did not return a valid path"
+    success_msg: "Image downloaded successfully to {{ download_result.response.path | default('<none>') }}"
+
+##############################################################################
+# 5. Repeat download                                                         #
+##############################################################################
+
+- name: Download image a second time using the same valid ext_id
+  nutanix.ncp.ntnx_image_download_v2:
+    image_ext_id: "{{ image_ext_id }}"
+  register: download_repeat_result
+  ignore_errors: true
+
+- name: Assert repeat download still succeeds cleanly
+  ansible.builtin.assert:
+    that:
+      - download_repeat_result.failed == false
+      - download_repeat_result.changed == true
+      - download_repeat_result.ext_id == image_ext_id
+      - download_repeat_result.response is defined
+      - download_repeat_result.response.path is defined
+      - download_repeat_result.response.path | length > 0
+    fail_msg: "Repeat image download did not behave the same way as the first call"
+    success_msg: "Repeat image download succeeded — the module has no unwanted stateful side-effects"
+
+##############################################################################
+# 6. Negative: download with an invalid ext_id                                #
+##############################################################################
+
+- name: Download image using invalid ext_id
+  nutanix.ncp.ntnx_image_download_v2:
+    image_ext_id: "{{ invalid_ext_id }}"
+  register: download_invalid_result
+  ignore_errors: true
+
+- name: Assert download with invalid ext_id fails cleanly
+  ansible.builtin.assert:
+    that:
+      - download_invalid_result.failed == true
+      - download_invalid_result.changed == false
+      - download_invalid_result.msg == "Api Exception raised while downloading image"
+    fail_msg: "Download with invalid ext_id did not fail as expected"
+    success_msg: "Download with invalid ext_id failed as expected"
+
+##############################################################################
+# 7. Argument-spec validation on the INFO module (missing ext_id)             #
+##############################################################################
+
+- name: Negative — call ntnx_file_by_image_ids_info_v2 without required ext_id
+  nutanix.ncp.ntnx_file_by_image_ids_info_v2: {}
+  register: no_ext_id_info
+  ignore_errors: true
+
+- name: Assert info module rejects missing ext_id
+  ansible.builtin.assert:
+    that:
+      - no_ext_id_info.failed == true
+      - no_ext_id_info.changed == false
+      - '"ext_id" in no_ext_id_info.msg'
+    fail_msg: "Info module did NOT reject missing ext_id"
+    success_msg: "Info module correctly rejected missing ext_id"
+
+##############################################################################
+# 8. Info fetch with valid ext_id                                             #
+##############################################################################
+
+- name: Fetch image file info using valid ext_id
+  nutanix.ncp.ntnx_file_by_image_ids_info_v2:
+    ext_id: "{{ image_ext_id }}"
+  register: info_result
+  ignore_errors: true
+
+- name: Assert info fetch succeeded and populated all return fields
+  ansible.builtin.assert:
+    that:
+      - info_result.failed == false
+      - info_result.changed == false
+      - info_result.ext_id == image_ext_id
+      - info_result.response is defined
+      - info_result.response.path is defined
+      - info_result.response.path | length > 0
+      - info_result.response.path is string
+      - info_result.response.path.startswith("/")
+    fail_msg: "Info fetch failed or did not return a valid path"
+    success_msg: "Image file info fetched successfully — path={{ info_result.response.path | default('<none>') }}"
+
+##############################################################################
+# 9. Negative: info fetch with invalid ext_id                                 #
+##############################################################################
+
+- name: Fetch image file info using invalid ext_id
+  nutanix.ncp.ntnx_file_by_image_ids_info_v2:
+    ext_id: "{{ invalid_ext_id }}"
+  register: info_invalid_result
+  ignore_errors: true
+
+- name: Assert info fetch with invalid ext_id fails cleanly
+  ansible.builtin.assert:
+    that:
+      - info_invalid_result.failed == true
+      - info_invalid_result.changed == false
+      - info_invalid_result.msg == "Api Exception raised while fetching image file info"
+    fail_msg: "Info fetch with invalid ext_id did not fail as expected"
+    success_msg: "Info fetch with invalid ext_id failed as expected"

--- a/tests/integration/targets/ntnx_image_download_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_image_download_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module_defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import file_by_image_id_operations.yml
+      ansible.builtin.import_tasks: file_by_image_id_operations.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **virtual_machine_management**
namespace, entity **FileByImageId**, based on the inline `sdk_info.json`. One
PR per code-gen run.

- Modules generated: `ntnx_image_download_v2` (action / download),
  `ntnx_file_by_image_ids_info_v2` (info / GetFileByImageId).
- API methods covered by `FileByImageId`: **1** (`GetFileByImageId`,
  `GET /api/vmm/v4.2/content/images/{imageExtId}/file`).
- Fields in the download-action module spec: **1** (`image_ext_id`).
- Fields in the info module spec: **1** (`ext_id`).
- Both modules registered in `meta/runtime.yml → action_groups.ntnx` so the
  `group/nutanix.ncp.ntnx` `module_defaults` block applies.

## Domain knowledge (from Glean)

### Entity summary

`FileByImageId` in the `virtual_machine_management` namespace refers to the
file (image binary) associated with a Prism Central Image. The Nutanix VMM
v4.2 SDK (`ntnx_vmm_py_client`) exposes exactly one operation for it:

| Attribute | Value |
|-----------|-------|
| SDK method | `ntnx_vmm_py_client.ImagesApi.get_file_by_image_id(imageExtId=...)` |
| HTTP verb | GET |
| URI | `/api/vmm/v4.2/content/images/{imageExtId}/file` |
| Description | Download an image (returns the binary file) |
| Response type | `GetImageFileApiResponse` whose `data` is either a `pathlib.Path` (successful download) or `vmm.v4.error.ErrorResponse` |

The SDK helper writes the streamed bytes to a temporary file and returns the
local `path`, exactly like `get_file_by_ova_id` for OVAs — so an Ansible
module that wraps this call ends up with a `response.path` field pointing at
the downloaded file on disk. The v4 flow is documented in the "V4 Image
Download Kronos" spec: Prism Central (PC) itself never streams the image
bytes and never signs URLs; instead PC asks the hosting Prism Element (PE)
to mint a short-lived, cryptographically signed download URL and the bytes
are pulled directly from that PE (or, for content-cache backed images, from
Objects-Lite).

### Prerequisites

- The image must exist and be in an `ACTIVE` (available) state on at least
  one Prism Element cluster that PC can reach (`cluster_location_ext_ids`
  populated with a live PE). An image that is only partially uploaded, still
  registering, or whose only supporting PE has been disconnected/removed
  will cause download to fail (see JIRA "V4 Download Image API is failing"
  and "TestDownloadScenarios.test_download_with_two_supporting_pe fails …").
- The requesting user must hold one of the download-capable roles:
  **Prism Admin, Prism Viewer, Super Admin**.
- Network connectivity to PC (port 9440) is required to hit the API, and
  PC must itself have network reach to the supporting PE(s) so it can
  forward the client to the PE-signed URL. External URLs used for download
  are documented in the "Nutanix Port List" (SharePoint).
- The v4 download API is separate from — and NOT reachable from — the Prism
  Central web console (see JIRA "V4 Download Image API is failing"):
  callers must use the REST API / SDK directly.

### Workflow (end-to-end)

1. Caller obtains the target image `ext_id` (e.g. via `list_images` /
   `get_image_by_id` — the existing `ntnx_images_v2` /
   `ntnx_images_info_v2` modules).
2. Caller invokes `ImagesApi.get_file_by_image_id(imageExtId=<ext_id>)`.
3. PC resolves the image's supporting PE(s), asks the PE to mint a
   short-lived signed URL, streams the bytes back through the SDK.
4. The Python SDK writes the bytes to a local temp file and returns a
   response object whose `.data` is a `pathlib.Path` pointing at that file.
5. The caller can then move / rename / consume that file. If the operation
   fails (image not found, PE not reachable, image not ACTIVE, role
   missing, etc.), `.data` will be a `vmm.v4.error.ErrorResponse` and the
   SDK raises an `ApiException` that the module surfaces via
   `raise_api_exception`.

### Behavioural details

- Downloads are synchronous — no task ext_id, no `wait_for_completion`.
- The response contains only the local file `path`; there is no metadata
  (size, checksum, name) in the download response itself — those come from
  `get_image_by_id` and are exposed by `ntnx_images_info_v2`.
- ETag/If-Match are NOT required for this endpoint (it is a read-only GET).
- Because the endpoint proxies through PE, a download can fail even when
  the PC metadata GET (`get_image_by_id`) succeeds, if the supporting PE
  is disconnected or removed from multicluster.
- In the newer Kronos release the flow will change to expose a
  `generate-download-url` action returning the pre-signed URL directly to
  the client, but that is v4.4+ and is out of scope for this v4.2 module.

### Related engineering tickets, design docs, and references

- JIRA: **V4 Download Image API is failing** — advises callers to use the
  v4 download API and links the API reference:
  `https://developers.nutanix.com/api-reference?namespace=vmm&version=v4.2#tag/Images/operation/getFileByImageId`
- JIRA: **v4 API / Download an image issue** — tracks the earlier download
  breakage and confirms the fix ships as a new v4 image download API in
  the Kronos release.
- JIRA: **[PC 7.6] REST API: Unhandled HTTP 500 (NullPointerException)
  during image upload due to accept-language header parsing failure** —
  related PC image API robustness ticket.
- JIRA: **TestDownloadScenarios.test_download_with_two_supporting_pe fails
  with NuTestCommandExecutionError during multicluster
  "remove-from-multicluster"** — canonical failure mode when a supporting
  PE is removed while a download is in flight.
- JIRA: **Allow filtering by extId in images list APIs** — related list
  filter improvements for images.
- Confluence: **V4 Image Download Kronos** (`~salilkumar.singh` space) —
  design doc for the PE-signed URL flow that `get_file_by_image_id` relies
  on.
- Confluence: **Implement File Upload and Download in v4 APIs** (AI space,
  page 314649065) — cross-service design for upload/download of files.
- Confluence: **VMM images API Mapping Documentation** (PRIS space, page
  269290036) — maps legacy vs v4 permissions for the "Download Image"
  verb (`GET /api/vmm/v4.0/content/images/{extId}/file` → Prism Admin /
  Super Admin / Prism Viewer).
- Confluence: **Spike: Prism V4 API Authentication** (SIZER space, page
  528532000) — authentication patterns for calling the v4 Images API from
  a Python client (basic auth / API key).
- Confluence: **v4 Migration Guide** (PRIS space, page 236212461) —
  official guide for moving from v3 images to
  `ntnx_vmm_py_client.ImagesApi`.
- Confluence: **VMM-Images v4 API** (PRIS space, page 257513199) — perf
  and latency numbers for the v4 Images API surface.
- Confluence: **Prism V4 API'S** (SIZER space, page 528533216) —
  canonical v4 API reference for VMM.
- GitHub: **vmm_v4_r2_proto.proto** — protobuf definition of
  `Getfilebyimageid` with the exact HTTP mapping.
- GitHub: **test_download_scenarios.py** / **test_download.py** — internal
  test suites for the download flow (use `V4LibDownloadHelper` /
  `get_download_details`).
- SharePoint: **Nutanix Port List** — network ports and external URLs
  required for image download.
- Public API reference:
  `https://developers.nutanix.com/api-reference?namespace=vmm&version=v4.2#tag/Images/operation/getFileByImageId`

### Skills required to own this feature end-to-end

1. Nutanix VMM v4.x APIs (Content / Images tag) and the
   `ntnx_vmm_py_client` Python SDK — request/response models,
   ApiException semantics, ETag handling.
2. Prism Central ↔ Prism Element multicluster topology — how PC delegates
   file streaming to the supporting PE and what "supporting PE" means for
   an image (`cluster_location_ext_ids`).
3. Nutanix IAM roles/permissions (Prism Admin / Viewer / Super Admin) and
   how they gate image reads.
4. Ansible module authoring for the `nutanix.ncp` collection — v4 base
   module (`BaseModuleV4`), `SpecGenerator`, `strip_internal_attributes`,
   `raise_api_exception`, `remove_param_with_none_value`, and the
   check-mode / idempotency patterns already established in the repo.
5. `ansible-test` integration harness, `integration_config.yml`, and the
   existing `prepare_env` target used by every live-cluster test.
6. Ability to read `sdk_info.json` / SDK docs to correctly map SDK method
   names, parameters, and response models to Ansible spec fields.

## Files changed

- `plugins/modules/ntnx_image_download_v2.py` — new action module wrapping
  `ImagesApi.get_file_by_image_id`; returns the downloaded local `path`,
  supports `check_mode`, `no_log` for any sensitive proxy credentials via
  `BaseModuleV4`, and full v4-style error handling via
  `raise_api_exception`.
- `plugins/modules/ntnx_file_by_image_ids_info_v2.py` — new info module
  wrapping the same SDK method; `changed=False` and `check_mode` disabled
  per info-module convention; required `ext_id` param.
- `meta/runtime.yml` — added both new module names to
  `action_groups.ntnx` so `module_defaults: group/nutanix.ncp.ntnx: …`
  applies (the very first ad-hoc test run failed with
  `missing required arguments: nutanix_host` until this was added — see
  Analysis).
- `examples/virtual_machine_management/FileByImageId/file_by_image_id.yml`
  — single example playbook covering discover → download → info; uses a
  play-level `module_defaults` block (no per-task credentials); picks the
  smallest available DISK_IMAGE to keep the demo download cheap.
- `examples/virtual_machine_management/FileByImageId/examples_run.log` —
  REAL captured `ansible-playbook -v` output from a live run against
  Prism Central `10.44.76.28`.
- `tests/integration/targets/ntnx_image_download_v2/*` — new integration
  test target (disabled by default, matching the existing v2 targets)
  covering: prerequisite discovery, missing-required-arg validation
  (both modules), one check_mode test, real download, repeat download,
  negative (invalid ext_id) for both modules, and full response-field
  assertions.
- `.gitignore` — added `tests/integration/integration_config.yml` (which
  contains cluster credentials and must never be committed) and
  `plugins/modules/__pycache__/`.

## Test execution

| Metric              | Value                                                                 |
|---------------------|-----------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_image_download_v2 --python 3.12 -v`    |
| Total tasks         | 27                                                                    |
| Passed (ok)         | 23                                                                    |
| Changed             | 2 (the two real download tasks)                                       |
| Failed              | 0                                                                     |
| Ignored             | 4 (all four intentional negative tests using `ignore_errors: true`)   |
| Skipped             | 0                                                                     |
| Duration            | ~1m 30s                                                               |
| Cluster (PC)        | `10.44.76.28:9440` (Prism Central 7.6 el9-release-ganges)             |
| Sample image used   | `CentOS-7-cloudinit` (ext_id `6894187e-0549-4816-8aa6-4aee85ac4dab`)  |

Additional runs:

- **`ansible-playbook examples/virtual_machine_management/FileByImageId/file_by_image_id.yml -v`**
  against the same PC: **7 ok, 1 changed, 0 failed** — full transcript
  in `examples/virtual_machine_management/FileByImageId/examples_run.log`.
- **`black --check`, `isort --check`, `flake8`, `ansible-lint`** on the two
  new module files and the new example / test YAML: **0 failures**.
  `ansible-lint` reported two `args[module]: missing required arguments`
  **warnings** on the intentional negative tests (they call the module
  with `{}` on purpose to prove the spec rejects it) — kept as-is, they
  are warnings not failures.

### Analysis

- All 23 asserted tasks passed on the first successful run. The two
  `changed=True` tasks are the real and the repeat download.
- Four tasks are `...ignoring` on purpose — they are the negative tests
  that intentionally trigger `failed=True` so a follow-up `assert`
  statement can confirm the module surfaced the exact expected error
  string.
- One root-cause fix was needed during the first dry run: the two new
  modules were not yet in `meta/runtime.yml → action_groups.ntnx`, so
  `module_defaults: group/nutanix.ncp.ntnx:` was silently NOT applied
  and every task failed with `missing required arguments: nutanix_host`.
  Adding both module names to the `ntnx` action group resolved this and
  the test suite went green on the next run.
- One example-run fix was needed: the original example seeded a fresh
  2.3 GB Ubuntu cloud image and then downloaded it; the controller's
  `/tmp` was only 2 GB, so the download failed with
  `[Errno 28] No space left on device`. The example was rewritten to
  reuse the smallest existing DISK_IMAGE on the cluster (discovered
  via `ntnx_images_info_v2 orderby=sizeBytes asc`), which makes the
  example both faster and portable to any controller. The leftover image
  from the failed run was deleted from PC. Final example run:
  ok=7 / changed=1 / failed=0.
- No **Known issues** remain.

### Test logs (tail)

<details>
<summary>tail -n 100 test_logs.log</summary>

```text
TASK [ntnx_image_download_v2 : Assert we found at least one image on the cluster] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Prerequisite met: found 16 DISK_IMAGE(s) on the cluster"
}

TASK [ntnx_image_download_v2 : Save the target image ext_id (first DISK_IMAGE returned)] ***
ok: [testhost] => {"ansible_facts": {"image_ext_id": "6894187e-0549-4816-8aa6-4aee85ac4dab"}, "changed": false}

TASK [ntnx_image_download_v2 : Log the target image ext_id] ********************
ok: [testhost] => {
    "msg": "Using image_ext_id = 6894187e-0549-4816-8aa6-4aee85ac4dab (name=CentOS-7-cloudinit)"
}

TASK [ntnx_image_download_v2 : Negative — call ntnx_image_download_v2 without required image_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: image_ext_id"}
...ignoring

TASK [ntnx_image_download_v2 : Assert download module rejects missing image_ext_id] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Download module correctly rejected missing image_ext_id"
}

TASK [ntnx_image_download_v2 : Download image in check_mode] *******************
ok: [testhost] => {"changed": false, "ext_id": "6894187e-0549-4816-8aa6-4aee85ac4dab", "msg": "Image with ext_id:6894187e-0549-4816-8aa6-4aee85ac4dab will be downloaded.", "response": null}

TASK [ntnx_image_download_v2 : Assert download check_mode behavior] ************
ok: [testhost] => {
    "changed": false,
    "msg": "Download check_mode behaved as expected"
}

TASK [ntnx_image_download_v2 : Download image using valid ext_id] **************
changed: [testhost] => {"changed": true, "ext_id": "6894187e-0549-4816-8aa6-4aee85ac4dab", "response": {"path": "…/CentOS-7-cloudinit_2026-07-21T04:51:35.991"}}

TASK [ntnx_image_download_v2 : Assert real download succeeded and populated all return fields] ***
ok: [testhost] => {"changed": false, "msg": "Image downloaded successfully to …/CentOS-7-cloudinit_2026-07-21T04:51:35.991"}

TASK [ntnx_image_download_v2 : Download image a second time using the same valid ext_id] ***
changed: [testhost] => {"changed": true, "ext_id": "6894187e-0549-4816-8aa6-4aee85ac4dab", "response": {"path": "…/CentOS-7-cloudinit_2026-07-21T04:52:02.889"}}

TASK [ntnx_image_download_v2 : Assert repeat download still succeeds cleanly] ***
ok: [testhost] => {"changed": false, "msg": "Repeat image download succeeded — the module has no unwanted stateful side-effects"}

TASK [ntnx_image_download_v2 : Download image using invalid ext_id] ************
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while downloading image", "status": 404}
...ignoring

TASK [ntnx_image_download_v2 : Assert download with invalid ext_id fails cleanly] ***
ok: [testhost] => {"changed": false, "msg": "Download with invalid ext_id failed as expected"}

TASK [ntnx_image_download_v2 : Negative — call ntnx_file_by_image_ids_info_v2 without required ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_image_download_v2 : Assert info module rejects missing ext_id] ******
ok: [testhost] => {"changed": false, "msg": "Info module correctly rejected missing ext_id"}

TASK [ntnx_image_download_v2 : Fetch image file info using valid ext_id] *******
ok: [testhost] => {"changed": false, "error": null, "ext_id": "6894187e-0549-4816-8aa6-4aee85ac4dab", "response": {"path": "…/CentOS-7-cloudinit_2026-07-21T04:52:31.852"}}

TASK [ntnx_image_download_v2 : Assert info fetch succeeded and populated all return fields] ***
ok: [testhost] => {"changed": false, "msg": "Image file info fetched successfully — path=…/CentOS-7-cloudinit_2026-07-21T04:52:31.852"}

TASK [ntnx_image_download_v2 : Fetch image file info using invalid ext_id] *****
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching image file info", "status": 404}
...ignoring

TASK [ntnx_image_download_v2 : Assert info fetch with invalid ext_id fails cleanly] ***
ok: [testhost] => {"changed": false, "msg": "Info fetch with invalid ext_id failed as expected"}

PLAY RECAP *********************************************************************
testhost                   : ok=23   changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=4
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
