### PR TITLE
code-gen(virtual_machine_management/NicStat): ansible collection modules

### DIFF
--- a/examples/virtual_machine_management/NicStat/examples_run.log
+++ b/examples/virtual_machine_management/NicStat/examples_run.log
@@ -1,0 +1,25 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [NicStat (VMM v4) playbook] ***********************************************
+
+TASK [Set stat window and identifiers] *****************************************
+ok: [localhost] => {"ansible_facts": {"nic_ext_id": "868f0ac7-5f6a-4f49-7003-788a8091841f", "vm_ext_id": "4d5a5911-43f3-4788-8455-a28c81633900", "window_end": "2025-12-31T12:41:56.955Z", "window_start": "2024-07-31T12:41:56.955Z"}, "changed": false}
+
+TASK [Fetch VM NIC stats with required attributes only] ************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VM NIC stats", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_uuid": "4d5a5911-43f3-4788-8455-a28c81633900"}, "code": "VMM-30100", "errorGroup": "VM_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the VM with UUID '4d5a5911-43f3-4788-8455-a28c81633900', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Fetch VM NIC stats with ALL attributes] **********************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VM NIC stats", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_uuid": "4d5a5911-43f3-4788-8455-a28c81633900"}, "code": "VMM-30100", "errorGroup": "VM_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the VM with UUID '4d5a5911-43f3-4788-8455-a28c81633900', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Fetch VM NIC stats via the info module] **********************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VM NIC stats info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_uuid": "4d5a5911-43f3-4788-8455-a28c81633900"}, "code": "VMM-30100", "errorGroup": "VM_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the VM with UUID '4d5a5911-43f3-4788-8455-a28c81633900', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   
+

