### PR TITLE
code-gen(networking/NodeSchedulableStatus): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/networking/NodeSchedulableStatus/examples_run.log
+++ b/examples/networking/NodeSchedulableStatus/examples_run.log
@@ -1,0 +1,45 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+running playbook inside collection nutanix.ncp
+
+PLAY [Node Schedulable Status playbook] ****************************************
+
+TASK [Discover a PE cluster (needed for the X-Cluster-Id header)] **************
+ok: [localhost] => {"changed": false, "error": null, "response": [{"backup_eligibility_score": 1, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDds8wxvJkt0Z/gXOLu8/q0ur7n71FNhVC6FUkhwpmu4gs+WVUi0BeyfJb7jJFFNLzbgmPCxEiAXwURw++74HWMiOpLg9vCKZiftaZxP84Fw8q8c1sgYKCoDsxlwYSIkAgwnfCnQOKlhEO+IHPhEYkoRNm+yu6o3iat0miyLyMZ8NvfLLFaUSPEQvWLVu4DStRd/w4kP5ik16oSe+uHH/jXoVmNaBigp1b9IOMLmG4QcXhuNOoTdP7Wk56JDmmtLCicAm820FHh+8cgiwqzfnXumQoVBDeAj0TaOxvFqIbuYAI3T80wCOXZgDzQa+0nyVWzyQLU3us33SUjoMiJygO90wg80qzriVxvTlGJ0AcDvNrDF1P190MisWDRXa6cP1LhMzBoU8NlSDAofd1Ey/Gj36TPWoJI0vB4hlu0gZmRUiL2b6FeW12P38BLewbYL+GO/VnUPTke9fe4VtmBuQiZO5SYaa6ccabMdkkEr9jnn1t+v6y9tGVqsFXu3RPo2JM= nutanix@ntnx-18fm6g460083-d-cvm", "name": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDIcx1XJP0fYzdetHAnyNijUyFOJCli8OITqix1mpuqfPUg2mEhQnbkxmdT4K9e+I6NadcDKxADsBWWcEwQXGuowgVzPByJmMXrmCfE36Bsit2iVRuFxxnImyiXcTPXcz1IQWvaszUs9vFHtjYdFcRhTnVhLCCKRr8XkR3OgWiuXzUmrOZZPfY06WWhhCXhuVo2WfgYA0nSFXQpLyQvCfQvo+ukM8XPZN/crFtD7xqhL2h0GWYR9HMJJ1TufWUjt0fRVDk/Ja1Pur3bPJAxruGZ1cUfmpKn5f2bJVBXQ2g36Fkxo6qXAzgIVbW3jy0+nZicZMf0vW49YkFPP6P++7F9KwQXwDQg7qiFZngjqwj1EfzPUtdtrafmrbkTUgD2k6FQEiKfq1Z4Jhp5MYZKH1MH4cUVLQUe16Qopyix7tQ9Hcf58g1kaXRKE/HtHXMdANfvZ8nYFRVXmezcE7EwuctW61HwJgP5qdOh8uQm7dd4HIdPkBoyyZhTxtAEq9L2jXc= root@phoenix", "name": "10.46.136.28"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAw8NhpiLG/6c8c0LocaQVM6+x8yBvLS+z13nYlqzSKr64HQSH+IIx14bS+uh0xf8ou5ROnbUa44YM9qG2RBK1hBVrwTIKZBwFwOTxDuXH9YoswqflnOeyTGUFerrMxlg5iYvKE01QIErKWt/BJ+hK/qVQi6SHh/WhyjAGNQPxjPBG3oEUFoLV9uDLX9RT/sLIQpBf91DCbF9+2rSToqjydj36d38JbmuGJGqr+DrEd0lKzfiJiQ39t3AXBE1bY2ISX+uwq07XkYZbrHaijrxnOBFZE7ETQmyxdcOvgDxvhnhZpFsUqbPqIqa45CwFWV+btzITvpJkveYjGSGR7ZJNHQ== nutanix@titan", "name": "agave"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6oDEABPvDtwtOFEJhu7sx9oUZskh0R4CWW6IM9uIxVtjYR/XXu587rXKac34InclJ3U3+PFQcAgEvdw2qiCEWWWMFMiALMneDELPd5qepKRrFJxc3hkyfagot3n7i6r7Y83ceIII4qM1mGLdUA3XdSWlttbgugnBrfB9yLq/BgtVqBvBVFayTGb6IsoMUSbODX6zZEt9Uzh/Yr49DV40ULpGhSYS9vWFB3GrajrliQ9Ea8oOB+8vK9Cavf7IOsaIaPsGI20mypeKFn4qcinBKc6O3PqU3YyYv7pLJWAvwXr9D9+rukgNAhKnd1fFQVLj4sAHA4ixfQk9+0kgAJM4P", "name": "nutest"}], "build_info": {"build_type": "release", "commit_id": "c62bea5d0b6c0010e794199221573a6062a01d14", "full_version": "el9-release-ganges-7.6-stable-c62bea5d0b6c0010e794199221573a6062a01d14", "short_commit_id": "c62bea", "version": "7.6"}, "cluster_arch": "X86_64", "cluster_function": ["AOS"], "cluster_software_map": [{"software_type": "NCC", "version": "ncc-6.0.0"}, {"software_type": "NOS", "version": "el9-release-ganges-7.6-stable-c62bea5d0b6c0010e794199221573a6062a01d14"}], "cluster_type": "HYPER_CONVERGED", "encryption_in_transit_status": null, "encryption_option": null, "encryption_scope": null, "fault_tolerance_state": {"current_cluster_fault_tolerance": "CFT_0N_AND_0D", "current_max_fault_tolerance": 0, "desired_cluster_fault_tolerance": "CFT_0N_AND_0D", "desired_max_fault_tolerance": 0, "domain_awareness_level": "DISK", "isStrictRackAwarenessEnabled": false, "redundancy_status": null}, "hypervisor_types": ["AHV"], "incarnation_id": 1782713390680670, "isDegradedNodeMonitoringDisabled": false, "is_available": true, "is_lts": false, "is_password_remote_login_enabled": true, "is_remote_support_enabled": false, "operation_mode": "NORMAL", "pulse_status": {"is_enabled": true, "pii_scrubbing_level": "DEFAULT"}, "redundancy_factor": 1, "timezone": "UTC"}, "container_name": null, "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "externalStorageProviderInfo": [{"$objectType": "clustermgmt.v4.config.ExternalStorageProviderInfo", "$reserved": {"$fv": "v4.r3"}, "compatibleVersion": "5.1.100.104_5594", "isInstalled": false, "providerType": "DELL_POWERFLEX"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "EVERPURE_FLASHARRAY"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "DELL_POWERSTORE"}], "inefficient_vm_count": null, "links": null, "name": "auto_cluster_prod_36acf9b012ca", "network": {"backplane": {"is_segmentation_enabled": false, "netmask": null, "subnet": null, "vlan_tag": null}, "external_address": {"ipv4": {"prefix_length": 32, "value": "10.46.136.38"}, "ipv6": null}, "external_data_service_ip": {"ipv4": {"prefix_length": 32, "value": "10.46.136.42"}, "ipv6": null}, "external_subnet": "10.46.136.0/255.255.248.0", "fqdn": null, "http_proxy_list": null, "http_proxy_white_list": null, "internal_subnet": "192.168.5.0/255.255.255.128", "key_management_server_type": null, "management_server": null, "masquerading_ip": null, "masquerading_port": null, "name_server_ip_list": [{"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.15"}, "ipv6": null}, {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.16"}, "ipv6": null}], "nfs_subnet_whitelist": null, "ntp_server_config_list": null, "ntp_server_ip_list": [{"fqdn": {"value": "0.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "1.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "2.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "3.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}], "smtp_server": null}, "nodes": {"node_list": [{"controller_vm_ip": {"ipv4": {"prefix_length": 32, "value": "10.46.136.32"}, "ipv6": null}, "host_ip": {"ipv4": {"prefix_length": 32, "value": "10.46.136.28"}, "ipv6": null}, "node_uuid": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b"}], "number_of_nodes": 1}, "tenant_id": null, "upgrade_status": "SUCCEEDED", "vm_count": 14}], "total_available_results": 1}
+
+TASK [Set PE cluster ext_id] ***************************************************
+ok: [localhost] => {"ansible_facts": {"pe_cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}, "changed": false}
+
+TASK [List all node schedulable statuses for the PE cluster] *******************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "is_never_schedulable": false, "links": null, "tenant_id": null}], "total_available_results": 1}
+
+TASK [Show total nodes reported] ***********************************************
+ok: [localhost] => {
+    "msg": "Total available results: 1; entries returned: 1"
+}
+
+TASK [List only never-schedulable (storage-only) nodes] ************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List only regular (schedulable) nodes] ***********************************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "is_never_schedulable": false, "links": null, "tenant_id": null}], "total_available_results": 1}
+
+TASK [List node schedulable statuses with a limit] *****************************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "is_never_schedulable": false, "links": null, "tenant_id": null}], "total_available_results": 1}
+
+TASK [Sort node schedulable statuses in ascending order of isNeverSchedulable] ***
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "is_never_schedulable": false, "links": null, "tenant_id": null}], "total_available_results": 1}
+
+TASK [Sort node schedulable statuses in descending order of isNeverSchedulable] ***
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "is_never_schedulable": false, "links": null, "tenant_id": null}], "total_available_results": 1}
+
+TASK [Set a node ext_id to fetch (from the earlier full listing)] **************
+ok: [localhost] => {"ansible_facts": {"first_node_ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b"}, "changed": false}
+
+TASK [Fetch a specific node's schedulable status by node ext_id] ***************
+ok: [localhost] => {"changed": false, "ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "response": {"ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "is_never_schedulable": false, "links": null, "tenant_id": null}}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=11   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/networking/NodeSchedulableStatus/node_schedulable_status_v2.yml
+++ b/examples/networking/NodeSchedulableStatus/node_schedulable_status_v2.yml
@@ -1,0 +1,97 @@
+---
+# Summary:
+# This playbook demonstrates the read-only Node Schedulable Status API.
+#
+# The underlying SDK exposes ONLY a list API
+# (GET /networking/v4/config/node-schedulable-statuses). There is no
+# Create/Update/Delete/Get-by-id for NodeSchedulableStatus, so a CRUD
+# (ntnx_node_schedulable_status_v2) companion module is intentionally NOT
+# provided.
+#
+# On a PC that manages a single PE cluster the API requires the X-Cluster-Id
+# header (SDK X_Cluster_Id / module param `cluster_ext_id`), so this playbook
+# discovers a PE cluster first and always scopes the calls with `cluster_ext_id`.
+#
+# Steps:
+# 1. Discover a PE cluster (needed for X-Cluster-Id).
+# 2. List all node schedulable statuses (cluster-scoped).
+# 3. Filter storage-only (never-schedulable) nodes only.
+# 4. Filter regular (schedulable) nodes only.
+# 5. List with a page size limit.
+# 6. Sort by isNeverSchedulable ascending.
+# 7. Sort by isNeverSchedulable descending.
+# 8. Fetch a single node's schedulable status by node ext_id.
+
+- name: Node Schedulable Status playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Discover a PE cluster (needed for the X-Cluster-Id header)
+      nutanix.ncp.ntnx_clusters_info_v2:
+        filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+      register: clusters_info
+
+    - name: Set PE cluster ext_id
+      ansible.builtin.set_fact:
+        pe_cluster_ext_id: "{{ clusters_info.response[0].ext_id }}"
+
+    - name: List all node schedulable statuses for the PE cluster
+      nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+        cluster_ext_id: "{{ pe_cluster_ext_id }}"
+      register: all_statuses
+
+    - name: Show total nodes reported
+      ansible.builtin.debug:
+        msg: >-
+          Total available results: {{ all_statuses.total_available_results | default('n/a') }};
+          entries returned: {{ all_statuses.response | length }}
+
+    - name: List only never-schedulable (storage-only) nodes
+      nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+        cluster_ext_id: "{{ pe_cluster_ext_id }}"
+        filter: "isNeverSchedulable eq true"
+      register: never_schedulable
+
+    - name: List only regular (schedulable) nodes
+      nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+        cluster_ext_id: "{{ pe_cluster_ext_id }}"
+        filter: "isNeverSchedulable eq false"
+      register: schedulable
+
+    - name: List node schedulable statuses with a limit
+      nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+        cluster_ext_id: "{{ pe_cluster_ext_id }}"
+        limit: 1
+      register: limited
+
+    - name: Sort node schedulable statuses in ascending order of isNeverSchedulable
+      nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+        cluster_ext_id: "{{ pe_cluster_ext_id }}"
+        orderby: "isNeverSchedulable asc"
+      register: sorted_asc
+
+    - name: Sort node schedulable statuses in descending order of isNeverSchedulable
+      nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+        cluster_ext_id: "{{ pe_cluster_ext_id }}"
+        orderby: "isNeverSchedulable desc"
+      register: sorted_desc
+
+    - name: Set a node ext_id to fetch (from the earlier full listing)
+      ansible.builtin.set_fact:
+        first_node_ext_id: "{{ all_statuses.response[0].ext_id }}"
+      when:
+        - all_statuses.response is defined
+        - (all_statuses.response | length) > 0
+
+    - name: Fetch a specific node's schedulable status by node ext_id
+      nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+        cluster_ext_id: "{{ pe_cluster_ext_id }}"
+        ext_id: "{{ first_node_ext_id }}"
+      register: by_ext_id
+      when: first_node_ext_id is defined

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -246,5 +246,6 @@ action_groups:
     - ntnx_iam_entities_info_v2
     - ntnx_virtual_switch_v2
     - ntnx_virtual_switches_info_v2
