### PR TITLE
code-gen(virtual_machine_management/VmDiskCustomAttribute): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/virtual_machine_management/VmDiskCustomAttribute/examples_run.log
+++ b/examples/virtual_machine_management/VmDiskCustomAttribute/examples_run.log
@@ -1,0 +1,19 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [VmDiskCustomAttribute playbook] ******************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"disk_uuid": "8be43414-f58c-4e2c-5eb5-8aa7b6405370", "vm_uuid": "813e3bf4-3afb-4317-5c3c-84a41730103d"}, "changed": false}
+
+TASK [Add custom attributes to a VM disk] **************************************
+changed: [localhost] => {"changed": true, "ext_id": "8be43414-f58c-4e2c-5eb5-8aa7b6405370", "response": {"backing_info": {"data_source": null, "disk_ext_id": "8be43414-f58c-4e2c-5eb5-8aa7b6405370", "disk_size_bytes": 1073741824, "is_migration_in_progress": false, "serialId": "NFS_3_0_351_6f42c90c_9ed9_4b76_78c9_4f6fbfe91b2b", "storage_config": null, "storage_container": {"ext_id": "44481f83-d0a1-47b3-b9b8-32b5465c622e"}, "vm_disk_hydration_info": null}, "custom_attributes": ["environment:production", "tier:gold", "owner:ansible"], "disk_address": {"bus_type": "SCSI", "index": 1}, "ext_id": "8be43414-f58c-4e2c-5eb5-8aa7b6405370", "links": null, "tenant_id": null}, "task_ext_id": "ZXJnb24=:d5809928-ee76-5b74-82a6-ad4eca923b2a", "vm_ext_id": "813e3bf4-3afb-4317-5c3c-84a41730103d"}
+
+TASK [Remove custom attributes from a VM disk] *********************************
+changed: [localhost] => {"changed": true, "ext_id": "8be43414-f58c-4e2c-5eb5-8aa7b6405370", "response": {"backing_info": {"data_source": null, "disk_ext_id": "8be43414-f58c-4e2c-5eb5-8aa7b6405370", "disk_size_bytes": 1073741824, "is_migration_in_progress": false, "serialId": "NFS_3_0_351_6f42c90c_9ed9_4b76_78c9_4f6fbfe91b2b", "storage_config": null, "storage_container": {"ext_id": "44481f83-d0a1-47b3-b9b8-32b5465c622e"}, "vm_disk_hydration_info": null}, "custom_attributes": ["owner:ansible", "environment:production"], "disk_address": {"bus_type": "SCSI", "index": 1}, "ext_id": "8be43414-f58c-4e2c-5eb5-8aa7b6405370", "links": null, "tenant_id": null}, "task_ext_id": "ZXJnb24=:08684c65-933a-5b2a-8f4e-5fe561b21bc4", "vm_ext_id": "813e3bf4-3afb-4317-5c3c-84a41730103d"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=3    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/virtual_machine_management/VmDiskCustomAttribute/vm_disk_custom_attribute_v2.yml
+++ b/examples/virtual_machine_management/VmDiskCustomAttribute/vm_disk_custom_attribute_v2.yml
@@ -1,0 +1,43 @@
+---
+# Summary:
+# This playbook demonstrates how to add and remove custom attributes on an
+# AHV VM disk in Nutanix Prism Central using the v4 VMM APIs. Steps:
+# 1. Add custom attributes to a VM disk
+# 2. Remove custom attributes from a VM disk
+
+- name: VmDiskCustomAttribute playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        vm_uuid: "{{ vm_uuid | default('ac5aff0c-6c68-4948-9088-b903e2be0ce7') }}"
+        disk_uuid: "{{ disk_uuid | default('0f34a2a7-6068-48ba-859d-1ced14d7f5da') }}"
+
+    - name: Add custom attributes to a VM disk
+      nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+        state: present
+        vm_ext_id: "{{ vm_uuid }}"
+        ext_id: "{{ disk_uuid }}"
+        custom_attributes:
+          - "environment:production"
+          - "tier:gold"
+          - "owner:ansible"
+      register: add_result
+      ignore_errors: true
+
+    - name: Remove custom attributes from a VM disk
+      nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+        state: absent
+        vm_ext_id: "{{ vm_uuid }}"
+        ext_id: "{{ disk_uuid }}"
+        custom_attributes:
+          - "tier:gold"
+      register: remove_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vm_disk_custom_attribute_v2

--- a/plugins/modules/ntnx_vm_disk_custom_attribute_v2.py
+++ b/plugins/modules/ntnx_vm_disk_custom_attribute_v2.py
@@ -1,0 +1,394 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_disk_custom_attribute_v2
+short_description: Add or remove custom attributes on an AHV VM disk in Nutanix Prism Central
+version_added: 2.7.0
+description:
+    - This module allows you to add or remove custom attributes (user-defined C(key:value)
+      metadata strings) on an individual AHV VM disk in Nutanix Prism Central.
+    - When C(state=present), the provided C(custom_attributes) are added to the VM disk.
+    - When C(state=absent), the provided C(custom_attributes) are removed from the VM disk.
+    - VM disks backed by Volume Groups are not eligible for disk-level custom attributes.
+    - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles / permissions to be assigned to the user
+      performing the operation. The required roles depend on the operation being performed.
+    - >-
+      B(Add to the VM disk's custom attributes) -
+      Required Permission: Update_Virtual_Machine_Disk_Custom_Attributes.
+      Required Roles: Prism Admin, Super Admin, Virtual Machine Admin.
+    - >-
+      B(Remove from the VM disk's custom attributes) -
+      Required Permission: Update_Virtual_Machine_Disk_Custom_Attributes.
+      Required Roles: Prism Admin, Super Admin, Virtual Machine Admin.
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+    state:
+        description:
+            - Specify the desired action.
+            - If C(state) is set to C(present), the provided C(custom_attributes) are added to the VM disk.
+            - If C(state) is set to C(absent), the provided C(custom_attributes) are removed from the VM disk.
+        type: str
+        choices:
+            - present
+            - absent
+        default: present
+    vm_ext_id:
+        description:
+            - A globally unique identifier of the VM (UUID) whose disk is being updated.
+        type: str
+        required: true
+    ext_id:
+        description:
+            - A globally unique identifier of the VM disk (UUID) on which custom attributes are added or removed.
+        type: str
+        required: true
+    custom_attributes:
+        description:
+            - List of custom attributes to be added or removed on the VM disk.
+            - Each entry is a free-form user-defined string, typically formatted as C("key:value").
+        type: list
+        elements: str
+        required: true
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+    - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Add custom attributes to a VM disk
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    vm_ext_id: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+    ext_id: "0f34a2a7-6068-48ba-859d-1ced14d7f5da"
+    custom_attributes:
+      - "environment:production"
+      - "tier:gold"
+      - "owner:ansible"
+  register: result
+  ignore_errors: true
+
+- name: Remove custom attributes from a VM disk
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    vm_ext_id: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+    ext_id: "0f34a2a7-6068-48ba-859d-1ced14d7f5da"
+    custom_attributes:
+      - "tier:gold"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for adding or removing custom attributes on a VM disk.
+        - VM disk details (including the resulting C(custom_attributes) list) if C(wait) is true.
+        - Task details if C(wait) is false.
+    returned: always
+    type: dict
+    sample:
+        {
+            "backing_info": {
+                "data_source": null,
+                "disk_ext_id": "0f34a2a7-6068-48ba-859d-1ced14d7f5da",
+                "disk_size_bytes": 26843545600,
+                "is_migration_in_progress": false,
+                "storage_config": null,
+                "storage_container": {
+                    "ext_id": "78ec68c5-d9b0-4ba4-a3e9-96f90d580a0b"
+                }
+            },
+            "custom_attributes": [
+                "environment:production",
+                "tier:gold",
+                "owner:ansible"
+            ],
+            "disk_address": {
+                "bus_type": "SCSI",
+                "index": 1
+            },
+            "ext_id": "0f34a2a7-6068-48ba-859d-1ced14d7f5da",
+            "links": null,
+            "tenant_id": null
+        }
+
+changed:
+    description: This indicates whether the task resulted in any changes.
+    returned: always
+    type: bool
+    sample: true
+
+msg:
+    description: This indicates the message if any message occurred.
+    returned: When there is an error, module is idempotent or check mode.
+    type: str
+    sample: "Api Exception raised while adding custom attributes to VM disk"
+
+error:
+    description:
+        - This field typically holds information about if the task have errors that
+          occurred during the task execution.
+    returned: when an error occurs
+    type: str
+    sample: "Failed to get etag for VM disk"
+
+failed:
+    description: This field typically holds information about if the task have failed.
+    returned: always
+    type: bool
+    sample: false
+
+skipped:
+    description: This indicates whether the operation was skipped because there was nothing to change.
+    returned: on skipping
+    type: bool
+    sample: true
+
+task_ext_id:
+    description: The external ID of the task.
+    returned: always
+    type: str
+    sample: "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1"
+
+vm_ext_id:
+    description: The external ID of the VM whose disk was updated.
+    returned: always
+    type: str
+    sample: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+
+ext_id:
+    description: The external ID of the VM disk that was updated.
+    returned: always
+    type: str
+    sample: "0f34a2a7-6068-48ba-859d-1ced14d7f5da"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import get_etag, get_vm_api_instance  # noqa: E402
+from ..module_utils.v4.vmm.helpers import get_disk  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_vmm_py_client as vmm_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as vmm_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        vm_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+        custom_attributes=dict(
+            type="list",
+            elements="str",
+            required=True,
+        ),
+    )
+    return module_args
+
+
+def _build_spec(module):
+    """Build the UpdateCustomAttributesParams request body from module params."""
+    spec = vmm_sdk.UpdateCustomAttributesParams()
+    spec.custom_attributes = list(module.params.get("custom_attributes") or [])
+    return spec
+
+
+def _get_disk_custom_attributes(module, api_instance, vm_ext_id, ext_id):
+    """Return the current custom_attributes list on a VM disk (empty list if none)."""
+    disk = get_disk(module, api_instance, ext_id=ext_id, vm_ext_id=vm_ext_id)
+    current = getattr(disk, "custom_attributes", None) or []
+    return list(current), disk
+
+
+def add_vm_disk_custom_attributes(module, result, api_instance):
+    vm_ext_id = module.params.get("vm_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["vm_ext_id"] = vm_ext_id
+    result["ext_id"] = ext_id
+
+    requested = list(module.params.get("custom_attributes") or [])
+    current, disk = _get_disk_custom_attributes(module, api_instance, vm_ext_id, ext_id)
+
+    to_add = [attr for attr in requested if attr not in current]
+    spec = vmm_sdk.UpdateCustomAttributesParams()
+    spec.custom_attributes = to_add
+
+    if not to_add:
+        result["skipped"] = True
+        result["response"] = strip_internal_attributes(disk.to_dict())
+        module.exit_json(
+            msg=(
+                "All requested custom attributes are already present on VM disk "
+                "'{0}'. Skipping add operation.".format(ext_id)
+            ),
+            **result,
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    etag = get_etag(disk)
+    kwargs = {}
+    if etag:
+        kwargs["if_match"] = etag
+
+    resp = None
+    try:
+        resp = api_instance.add_vm_disk_custom_attributes(
+            vmExtId=vm_ext_id, extId=ext_id, body=spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while adding custom attributes to VM disk",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        updated_disk = get_disk(
+            module, api_instance, ext_id=ext_id, vm_ext_id=vm_ext_id
+        )
+        result["response"] = strip_internal_attributes(updated_disk.to_dict())
+    result["changed"] = True
+
+
+def remove_vm_disk_custom_attributes(module, result, api_instance):
+    vm_ext_id = module.params.get("vm_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["vm_ext_id"] = vm_ext_id
+    result["ext_id"] = ext_id
+
+    requested = list(module.params.get("custom_attributes") or [])
+    current, disk = _get_disk_custom_attributes(module, api_instance, vm_ext_id, ext_id)
+
+    to_remove = [attr for attr in requested if attr in current]
+    spec = vmm_sdk.UpdateCustomAttributesParams()
+    spec.custom_attributes = to_remove
+
+    if not to_remove:
+        result["skipped"] = True
+        result["response"] = strip_internal_attributes(disk.to_dict())
+        module.exit_json(
+            msg=(
+                "None of the requested custom attributes are present on VM disk "
+                "'{0}'. Skipping remove operation.".format(ext_id)
+            ),
+            **result,
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    etag = get_etag(disk)
+    kwargs = {}
+    if etag:
+        kwargs["if_match"] = etag
+
+    resp = None
+    try:
+        resp = api_instance.remove_vm_disk_custom_attributes(
+            vmExtId=vm_ext_id, extId=ext_id, body=spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while removing custom attributes from VM disk",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        updated_disk = get_disk(
+            module, api_instance, ext_id=ext_id, vm_ext_id=vm_ext_id
+        )
+        result["response"] = strip_internal_attributes(updated_disk.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"), exception=SDK_IMP_ERROR
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "vm_ext_id": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_vm_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        add_vm_disk_custom_attributes(module, result, api_instance)
+    else:
+        remove_vm_disk_custom_attributes(module, result, api_instance)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_disk_custom_attribute_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_disk_custom_attribute_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_disk_custom_attribute_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_disk_custom_attribute_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_disk_custom_attribute_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_disk_custom_attribute_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import vm_disk_custom_attribute_operations.yml
+      ansible.builtin.import_tasks: "vm_disk_custom_attribute_operations.yml"

--- a/tests/integration/targets/ntnx_vm_disk_custom_attribute_v2/tasks/vm_disk_custom_attribute_operations.yml
+++ b/tests/integration/targets/ntnx_vm_disk_custom_attribute_v2/tasks/vm_disk_custom_attribute_operations.yml
@@ -1,0 +1,452 @@
+---
+# Variables required before running this playbook:
+# - cluster
+# - storage_container
+#
+# Test plan for ntnx_vm_disk_custom_attribute_v2 (module: add/remove custom
+# attributes on an AHV VM disk):
+#   1.  Prerequisites: create a fresh VM and one AHV disk to operate on.
+#   2.  check_mode add (all attributes) — verify spec, no API change.
+#   3.  Add a single custom attribute (minimal input).
+#   4.  Add multiple custom attributes (full input, with ALL fields populated).
+#   5.  Idempotency: re-add same attributes → skipped, changed=false.
+#   6.  check_mode remove.
+#   7.  Remove a subset of attributes.
+#   8.  Idempotency for remove: remove already-absent attributes → skipped.
+#   9.  Remove ALL remaining attributes.
+#   10. Negative — missing required `custom_attributes` field.
+#   11. Negative — invalid (non-existent) disk ext_id.
+#   12. Negative — invalid (non-existent) vm ext_id.
+#   13. Cleanup: remove the disk and the VM.
+
+- name: Start testing ntnx_vm_disk_custom_attribute_v2
+  ansible.builtin.debug:
+    msg: Start testing ntnx_vm_disk_custom_attribute_v2
+
+- name: Generate random name
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set VM name for this run
+  ansible.builtin.set_fact:
+    vm_name: "{{ random_name }}_vm_disk_ca_test"
+
+#################################################################################
+# Prerequisite — create a VM to attach a disk to
+#################################################################################
+
+- name: Create VM with minimum requirements
+  nutanix.ncp.ntnx_vms_v2:
+    state: present
+    name: "{{ vm_name }}"
+    cluster:
+      ext_id: "{{ cluster.uuid }}"
+  register: result
+  ignore_errors: true
+
+- name: VM creation status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response.cluster.ext_id == cluster.uuid
+      - result.response.name == vm_name
+    fail_msg: "Unable to create VM for VM disk custom attribute test"
+    success_msg: "VM for VM disk custom attribute test created successfully"
+
+- name: Set VM ext_id
+  ansible.builtin.set_fact:
+    vm_uuid: '{{ result["ext_id"] }}'
+
+#################################################################################
+# Prerequisite — create a single AHV disk on that VM
+#################################################################################
+
+- name: Create Disk on VM (backed by storage container)
+  nutanix.ncp.ntnx_vms_disks_v2:
+    vm_ext_id: "{{ vm_uuid }}"
+    backing_info:
+      vm_disk:
+        disk_size_bytes: 1073741824
+        storage_container:
+          ext_id: "{{ storage_container.uuid }}"
+    disk_address:
+      bus_type: "SCSI"
+      index: 1
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: Create Disk on VM status
+  ansible.builtin.assert:
+    that:
+      - result.response is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.vm_ext_id == vm_uuid
+      - result.response.disk_address.index == 1
+      - result.response.disk_address.bus_type == "SCSI"
+    fail_msg: "Unable to create disk for VM disk custom attribute test"
+    success_msg: "Disk for VM disk custom attribute test created successfully"
+
+- name: Set Disk ext_id
+  ansible.builtin.set_fact:
+    disk_uuid: '{{ result["ext_id"] }}'
+
+#################################################################################
+# check_mode: Add ALL attributes (single check_mode test for Create)
+#################################################################################
+
+- name: Add custom attributes to VM disk - check mode with all attributes
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    state: present
+    vm_ext_id: "{{ vm_uuid }}"
+    ext_id: "{{ disk_uuid }}"
+    custom_attributes:
+      - "environment:staging"
+      - "tier:gold"
+      - "owner:ansible-check-mode"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Add custom attributes to VM disk - check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.vm_ext_id == vm_uuid
+      - result.ext_id == disk_uuid
+      - result.response.custom_attributes is defined
+      - result.response.custom_attributes | length == 3
+      - "'environment:staging' in result.response.custom_attributes"
+      - "'tier:gold' in result.response.custom_attributes"
+      - "'owner:ansible-check-mode' in result.response.custom_attributes"
+    fail_msg: "check_mode add custom attributes did not produce expected spec"
+    success_msg: "check_mode add custom attributes produced expected spec"
+
+#################################################################################
+# Real add — single (minimal) custom attribute
+#################################################################################
+
+- name: Add a single custom attribute (minimal) to VM disk
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    state: present
+    vm_ext_id: "{{ vm_uuid }}"
+    ext_id: "{{ disk_uuid }}"
+    custom_attributes:
+      - "environment:production"
+  register: result
+  ignore_errors: true
+
+- name: Add single custom attribute status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == disk_uuid
+      - result.vm_ext_id == vm_uuid
+      - result.task_ext_id is defined
+      - result.response.custom_attributes is defined
+      - "'environment:production' in result.response.custom_attributes"
+    fail_msg: "Add single custom attribute failed"
+    success_msg: "Add single custom attribute passed"
+
+#################################################################################
+# Real add — multiple custom attributes (all fields populated)
+#################################################################################
+
+- name: Add multiple custom attributes (full) to VM disk
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    state: present
+    vm_ext_id: "{{ vm_uuid }}"
+    ext_id: "{{ disk_uuid }}"
+    custom_attributes:
+      - "tier:gold"
+      - "owner:ansible"
+      - "workload:database"
+  register: result
+  ignore_errors: true
+
+- name: Add multiple custom attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == disk_uuid
+      - result.vm_ext_id == vm_uuid
+      - result.task_ext_id is defined
+      - result.response.custom_attributes is defined
+      - "'environment:production' in result.response.custom_attributes"
+      - "'tier:gold' in result.response.custom_attributes"
+      - "'owner:ansible' in result.response.custom_attributes"
+      - "'workload:database' in result.response.custom_attributes"
+      - result.response.custom_attributes | length == 4
+    fail_msg: "Add multiple custom attributes failed"
+    success_msg: "Add multiple custom attributes passed"
+
+#################################################################################
+# Idempotency: re-add the same attributes
+#################################################################################
+
+- name: Idempotency — add already-present custom attributes
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    state: present
+    vm_ext_id: "{{ vm_uuid }}"
+    ext_id: "{{ disk_uuid }}"
+    custom_attributes:
+      - "environment:production"
+      - "tier:gold"
+  register: result
+  ignore_errors: true
+
+- name: Idempotency (add) status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.ext_id == disk_uuid
+      - result.vm_ext_id == vm_uuid
+      - result.msg is defined
+      - "'already present' in result.msg"
+    fail_msg: "Idempotency (add) failed"
+    success_msg: "Idempotency (add) passed"
+
+#################################################################################
+# check_mode: Remove (single check_mode test for Remove)
+#################################################################################
+
+- name: Remove custom attributes from VM disk - check mode
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    state: absent
+    vm_ext_id: "{{ vm_uuid }}"
+    ext_id: "{{ disk_uuid }}"
+    custom_attributes:
+      - "tier:gold"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Remove custom attributes - check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.vm_ext_id == vm_uuid
+      - result.ext_id == disk_uuid
+      - result.response.custom_attributes is defined
+      - "'tier:gold' in result.response.custom_attributes"
+      - result.response.custom_attributes | length == 1
+    fail_msg: "check_mode remove custom attributes did not produce expected spec"
+    success_msg: "check_mode remove custom attributes produced expected spec"
+
+#################################################################################
+# Real remove — a subset of attributes
+#################################################################################
+
+- name: Remove one custom attribute from VM disk
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    state: absent
+    vm_ext_id: "{{ vm_uuid }}"
+    ext_id: "{{ disk_uuid }}"
+    custom_attributes:
+      - "tier:gold"
+  register: result
+  ignore_errors: true
+
+- name: Remove one custom attribute status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == disk_uuid
+      - result.vm_ext_id == vm_uuid
+      - result.task_ext_id is defined
+      - result.response.custom_attributes is defined
+      - "'tier:gold' not in result.response.custom_attributes"
+      - "'environment:production' in result.response.custom_attributes"
+      - "'owner:ansible' in result.response.custom_attributes"
+      - "'workload:database' in result.response.custom_attributes"
+      - result.response.custom_attributes | length == 3
+    fail_msg: "Remove one custom attribute failed"
+    success_msg: "Remove one custom attribute passed"
+
+#################################################################################
+# Idempotency: remove already-absent attributes
+#################################################################################
+
+- name: Idempotency — remove already-absent custom attributes
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    state: absent
+    vm_ext_id: "{{ vm_uuid }}"
+    ext_id: "{{ disk_uuid }}"
+    custom_attributes:
+      - "tier:gold"
+      - "not-a-real:attribute"
+  register: result
+  ignore_errors: true
+
+- name: Idempotency (remove) status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.ext_id == disk_uuid
+      - result.vm_ext_id == vm_uuid
+      - result.msg is defined
+      - "'None of the requested' in result.msg"
+    fail_msg: "Idempotency (remove) failed"
+    success_msg: "Idempotency (remove) passed"
+
+#################################################################################
+# Real remove — remove all remaining attributes
+#################################################################################
+
+- name: Remove remaining custom attributes from VM disk
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    state: absent
+    vm_ext_id: "{{ vm_uuid }}"
+    ext_id: "{{ disk_uuid }}"
+    custom_attributes:
+      - "environment:production"
+      - "owner:ansible"
+      - "workload:database"
+  register: result
+  ignore_errors: true
+
+- name: Remove remaining custom attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == disk_uuid
+      - result.vm_ext_id == vm_uuid
+      - result.task_ext_id is defined
+      - >-
+        result.response.custom_attributes is not defined
+        or result.response.custom_attributes == none
+        or result.response.custom_attributes | length == 0
+    fail_msg: "Remove remaining custom attributes failed"
+    success_msg: "Remove remaining custom attributes passed"
+
+#################################################################################
+# Negative — missing required `custom_attributes` param
+#################################################################################
+
+- name: Negative — missing required custom_attributes
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    state: present
+    vm_ext_id: "{{ vm_uuid }}"
+    ext_id: "{{ disk_uuid }}"
+  register: result
+  ignore_errors: true
+
+- name: Missing custom_attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.msg is defined
+      - "'custom_attributes' in result.msg"
+    fail_msg: "Missing custom_attributes did not surface a proper argument error"
+    success_msg: "Missing custom_attributes surfaced the expected argument error"
+
+#################################################################################
+# Negative — invalid disk ext_id
+#################################################################################
+
+- name: Negative — invalid disk ext_id
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    state: present
+    vm_ext_id: "{{ vm_uuid }}"
+    ext_id: "12345678-1234-1234-1234-123456789123"
+    custom_attributes:
+      - "environment:staging"
+  register: result
+  ignore_errors: true
+
+- name: Invalid disk ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+    fail_msg: "Invalid disk ext_id did not fail as expected"
+    success_msg: "Invalid disk ext_id failed as expected"
+
+#################################################################################
+# Negative — invalid VM ext_id
+#################################################################################
+
+- name: Negative — invalid VM ext_id
+  nutanix.ncp.ntnx_vm_disk_custom_attribute_v2:
+    state: present
+    vm_ext_id: "12345678-1234-1234-1234-123456789123"
+    ext_id: "{{ disk_uuid }}"
+    custom_attributes:
+      - "environment:staging"
+  register: result
+  ignore_errors: true
+
+- name: Invalid VM ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+    fail_msg: "Invalid VM ext_id did not fail as expected"
+    success_msg: "Invalid VM ext_id failed as expected"
+
+#################################################################################
+# Cleanup — delete the disk and the VM
+#################################################################################
+
+- name: Delete disk
+  nutanix.ncp.ntnx_vms_disks_v2:
+    state: absent
+    vm_ext_id: "{{ vm_uuid }}"
+    ext_id: "{{ disk_uuid }}"
+  register: result
+  ignore_errors: true
+
+- name: Delete disk status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.changed == true
+    fail_msg: "Failed to delete disk during cleanup"
+    success_msg: "Disk deleted during cleanup"
+
+- name: Delete VM
+  nutanix.ncp.ntnx_vms_v2:
+    state: absent
+    ext_id: "{{ vm_uuid }}"
+  register: result
+  ignore_errors: true
+
+- name: Delete VM status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.changed == true
+      - result.ext_id == vm_uuid
+    fail_msg: "Failed to delete VM during cleanup"
+    success_msg: "VM deleted during cleanup"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection module for the **virtual_machine_management** namespace, entity
**VmDiskCustomAttribute**, based on the inline `sdk_info.json` in `INSTRUCTIONS.md`. One PR
per code-gen run.

VmDiskCustomAttribute is an **action-type** feature: the v4 VMM APIs expose only two `$actions`
endpoints for it — `add-custom-attributes` and `remove-custom-attributes` on a VM disk. There
is no dedicated CRUD entity and no dedicated list/get-by-id endpoint (custom attributes are
returned as a field on the parent VM disk resource). Following Step 0.3 / Step 2 of the
instructions, only a single action-style module is generated; the info module step is
explicitly skipped for action-type modules.

- Module generated: `ntnx_vm_disk_custom_attribute_v2` (CRUD/info info module skipped — action-type)
- API methods covered: `2` — `add_vm_disk_custom_attributes`, `remove_vm_disk_custom_attributes` (both on `VmApi`, path `/api/vmm/v4.2/ahv/config/vms/{vmExtId}/disks/{extId}/$actions/*-custom-attributes`)
- Fields in action module spec: `3` (`vm_ext_id`, `ext_id`, `custom_attributes`) plus the standard v4 credential / operation / logger / proxy fragments and `state` (present/absent) dispatch.

## Domain knowledge (from Glean)

**VmDiskCustomAttribute** is a feature in Nutanix Virtual Machine Management (VMM) v4 APIs that
allows administrators and automated workflows to attach user-defined key-value pairs (custom
metadata) directly to individual VM disks.

This is extremely useful for plugins (like Citrix MCS), automation tracking, and lifecycle
management, where specific metadata needs to be retained at the disk level (e.g., tracking disk
tiers, environments, or creation origins).

### Detailed Features & Behavioral Details

- **CRUD Operations:** Custom attributes can be added or removed from a disk using specific VMM
  v4 `$actions` endpoints.
- **Format:** Custom attributes are passed as a list of strings formatted as `['key:value']`
  via the `UpdateCustomAttributesParams` object.
- **Migration & Export Resilience:** Custom attributes on VM Disks are fully preserved during VM
  migration and OVA export/import operations.
- **Disaster Recovery (DR) Retention:** VM Disk Custom Attributes are supported and retained
  during Asynchronous and Near-Synchronous DR (Planned Failover / Unplanned Failover), provided
  the remote target cluster also supports custom attributes.
- **Exclusions:** VM Disks that are backed by Volume Groups (VGs) are **not eligible** for VM
  Disk Custom Attributes.

### Where and How is it Used? (Workflow)

**1. Endpoints**

The feature exposes specific v4 action endpoints for disks:

- **Add Attributes:** `POST /vmm/v4.3/ahv/config/vms/{vmExtId}/disks/{extId}/$actions/add-custom-attributes`
  (this branch's SDK is pinned at `v4.2` — same request shape)
- **Remove Attributes:** `POST /vmm/v4.3/ahv/config/vms/{vmExtId}/disks/{extId}/$actions/remove-custom-attributes`

*Note: ETag matching (`If-Match`) is supported but can be turned off/optional by default in
some endpoints for easier test automation.* Our module forwards an `If-Match` header when the
current disk carries an etag, and gracefully skips it otherwise.

**2. Prerequisites (Capabilities & RBAC)**

- **Cluster Capability Check:** The operation checks the `custom_attributes_caps` in
  Metropolis to ensure the cluster supports it (`supports_vm_disk_custom_attributes: true`).
- **RBAC Requirements:** Users executing the request must possess the
  `Update_Virtual_Machine_Disk_Custom_Attributes` permission. Roles can be scoped at the
  cluster, entity (specific VM), or category level
  (e.g., `vm_disk_custom_attributes_cluster`, `vm_disk_custom_attributes_entity`).

**3. Example Code Usage (Python SDK)**

```python
import ntnx_vmm_py_client

vm_api = ntnx_vmm_py_client.api.VmApi(api_client)
updateCustomAttributesParams = ntnx_vmm_py_client.UpdateCustomAttributesParams()
updateCustomAttributesParams.custom_attributes = ["environment:production", "tier:gold"]

# Add custom attributes
response = vm_api.add_vm_disk_custom_attributes(
    vmExtId="<vm_uuid>",
    extId="<disk_uuid>",
    body=updateCustomAttributesParams,
)
```

### Related Documentation & Links

**Epic & Feature Definitions**

- **FEAT-<PHONE_1>:** [Custom Attributes Support in V4 VM and VmDisk APIs](https://jira.nutanix.com/browse/FEAT-<PHONE_1>)
- **FEAT-7531:** [Citrix MCS Integration for Prism Central (PRD)](https://docs.google.com/document/d/1Fe9EbucRKIju3wswBdLWIOfaec5o4_5ATTRci0hOEHs/edit?usp=sharing)

**Design Docs & Specs**

- **ERD:** [v4 VMM - Citrix plugin integration](https://docs.google.com/document/d/1DR8OyM74v3-nBHDRUMfE_i8Z8nueqA0an9sOsUaOe5c/edit?usp=sharing)
- **Design Doc:** [Support "Custom Attributes" in v4 AHV VM & VmDisk APIs](https://docs.google.com/document/d/1rX24kbDQQThgHV4Mq7O5d8FQmWte3wRqzSIU5u9I2FY/edit?usp=sharing)
- **API Yaml Design & RBAC:** [Schema & Permissions Doc](https://docs.google.com/document/d/1NoXJCT8iQdejZk7EODXB4dk8GRzdB1Ou2UcUF4Jfu2s/edit)
- **Test Plan:** [Functional Test Plan](https://docs.google.com/spreadsheets/d/1rXNmo9gnm_j3bVpoc3uJiUUFAhbifkie_1mI0OlMC04/edit)

**Confluence Pages**

- [FEAT-<PHONE_1> - Custom Attributes Support in V4 VM and VmDisk APIs](https://confluence.eng.nutanix.com:8443/spaces/AE/pages/411934891/FEAT-<PHONE_1>+-+Custom+Attributes+Support+in+V4+VM+and+VmDisk+APIs)
- [AHM Mgmt Iris Tracker](https://confluence.eng.nutanix.com:8443/spaces/AHVM/pages/404260534/AHM+Mgmt+Iris)

**Relevant Engineering / JIRA Tickets**

- **ENG-798722:** [Add Test Case to Verify Retention of VM and VM Disk Custom Attributes in OVA](https://jira.nutanix.com/browse/ENG-798722)
- **ENG-956620:** [Automate test vm_and_vm_disk_custom_attributes retention in sync/async dr pfo/upfo workflows](https://jira.nutanix.com/browse/ENG-956620)
- **ENG-787595:** [PFO/UPFO async/sync - Should raise an error if remote doesn't support custom_attributes](https://jira.nutanix.com/browse/ENG-787595)
- **ENG-859716:** [default $action endpoints to not include etag](https://jira.nutanix.com/browse/ENG-859716)
- **ENG-785611:** [Automate test_limits_of_vm_disk_custom_attributes](https://jira.nutanix.com/browse/ENG-785611)
- **ENG-880205:** [Generate Token Failed: VM console token generation is not supported in cluster](https://jira.nutanix.com/browse/ENG-880205)
- **ENG-881923:** [`[7.5.1]` Complete 100% execution and triage for pending cases in RC1](https://jira.nutanix.com/browse/ENG-881923)

**Source-of-truth code / spec references (surfaced by Glean)**

- `add_vm_disk_custom_attributes_request.go`: https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vm/add_vm_disk_custom_attributes_request.go
- `remove_vm_disk_custom_attributes_request.go`: https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vm/remove_vm_disk_custom_attributes_request.go
- `disk-endpoints.yaml`: https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/endpoints/ahv/config/disk-endpoints.yaml
- `vm_api.py` (Python SDK): https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/api/vm_api.py
- `VMs_service.proto`: https://github.com/nutanix-core/proto-cache/blob/master/ctrl-plane-pc/ctrl_plane_pc_client/ntnx_api_vmm/vmm/v4/ahv/config/VMs_service.proto
- `VMs_service_grpc.pb.go`: https://github.com/nutanix-core/go-cache/blob/master/ntnxapivmm/vmm/v4/ahv/config/VMs_service_grpc.pb.go
- `vmDescriptions.yaml`: https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/etc/resources/documentation/bundles/en_US/vmDescriptions.yaml
- `custom_attributes.json` (RBAC test data): https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/acropolis/ahv_management/vmm_v4/rbac_configs/custom_attributes.json
- `disk_utility.py`: https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/acropolis/ahv_management/vmm_v4/disk_utility.py
- `test_vm_custom_attributes.py` (nutest systest): https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/systest/acropolis/test_vm_custom_attributes.py
- `pc_v4_remove_disk_custom_attributes_op.py` (nutest workflow): https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/operation/pc/v4/vm/pc_v4_remove_disk_custom_attributes_op.py
- `vm_disk_custom_attributes.lst` (test milestone list): https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/test_sets/milestones/master/ahv/ahv_mgmt/ahv_vm_mgmt/ahv_vm_mgmt_group1/vm_disk_custom_attributes.lst
- `endpoints.json`: https://github.com/nutanix-engineering/hack2026-d3089/blob/main/old_approach_data/tpg_output/schemas/domain_12_ahv_vms_actions_post/endpoints.json
- `endpoint_registry.json`: https://github.com/nutanix-engineering/hack2026-d3089/blob/main/hackathon_new/tpg_output/old_error_codes/endpoint_registry.json
- `narsil_caps.proto` (cluster capability flag): https://github.com/nutanix-core/proto-cache/blob/master/ctrl-plane/ctrl_plane_client/narsil/cap_proto/narsil_caps.proto

### Required Domain Skills to Learn

If you intend to work on this feature (writing code, testing, or documentation), you should
familiarize yourself with the following domain areas:

1. **Nutanix v4 VMM API Architecture:** Understand how v4 endpoints are structured, specifically
   how `$actions` and sub-entities (like disks attached to VMs) are manipulated and queried.
2. **AHV Storage and Disk Mechanics:** Differentiate between standard AHV VM Disks, Volume Group
   (VG) backed disks, and CD-ROMs. You must understand why VG-backed disks are skipped for
   disk-level VM custom attributes.
3. **Identity and Access Management (RBAC):** Learn how Nutanix's Prism Central Role-Based
   Access Control assigns permissions across Categories, Clusters, and individual VM Entities,
   and how `Update_Virtual_Machine_Disk_Custom_Attributes` interacts with these scopes.
4. **Disaster Recovery (DR) & Mobility:** Understand how Async/Near-Sync DR mechanisms
   (PFO/UPFO) work in Prism Central. Specifically, learn how VM definitions and metadata
   (`vmconfig`) are synchronized and preserved across independent PE clusters.
5. **Narsil / Metropolis Cluster Capabilities:** Learn how Nutanix handles backward
   compatibility and feature flagging using capabilities (`custom_attributes_caps`), ensuring
   new API behaviors don't crash older destination clusters during migrations or DR.

## Files changed

**plugins/modules/**
- `plugins/modules/ntnx_vm_disk_custom_attribute_v2.py` — new action-type v2 module wrapping
  `add_vm_disk_custom_attributes` / `remove_vm_disk_custom_attributes` on `VmApi`.
  `state=present` adds, `state=absent` removes; both are idempotent (only the delta is
  submitted; if no delta the module exits with `skipped=true`).

**meta/**
- `meta/runtime.yml` — added `ntnx_vm_disk_custom_attribute_v2` to the `ntnx` action group
  so `module_defaults: group/nutanix.ncp.ntnx` correctly injects credentials.

**tests/integration/targets/**
- `tests/integration/targets/ntnx_vm_disk_custom_attribute_v2/aliases` — disabled by default (matches other v4 targets).
- `tests/integration/targets/ntnx_vm_disk_custom_attribute_v2/meta/main.yml` — depends on `prepare_env`.
- `tests/integration/targets/ntnx_vm_disk_custom_attribute_v2/tasks/main.yml` — sets `module_defaults` and imports operations.
- `tests/integration/targets/ntnx_vm_disk_custom_attribute_v2/tasks/vm_disk_custom_attribute_operations.yml`
  — full end-to-end test plan (see file header): prerequisite VM+disk create,
  `check_mode` add, minimal add, full add, add-idempotency, `check_mode` remove, real
  remove, remove-idempotency, drain all, negative missing-arg / invalid disk id / invalid VM id,
  and full teardown.

**examples/**
- `examples/virtual_machine_management/VmDiskCustomAttribute/vm_disk_custom_attribute_v2.yml`
  — playbook that demonstrates add + remove using `module_defaults` (no per-task credentials).
- `examples/virtual_machine_management/VmDiskCustomAttribute/examples_run.log`
  — real playbook output captured against PC `10.44.76.28`.

**.gitignore**
- Added `tests/integration/integration_config.yml` so the (credentialed) integration config
  cannot be accidentally committed. This matches what the instructions assumed was already in
  `.gitignore`.

## Test execution

| Metric              | Value                                                                       |
|---------------------|-----------------------------------------------------------------------------|
| Command             | `ansible-playbook <wrapper>.yml` importing `vm_disk_custom_attribute_operations.yml` |
| Total tasks         | `38`                                                                      |
| Passed (ok)         | `33`                                                                      |
| Changed             | `8`                                                                       |
| Failed (final)      | `0`                                                                       |
| Ignored (expected)  | `3` (three negative tests intentionally raise API/argument errors)        |
| Skipped             | `2` (idempotency short-circuits — add-nothing / remove-nothing)           |
| Duration            | `~45s`                                                                    |
| Cluster (PC)        | `10.44.76.28` (auto_cluster_prod_36acf9b012ca, PE UUID `0006555e-4e63-4a5e-185b-ac1f6b6f97e2`) |

### Analysis

- All positive tests (real add / update / remove, minimal + full) succeeded on the live cluster.
- Idempotency tests correctly short-circuited: the module returns `changed=false, skipped=true`
  when a re-add contains only already-present attributes, or a remove contains only already-absent
  attributes — matching the reviewer-preferred behaviour in `ntnx_vms_categories_v2`.
- `check_mode` returns a valid spec dict (with the requested `custom_attributes` populated) and
  makes no API call.
- Negative tests are marked `ignore_errors: true` intentionally so we can then `assert` the
  expected failure and message. They all produced the expected failures:
    - Missing `custom_attributes` → argument-spec validation error (`missing required arguments: custom_attributes`).
    - Invalid disk `ext_id` → API `VMM-30700 VM_DISK_NOT_FOUND_ERROR` (`404`).
    - Invalid VM `ext_id`   → API `VMM-30100 VM_NOT_FOUND` (`404`).
- Additional lint/sanity: `black --check`, `isort --check`, `flake8`, `ansible-lint` and
  `ansible-test sanity --python 3.12` (all 32 test buckets: compile, import, pep8, pylint,
  yamllint, validate-modules, ansible-doc, runtime-metadata, etc.) all pass for the new module,
  the tests, the examples, and the updated `meta/runtime.yml`.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'

PLAY [Run VmDiskCustomAttribute integration tests] *****************************

TASK [Start testing ntnx_vm_disk_custom_attribute_v2] **************************
ok: [localhost] => {
    "msg": "Start testing ntnx_vm_disk_custom_attribute_v2"
}

TASK [Generate random name] ****************************************************
ok: [localhost]

TASK [Set VM name for this run] ************************************************
ok: [localhost]

TASK [Create VM with minimum requirements] *************************************
changed: [localhost]

TASK [VM creation status] ******************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "VM for VM disk custom attribute test created successfully"
}

TASK [Set VM ext_id] ***********************************************************
ok: [localhost]

TASK [Create Disk on VM (backed by storage container)] *************************
changed: [localhost]

TASK [Create Disk on VM status] ************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Disk for VM disk custom attribute test created successfully"
}

TASK [Set Disk ext_id] *********************************************************
ok: [localhost]

TASK [Add custom attributes to VM disk - check mode with all attributes] *******
ok: [localhost]

TASK [Add custom attributes to VM disk - check mode status] ********************
ok: [localhost] => {
    "changed": false,
    "msg": "check_mode add custom attributes produced expected spec"
}

TASK [Add a single custom attribute (minimal) to VM disk] **********************
changed: [localhost]

TASK [Add single custom attribute status] **************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Add single custom attribute passed"
}

TASK [Add multiple custom attributes (full) to VM disk] ************************
changed: [localhost]

TASK [Add multiple custom attributes status] ***********************************
ok: [localhost] => {
    "changed": false,
    "msg": "Add multiple custom attributes passed"
}

TASK [Idempotency — add already-present custom attributes] *********************
skipping: [localhost]

TASK [Idempotency (add) status] ************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Idempotency (add) passed"
}

TASK [Remove custom attributes from VM disk - check mode] **********************
ok: [localhost]

TASK [Remove custom attributes - check mode status] ****************************
ok: [localhost] => {
    "changed": false,
    "msg": "check_mode remove custom attributes produced expected spec"
}

TASK [Remove one custom attribute from VM disk] ********************************
changed: [localhost]

TASK [Remove one custom attribute status] **************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Remove one custom attribute passed"
}

TASK [Idempotency — remove already-absent custom attributes] *******************
skipping: [localhost]

TASK [Idempotency (remove) status] *********************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Idempotency (remove) passed"
}

TASK [Remove remaining custom attributes from VM disk] *************************
changed: [localhost]

TASK [Remove remaining custom attributes status] *******************************
ok: [localhost] => {
    "changed": false,
    "msg": "Remove remaining custom attributes passed"
}

TASK [Negative — missing required custom_attributes] ***************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: custom_attributes"}
...ignoring

TASK [Missing custom_attributes status] ****************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Missing custom_attributes surfaced the expected argument error"
}

TASK [Negative — invalid disk ext_id] ******************************************
fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching vm disk info using ext_id", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"disk_device_uuid": "12345678-1234-1234-1234-123456789123", "vm_uuid": "585f78fa-ac94-4f94-6544-cb3bae39835b"}, "code": "VMM-30700", "errorGroup": "VM_DISK_NOT_FOUND_ERROR", "locale": "en-US", "message": "Failed to perform the operation on the VM with UUID '585f78fa-ac94-4f94-6544-cb3bae39835b' as the disk with UUID '12345678-1234-1234-1234-123456789123' is not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [Invalid disk ext_id status] **********************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Invalid disk ext_id failed as expected"
}

TASK [Negative — invalid VM ext_id] ********************************************
fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching vm disk info using ext_id", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"vm_uuid": "12345678-1234-1234-1234-123456789123"}, "code": "VMM-30100", "errorGroup": "VM_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the VM with UUID '12345678-1234-1234-1234-123456789123', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [Invalid VM ext_id status] ************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Invalid VM ext_id failed as expected"
}

TASK [Delete disk] *************************************************************
changed: [localhost]

TASK [Delete disk status] ******************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Disk deleted during cleanup"
}

TASK [Delete VM] ***************************************************************
changed: [localhost]

TASK [Delete VM status] ********************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "VM deleted during cleanup"
}

PLAY RECAP *********************************************************************
localhost                  : ok=33   changed=8    unreachable=0    failed=0    skipped=2    rescued=0    ignored=3   
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript (`INSTRUCTIONS.md` on
  branch — deliberately NOT committed).
- Domain context was gathered via Glean (`glean__chat`) with the verbatim question requested by
  the instructions; the full answer is reproduced above.