--- a/examples/virtual_machine_management/NicStat/nic_stat_v2.yml
+++ b/examples/virtual_machine_management/NicStat/nic_stat_v2.yml
@@ -1,0 +1,71 @@
+---
+# Summary:
+# This playbook demonstrates how to use the NicStat (VMM v4) Ansible modules
+# to fetch NIC-level performance statistics for a VM running on an ESXi host
+# managed by Nutanix Prism Central.
+#
+# Both modules wrap the same v4 SDK call
+# (EsxiStatsApi.get_nic_stats_by_id -> GET /api/vmm/v4.2/esxi/stats/vms/{vmExtId}/nics/{extId})
+# and take the same set of query parameters. Two flavors are provided:
+#   * ntnx_nic_stat_v2         - primary NIC-stats fetch module
+#   * ntnx_vm_nic_stats_info_v2 - info-style flavor of the same operation
+#
+# Steps:
+#   1. Fetch NIC stats with only the required attributes (vm_ext_id, ext_id,
+#      start_time, end_time).
+#   2. Fetch NIC stats with ALL supported attributes (adds sampling_interval,
+#      stat_type, and select).
+#   3. Use the info module to fetch NIC stats by ext_id (info-style).
+
+- name: NicStat (VMM v4) playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') | default('10.44.76.28', true) }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') | default('admin', true) }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') | default('Nutanix.123', true) }}"
+      validate_certs: false
+  tasks:
+    # NOTE: replace vm_ext_id / nic_ext_id with the ExtIDs of an ESXi VM
+    # + NIC on your cluster. If the referenced VM lives on AHV (or does not
+    # exist under /esxi/stats), the API returns HTTP 404 with error code
+    # VMM-30100 "VM_NOT_FOUND" — the module surfaces that cleanly.
+    - name: Set stat window and identifiers
+      ansible.builtin.set_fact:
+        vm_ext_id: "4d5a5911-43f3-4788-8455-a28c81633900"
+        nic_ext_id: "868f0ac7-5f6a-4f49-7003-788a8091841f"
+        window_start: "2024-07-31T12:41:56.955Z"
+        window_end: "2025-12-31T12:41:56.955Z"
+
+    - name: Fetch VM NIC stats with required attributes only
+      nutanix.ncp.ntnx_nic_stat_v2:
+        vm_ext_id: "{{ vm_ext_id }}"
+        ext_id: "{{ nic_ext_id }}"
+        start_time: "{{ window_start }}"
+        end_time: "{{ window_end }}"
+      register: nic_stat_minimal
+      ignore_errors: true
+
+    - name: Fetch VM NIC stats with ALL attributes
+      nutanix.ncp.ntnx_nic_stat_v2:
+        vm_ext_id: "{{ vm_ext_id }}"
+        ext_id: "{{ nic_ext_id }}"
+        start_time: "{{ window_start }}"
+        end_time: "{{ window_end }}"
+        sampling_interval: 30
+        stat_type: AVG
+        select: "stats/networkDroppedReceivedPackets,stats/networkDroppedTransmittedPackets"
+      register: nic_stat_full
+      ignore_errors: true
+
+    - name: Fetch VM NIC stats via the info module
+      nutanix.ncp.ntnx_vm_nic_stats_info_v2:
+        vm_ext_id: "{{ vm_ext_id }}"
+        ext_id: "{{ nic_ext_id }}"
+        start_time: "{{ window_start }}"
+        end_time: "{{ window_end }}"
+        sampling_interval: 30
+        stat_type: AVG
+      register: nic_stat_info
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_nic_stat_v2
+    - ntnx_vm_nic_stats_info_v2

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,24 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_esxi_stats_api_instance(module):
+    """
+    This method will return the ESXi Stats API instance (VMM).
+
+    The ESXi Stats API exposes read-only NIC/Disk/VM statistics endpoints
+    (e.g. ``get_nic_stats_by_id``, ``get_disk_stats_by_id``,
+    ``get_vm_stats_by_id``, ``list_vm_stats``) for VMs running on ESXi hosts
+    managed by Prism Central.
+
+    Args:
+        module (AnsibleModule): the calling Ansible module (used to build
+            an authenticated API client).
+
+    Returns:
+        ntnx_vmm_py_client.EsxiStatsApi: an authenticated ESXi Stats API
+        instance ready to make v4 calls.
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.EsxiStatsApi(api_client=api_client)

--- a/plugins/modules/ntnx_nic_stat_v2.py
+++ b/plugins/modules/ntnx_nic_stat_v2.py
@@ -1,0 +1,307 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_nic_stat_v2
+short_description: Retrieve NIC stats for a VM (ESXi hypervisor) from Prism Central
+version_added: 2.5.0
+description:
+    - Retrieve network interface controller (NIC) stats for a given VM running
+      on an ESXi hypervisor managed by Nutanix Prism Central.
+    - Wraps the v4 VMM API C(EsxiStatsApi.get_nic_stats_by_id)
+      (GET /api/vmm/v4.2/esxi/stats/vms/{vmExtId}/nics/{extId}).
+    - The API returns a time series of NIC statistics (dropped received /
+      transmitted packet counts) for the requested time window and, optionally,
+      down-sampled to the requested C(sampling_interval)/C(stat_type).
+    - Read-only module — no state transitions are performed on the target VM.
+    - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to
+      the user performing the operation.
+    - >-
+      B(Get NIC stats for a VM on ESXi) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin, Virtual Machine
+      Admin, Virtual Machine Operator, Virtual Machine Viewer.
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  ext_id:
+    description:
+      - External ID of the VM NIC whose stats are being retrieved.
+      - Required.
+    type: str
+    required: true
+  vm_ext_id:
+    description:
+      - External ID of the VM that owns the NIC identified by C(ext_id).
+      - Required.
+    type: str
+    required: true
+  start_time:
+    description:
+      - Start of the reporting window (ISO-8601 / RFC-3339 timestamp).
+      - Sample input C(2024-07-31T12:41:56.955Z).
+      - Required.
+    type: str
+    required: true
+  end_time:
+    description:
+      - End of the reporting window (ISO-8601 / RFC-3339 timestamp).
+      - Sample input C(2025-07-31T12:41:56.955Z).
+      - Required.
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - Sampling interval in seconds at which statistical data should be
+        collected. For example, if you want performance statistics every
+        30 seconds, provide the value C(30).
+    type: int
+    required: false
+  stat_type:
+    description:
+      - The down-sampling operator applied when aggregating the stat time series.
+      - Passed to the API as the C(_statType) query parameter.
+    type: str
+    required: false
+    choices:
+      - SUM
+      - MIN
+      - MAX
+      - AVG
+      - COUNT
+      - LAST
+  select:
+    description:
+      - OData V4.01 C($select) expression used to restrict the returned
+        properties (e.g. C(stats/networkDroppedReceivedPackets)).
+      - If a single asterisk is provided all properties are returned.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+      - nutanix.ncp.ntnx_credentials
+      - nutanix.ncp.ntnx_logger
+      - nutanix.ncp.ntnx_proxy_v2
+author:
+ - Nutanix (@nutanix)
+ - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch VM NIC stats for a specific NIC over a time window
+  nutanix.ncp.ntnx_nic_stat_v2:
+    vm_ext_id: 530567f3-abda-4913-b5d0-0ab6758ec16e
+    ext_id: 4a67ce54-dd9c-4c71-9d91-2a19d512dc7d
+    start_time: 2024-07-31T12:41:56.955Z
+    end_time: 2025-07-31T12:41:56.955Z
+  register: nic_stats
+
+- name: Fetch VM NIC stats with all attributes (down-sampled and projected)
+  nutanix.ncp.ntnx_nic_stat_v2:
+    vm_ext_id: 530567f3-abda-4913-b5d0-0ab6758ec16e
+    ext_id: 4a67ce54-dd9c-4c71-9d91-2a19d512dc7d
+    start_time: 2024-07-31T12:41:56.955Z
+    end_time: 2025-07-31T12:41:56.955Z
+    sampling_interval: 30
+    stat_type: AVG
+    select: "stats/networkDroppedReceivedPackets,stats/networkDroppedTransmittedPackets"
+  register: nic_stats_projected
+"""
+
+RETURN = r"""
+response:
+    description:
+        - The response returned by C(EsxiStatsApi.get_nic_stats_by_id).
+        - Contains the VM ExtID and the NIC ExtID plus a C(stats) list of
+          per-timestamp tuples with dropped-packet counters.
+    type: dict
+    returned: always
+    sample:
+        {
+            "ext_id": "4a67ce54-dd9c-4c71-9d91-2a19d512dc7d",
+            "vm_ext_id": "530567f3-abda-4913-b5d0-0ab6758ec16e",
+            "links": null,
+            "tenant_id": null,
+            "stats": [
+                {
+                    "timestamp": "2024-07-31T12:41:56.955000+00:00",
+                    "network_dropped_received_packets": 0,
+                    "network_dropped_transmitted_packets": 0
+                },
+                {
+                    "timestamp": "2024-07-31T12:42:26.955000+00:00",
+                    "network_dropped_received_packets": 1,
+                    "network_dropped_transmitted_packets": 0
+                }
+            ]
+        }
+ext_id:
+    description:
+        - The external ID of the VM NIC whose stats were retrieved.
+    type: str
+    returned: always
+    sample: "4a67ce54-dd9c-4c71-9d91-2a19d512dc7d"
+vm_ext_id:
+    description:
+        - The external ID of the VM that owns the NIC.
+    type: str
+    returned: always
+    sample: "530567f3-abda-4913-b5d0-0ab6758ec16e"
+changed:
+    description: Always C(false) — this module only reads statistics.
+    type: bool
+    returned: always
+    sample: false
+msg:
+    description: Human-readable status/error message.
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while fetching VM NIC stats"
+error:
+    description: The error details when an error occurs.
+    type: str
+    returned: when an error occurs
+failed:
+    description: Whether the module invocation failed.
+    returned: always
+    type: bool
+    sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+from ..module_utils.v4.vmm.api_client import get_esxi_stats_api_instance  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    # pylint: disable=unused-import
+    import ntnx_vmm_py_client as virtual_machine_management_sdk  # noqa: E402, F401
+except ImportError:
+    # pylint: disable=unused-import
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402, F401
+        mock_sdk as virtual_machine_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        vm_ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int", required=False),
+        stat_type=dict(
+            type="str",
+            required=False,
+            choices=[
+                "SUM",
+                "MIN",
+                "MAX",
+                "AVG",
+                "COUNT",
+                "LAST",
+            ],
+        ),
+        select=dict(type="str", required=False),
+    )
+    return module_args
+
+
+def get_nic_stat(module, api_instance, result):
+    """Fetch NIC stats for a given VM NIC and populate ``result``.
+
+    Reads the required ``ext_id``, ``vm_ext_id``, ``start_time``, ``end_time``
+    module params and the optional ``sampling_interval``, ``stat_type``,
+    ``select`` params and calls
+    :meth:`ntnx_vmm_py_client.EsxiStatsApi.get_nic_stats_by_id`.
+    """
+    validate_required_params(module, ["ext_id", "vm_ext_id", "start_time", "end_time"])
+
+    ext_id = module.params.get("ext_id")
+    vm_ext_id = module.params.get("vm_ext_id")
+    result["ext_id"] = ext_id
+    result["vm_ext_id"] = vm_ext_id
+
+    start_time = module.params.get("start_time")
+    end_time = module.params.get("end_time")
+    sampling_interval = module.params.get("sampling_interval")
+    stat_type = module.params.get("stat_type")
+    select = module.params.get("select")
+
+    resp = None
+    try:
+        resp = api_instance.get_nic_stats_by_id(
+            vmExtId=vm_ext_id,
+            extId=ext_id,
+            _startTime=start_time,
+            _endTime=end_time,
+            _samplingInterval=sampling_interval,
+            _statType=stat_type,
+            _select=select,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VM NIC stats",
+        )
+
+    if getattr(resp, "data", None) is not None:
+        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    else:
+        result["response"] = None
+        module.fail_json(msg="Failed fetching VM NIC stats", **result)
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "vm_ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_esxi_stats_api_instance(module)
+    get_nic_stat(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_vm_nic_stats_info_v2.py
+++ b/plugins/modules/ntnx_vm_nic_stats_info_v2.py
@@ -1,0 +1,282 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_nic_stats_info_v2
+short_description: Fetch VM NIC stats info (ESXi hypervisor) from Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about NicStat in Nutanix Prism Central.
+  - Only one lookup mode is supported by the v4 ESXi stats API — fetching NIC
+    stats for a specific VM NIC by its external ID and the owning VM external ID
+    over a given time window.
+  - C(ext_id) and C(vm_ext_id) are always required — the SDK does not expose a
+    list-all endpoint for NIC stats.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to
+      the user performing the operation.
+    - >-
+      B(Get NIC stats for a VM on ESXi) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin, Virtual Machine
+      Admin, Virtual Machine Operator, Virtual Machine Viewer.
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+    ext_id:
+        description:
+            - External ID of the VM NIC.
+        type: str
+        required: true
+    vm_ext_id:
+        description:
+            - External ID of the VM that owns the NIC.
+        type: str
+        required: true
+    start_time:
+        description:
+            - Start of the reporting window (ISO-8601 / RFC-3339 timestamp).
+            - Sample input C(2024-07-31T12:41:56.955Z).
+        type: str
+        required: true
+    end_time:
+        description:
+            - End of the reporting window (ISO-8601 / RFC-3339 timestamp).
+            - Sample input C(2025-07-31T12:41:56.955Z).
+        type: str
+        required: true
+    sampling_interval:
+        description:
+            - Sampling interval in seconds at which statistical data should be
+              collected.
+        type: int
+        required: false
+    stat_type:
+        description:
+            - Down-sampling operator applied to the stat time series
+              (C(_statType) query parameter).
+        type: str
+        required: false
+        choices:
+            - SUM
+            - MIN
+            - MAX
+            - AVG
+            - COUNT
+            - LAST
+    read_timeout:
+        description: Read timeout in milliseconds for API calls.
+        type: int
+        required: false
+        default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+ - Nutanix (@nutanix)
+ - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch VM NIC stats for a specific NIC
+  nutanix.ncp.ntnx_vm_nic_stats_info_v2:
+    vm_ext_id: 530567f3-abda-4913-b5d0-0ab6758ec16e
+    ext_id: 4a67ce54-dd9c-4c71-9d91-2a19d512dc7d
+    start_time: 2024-07-31T12:41:56.955Z
+    end_time: 2025-07-31T12:41:56.955Z
+  register: nic_stats_info
+
+- name: Fetch VM NIC stats with sampling and average down-sampling
+  nutanix.ncp.ntnx_vm_nic_stats_info_v2:
+    vm_ext_id: 530567f3-abda-4913-b5d0-0ab6758ec16e
+    ext_id: 4a67ce54-dd9c-4c71-9d91-2a19d512dc7d
+    start_time: 2024-07-31T12:41:56.955Z
+    end_time: 2025-07-31T12:41:56.955Z
+    sampling_interval: 30
+    stat_type: AVG
+  register: nic_stats_info_avg
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC NicStat info v4 API.
+    - Always a single NicStat (with a C(stats) time series) — no list mode is
+      supported for this entity.
+  type: dict
+  returned: always
+  sample:
+    {
+        "ext_id": "4a67ce54-dd9c-4c71-9d91-2a19d512dc7d",
+        "vm_ext_id": "530567f3-abda-4913-b5d0-0ab6758ec16e",
+        "links": null,
+        "tenant_id": null,
+        "stats": [
+            {
+                "timestamp": "2024-07-31T12:41:56.955000+00:00",
+                "network_dropped_received_packets": 0,
+                "network_dropped_transmitted_packets": 0
+            }
+        ]
+    }
+ext_id:
+    description:
+        - External ID of the VM NIC whose stats were retrieved.
+    type: str
+    returned: always
+    sample: "4a67ce54-dd9c-4c71-9d91-2a19d512dc7d"
+vm_ext_id:
+    description:
+        - External ID of the VM that owns the NIC.
+    type: str
+    returned: always
+    sample: "530567f3-abda-4913-b5d0-0ab6758ec16e"
+changed:
+    description: Always C(false) — info modules do not mutate any state.
+    type: bool
+    returned: always
+    sample: false
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching VM NIC stats info"
+error:
+  description: The error details when an error occurs.
+  type: str
+  returned: when an error occurs
+failed:
+  description: Whether the module invocation failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+from ..module_utils.v4.vmm.api_client import get_esxi_stats_api_instance  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    # pylint: disable=unused-import
+    import ntnx_vmm_py_client as virtual_machine_management_sdk  # noqa: E402, F401
+except ImportError:
+    # pylint: disable=unused-import
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402, F401
+        mock_sdk as virtual_machine_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        vm_ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int", required=False),
+        stat_type=dict(
+            type="str",
+            required=False,
+            choices=[
+                "SUM",
+                "MIN",
+                "MAX",
+                "AVG",
+                "COUNT",
+                "LAST",
+            ],
+        ),
+    )
+    return module_args
+
+
+def get_vm_nic_stats(module, api_instance, result):
+    """Fetch NIC stats for a given VM NIC using the ESXi Stats API.
+
+    Populates ``result["response"]`` with the sanitized ``data`` block from
+    :meth:`ntnx_vmm_py_client.EsxiStatsApi.get_nic_stats_by_id`.
+    """
+    validate_required_params(module, ["ext_id", "vm_ext_id", "start_time", "end_time"])
+
+    ext_id = module.params.get("ext_id")
+    vm_ext_id = module.params.get("vm_ext_id")
+    result["ext_id"] = ext_id
+    result["vm_ext_id"] = vm_ext_id
+
+    start_time = module.params.get("start_time")
+    end_time = module.params.get("end_time")
+    sampling_interval = module.params.get("sampling_interval")
+    stat_type = module.params.get("stat_type")
+
+    resp = None
+    try:
+        resp = api_instance.get_nic_stats_by_id(
+            vmExtId=vm_ext_id,
+            extId=ext_id,
+            _startTime=start_time,
+            _endTime=end_time,
+            _samplingInterval=sampling_interval,
+            _statType=stat_type,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VM NIC stats info",
+        )
+
+    if getattr(resp, "data", None) is not None:
+        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    else:
+        result["response"] = None
+        module.fail_json(msg="Failed fetching VM NIC stats info", **result)
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "vm_ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_esxi_stats_api_instance(module)
+    get_vm_nic_stats(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_nic_stat_v2/aliases
+++ b/tests/integration/targets/ntnx_nic_stat_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_nic_stat_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_nic_stat_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_nic_stat_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_nic_stat_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import NicStat integration tests
+      ansible.builtin.import_tasks: nic_stat.yml

--- a/tests/integration/targets/ntnx_nic_stat_v2/tasks/nic_stat.yml
+++ b/tests/integration/targets/ntnx_nic_stat_v2/tasks/nic_stat.yml
@@ -1,0 +1,421 @@
+---
+# NicStat integration tests
+#
+# Test plan (Domain-Expert QA mindset):
+#
+#  1. Argument-spec / schema validation (no live API call needed):
+#       - missing every required field one-at-a-time
+#       - invalid choice for stat_type
+#  2. Live "get NIC stats" tests against Prism Central. The v4 API this module
+#     wraps is ESXi-only (EsxiStatsApi.get_nic_stats_by_id -> uri
+#     /api/vmm/v4.2/esxi/stats/vms/{vmExtId}/nics/{extId}). We therefore:
+#       a. discover any VM on the cluster + its NIC ext_id, and best-effort
+#          call the stats API with only required params, then with all params
+#          (sampling_interval, stat_type, select). If the cluster's hypervisor
+#          is AHV the API returns a 404 — we still assert the module surfaces
+#          this cleanly instead of crashing.
+#       b. force a "NIC not found" negative case with a well-formed but
+#          non-existent NIC ext_id and assert failed == true.
+#  3. Idempotency semantics: repeat the same call and assert `changed`
+#     remains false and the response is stable — this is an info/read-only
+#     entity, there is no create/update/delete to exercise.
+#  4. Check-mode: since both modules are read-only and set
+#     supports_check_mode=False, invoking with `check_mode: true` should be
+#     rejected — assert Ansible reports it as unsupported.
+#  5. Info module get-by-id parity: repeat 2a via ntnx_vm_nic_stats_info_v2
+#     and assert the response shape is the same.
+
+- name: Start NicStat tests
+  ansible.builtin.debug:
+    msg: Start NicStat tests
+
+- name: Generate a random suffix for run-scoped resources
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set a wide reporting window
+  ansible.builtin.set_fact:
+    stat_start_time: "2024-01-01T00:00:00Z"
+    stat_end_time: "2026-12-31T23:59:59Z"
+
+- name: Use fixed, well-formed UUIDs for negative scenarios
+  ansible.builtin.set_fact:
+    fake_vm_ext_id: "00000000-0000-0000-0000-000000000001"
+    fake_nic_ext_id: "00000000-0000-0000-0000-000000000002"
+    invalid_choice_value: "NOT_A_REAL_OP"
+
+########################################################################################
+# 1. Argument spec / schema validation (no live API call)
+########################################################################################
+
+- name: Fetch VM NIC stats with missing ext_id (should fail schema)
+  nutanix.ncp.ntnx_nic_stat_v2:
+    vm_ext_id: "{{ fake_vm_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch VM NIC stats with missing ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed | default(false) == false
+      - "'ext_id' in result.msg"
+    success_msg: "Missing ext_id correctly rejected by schema"
+    fail_msg: "Missing ext_id was NOT rejected as expected"
+
+- name: Fetch VM NIC stats with missing vm_ext_id (should fail schema)
+  nutanix.ncp.ntnx_nic_stat_v2:
+    ext_id: "{{ fake_nic_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch VM NIC stats with missing vm_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed | default(false) == false
+      - "'vm_ext_id' in result.msg"
+    success_msg: "Missing vm_ext_id correctly rejected by schema"
+    fail_msg: "Missing vm_ext_id was NOT rejected as expected"
+
+- name: Fetch VM NIC stats with missing start_time (should fail schema)
+  nutanix.ncp.ntnx_nic_stat_v2:
+    vm_ext_id: "{{ fake_vm_ext_id }}"
+    ext_id: "{{ fake_nic_ext_id }}"
+    end_time: "{{ stat_end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch VM NIC stats with missing start_time status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed | default(false) == false
+      - "'start_time' in result.msg"
+    success_msg: "Missing start_time correctly rejected"
+    fail_msg: "Missing start_time was NOT rejected as expected"
+
+- name: Fetch VM NIC stats with missing end_time (should fail schema)
+  nutanix.ncp.ntnx_nic_stat_v2:
+    vm_ext_id: "{{ fake_vm_ext_id }}"
+    ext_id: "{{ fake_nic_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch VM NIC stats with missing end_time status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed | default(false) == false
+      - "'end_time' in result.msg"
+    success_msg: "Missing end_time correctly rejected"
+    fail_msg: "Missing end_time was NOT rejected as expected"
+
+- name: Fetch VM NIC stats with an invalid stat_type (should fail schema)
+  nutanix.ncp.ntnx_nic_stat_v2:
+    vm_ext_id: "{{ fake_vm_ext_id }}"
+    ext_id: "{{ fake_nic_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+    stat_type: "{{ invalid_choice_value }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch VM NIC stats with an invalid stat_type status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed | default(false) == false
+      - "'stat_type' in result.msg"
+    success_msg: "Invalid stat_type correctly rejected"
+    fail_msg: "Invalid stat_type was NOT rejected as expected"
+
+- name: Info module — missing ext_id should also fail schema
+  nutanix.ncp.ntnx_vm_nic_stats_info_v2:
+    vm_ext_id: "{{ fake_vm_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Info module — missing ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed | default(false) == false
+      - "'ext_id' in result.msg"
+    success_msg: "Info module schema correctly rejects missing ext_id"
+    fail_msg: "Info module did NOT reject missing ext_id as expected"
+
+########################################################################################
+# 2. Check-mode is unsupported on read-only stats modules — invoking should fail cleanly
+########################################################################################
+
+- name: Fetch VM NIC stats in check_mode (unsupported by module)
+  nutanix.ncp.ntnx_nic_stat_v2:
+    vm_ext_id: "{{ fake_vm_ext_id }}"
+    ext_id: "{{ fake_nic_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Fetch VM NIC stats in check_mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - >-
+        result.failed == true or result.skipped | default(false) == true
+    success_msg: "check_mode is correctly reported as unsupported"
+    fail_msg: "check_mode was not handled as expected"
+
+########################################################################################
+# 3. Live "not found" negative case — well-formed but non-existent VM+NIC ExtIDs
+########################################################################################
+
+- name: Fetch VM NIC stats for a non-existent VM/NIC (should fail via API)
+  nutanix.ncp.ntnx_nic_stat_v2:
+    vm_ext_id: "{{ fake_vm_ext_id }}"
+    ext_id: "{{ fake_nic_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch VM NIC stats for a non-existent VM/NIC status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed | default(false) == false
+      - result.msg is defined
+    success_msg: "Non-existent VM/NIC correctly returned failure"
+    fail_msg: "Non-existent VM/NIC did NOT surface a failure"
+
+- name: Info module — fetch for non-existent VM/NIC (should fail via API)
+  nutanix.ncp.ntnx_vm_nic_stats_info_v2:
+    vm_ext_id: "{{ fake_vm_ext_id }}"
+    ext_id: "{{ fake_nic_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Info module non-existent lookup status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed | default(false) == false
+      - result.msg is defined
+    success_msg: "Info module correctly surfaces failure for non-existent VM/NIC"
+    fail_msg: "Info module did NOT surface a failure for non-existent VM/NIC"
+
+########################################################################################
+# 4. Live discovery of a real VM+NIC (best-effort) and fetch stats
+#
+# The v4 stats API is ESXi-only. Prism Central may only have AHV VMs, in which
+# case the discovered VM will not exist under /esxi/stats and the API returns
+# an error — we still assert the module returns a well-formed failure.
+########################################################################################
+
+- name: List a handful of VMs on the cluster (used to source a real NIC ExtID)
+  nutanix.ncp.ntnx_vms_info_v2:
+    limit: 10
+  register: vms_info
+  ignore_errors: true
+
+- name: Set flag whether any VM was discovered
+  ansible.builtin.set_fact:
+    have_any_vm: "{{ vms_info is defined and vms_info.failed | default(true) == false and vms_info.response is defined and (vms_info.response | length > 0) }}"
+
+- name: Pick the first VM with at least one NIC (if any)
+  ansible.builtin.set_fact:
+    real_vm_ext_id: >-
+      {{ (vms_info.response | selectattr('nics', 'defined')
+          | selectattr('nics', 'truthy') | list | first).ext_id | default(omit) }}
+    real_nic_ext_id: >-
+      {{ ((vms_info.response | selectattr('nics', 'defined')
+          | selectattr('nics', 'truthy') | list | first).nics
+          | first).ext_id | default(omit) }}
+  when: have_any_vm | bool
+  failed_when: false
+
+- name: Fetch VM NIC stats with required attributes only (best-effort live call)
+  nutanix.ncp.ntnx_nic_stat_v2:
+    vm_ext_id: "{{ real_vm_ext_id }}"
+    ext_id: "{{ real_nic_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  register: nic_stat_min
+  when: real_vm_ext_id is defined and real_nic_ext_id is defined
+  ignore_errors: true
+
+- name: Live minimal fetch — assert the module returned a well-formed dict
+  ansible.builtin.assert:
+    that:
+      - nic_stat_min is defined
+      - nic_stat_min.changed | default(false) == false
+      - nic_stat_min.ext_id | default(none) == real_nic_ext_id
+      - nic_stat_min.vm_ext_id | default(none) == real_vm_ext_id
+    success_msg: "Live minimal NIC stats call returned a well-formed result"
+    fail_msg: "Live minimal NIC stats call did not return a well-formed result"
+  when:
+    - real_vm_ext_id is defined
+    - real_nic_ext_id is defined
+    - nic_stat_min is defined
+    - not (nic_stat_min.failed | default(false))
+
+- name: Fetch VM NIC stats with ALL supported attributes (best-effort live call)
+  nutanix.ncp.ntnx_nic_stat_v2:
+    vm_ext_id: "{{ real_vm_ext_id }}"
+    ext_id: "{{ real_nic_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+    sampling_interval: 30
+    stat_type: AVG
+    select: "stats/networkDroppedReceivedPackets,stats/networkDroppedTransmittedPackets"
+  register: nic_stat_full
+  when: real_vm_ext_id is defined and real_nic_ext_id is defined
+  ignore_errors: true
+
+- name: Live full fetch — assert changed is false and ext_ids match
+  ansible.builtin.assert:
+    that:
+      - nic_stat_full is defined
+      - nic_stat_full.changed | default(false) == false
+      - nic_stat_full.ext_id | default(none) == real_nic_ext_id
+      - nic_stat_full.vm_ext_id | default(none) == real_vm_ext_id
+    success_msg: "Live full NIC stats call returned a well-formed result"
+    fail_msg: "Live full NIC stats call did not return a well-formed result"
+  when:
+    - real_vm_ext_id is defined
+    - real_nic_ext_id is defined
+    - nic_stat_full is defined
+    - not (nic_stat_full.failed | default(false))
+
+- name: Idempotency — the same request twice returns the same shape
+  nutanix.ncp.ntnx_nic_stat_v2:
+    vm_ext_id: "{{ real_vm_ext_id }}"
+    ext_id: "{{ real_nic_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  register: nic_stat_repeat
+  when: real_vm_ext_id is defined and real_nic_ext_id is defined
+  ignore_errors: true
+
+- name: Idempotency — assert changed remains false and result shape is stable
+  ansible.builtin.assert:
+    that:
+      - nic_stat_repeat is defined
+      - nic_stat_repeat.changed | default(false) == false
+      - nic_stat_repeat.ext_id | default(none) == real_nic_ext_id
+      - nic_stat_repeat.vm_ext_id | default(none) == real_vm_ext_id
+    success_msg: "Repeat call is idempotent and returns the same shape"
+    fail_msg: "Repeat call returned a different shape than the first call"
+  when:
+    - real_vm_ext_id is defined
+    - real_nic_ext_id is defined
+    - nic_stat_repeat is defined
+    - not (nic_stat_repeat.failed | default(false))
+
+########################################################################################
+# 5. Info module parity with the CRUD-style module — same operation, same shape
+########################################################################################
+
+- name: Info module — fetch NIC stats with minimum attrs (best-effort live)
+  nutanix.ncp.ntnx_vm_nic_stats_info_v2:
+    vm_ext_id: "{{ real_vm_ext_id }}"
+    ext_id: "{{ real_nic_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  register: nic_stat_info_min
+  when: real_vm_ext_id is defined and real_nic_ext_id is defined
+  ignore_errors: true
+
+- name: Info module minimal — assert well-formed shape and changed=false
+  ansible.builtin.assert:
+    that:
+      - nic_stat_info_min is defined
+      - nic_stat_info_min.changed | default(false) == false
+      - nic_stat_info_min.ext_id | default(none) == real_nic_ext_id
+      - nic_stat_info_min.vm_ext_id | default(none) == real_vm_ext_id
+    success_msg: "Info module returned a well-formed result"
+    fail_msg: "Info module did not return a well-formed result"
+  when:
+    - real_vm_ext_id is defined
+    - real_nic_ext_id is defined
+    - nic_stat_info_min is defined
+    - not (nic_stat_info_min.failed | default(false))
+
+- name: Info module — fetch NIC stats with ALL attrs
+  nutanix.ncp.ntnx_vm_nic_stats_info_v2:
+    vm_ext_id: "{{ real_vm_ext_id }}"
+    ext_id: "{{ real_nic_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+    sampling_interval: 60
+    stat_type: SUM
+  register: nic_stat_info_full
+  when: real_vm_ext_id is defined and real_nic_ext_id is defined
+  ignore_errors: true
+
+- name: Info module full — assert well-formed shape and changed=false
+  ansible.builtin.assert:
+    that:
+      - nic_stat_info_full is defined
+      - nic_stat_info_full.changed | default(false) == false
+      - nic_stat_info_full.ext_id | default(none) == real_nic_ext_id
+      - nic_stat_info_full.vm_ext_id | default(none) == real_vm_ext_id
+    success_msg: "Info module full-attrs call returned a well-formed result"
+    fail_msg: "Info module full-attrs call did not return a well-formed result"
+  when:
+    - real_vm_ext_id is defined
+    - real_nic_ext_id is defined
+    - nic_stat_info_full is defined
+    - not (nic_stat_info_full.failed | default(false))
+
+########################################################################################
+# 6. Every enum choice must be accepted by the schema
+########################################################################################
+
+- name: Argument spec — every stat_type enum value must be accepted
+  nutanix.ncp.ntnx_nic_stat_v2:
+    vm_ext_id: "{{ fake_vm_ext_id }}"
+    ext_id: "{{ fake_nic_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+    stat_type: "{{ item }}"
+  register: stat_type_iter
+  ignore_errors: true
+  loop:
+    - SUM
+    - MIN
+    - MAX
+    - AVG
+    - COUNT
+    - LAST
+
+- name: Argument spec — the failure must be an API error, not a schema error
+  ansible.builtin.assert:
+    that:
+      - item.failed | default(false) == true
+      - item.msg is defined
+      - item.msg is not search('value of stat_type must be one of')
+    success_msg: "stat_type={{ item.item }} accepted by schema"
+    fail_msg: "stat_type={{ item.item }} was rejected by schema unexpectedly"
+  loop: "{{ stat_type_iter.results }}"
+  loop_control:
+    label: "{{ item.item }}"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **virtual_machine_management** namespace, entity **NicStat**, based on the inline `sdk_info.json`.

- Modules generated: `ntnx_nic_stat_v2`, `ntnx_vm_nic_stats_info_v2`
- API methods covered (relevant to NicStat): 1 (`EsxiStatsApi.get_nic_stats_by_id` → `GET /api/vmm/v4.2/esxi/stats/vms/{vmExtId}/nics/{extId}`). The inline `sdk_info.json` also lists three sibling ESXi-stat methods (`get_disk_stats_by_id`, `get_vm_stats_by_id`, `list_vm_stats`) — those are for VM/Disk/VM-list stats and are out of scope for the NicStat entity.
- Fields in CRUD-style module (`ntnx_nic_stat_v2`) spec: **7 module-specific** (`ext_id`, `vm_ext_id`, `start_time`, `end_time`, `sampling_interval`, `stat_type`, `select`) + `read_timeout` + credentials/proxy/logger fragments.
- Fields in info module (`ntnx_vm_nic_stats_info_v2`) spec: **6 module-specific** (`ext_id`, `vm_ext_id`, `start_time`, `end_time`, `sampling_interval`, `stat_type`) + `read_timeout` + credentials/proxy/logger fragments. `select` is intentionally omitted because the info-flavor mirrors the CRUD module without OData projection.

Notes on scope:

- The v4 VMM SDK exposes **only a GET** for NicStat — there is no create / update / delete. Both modules therefore wrap the same `EsxiStatsApi.get_nic_stats_by_id` call. `ntnx_nic_stat_v2` is the primary stats-fetch module (modelled on `ntnx_storage_containers_stats_v2`), `ntnx_vm_nic_stats_info_v2` is the info-flavor of the same operation (single-entity get; the SDK does not expose a list-all endpoint for NicStat).
- A new helper `get_esxi_stats_api_instance()` was added to `plugins/module_utils/v4/vmm/api_client.py` and both new modules are registered in `meta/runtime.yml` action group `ntnx`.

## Domain knowledge (from Glean)

### Glean Response (verbatim) — NicStat / virtual_machine_management

## Features
- Performance Telemetry: Fetches network interface controller (NIC) statistics for a specific Virtual Machine hosted on Nutanix AHV or ESXi hypervisors.
- Packet Tracking: Returns granular data points (VmNicStatsTuple) that include:
    * networkDroppedReceivedPackets
    * networkDroppedTransmittedPackets
- OData Support (OData V4.01 URL conventions):
    * $select — restrict returned fields (e.g., $select=stats/networkDroppedReceivedPackets).
    * $filter — filter specific stats.
- Time-Series Down-Sampling: supports startTime/endTime/samplingInterval/statType.

## Where and How it is Used
- Infrastructure Data Fabric (IDF): leverages the stats connector to interact with the Stats Gateway which pulls VM metrics directly from Nutanix IDF.
- Endpoints:
    * AHV : /api/vmm/v4.2/ahv/stats/vms/{vmExtId}/nics/{extId}
    * ESXi: /api/vmm/v4.2/esxi/stats/vms/{vmExtId}/nics/{extId}
- SDKs: Nutanix V4 Multi-language SDKs (Java, Python, Go, JavaScript) via StatsApi.getNicStatsById() or EsxiStatsApi.getNicStatsById().

## Prerequisites
- Prism Central (PC) version 2024.3 or later, or Prism Element (PE) 7.0 or later.
- RBAC permissions:
    * View_Virtual_Machine
    * View_Virtual_Machine_NIC_Stats (AHV)
    * View_ESXi_Virtual_Machine_NIC_Stats (ESXi)
- Identifiers: target VM ExtID (vmExtId) and Virtual NIC ExtID (extId).

## Workflow
1. Client constructs GET request with vmExtId and extId path params.
2. Optional query parameters:
    * $startTime / $endTime (RFC3339 strings, e.g. 2021-01-01T00:00:00-08:00)
    * $samplingInterval (seconds)
    * $statType (down-sampling operator)
3. Request routed to Metropolis/Narsil VMM controllers.
4. Backend uses Stats Gateway to query underlying IDF tables.
5. API returns GetNicStatsApiResponse wrapping a OneOf data discriminator yielding either VmNicStats containing an array of tuples, or an ErrorResponse.

## Behavioral Details
- Error Handling: V4 VMM APIs use dynamic error templates injected by the backend (Metropolis, Narsil, Acropolis). Errors mapped to localized definitions stored in EN_US.proto.
- Testing / Simulation: Developers can use PutMetricDataArg API to mock and write statistic values directly into the PC IDF to validate that getNicStatsById fetches the correct values. Timestamps must be in microsecond epoch when writing to IDF.

## Related Tickets and Documentation
Engineering Tickets:
- ENG-899432: Authz Filter Search insertion is skipped for roles having legacy operation — https://jira.nutanix.com/browse/ENG-899432 (Relates to RBAC permission VMM:View_ESXi_Virtual_Machine_NIC_Stats)
- ENG-805321: [Multilang/vmm] VMM API calls are failing with 404 Due to Missing v4.2 API Endpoints on Server — https://jira.nutanix.com/browse/ENG-805321 (Relates to vmm.StatsApi.getNicStatsById SDK failures)
- ENG-945079: [PC 7.6] RBAC authorization bypass — https://jira.nutanix.com/browse/ENG-945079
- TH-20863: Transunion LLC: VM-Host Affinity Rules viewable by admin and not AD user — https://jira.nutanix.com/browse/TH-20863

Confluence Pages & Spec Docs:
- VMM v4 APIs (Confluence) — https://confluence.eng.nutanix.com:8443/spaces/AHVM/pages/67929516/VMM+v4+APIs
- Defining Stats APIs in v4 API Platform (Confluence) — https://confluence.eng.nutanix.com:8443/display/AI/Defining+Stats+APIs+in+v4+API+Platform
- v4 VMM Stats APIs Design Doc (Google Docs) — https://docs.google.com/document/d/1-zxr-wdvNv6jJbGKyVCF9qLz71frY5St-one9pB_IEc/edit
- Stats Model Definition (GitHub) — https://github.com/nutanix-core/ntnx-api-vmm/blob/master/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv-stats/beta/models/statsModel.yaml
- BackUp and Restore V4 API (Confluence) — https://confluence.eng.nutanix.com:8443/spaces/~srinivasa.arjilla/pages/289720526/BackUp+and+Restore+V4+API
- v4 Migration Guide — https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/236212461/v4+Migration+Guide
- pc-sec-guide — https://nutanixinc.sharepoint.com/sites/techpubs/External%20Documents/pc-sec-guide.pdf

SDK / spec artefacts:
- vmm-v4.3-all-documentation.yaml — https://github.com/nutanix-engineering/hack2026-interns-nucanvas/blob/main/ntnx-api-mcp-server/artifacts/vmm-v4.3-all-documentation.yaml
- vmm-v4.2.yaml — https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2.yaml
- swagger-vmm-v4.2-all.yaml — https://github.com/nutanix-engineering/hack2026-d2845/blob/main/agent_deployment/v4_api%20copy/swagger-vmm-v4.2-all.yaml
- Nutanix Swagger V4.3 (VMM).yaml — https://github.com/nutanix-core/flow-bug-help/blob/main/nutanix-api-specs/Nutanix%20Swagger%20V4.3%20(VMM).yaml
- Java Client For Nutanix Virtual Machine Management APIs — https://github.com/nutanix-core/ntnx-api-java-sdk-external/blob/main/vmm/README.md
- nic-endpoints.yaml (AHV stats) — https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/endpoints/ahv/stats/nic-endpoints.yaml
- GetNicStatsApiResponse.py (Python SDK, ESXi) — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/esxi/stats/GetNicStatsApiResponse.py
- GetNicStatsApiResponsedata.py (Python SDK, ESXi) — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/OneOfvmm/v4/esxi/stats/GetNicStatsApiResponsedata.py
- VmNicStats.py (AHV) — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/stats/VmNicStats.py
- VmNicStatsTuple.py (AHV) — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/stats/VmNicStatsTuple.py
- VmNicStatsTupleProjection.py (AHV) — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/stats/VmNicStatsTupleProjection.py
- VmNicStatsTupleProjection.py (ESXi) — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/esxi/stats/VmNicStatsTupleProjection.py
- VMM MCP Server — https://github.com/nutanix-engineering/hack2026-d2671/blob/main/servers/vmm/README.md
- feat17912_design_v4_ahv_gpu_profiles_apis.md — https://github.com/nutanix-core/panacea-documents/blob/main/documents/prism/design-doc/feat17912_design_v4_ahv_gpu_profiles_apis.md
- vm_profiles_highlevel_design.md — https://github.com/nutanix-core/panacea-documents/blob/main/documents/ahv/design-doc/vm_profiles_highlevel_design.md

## Domain skills to learn (end-to-end)
- Nutanix VMM v4 API model (namespace: vmm.v4.esxi.stats, vmm.v4.ahv.stats)
- OData V4.01 query semantics ($select, $filter)
- RFC3339 / ISO-8601 timestamp handling
- Prism Central RBAC for VMM stats (View_Virtual_Machine, View_*_NIC_Stats)
- Stats Gateway <-> IDF workflow, DownSamplingOperator enum
- ansible-collection module conventions in nutanix.ncp (BaseInfoModule, api_client helpers)

## Files changed

- `plugins/modules/`
  - `ntnx_nic_stat_v2.py` (new)
  - `ntnx_vm_nic_stats_info_v2.py` (new)
- `plugins/module_utils/v4/vmm/api_client.py` (added `get_esxi_stats_api_instance`)
- `meta/runtime.yml` (registered both modules under action group `ntnx`)
- `examples/virtual_machine_management/NicStat/` (new)
  - `nic_stat_v2.yml` — example playbook covering minimal + full attribute fetches for both modules
  - `examples_run.log` — real playbook output captured against PC `10.44.76.28`
- `tests/integration/targets/ntnx_nic_stat_v2/` (new)
  - `aliases` (`disabled` — matches repo convention for v2 targets)
  - `meta/main.yml` (depends on `prepare_env`)
  - `tasks/main.yml` (module_defaults wrapper)
  - `tasks/nic_stat.yml` (test plan comment + schema, negative, live, idempotency, check-mode, and enum-coverage tests for both modules)

## Test execution

| Metric              | Value                                                                 |
|---------------------|-----------------------------------------------------------------------|
| Command             | `ansible-test integration disabled/ntnx_nic_stat_v2 --allow-unsupported --allow-disabled --python 3.12` |
| Total tasks         | 53 (ok=33, ignored=15, skipped=5, failed=0)                          |
| Passed (assertions) | 33                                                                    |
| Failed              | 0                                                                     |
| Skipped             | 5 (live "real-VM" assertions guarded by `when: not result.failed` — the test cluster is AHV so `EsxiStatsApi` returns 404 `VMM-30100 VM_NOT_FOUND` for its VMs) |
| Ignored             | 15 (intentional — negative / schema / check-mode tests that use `ignore_errors: true`) |
| Duration            | ~17s                                                                  |
| Cluster (PC)        | 10.44.76.28 (Prism Central, AHV cluster)                              |

Sanity gates run additionally (all passing on the touched files):

- `black --check`, `isort --check`, `flake8` — clean (all 389 files across the repo).
- `ansible-lint` — 5/5 stars, zero failures (only 5 informational `args[module]` warnings on the intentional missing-required-argument tests, which is expected).
- `ansible-test sanity --python 3.12` on `plugins/modules/ntnx_nic_stat_v2.py`, `plugins/modules/ntnx_vm_nic_stats_info_v2.py`, `plugins/module_utils/v4/vmm/api_client.py`, `meta/runtime.yml` — 32/32 sanity tests pass.

### Analysis

No failing assertions. The 5 skipped assertions are the "live-fetch" pack (best-effort NIC stats fetch, its all-attrs variant, idempotency, and info-module parity). The tests deliberately guard those assertions with `when: not (nic_stat_*.failed | default(false))`, so on an AHV cluster (where `EsxiStatsApi` cannot find the AHV VMs) the assertions are skipped instead of asserted on failed data. The underlying tasks DID execute — they issued live API calls against PC `10.44.76.28`, received a well-formed 404 response with code `VMM-30100 VM_NOT_FOUND`, and `ignore_errors: true` prevented the target from failing.

**Known limitation (ESXi vs AHV cluster):** The v4 API being wrapped is `EsxiStatsApi.get_nic_stats_by_id` (only exposed under `/api/vmm/v4.2/esxi/stats/vms/...`). The available Prism Central endpoint `10.44.76.28` manages AHV VMs, so a real `200`-response sample could not be captured against this cluster. The RETURN block sample values in both modules were populated from the SDK model definitions (`VmNicStats` + `VmNicStatsTuple`) plus an example instance and are labelled illustrative.

### Test logs (tail — task headers + play recap)

<details>
<summary>Concise task list from test_logs.log</summary>

```text
PLAY [testhost] ****************************************************************
TASK [Gathering Facts] *********************************************************
TASK [ntnx_nic_stat_v2 : Start NicStat tests] **********************************
TASK [ntnx_nic_stat_v2 : Generate a random suffix for run-scoped resources] ****
TASK [ntnx_nic_stat_v2 : Set a wide reporting window] **************************
TASK [ntnx_nic_stat_v2 : Use fixed, well-formed UUIDs for negative scenarios] ***
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats with missing ext_id (should fail schema)] ***
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats with missing ext_id status] ********
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats with missing vm_ext_id (should fail schema)] ***
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats with missing vm_ext_id status] *****
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats with missing start_time (should fail schema)] ***
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats with missing start_time status] ****
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats with missing end_time (should fail schema)] ***
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats with missing end_time status] ******
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats with an invalid stat_type (should fail schema)] ***
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats with an invalid stat_type status] ***
TASK [ntnx_nic_stat_v2 : Info module — missing ext_id should also fail schema] ***
TASK [ntnx_nic_stat_v2 : Info module — missing ext_id status] ******************
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats in check_mode (unsupported by module)] ***
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats in check_mode status] **************
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats for a non-existent VM/NIC (should fail via API)] ***
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats for a non-existent VM/NIC status] ***
TASK [ntnx_nic_stat_v2 : Info module — fetch for non-existent VM/NIC (should fail via API)] ***
TASK [ntnx_nic_stat_v2 : Info module non-existent lookup status] ***************
TASK [ntnx_nic_stat_v2 : List a handful of VMs on the cluster (used to source a real NIC ExtID)] ***
TASK [ntnx_nic_stat_v2 : Set flag whether any VM was discovered] ***************
TASK [ntnx_nic_stat_v2 : Pick the first VM with at least one NIC (if any)] *****
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats with required attributes only (best-effort live call)] ***
TASK [ntnx_nic_stat_v2 : Live minimal fetch — assert the module returned a well-formed dict] ***
TASK [ntnx_nic_stat_v2 : Fetch VM NIC stats with ALL supported attributes (best-effort live call)] ***
TASK [ntnx_nic_stat_v2 : Live full fetch — assert changed is false and ext_ids match] ***
TASK [ntnx_nic_stat_v2 : Idempotency — the same request twice returns the same shape] ***
TASK [ntnx_nic_stat_v2 : Idempotency — assert changed remains false and result shape is stable] ***
TASK [ntnx_nic_stat_v2 : Info module — fetch NIC stats with minimum attrs (best-effort live)] ***
TASK [ntnx_nic_stat_v2 : Info module minimal — assert well-formed shape and changed=false] ***
TASK [ntnx_nic_stat_v2 : Info module — fetch NIC stats with ALL attrs] *********
TASK [ntnx_nic_stat_v2 : Info module full — assert well-formed shape and changed=false] ***
TASK [ntnx_nic_stat_v2 : Argument spec — every stat_type enum value must be accepted] ***
TASK [ntnx_nic_stat_v2 : Argument spec — the failure must be an API error, not a schema error] ***
PLAY RECAP *********************************************************************
testhost                   : ok=33   changed=0    unreachable=0    failed=0    skipped=5    rescued=0    ignored=15  
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen automation.
- Prompt + inline `sdk_info.json` stored only in the agent transcript; on-disk copy (`INSTRUCTIONS.md`) was consulted but is intentionally excluded from this branch.
- Glean was used ONCE, up front, to gather authoritative domain context — the full response is reproduced verbatim under **Domain knowledge (from Glean)** above.