+    - ntnx_node_schedulable_status_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,20 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_virtual_switch_nodes_info_api_instance(module):
+    """
+    This method will return VirtualSwitchNodesInfoApi instance.
+
+    The VirtualSwitchNodesInfoApi exposes the node-schedulable-status listing
+    endpoint (GET /networking/v4/config/node-schedulable-statuses), which is
+    used to determine whether each AHV node in a cluster is a storage-only
+    ("never schedulable") node or a regular schedulable node.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Virtual Switch Nodes Info Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.VirtualSwitchNodesInfoApi(api_client=api_client)

--- a/plugins/modules/ntnx_node_schedulable_status_info_v2.py
+++ b/plugins/modules/ntnx_node_schedulable_status_info_v2.py
@@ -1,0 +1,281 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_node_schedulable_status_info_v2
+short_description: Fetch Node Schedulable Status info in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about NodeSchedulableStatus in Nutanix Prism Central.
+  - Each entry indicates whether an AHV node in the cluster is a storage-only
+    ("never schedulable") node or a regular schedulable node.
+  - If C(ext_id) is not provided, list multiple NodeSchedulableStatus entries
+    optionally filtered / paginated / sorted.
+  - The underlying SDK endpoint C(/networking/v4/config/node-schedulable-statuses)
+    is a list-only API — there is no get-by-id endpoint, so C(ext_id) is used to
+    client-side filter the listed results.
+  - This module uses PC v4 APIs based SDKs
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get list of Node Schedulable Statuses) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer,
+      Project Admin, Super Admin, Virtual Machine Admin, Virtual Machine Operator,
+      Virtual Machine Viewer, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID (UUID) of a specific node.
+      - When provided, the list is fetched from the API and the entry with a matching
+        C(ext_id) is returned (the underlying SDK does not expose a get-by-id endpoint).
+    type: str
+    required: false
+  cluster_ext_id:
+    description:
+      - Prism Element cluster UUID (maps to the C(X-Cluster-Id) header).
+      - Optional. When supplied, the API scopes the listing to the given PE cluster.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all node schedulable statuses
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List node schedulable statuses for a specific PE cluster
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+  register: result
+  ignore_errors: true
+
+- name: List only never-schedulable (storage-only) nodes
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    filter: "isNeverSchedulable eq true"
+  register: result
+  ignore_errors: true
+
+- name: List only regular (schedulable) nodes
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    filter: "isNeverSchedulable eq false"
+  register: result
+  ignore_errors: true
+
+- name: List node schedulable statuses with a limit
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: Sort node schedulable statuses in ascending order of isNeverSchedulable
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    orderby: "isNeverSchedulable asc"
+  register: result
+  ignore_errors: true
+
+- name: Fetch a specific node's schedulable status by node ext_id
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    ext_id: "f28e7475-f835-42ef-ac35-ecbc48d5421e"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC NodeSchedulableStatus info v4 API.
+    - It is a single NodeSchedulableStatus entry (as a dict) when C(ext_id) is
+      provided and a match is found in the listed results.
+    - It is a list of multiple NodeSchedulableStatus entries when C(ext_id) is
+      not provided, optionally narrowed by filter, limit, page, orderby, or
+      cluster_ext_id.
+    - Each entry contains C(ext_id) (the node UUID) and C(is_never_schedulable)
+      (True for storage-only nodes, False for regular schedulable nodes).
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "ext_id": "f28e7475-f835-42ef-ac35-ecbc48d5421e",
+        "is_never_schedulable": false,
+        "links": null,
+        "tenant_id": null
+      }
+    ]
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error or a specific ext_id is not found.
+  type: str
+  sample: "Api Exception raised while fetching node schedulable statuses info"
+
+error:
+  description: This field typically holds information about the error that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: Whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the node whose schedulable status was fetched.
+  type: str
+  returned: when external ID is provided
+  sample: "f28e7475-f835-42ef-ac35-ecbc48d5421e"
+
+total_available_results:
+  description: The total number of available NodeSchedulableStatus entries in PC.
+  type: int
+  returned: when all node schedulable statuses are fetched (no ext_id supplied)
+  sample: 4
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_virtual_switch_nodes_info_api_instance,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        cluster_ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def _fetch_node_schedulable_statuses(module, api_instance, kwargs):
+    try:
+        return api_instance.list_node_schedulable_status(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching node schedulable statuses info",
+        )
+
+
+def get_node_schedulable_status_by_ext_id(module, api_instance, result):
+    """List and locally filter by ext_id.
+
+    The underlying SDK exposes only a list endpoint; there is no get-by-id
+    for NodeSchedulableStatus. We fetch the list (optionally scoped by
+    cluster_ext_id) and return the entry matching the caller-supplied ext_id.
+    """
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    kwargs = {}
+    if module.params.get("cluster_ext_id"):
+        kwargs["X_Cluster_Id"] = module.params.get("cluster_ext_id")
+
+    resp = _fetch_node_schedulable_statuses(module, api_instance, kwargs)
+
+    resp = strip_internal_attributes(resp.to_dict())
+    entries = resp.get("data") or []
+
+    match = next(
+        (entry for entry in entries if entry.get("ext_id") == ext_id),
+        None,
+    )
+    if match is None:
+        module.fail_json(
+            msg=(
+                "Node schedulable status with ext_id '{0}' not found in the "
+                "listed results.".format(ext_id)
+            ),
+            **result,
+        )
+
+    result["response"] = match
+
+
+def get_node_schedulable_statuses(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating node schedulable statuses info spec", **result
+        )
+
+    if module.params.get("cluster_ext_id"):
+        kwargs["X_Cluster_Id"] = module.params.get("cluster_ext_id")
+
+    resp = _fetch_node_schedulable_statuses(module, api_instance, kwargs)
+
+    resp = strip_internal_attributes(resp.to_dict())
+    metadata = resp.get("metadata") or {}
+    total_available_results = metadata.get("total_available_results")
+    result["total_available_results"] = total_available_results
+
+    resp = resp.get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_virtual_switch_nodes_info_api_instance(module)
+    if module.params.get("ext_id"):
+        get_node_schedulable_status_by_ext_id(module, api_instance, result)
+    else:
+        get_node_schedulable_statuses(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_node_schedulable_status_info_v2/aliases
+++ b/tests/integration/targets/ntnx_node_schedulable_status_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_node_schedulable_status_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_node_schedulable_status_info_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_node_schedulable_status_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_node_schedulable_status_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import node_schedulable_status_info.yml
+      ansible.builtin.import_tasks: node_schedulable_status_info.yml

--- a/tests/integration/targets/ntnx_node_schedulable_status_info_v2/tasks/node_schedulable_status_info.yml
+++ b/tests/integration/targets/ntnx_node_schedulable_status_info_v2/tasks/node_schedulable_status_info.yml
@@ -1,0 +1,332 @@
+---
+# Test plan for ntnx_node_schedulable_status_info_v2 module
+#
+# The NodeSchedulableStatus SDK only exposes a list endpoint
+# (GET /networking/v4/config/node-schedulable-statuses). There is no
+# Create/Update/Delete/Get-by-id, so the tests below focus on:
+#   1. Listing all node schedulable statuses (with cluster scoping).
+#   2. Filtering with $filter=isNeverSchedulable eq true|false (see
+#      NET-19823 for the schema rename from neverSchedulable to
+#      isNeverSchedulable).
+#   3. Paging / limiting.
+#   4. Sorting with $orderby.
+#   5. Fetching a single node by ext_id (client-side match on listed data).
+#   6. Negative test: unknown ext_id -> module fails cleanly.
+#   7. Negative test: mutually exclusive ext_id + filter.
+#   8. Schema assertions on every listed entry: ext_id + is_never_schedulable.
+#
+# Note: on Prism Central deployments that manage a single PE cluster, the
+# underlying API requires the X-Cluster-Id header (SDK param
+# X_Cluster_Id -> module arg cluster_ext_id). If a PE cluster is not
+# supplied by prepare_env, we discover one dynamically via
+# ntnx_clusters_info_v2 and pass it into every call.
+
+- name: Start Node Schedulable Status info tests
+  ansible.builtin.debug:
+    msg: Start Node Schedulable Status info tests
+
+########################################################################################
+# Discover a PE cluster to scope the list calls against
+########################################################################################
+
+- name: Discover PE clusters
+  nutanix.ncp.ntnx_clusters_info_v2:
+    filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+  register: clusters_info
+  ignore_errors: true
+
+- name: Assert at least one PE cluster is present
+  ansible.builtin.assert:
+    that:
+      - clusters_info is defined
+      - clusters_info.failed == false
+      - clusters_info.response is defined
+      - clusters_info.response | length >= 1
+    success_msg: "Discovered at least one PE cluster"
+    fail_msg: "No PE cluster found — Node Schedulable Status tests cannot proceed"
+
+- name: Set PE cluster ext_id
+  ansible.builtin.set_fact:
+    pe_cluster_ext_id: >-
+      {{
+        (cluster.uuid
+         if (cluster is defined and cluster.uuid is defined)
+         else clusters_info.response[0].ext_id)
+      }}
+
+- name: Show PE cluster ext_id being used
+  ansible.builtin.debug:
+    msg: "Using PE cluster ext_id: {{ pe_cluster_ext_id }}"
+
+########################################################################################
+# 1. List node schedulable statuses scoped by cluster_ext_id (baseline)
+########################################################################################
+
+- name: List all node schedulable statuses (cluster-scoped)
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    cluster_ext_id: "{{ pe_cluster_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Baseline list status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 1
+      - result.total_available_results is defined
+      - result.total_available_results >= (result.response | length)
+    success_msg: "Baseline list succeeded"
+    fail_msg: "Baseline list failed"
+
+- name: Assert every listed entry has ext_id and is_never_schedulable
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined
+      - item.ext_id | length > 0
+      - item.is_never_schedulable is defined
+      - item.is_never_schedulable in [true, false]
+    success_msg: "Entry {{ item.ext_id }} has the expected schema"
+    fail_msg: "Entry missing ext_id or is_never_schedulable: {{ item }}"
+  loop: "{{ result.response }}"
+  loop_control:
+    label: "{{ item.ext_id | default('unknown') }}"
+
+- name: Capture baseline listing for downstream tests
+  ansible.builtin.set_fact:
+    all_statuses: "{{ result.response }}"
+    total_statuses: "{{ result.total_available_results }}"
+    first_node_ext_id: "{{ result.response[0].ext_id }}"
+
+########################################################################################
+# 2. Filter with isNeverSchedulable eq true / false
+########################################################################################
+
+- name: List only never-schedulable (storage-only) nodes
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    cluster_ext_id: "{{ pe_cluster_ext_id }}"
+    filter: "isNeverSchedulable eq true"
+  register: result_never
+  ignore_errors: true
+
+- name: List only never-schedulable nodes status
+  ansible.builtin.assert:
+    that:
+      - result_never is defined
+      - result_never.changed == false
+      - result_never.failed == false
+      - result_never.response is defined
+    success_msg: "Filter isNeverSchedulable eq true returned successfully"
+    fail_msg: "Filter isNeverSchedulable eq true failed"
+
+- name: Assert every never-schedulable entry has is_never_schedulable == true
+  ansible.builtin.assert:
+    that:
+      - item.is_never_schedulable == true
+    success_msg: "Entry {{ item.ext_id }} is correctly never-schedulable"
+    fail_msg: "Filter returned wrong entry: {{ item }}"
+  loop: "{{ result_never.response }}"
+  loop_control:
+    label: "{{ item.ext_id | default('unknown') }}"
+  when: result_never.response | length > 0
+
+- name: List only regular (schedulable) nodes
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    cluster_ext_id: "{{ pe_cluster_ext_id }}"
+    filter: "isNeverSchedulable eq false"
+  register: result_schedulable
+  ignore_errors: true
+
+- name: List only regular nodes status
+  ansible.builtin.assert:
+    that:
+      - result_schedulable is defined
+      - result_schedulable.changed == false
+      - result_schedulable.failed == false
+      - result_schedulable.response is defined
+    success_msg: "Filter isNeverSchedulable eq false returned successfully"
+    fail_msg: "Filter isNeverSchedulable eq false failed"
+
+- name: Assert every schedulable entry has is_never_schedulable == false
+  ansible.builtin.assert:
+    that:
+      - item.is_never_schedulable == false
+    success_msg: "Entry {{ item.ext_id }} is correctly schedulable"
+    fail_msg: "Filter returned wrong entry: {{ item }}"
+  loop: "{{ result_schedulable.response }}"
+  loop_control:
+    label: "{{ item.ext_id | default('unknown') }}"
+  when: result_schedulable.response | length > 0
+
+- name: Assert the filtered subsets partition the full list correctly
+  ansible.builtin.assert:
+    that:
+      - (result_never.response | length) + (result_schedulable.response | length) == (all_statuses | length)
+    success_msg: "Filtered subsets partition the full list correctly"
+    fail_msg: >-
+      Filtered subsets do not partition the full list:
+      never={{ result_never.response | length }},
+      schedulable={{ result_schedulable.response | length }},
+      total={{ all_statuses | length }}
+
+########################################################################################
+# 3. Pagination / limit
+########################################################################################
+
+- name: List node schedulable statuses with limit=1
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    cluster_ext_id: "{{ pe_cluster_ext_id }}"
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List with limit=1 status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    success_msg: "Limit=1 returned exactly one entry"
+    fail_msg: "Limit=1 did not return exactly one entry"
+
+- name: List node schedulable statuses with page=0
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    cluster_ext_id: "{{ pe_cluster_ext_id }}"
+    page: 0
+    limit: 5
+  register: result
+  ignore_errors: true
+
+- name: List with page=0 status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length <= 5
+    success_msg: "Paged listing returned <=5 entries"
+    fail_msg: "Paged listing returned more than 5 entries"
+
+########################################################################################
+# 4. Sorting with orderby
+########################################################################################
+
+- name: Sort node schedulable statuses in ascending order of isNeverSchedulable
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    cluster_ext_id: "{{ pe_cluster_ext_id }}"
+    orderby: "isNeverSchedulable asc"
+  register: result_asc
+  ignore_errors: true
+
+- name: Sort ascending status
+  ansible.builtin.assert:
+    that:
+      - result_asc is defined
+      - result_asc.changed == false
+      - result_asc.failed == false
+      - result_asc.response is defined
+    success_msg: "orderby asc returned successfully"
+    fail_msg: "orderby asc failed"
+
+- name: Assert ascending sort order (false <= true)
+  ansible.builtin.assert:
+    that:
+      - (result_asc.response[idx].is_never_schedulable | ternary(1, 0))
+        <= (result_asc.response[idx + 1].is_never_schedulable | ternary(1, 0))
+    success_msg: "Ascending order preserved between {{ idx }} and {{ idx + 1 }}"
+    fail_msg: "Ascending order violated between {{ idx }} and {{ idx + 1 }}"
+  loop: "{{ range(0, (result_asc.response | length) - 1) | list }}"
+  loop_control:
+    loop_var: idx
+  when: result_asc.response | length > 1
+
+- name: Sort node schedulable statuses in descending order of isNeverSchedulable
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    cluster_ext_id: "{{ pe_cluster_ext_id }}"
+    orderby: "isNeverSchedulable desc"
+  register: result_desc
+  ignore_errors: true
+
+- name: Sort descending status
+  ansible.builtin.assert:
+    that:
+      - result_desc is defined
+      - result_desc.changed == false
+      - result_desc.failed == false
+      - result_desc.response is defined
+    success_msg: "orderby desc returned successfully"
+    fail_msg: "orderby desc failed"
+
+########################################################################################
+# 5. Fetch a specific node by ext_id (client-side match on the listed data)
+########################################################################################
+
+- name: Fetch node schedulable status by ext_id
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    cluster_ext_id: "{{ pe_cluster_ext_id }}"
+    ext_id: "{{ first_node_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch by ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.ext_id == first_node_ext_id
+      - result.response.is_never_schedulable in [true, false]
+      - result.ext_id == first_node_ext_id
+    success_msg: "Fetch by ext_id returned the correct node"
+    fail_msg: "Fetch by ext_id returned wrong or missing data"
+
+########################################################################################
+# 6. Negative — unknown ext_id
+########################################################################################
+
+- name: Fetch node schedulable status with a non-existent ext_id
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    cluster_ext_id: "{{ pe_cluster_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Non-existent ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg is defined
+      - "'not found' in result.msg"
+      - result.ext_id == "00000000-0000-0000-0000-000000000000"
+    success_msg: "Non-existent ext_id failed as expected"
+    fail_msg: "Non-existent ext_id did not fail as expected"
+
+########################################################################################
+# 7. Negative — mutually exclusive ext_id + filter
+########################################################################################
+
+- name: Fetch with both ext_id and filter (should be rejected)
+  nutanix.ncp.ntnx_node_schedulable_status_info_v2:
+    cluster_ext_id: "{{ pe_cluster_ext_id }}"
+    ext_id: "{{ first_node_ext_id }}"
+    filter: "isNeverSchedulable eq true"
+  register: result
+  ignore_errors: true
+
+- name: Mutually exclusive params status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'mutually exclusive' in result.msg"
+    success_msg: "ext_id + filter correctly rejected as mutually exclusive"
+    fail_msg: "ext_id + filter was NOT rejected as mutually exclusive"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection module for the **networking** namespace, entity
**NodeSchedulableStatus**, based on the inline SDK info. One PR per code-gen run.

- Modules generated: **only** `ntnx_node_schedulable_status_info_v2`
- Modules intentionally NOT generated: `ntnx_node_schedulable_status_v2` (CRUD)
  — the underlying SDK (`ntnx_networking_py_client.VirtualSwitchNodesInfoApi`)
  exposes **only** a list endpoint
  (`GET /networking/v4/config/node-schedulable-statuses`). There is no
  Create / Update / Delete / Get-by-id API for `NodeSchedulableStatus`, so
  emitting a CRUD companion would have produced fabricated operations. If
  Nutanix introduces write endpoints for this entity in a later SDK release,
  the CRUD module should be added then.
- API methods covered: `1` (`list_node_schedulable_status`)
- Fields in info module spec: `2` (`ext_id`, `cluster_ext_id`) + info-common
  spec (`filter`, `page`, `limit`, `orderby`, `select`) from `BaseInfoModule`.

## Files changed

- `plugins/modules/ntnx_node_schedulable_status_info_v2.py` — new info module
- `plugins/module_utils/v4/network/api_client.py` — added
  `get_virtual_switch_nodes_info_api_instance` helper (returns
  `ntnx_networking_py_client.VirtualSwitchNodesInfoApi`)
- `meta/runtime.yml` — registered `ntnx_node_schedulable_status_info_v2`
  in the `ntnx` action group so `module_defaults` (credentials) propagates.
- `.gitignore` — ignore `tests/integration/integration_config.yml` (contains
  cluster credentials; must never be committed).
- `examples/networking/NodeSchedulableStatus/node_schedulable_status_v2.yml`
  — end-to-end example playbook (list-all, cluster-scoped, filter, limit,
  page, orderby asc/desc, get-by-ext_id).
- `examples/networking/NodeSchedulableStatus/examples_run.log` — real
  `ansible-playbook` output captured against the PC below.
- `tests/integration/targets/ntnx_node_schedulable_status_info_v2/` — new
  integration target (aliases, meta, tasks/main.yml, tasks/node_schedulable_status_info.yml).

## Design notes

- **Client-side get-by-id.** Since the SDK has no get-by-id, the module fetches
  the list (optionally scoped by `cluster_ext_id` -> `X-Cluster-Id`) and
  returns the entry whose `ext_id` matches. Unknown `ext_id` -> module fails
  cleanly with `Node schedulable status with ext_id '<uuid>' not found …`.
- **`cluster_ext_id` is optional per SDK** but practically required on PCs
  that manage a single PE cluster (the API returns
  `NETWORKING-10002 "Required X-Cluster-Id missing in header"`). The example
  and tests always discover a PE cluster and pass `cluster_ext_id`.
- **Filter/limit/page/orderby** come from `BaseInfoModule.info_argument_spec`
  and are passed through via `SpecGenerator.get_info_spec()`.
- **`ext_id` and `filter` are mutually exclusive** (matches the
  `ntnx_virtual_switches_info_v2` pattern).

## Test execution

| Metric              | Value                                                                        |
|---------------------|------------------------------------------------------------------------------|
| Integration command | `ansible-test integration ntnx_node_schedulable_status_info_v2 --allow-disabled -v` |
| Sanity command      | `ansible-test sanity plugins/modules/ntnx_node_schedulable_status_info_v2.py plugins/module_utils/v4/network/api_client.py meta/runtime.yml` |
| Playbook command    | `ansible-playbook examples/networking/NodeSchedulableStatus/node_schedulable_status_v2.yml -v` |
| Total tasks         | 30 assertions + 2 negative-path expected failures (both handled by `ignore_errors`) |
| Passed              | 30 |
| Failed              | 0 |
| Skipped             | 2 (conditional-only assertion / no items to sort) |
| Ignored             | 2 (expected failures from negative tests: unknown `ext_id`, mutually exclusive `ext_id`+`filter`) |
| Cluster (PC)        | 10.44.76.28 (auto_cluster_prod_36acf9b012ca / PE ext_id 0006555e-4e63-4a5e-185b-ac1f6b6f97e2) |
| Sanity              | `black`, `isort`, `flake8`, `ansible-lint`, `ansible-test sanity` all clean |

### Analysis

- No failing assertions.
- The two "ignored" task failures are intentional negative-path tests:
  - `Fetch node schedulable status with a non-existent ext_id` — module
    correctly fails with `"Node schedulable status with ext_id '00000000-0000-0000-0000-000000000000' not found in the listed results."`, which the following assertion validates.
  - `Fetch with both ext_id and filter (should be rejected)` — module
    correctly fails with `"parameters are mutually exclusive: ext_id|filter"`, which the following assertion validates.
- The two `skipping` tasks (in the integration run) are conditional guards
  that only run when a filter subset has entries; on the current single-node
  cluster the "never-schedulable" bucket is empty, so per-item assertions
  are skipped as designed.
- The playbook run (`examples_run.log`) also finishes with
  `ok=11 changed=0 failed=0 skipped=0 ignored=0` end-to-end.

### Test logs (tail)

<details>
<summary>tail -n 100 test_logs.log</summary>

```text
"is_never_schedulable": false,
        "links": null,
        "tenant_id": null
    },
    "msg": "Entry adf0c9e0-4051-4cd2-9f6f-ca9f962e941b is correctly schedulable"
}

TASK [ntnx_node_schedulable_status_info_v2 : Assert the filtered subsets partition the full list correctly] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Filtered subsets partition the full list correctly"
}

TASK [ntnx_node_schedulable_status_info_v2 : List node schedulable statuses with limit=1] ***
ok: [testhost] => {"changed": false, "response": [{"ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "is_never_schedulable": false, "links": null, "tenant_id": null}], "total_available_results": 1}

TASK [ntnx_node_schedulable_status_info_v2 : List with limit=1 status] *********
ok: [testhost] => {
    "changed": false,
    "msg": "Limit=1 returned exactly one entry"
}

TASK [ntnx_node_schedulable_status_info_v2 : List node schedulable statuses with page=0] ***
ok: [testhost] => {"changed": false, "response": [{"ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "is_never_schedulable": false, "links": null, "tenant_id": null}], "total_available_results": 1}

TASK [ntnx_node_schedulable_status_info_v2 : List with page=0 status] **********
ok: [testhost] => {
    "changed": false,
    "msg": "Paged listing returned <=5 entries"
}

TASK [ntnx_node_schedulable_status_info_v2 : Sort node schedulable statuses in ascending order of isNeverSchedulable] ***
ok: [testhost] => {"changed": false, "response": [{"ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "is_never_schedulable": false, "links": null, "tenant_id": null}], "total_available_results": 1}

TASK [ntnx_node_schedulable_status_info_v2 : Sort ascending status] ************
ok: [testhost] => {
    "changed": false,
    "msg": "orderby asc returned successfully"
}

TASK [ntnx_node_schedulable_status_info_v2 : Assert ascending sort order (false <= true)] ***
skipping: [testhost] => {"changed": false, "skip_reason": "No items in the list", "skipped_reason": "No items in the list"}

TASK [ntnx_node_schedulable_status_info_v2 : Sort node schedulable statuses in descending order of isNeverSchedulable] ***
ok: [testhost] => {"changed": false, "response": [{"ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "is_never_schedulable": false, "links": null, "tenant_id": null}], "total_available_results": 1}

TASK [ntnx_node_schedulable_status_info_v2 : Sort descending status] ***********
ok: [testhost] => {
    "changed": false,
    "msg": "orderby desc returned successfully"
}

TASK [ntnx_node_schedulable_status_info_v2 : Fetch node schedulable status by ext_id] ***
ok: [testhost] => {"changed": false, "ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "response": {"ext_id": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "is_never_schedulable": false, "links": null, "tenant_id": null}}

TASK [ntnx_node_schedulable_status_info_v2 : Fetch by ext_id status] ***********
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch by ext_id returned the correct node"
}

TASK [ntnx_node_schedulable_status_info_v2 : Fetch node schedulable status with a non-existent ext_id] ***
[ERROR]: Task failed: Module failed: Node schedulable status with ext_id '00000000-0000-0000-0000-000000000000' not found in the listed results.
Origin: /tmp/ncp_sanity/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_node_schedulable_status_info_v2-dpa9jq8v-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_node_schedulable_status_info_v2/tasks/node_schedulable_status_info.yml:293:3

291 ########################################################################################
292
293 - name: Fetch node schedulable status with a non-existent ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "ext_id": "00000000-0000-0000-0000-000000000000", "msg": "Node schedulable status with ext_id '00000000-0000-0000-0000-000000000000' not found in the listed results.", "response": null}
...ignoring

TASK [ntnx_node_schedulable_status_info_v2 : Non-existent ext_id status] *******
ok: [testhost] => {
    "changed": false,
    "msg": "Non-existent ext_id failed as expected"
}

TASK [ntnx_node_schedulable_status_info_v2 : Fetch with both ext_id and filter (should be rejected)] ***
[ERROR]: Task failed: Module failed: parameters are mutually exclusive: ext_id|filter
Origin: /tmp/ncp_sanity/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_node_schedulable_status_info_v2-dpa9jq8v-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_node_schedulable_status_info_v2/tasks/node_schedulable_status_info.yml:316:3

314 ########################################################################################
315
316 - name: Fetch with both ext_id and filter (should be rejected)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_node_schedulable_status_info_v2 : Mutually exclusive params status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "ext_id + filter correctly rejected as mutually exclusive"
}

PLAY RECAP *********************************************************************
testhost                   : ok=30   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=2
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline SDK info stored only in the agent transcript.
- SDK: `ntnx-networking-py-client==latest` (pinned in this branch's
  `requirements.txt`), verified against the running PC.
