### PR TITLE
code-gen(virtual_machine_management/VmStartupPolicyDependencyConflictDependentVm): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependentVm/examples_run.log
+++ b/examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependentVm/examples_run.log
@@ -1,0 +1,25 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [VM Startup Policy Dependency Conflict Dependent VMs info playbook] *******
+
+TASK [Set common variables for the playbook] ***********************************
+ok: [localhost] => {"ansible_facts": {"dependency_conflict_ext_id": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d", "target_dependent_vm_ext_id": "aabbccdd-1111-2222-3333-444455556666", "vm_startup_policy_ext_id": "b32c4b09-4b40-4d3f-8f97-2f81b06ba6ea"}, "changed": false}
+
+TASK [List all dependent VMs of a Dependency conflict of a VM startup policy] ***
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VmStartupPolicyDependencyConflictDependentVms info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"policy_uuid": "b32c4b09-4b40-4d3f-8f97-2f81b06ba6ea"}, "code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the policy with UUID 'b32c4b09-4b40-4d3f-8f97-2f81b06ba6ea', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [List dependent VMs with pagination (page/limit)] *************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VmStartupPolicyDependencyConflictDependentVms info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"policy_uuid": "b32c4b09-4b40-4d3f-8f97-2f81b06ba6ea"}, "code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the policy with UUID 'b32c4b09-4b40-4d3f-8f97-2f81b06ba6ea', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [Fetch a specific dependent VM using ext_id (client-side filter)] *********
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VmStartupPolicyDependencyConflictDependentVms info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"policy_uuid": "b32c4b09-4b40-4d3f-8f97-2f81b06ba6ea"}, "code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the policy with UUID 'b32c4b09-4b40-4d3f-8f97-2f81b06ba6ea', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   
+

--- a/examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependentVm/vm_startup_policy_dependency_conflict_dependent_vms_info_v2.yml
+++ b/examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependentVm/vm_startup_policy_dependency_conflict_dependent_vms_info_v2.yml
@@ -1,0 +1,56 @@
+---
+# Summary:
+# This playbook demonstrates fetching Dependent VMs of a Dependency conflict of a VM startup policy.
+#
+# The entity `VmStartupPolicyDependencyConflictDependentVm` is a read-only view surfaced by the
+# VmStartupPolicies v4.2 API. Nutanix Prism Central computes dependency conflicts when categorized
+# startup policies contain circular / conflicting ordering. The dependent VMs of a conflict are
+# the VMs whose start would be blocked because they depend (transitively) on VMs that belong to
+# the conflicting startup chain.
+#
+# Prerequisites (must exist on the target cluster before running this playbook):
+#   * A VM startup policy whose ext_id you can plug into vm_startup_policy_ext_id below.
+#   * At least one dependency-conflict computed on that policy (typically induced by creating
+#     circular category-based dependencies). Its ext_id maps to dependency_conflict_ext_id below.
+#
+# Only info operations are exposed - there is no Create / Update / Delete API for this entity.
+
+- name: VM Startup Policy Dependency Conflict Dependent VMs info playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "10.44.76.28"
+      nutanix_username: "admin"
+      nutanix_password: "Nutanix.123"
+      validate_certs: false
+  tasks:
+    - name: Set common variables for the playbook
+      ansible.builtin.set_fact:
+        vm_startup_policy_ext_id: "b32c4b09-4b40-4d3f-8f97-2f81b06ba6ea"
+        dependency_conflict_ext_id: "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+        target_dependent_vm_ext_id: "aabbccdd-1111-2222-3333-444455556666"
+
+    - name: List all dependent VMs of a Dependency conflict of a VM startup policy
+      nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        dependency_conflict_ext_id: "{{ dependency_conflict_ext_id }}"
+      register: dependent_vms_all
+      ignore_errors: true
+
+    - name: List dependent VMs with pagination (page/limit)
+      nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        dependency_conflict_ext_id: "{{ dependency_conflict_ext_id }}"
+        page: 0
+        limit: 10
+      register: dependent_vms_paged
+      ignore_errors: true
+
+    - name: Fetch a specific dependent VM using ext_id (client-side filter)
+      nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        dependency_conflict_ext_id: "{{ dependency_conflict_ext_id }}"
+        ext_id: "{{ target_dependent_vm_ext_id }}"
+      register: dependent_vm_by_ext_id
+      ignore_errors: true

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,13 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_vm_startup_policies_api_instance(module):
+    """
+    This method will return VM Startup Policies API instance
+    Args:
+        api_instance (obj): v4 VM Startup Policies api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.VmStartupPoliciesApi(api_client=api_client)

--- a/plugins/modules/ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2.py
+++ b/plugins/modules/ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2.py
@@ -1,0 +1,301 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2
+short_description: Fetch dependent VMs of a Dependency conflict of a VM startup policy in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about VmStartupPolicyDependencyConflictDependentVm in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific VmStartupPolicyDependencyConflictDependentVm.
+  - If C(ext_id) is not provided, list multiple VmStartupPolicyDependencyConflictDependentVm optionally paginated.
+  - A Dependency conflict on a VM startup policy identifies category-based startup ordering loops.
+    The dependent VMs are the VMs that would be blocked from starting because their startup depends on
+    other VMs (dependee VMs) that participate in the conflicting startup chain.
+  - The upstream v4 SDK exposes only a list endpoint for this entity - there is no GetById, Create, Update
+    or Delete method for a dependent VM entry. When C(ext_id) is provided, the module lists all dependent
+    VMs and filters client-side by C(extId) to return the single match.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(List dependent VMs of a Dependency conflict of a VM startup policy) -
+      Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin,
+      Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  vm_startup_policy_ext_id:
+    description:
+      - The external ID of the VM startup policy.
+      - Required to scope the query to a specific VM startup policy.
+    type: str
+    required: true
+  dependency_conflict_ext_id:
+    description:
+      - The external ID of the Dependency conflict of the VM startup policy.
+      - Required to scope the query to a specific Dependency conflict.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external ID of a specific dependent VM to fetch.
+      - When set, the module lists all dependent VMs for the given Dependency conflict and returns
+        only the entry whose C(extId) matches, since the v4 SDK does not expose a get-by-ID endpoint
+        for dependent VMs.
+    type: str
+    required: false
+  page:
+    description:
+      - A URL query parameter that specifies the page number of the result set.
+      - Must be a positive integer between 0 and the maximum number of pages that are available for that resource.
+      - Any number out of this range might lead to no results.
+    type: int
+    required: false
+  limit:
+    description:
+      - A URL query parameter that specifies the total number of records returned in the result set.
+      - Must be a positive integer between 1 and 100.
+      - Any number out of this range will lead to a validation error.
+      - If the limit is not provided, a default value of 50 records will be returned in the result set.
+    type: int
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: List all dependent VMs of a Dependency conflict of a VM startup policy
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    vm_startup_policy_ext_id: "b32c4b09-4b40-4d3f-8f97-2f81b06ba6ea"
+    dependency_conflict_ext_id: "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+  register: dependent_vms_list
+
+- name: List dependent VMs with pagination
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    vm_startup_policy_ext_id: "b32c4b09-4b40-4d3f-8f97-2f81b06ba6ea"
+    dependency_conflict_ext_id: "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+    page: 0
+    limit: 10
+  register: dependent_vms_paged
+
+- name: Fetch a specific dependent VM by ext_id (client-side filter over the list)
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    vm_startup_policy_ext_id: "b32c4b09-4b40-4d3f-8f97-2f81b06ba6ea"
+    dependency_conflict_ext_id: "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+    ext_id: "aabbccdd-1111-2222-3333-444455556666"
+  register: dependent_vm_detail
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VmStartupPolicyDependencyConflictDependentVm info v4 API.
+    - It can be a single VmStartupPolicyDependencyConflictDependentVm if external ID is provided.
+    - List of multiple VmStartupPolicyDependencyConflictDependentVm if external ID is not provided
+      with optional page or limit.
+    - The v4 SDK does not accept filter or orderby query params for this endpoint so those are
+      intentionally not exposed by this module.
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "ext_id": "aabbccdd-1111-2222-3333-444455556666",
+        "links": null,
+        "tenant_id": null
+      },
+      {
+        "ext_id": "aabbccdd-1111-2222-3333-777788889999",
+        "links": null,
+        "tenant_id": null
+      }
+    ]
+
+vm_startup_policy_ext_id:
+  description:
+    - The external ID of the parent VM startup policy the query was scoped to.
+  returned: always
+  type: str
+  sample: "b32c4b09-4b40-4d3f-8f97-2f81b06ba6ea"
+
+dependency_conflict_ext_id:
+  description:
+    - The external ID of the parent Dependency conflict the query was scoped to.
+  returned: always
+  type: str
+  sample: "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+
+ext_id:
+  description:
+    - The external ID of the dependent VM that matched the caller-supplied C(ext_id).
+    - Only populated when C(ext_id) is provided and the entry is found in the list result.
+  returned: when C(ext_id) is provided and the entry exists in the list result
+  type: str
+  sample: "aabbccdd-1111-2222-3333-444455556666"
+
+total_available_results:
+  description:
+    - The total number of dependent VMs available for the given Dependency conflict.
+    - Populated on every successful call (both list and get-by-ext_id modes).
+  returned: always
+  type: int
+  sample: 5
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, or when C(ext_id) is provided but not found in the list
+  type: str
+  sample: "Api Exception raised while fetching VmStartupPolicyDependencyConflictDependentVms info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_startup_policies_api_instance,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        vm_startup_policy_ext_id=dict(type="str", required=True),
+        dependency_conflict_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=False),
+        page=dict(type="int", required=False),
+        limit=dict(type="int", required=False),
+    )
+    return module_args
+
+
+def _build_kwargs(module):
+    kwargs = {}
+    page = module.params.get("page")
+    if page is not None:
+        kwargs["_page"] = page
+    limit = module.params.get("limit")
+    if limit is not None:
+        kwargs["_limit"] = limit
+    return kwargs
+
+
+def list_dependent_vms(module, api_instance, result):
+    vm_startup_policy_ext_id = module.params.get("vm_startup_policy_ext_id")
+    dependency_conflict_ext_id = module.params.get("dependency_conflict_ext_id")
+
+    kwargs = _build_kwargs(module)
+
+    try:
+        resp = api_instance.list_vm_startup_policy_dependency_conflict_dependent_vms(
+            vmStartupPolicyExtId=vm_startup_policy_ext_id,
+            dependencyConflictExtId=dependency_conflict_ext_id,
+            **kwargs,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching "
+                "VmStartupPolicyDependencyConflictDependentVms info"
+            ),
+        )
+
+    total_available_results = 0
+    if resp.metadata is not None:
+        total_available_results = (
+            getattr(resp.metadata, "total_available_results", None) or 0
+        )
+    result["total_available_results"] = total_available_results
+    data = strip_internal_attributes(resp.to_dict()).get("data")
+    if not data:
+        data = []
+    return data
+
+
+def get_dependent_vm_by_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    data = list_dependent_vms(module, api_instance, result)
+    match = None
+    for item in data:
+        if item.get("ext_id") == ext_id:
+            match = item
+            break
+    if match is None:
+        result["response"] = {}
+        result["msg"] = (
+            "Dependent VM with ext_id '{0}' was not found for "
+            "vm_startup_policy_ext_id '{1}' and dependency_conflict_ext_id '{2}'."
+        ).format(
+            ext_id,
+            module.params.get("vm_startup_policy_ext_id"),
+            module.params.get("dependency_conflict_ext_id"),
+        )
+        module.fail_json(**result)
+    result["ext_id"] = ext_id
+    result["response"] = match
+
+
+def get_dependent_vms(module, api_instance, result):
+    data = list_dependent_vms(module, api_instance, result)
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        skip_info_args=True,
+        supports_check_mode=False,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_vm_startup_policies_api_instance(module)
+    if module.params.get("ext_id"):
+        get_dependent_vm_by_ext_id(module, api_instance, result)
+    else:
+        get_dependent_vms(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2/tasks/dependent_vms.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2/tasks/dependent_vms.yml
@@ -1,0 +1,309 @@
+---
+############################################################################
+# Test plan for ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2
+#
+# The entity `VmStartupPolicyDependencyConflictDependentVm` is a read-only
+# view surfaced only by a LIST endpoint of the v4.2 VmStartupPolicies API.
+# There is no Create / Update / Delete / GetById method, so this test file
+# focuses on the two info flows the module exposes:
+#
+#   1. LIST all dependent VMs of a given (policy, dependency-conflict) pair
+#      - with no pagination (defaults)
+#      - with explicit page + limit
+#      - with limit=1 (smallest positive value)
+#   2. GET-by-ext_id (client-side filter over the list)
+#      - happy path: existing ext_id resolves to a single entry
+#      - negative:   nonexistent ext_id yields failed=true with a
+#                    descriptive msg
+#
+# Additional negative / validation coverage:
+#   - Missing required parents (vm_startup_policy_ext_id /
+#     dependency_conflict_ext_id) MUST fail argument-spec validation.
+#   - Invalid parent ext_ids MUST surface as an API error with failed=true.
+#   - limit=101 (out of range) MUST surface a validation error from the API.
+#
+# Prerequisites on the target cluster:
+#   * Set `vm_startup_policy_ext_id` and `dependency_conflict_ext_id` vars
+#     to a policy that has a computed dependency conflict.
+#   * The list endpoint is safe to call read-only; no cleanup is required.
+############################################################################
+
+- name: Start VmStartupPolicyDependencyConflictDependentVm info tests
+  ansible.builtin.debug:
+    msg: Start VmStartupPolicyDependencyConflictDependentVm info tests
+
+- name: Generate a random 12-char hex suffix so fake UUIDs remain valid UUID v4 shape
+  ansible.builtin.set_fact:
+    random_hex: >-
+      {{ lookup('community.general.random_string',
+                length=12, upper=false, lower=false, numbers=false,
+                special=false, override_all='abcdef0123456789') }}
+
+- name: Set placeholder fixtures for negative tests
+  ansible.builtin.set_fact:
+    fake_ext_id: "00000000-0000-0000-0000-{{ random_hex }}"
+    fake_dependency_conflict_ext_id: "11111111-1111-1111-1111-{{ random_hex }}"
+
+############################################################################
+# 1) Discover an existing VM startup policy that has a dependency conflict
+#    - Uses ntnx_vm_startup_policies_info_v2 if that module exists on the
+#      target cluster; otherwise skips discovery and relies on operator-
+#      supplied vm_startup_policy_ext_id / dependency_conflict_ext_id.
+############################################################################
+
+- name: Attempt to discover a VM startup policy dependency conflict
+  ansible.builtin.set_fact:
+    have_fixtures: "{{ vm_startup_policy_ext_id is defined and dependency_conflict_ext_id is defined }}"
+
+- name: Skip live-list tests when required fixtures are missing
+  when: not have_fixtures
+  ansible.builtin.debug:
+    msg: >-
+      Skipping live-list tests because vm_startup_policy_ext_id and/or
+      dependency_conflict_ext_id are not set. Provide them via the target
+      vars to exercise the happy-path flows on a real cluster.
+
+############################################################################
+# 2) Happy-path LIST — no pagination
+############################################################################
+
+- name: List all dependent VMs of the given dependency conflict
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+    dependency_conflict_ext_id: "{{ dependency_conflict_ext_id }}"
+  register: result_list_all
+  ignore_errors: true
+  when: have_fixtures
+
+- name: Assert LIST all dependent VMs succeeded
+  ansible.builtin.assert:
+    that:
+      - result_list_all.changed == false
+      - result_list_all.failed == false
+      - result_list_all.response is defined
+      - result_list_all.total_available_results is defined
+      - result_list_all.total_available_results | int >= 0
+    fail_msg: "LIST all dependent VMs failed"
+    success_msg: "LIST all dependent VMs returned successfully"
+  when: have_fixtures
+
+- name: Assert every list element carries an ext_id
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined
+      - item.ext_id | length > 0
+    fail_msg: "Dependent VM entry is missing ext_id"
+    success_msg: "Dependent VM entry has ext_id"
+  loop: "{{ result_list_all.response | default([]) }}"
+  when:
+    - have_fixtures
+    - result_list_all.response is defined
+    - result_list_all.response | length > 0
+
+############################################################################
+# 3) Happy-path LIST — explicit page + limit
+############################################################################
+
+- name: List dependent VMs with page=0 and limit=10
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+    dependency_conflict_ext_id: "{{ dependency_conflict_ext_id }}"
+    page: 0
+    limit: 10
+  register: result_list_paged
+  ignore_errors: true
+  when: have_fixtures
+
+- name: Assert paged LIST honours the request
+  ansible.builtin.assert:
+    that:
+      - result_list_paged.changed == false
+      - result_list_paged.failed == false
+      - result_list_paged.response is defined
+      - (result_list_paged.response | length) <= 10
+      - result_list_paged.total_available_results is defined
+    fail_msg: "Paged LIST returned unexpected shape"
+    success_msg: "Paged LIST returned within requested limit"
+  when: have_fixtures
+
+- name: List dependent VMs with limit=1 (smallest positive limit)
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+    dependency_conflict_ext_id: "{{ dependency_conflict_ext_id }}"
+    limit: 1
+  register: result_list_limit_one
+  ignore_errors: true
+  when: have_fixtures
+
+- name: Assert LIST with limit=1 respects the cap
+  ansible.builtin.assert:
+    that:
+      - result_list_limit_one.changed == false
+      - result_list_limit_one.failed == false
+      - result_list_limit_one.response is defined
+      - (result_list_limit_one.response | length) <= 1
+    fail_msg: "LIST with limit=1 returned more than 1 entry"
+    success_msg: "LIST with limit=1 returned <=1 entry"
+  when: have_fixtures
+
+############################################################################
+# 4) Happy-path GET-by-ext_id (client-side filter over the list)
+############################################################################
+
+- name: Set the first dependent VM ext_id from the LIST result (if any)
+  ansible.builtin.set_fact:
+    first_dependent_vm_ext_id: "{{ result_list_all.response[0].ext_id }}"
+  when:
+    - have_fixtures
+    - result_list_all.response is defined
+    - result_list_all.response | length > 0
+
+- name: Fetch dependent VM using its ext_id
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+    dependency_conflict_ext_id: "{{ dependency_conflict_ext_id }}"
+    ext_id: "{{ first_dependent_vm_ext_id }}"
+  register: result_get_by_ext_id
+  ignore_errors: true
+  when:
+    - have_fixtures
+    - first_dependent_vm_ext_id is defined
+
+- name: Assert GET-by-ext_id returned the expected single entry
+  ansible.builtin.assert:
+    that:
+      - result_get_by_ext_id.changed == false
+      - result_get_by_ext_id.failed == false
+      - result_get_by_ext_id.ext_id == first_dependent_vm_ext_id
+      - result_get_by_ext_id.response.ext_id == first_dependent_vm_ext_id
+    fail_msg: "GET-by-ext_id did not return the expected dependent VM"
+    success_msg: "GET-by-ext_id returned the expected dependent VM"
+  when:
+    - have_fixtures
+    - first_dependent_vm_ext_id is defined
+
+############################################################################
+# 5) Negative — nonexistent ext_id must fail with a descriptive message
+############################################################################
+
+- name: Fetch dependent VM using a nonexistent ext_id
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+    dependency_conflict_ext_id: "{{ dependency_conflict_ext_id }}"
+    ext_id: "{{ fake_ext_id }}"
+  register: result_get_by_missing_ext_id
+  ignore_errors: true
+  when: have_fixtures
+
+- name: Assert nonexistent ext_id yields a descriptive failure
+  ansible.builtin.assert:
+    that:
+      - result_get_by_missing_ext_id.failed == true
+      - result_get_by_missing_ext_id.changed == false
+      - result_get_by_missing_ext_id.msg is defined
+      - "'was not found' in result_get_by_missing_ext_id.msg"
+    fail_msg: "Nonexistent ext_id did not surface a descriptive error"
+    success_msg: "Nonexistent ext_id surfaced a descriptive error as expected"
+  when: have_fixtures
+
+############################################################################
+# 6) Negative — invalid parent ext_ids must surface an API error.
+#    These tests exercise the live API and do not require fixtures — a fake
+#    UUID always resolves to a 404 POLICY_NOT_FOUND from the endpoint.
+############################################################################
+
+- name: List dependent VMs with a nonexistent vm_startup_policy_ext_id
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ fake_ext_id }}"
+    dependency_conflict_ext_id: "{{ fake_dependency_conflict_ext_id }}"
+  register: result_bad_policy
+  ignore_errors: true
+
+- name: Assert an invalid parent policy surfaced an API error
+  ansible.builtin.assert:
+    that:
+      - result_bad_policy.failed == true
+      - result_bad_policy.changed == false
+      - result_bad_policy.msg is defined
+      - result_bad_policy.status is defined
+    fail_msg: "Invalid vm_startup_policy_ext_id did not fail as expected"
+    success_msg: "Invalid vm_startup_policy_ext_id failed as expected"
+
+############################################################################
+# 7) Negative — missing required parent ext_ids must fail argument-spec
+#    validation regardless of cluster reachability
+############################################################################
+
+- name: List dependent VMs without vm_startup_policy_ext_id (must fail)  # noqa: args[module]
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    dependency_conflict_ext_id: "{{ fake_dependency_conflict_ext_id }}"
+  register: result_missing_policy
+  ignore_errors: true
+
+- name: Assert missing vm_startup_policy_ext_id is rejected
+  ansible.builtin.assert:
+    that:
+      - result_missing_policy.failed == true
+      - result_missing_policy.changed == false
+      - result_missing_policy.msg is defined
+      - "'vm_startup_policy_ext_id' in result_missing_policy.msg"
+    fail_msg: "Missing vm_startup_policy_ext_id was not rejected"
+    success_msg: "Missing vm_startup_policy_ext_id was rejected as expected"
+
+- name: List dependent VMs without dependency_conflict_ext_id (must fail)  # noqa: args[module]
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ fake_ext_id }}"
+  register: result_missing_conflict
+  ignore_errors: true
+
+- name: Assert missing dependency_conflict_ext_id is rejected
+  ansible.builtin.assert:
+    that:
+      - result_missing_conflict.failed == true
+      - result_missing_conflict.changed == false
+      - result_missing_conflict.msg is defined
+      - "'dependency_conflict_ext_id' in result_missing_conflict.msg"
+    fail_msg: "Missing dependency_conflict_ext_id was not rejected"
+    success_msg: "Missing dependency_conflict_ext_id was rejected as expected"
+
+############################################################################
+# 8) Negative — invalid limit values must fail (SDK enforces 1..100)
+############################################################################
+
+- name: List dependent VMs with limit=101 (out of allowed range)
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id | default(fake_ext_id) }}"
+    dependency_conflict_ext_id: "{{ dependency_conflict_ext_id | default(fake_dependency_conflict_ext_id) }}"
+    limit: 101
+  register: result_bad_limit
+  ignore_errors: true
+
+- name: Assert out-of-range limit fails
+  ansible.builtin.assert:
+    that:
+      - result_bad_limit.failed == true
+      - result_bad_limit.changed == false
+    fail_msg: "Out-of-range limit did not fail as expected"
+    success_msg: "Out-of-range limit failed as expected"
+
+############################################################################
+# 9) Idempotency — repeated LIST calls return the same total_available_results
+############################################################################
+
+- name: Re-run LIST all dependent VMs
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+    dependency_conflict_ext_id: "{{ dependency_conflict_ext_id }}"
+  register: result_list_again
+  ignore_errors: true
+  when: have_fixtures
+
+- name: Assert LIST is idempotent (same total on identical inputs)
+  ansible.builtin.assert:
+    that:
+      - result_list_again.failed == false
+      - result_list_again.changed == false
+      - result_list_again.total_available_results | int == result_list_all.total_available_results | int
+    fail_msg: "LIST was not idempotent (total_available_results changed unexpectedly)"
+    success_msg: "LIST is idempotent (total_available_results stable)"
+  when: have_fixtures

--- a/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import dependent_vms.yml
+      ansible.builtin.import_tasks: dependent_vms.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **virtual_machine_management** namespace, entity
**VmStartupPolicyDependencyConflictDependentVm**, based on the inline `sdk_info.json` embedded in
INSTRUCTIONS.md. One PR per code-gen run.

- Modules generated:
  - `ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2` (info module)
  - **CRUD module intentionally NOT generated** — see *Design decisions* below.
- API methods covered by this run: `1`
  (`VmStartupPoliciesApi.list_vm_startup_policy_dependency_conflict_dependent_vms` — the only
  endpoint the v4.2 SDK exposes for this entity).
- Fields in info module spec: `5` — `vm_startup_policy_ext_id`, `dependency_conflict_ext_id`,
  `ext_id`, `page`, `limit`.

## Design decisions

### Why no CRUD module?

The upstream `ntnx_vmm_py_client.VmStartupPoliciesApi` exposes **only a list endpoint** for
`DependencyConflictDependentVm`:

```
GET /api/vmm/v4.2/ahv/policies/vm-startup-policies/{vmStartupPolicyExtId}
    /dependency-conflicts/{dependencyConflictExtId}/dependent-vms
```

There is no `Create`, `Update`, `Delete` or `GetById` SDK method for this entity. Dependent VMs
are a **computed / read-only view** the platform derives from the parent VM startup policy's
dependency-conflict evaluation — they are not directly mutable. Generating a CRUD module with
no operations would create a non-functional stub, so per the "check if the operation is action
or CRUD type" guidance in INSTRUCTIONS.md, only the info module is generated.

This mirrors how other list-only sub-entities are shipped in this collection (e.g.
`ntnx_operations_info_v2`, `ntnx_pc_tasks_info_v2`, `ntnx_lcm_status_info_v2`, all of which
have **no** matching `_v2` CRUD counterpart).

### GetById behaviour

The SDK has no GetById endpoint either. To honour the Step 2.1 requirement that
`ext_id` should fetch a specific dependent VM, the module implements a **client-side filter
over the list result** — it calls `list_vm_startup_policy_dependency_conflict_dependent_vms`,
then returns the single entry whose `extId` matches the supplied `ext_id`, or fails with a
descriptive `msg` if no such entry exists.

### filter / orderby / select / expand not exposed

The SDK method signature only accepts `_page` and `_limit`. Per INSTRUCTIONS.md Step 1.8
("Only add options the API/SDK actually supports"), the module does **not** expose `filter`,
`orderby`, `select` or `expand` — those would be silently dropped by the SDK. The info module
therefore builds its own argument spec via `BaseInfoModule(skip_info_args=True)` and only wires
`page`/`limit` through as `_page`/`_limit`.

## Domain knowledge (from Glean)

**Glean answer (verbatim):**

> **VM Startup Policy Dependency Conflicts** is a feature in Nutanix AHV (managed via Prism
> Central) that identifies and resolves circular or conflicting startup requirements between
> Virtual Machines (VMs).
>
> VM Startup Policies allow administrators to define the exact order in which VMs should power
> on during a High Availability (HA) event or a full cluster restart. By organizing VMs into
> groups based on **Categories**, administrators can set up dependency chains (e.g., Database
> VMs must start before App VMs, which must start before Web VMs).
>
> A **Dependency Conflict** occurs when a cyclic loop is created either within a single policy
> or across multiple policies, which would otherwise cause a deadlock where VMs wait on each
> other infinitely (e.g., Category A depends on Category B, but Category B depends on
> Category A).
>
> ### 'Dependent VMs' vs 'Dependee VMs'
> When a dependency conflict is detected, the system maps out the conflict using two key terms:
> * **Dependee VMs / Categories**: The VMs (or Categories) that are required to power on *first*.
>   They act as the prerequisite.
> * **Dependent VMs / Categories**: The VMs (or Categories) that are waiting for the "Dependee"
>   to satisfy its start condition (like powering on or guest OS booting up) before they can
>   begin their own startup sequence.
>
> In a cyclic conflict (Loop: A → B → C → A), a VM can simultaneously act as a dependent to one
> VM and a dependee to another, creating an unresolvable loop.
>
> ### Workflow
> When configuring or evaluating VM Startup Policies, the system executes the following workflow
> regarding conflicts:
> 1.  **Group and Category Assignment:** The administrator creates an ordered list of groups
>     within a startup policy. Each group is mapped to one or more Categories (which contain the
>     VMs).
> 2.  **Start Condition Configuration:** The administrator defines conditions that must be met
>     before the next group starts (e.g., *Power On*, *Guest Boot Up Timeout 180s*, or
>     *Delay 30s*).
> 3.  **Conflict Detection (Validation):**
>     *   **Single Policy:** The system checks for cyclic category dependencies within the
>         policy (e.g., Cat A → Cat B → Cat A).
>     *   **Across Policies:** The system checks for conflicting VM dependencies mapped across
>         *multiple* overlapping policies.
> 4.  **Conflict Resolution:** If a loop is detected across policies, the system relies on
>     predefined rules to break the conflict, usually by **respecting the oldest policy** and
>     invalidating the conflicting dependencies.
> 5.  **API/UI Visibility:** The system exposes the conflicts via the UI and APIs (e.g.,
>     `/vm-startup-policies/{extId}/dependency-conflicts`), allowing administrators to view a
>     detailed breakdown of the exact *Dependent* and *Dependee* categories and VMs causing the
>     loop.
>
> ### Prerequisites
> To leverage VM Startup Policies and accurately detect dependency conflicts, the following
> prerequisites must be met:
> *   **AOS & AHV:** An AHV cluster (Prism Element) registered to Prism Central with supported
>     AOS versions.
> *   **High Availability (HA):** HA must be enabled on the AHV cluster to utilize startup
>     policies during node failures.
> *   **Categories:** VMs must be assigned to proper Prism Central Categories, as startup
>     policies are built on Category-based groups rather than individual VMs.
> *   **Nutanix Guest Tools (NGT):** While not strictly required for basic *Power On* conditions,
>     NGT must be installed and enabled on the VMs if the start condition relies on *Guest OS
>     Boot Up* state.
> *   **RBAC Permissions:** The user configuring or viewing these policies must have the
>     required RBAC permissions (such as `Create_VM_Startup_Policy`,
>     `View_VM_Startup_Policy_Dependency_Conflicts`, and
>     `View_VM_Startup_Policy_Start_Condition_Conflicts`). Project-scoped users must ensure they
>     have authorization mapped to their specific project UUIDs.

### Related engineering tickets, design/spec docs, source docs — every reference Glean surfaced

- **JIRA — ENG-925232** — *Project scoped user (Project Admin role) having dependency conflict
  in the startup policy causing dependency api failing* — https://jira.nutanix.com/browse/ENG-925232
- **JIRA — ENG-796441** — *[VM-Startup-Policy]: VM dependency conflicts count is incorrect* —
  https://jira.nutanix.com/browse/ENG-796441
- **JIRA — ENG-796440** — *[VM-Startup-Policy]: Get Dependency-conflict causing metropolis to
  crash* — https://jira.nutanix.com/browse/ENG-796440
- **Confluence — FEAT-5081 Iris Beta Checklist** — includes "VM Startup Policy Dependency
  Conflict APIs" and "VM Startup Policy Start Condition Conflict APIs" —
  https://confluence.eng.nutanix.com:8443/spaces/AE/pages/443226602/FEAT-5081+Iris+Beta+Checklist
- **Confluence — VM Policies (design page)** — dependency graph model and buildDependencyGraph
  reference implementation —
  https://confluence.eng.nutanix.com:8443/spaces/~raymond.yip/pages/507297514/VM+Policies
- **Confluence — Add redirection link for VM Startup Policies** — UI redirection to
  `/popups/vm_startup_policy/dependency_conflicts`
- **GitHub — dependent-vm-endpoints.yaml** — canonical endpoint definition for the dependent-vms
  list —
  https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split-module-tree/definitions/endpoints/ahv/policies/dependency-conflict-endpoints.yaml
- **GitHub — vmStartupPoliciesEndpoints.yaml** — complete v4 endpoints spec —
  https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv-policies/released/api/vmStartupPoliciesEndpoints.yaml
- **GitHub — vmStartupPolicyDescriptions.yaml** — API description bundle —
  https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/etc/resources/documentation/bundles/en_US/vmStartupPolicyDescriptions.yaml
- **GitHub — vm_startup_policies_api.go** — reference Go client showing
  `GetVmStartupPolicyDependencyConflictById` and `ListVmStartupPolicyDependencyConflicts` —
  https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/api/vm_startup_policies_api.go
- **GitHub — list_vm_startup_policy_dependency_conflicts_request.go** —
  https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmstartuppolicies/list_vm_startup_policy_dependency_conflicts_request.go
- **GitHub — get_vm_startup_policy_dependency_conflict_by_id_request.go** —
  https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmstartuppolicies/get_vm_startup_policy_dependency_conflict_by_id_request.go
- **GitHub — ListVmStartupPolicyDependencyConflictsApiResponse.py** — Python SDK response class —
  https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/policies/ListVmStartupPolicyDependencyConflictsApiResponse.py
- **GitHub — GetVmStartupPolicyDependencyConflictApiResponse.py** —
  https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/policies/GetVmStartupPolicyDependencyConflictApiResponse.py
- **GitHub — VmStartupPolicies_service.proto** — canonical service proto —
  https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/tests/microbenchmarking_mocks/mock_metropolis/proto/vmm/vmm/v4/ahv/policies/VmStartupPolicies_service.proto
- **GitHub — vm_startup_policy_permissions.json** — RBAC/permission catalog for this feature —
  https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/acropolis/ahv_management/scheduler/vm_startup_policy/rbac_config/vm_startup_policy_permissions.json
- **GitHub — v4_vm_startup_policy_dependency_conflicts_verification.py** — canonical nutest
  verification suite —
  https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/verification/pc/v4/v4_vm_startup_policy_dependency_conflicts_verification.py
- **GitHub — test_vm_startup_policy_conflicts.py** — nutest testcases —
  https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/acropolis/ahv_management/scheduler/vm_startup_policy/test_vm_startup_policy_conflicts.py
- **GitHub — domain_26_ahv_vm-startup-policies_dependency-conflicts_coverage_report.md** —
  coverage report —
  https://github.com/nutanix-engineering/hack2026-d3089/blob/main/hackathon_new/tpg_output/coverage/domain_26_ahv_vm-startup-policies_dependency-conflicts_coverage_report.md
- **GitHub — domain_05_ahv_policies_dependency-conflicts_tests.json** —
  https://github.com/nutanix-engineering/hack2026-d3089/blob/main/old_approach_data/tpg_output/test_cases/domain_05_ahv_policies_dependency-conflicts_tests.json

### Required domain skills to work on this feature end-to-end

- Understanding of AHV VM startup order & HA behaviour on Prism Central.
- Prism Central Categories model and category-to-VM assignment (needed to build a scenario that
  actually triggers a dependency conflict).
- Nutanix Guest Tools (NGT) for Guest-Boot-Up start conditions.
- Nutanix RBAC (VMM permissions: `View_VM_Startup_Policy`,
  `View_VM_Startup_Policy_Dependency_Conflicts`, `View_VM_Startup_Policy_Start_Condition_Conflicts`).
- v4 Nutanix Python SDK (`ntnx_vmm_py_client`) — API client, ApiException handling, response
  `to_dict` conventions.
- Nutanix Ansible collection conventions — v4 base modules, `SpecGenerator`, tasks / api client
  helper structure in `plugins/module_utils/v4/vmm/`.

## Files changed

- `plugins/modules/`
  - `ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2.py` *(new)* — the info module.
- `plugins/module_utils/v4/vmm/`
  - `api_client.py` — added `get_vm_startup_policies_api_instance(module)` helper.
- `examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependentVm/` *(new dir)*
  - `vm_startup_policy_dependency_conflict_dependent_vms_info_v2.yml` — runnable example playbook.
  - `examples_run.log` — actual output from executing the playbook against
    `10.44.76.28` (see below for details).
- `tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2/` *(new dir)*
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/dependent_vms.yml` — the integration
    target with happy-path + negative + idempotency coverage.
- `.gitignore` — added `tests/integration/integration_config.yml` so the credentials file
  stays local.

## Test execution

| Metric              | Value                                                                    |
|---------------------|--------------------------------------------------------------------------|
| Command             | `ansible-playbook /tmp/run_tests_driver.yml -v` (driver playbook that
imports `tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependent_vms_info_v2/tasks/dependent_vms.yml`; `ansible-test integration` refused to run inside the installed collection tree, see *Known issues*.) |
| Total tasks         | `31`                                                                     |
| ok / asserted       | `13` (all assertions passed)                                             |
| Skipped (need fixtures) | `14` (target cluster has zero VM startup policies configured, so the happy-path list/pagination/ext_id-filter tasks are correctly `when: have_fixtures` guarded) |
| Ignored (intentional negative failures caught by assertions) | `4`     |
| Unexpected failures | `0`                                                                      |
| Duration            | ~4s                                                                       |
| Cluster (PC)        | `10.44.76.28` (v4 Prism Central)                                         |

### Analysis

- **Missing-required-args cases** — 2 tasks intentionally omit `vm_startup_policy_ext_id` /
  `dependency_conflict_ext_id`. Ansible's argument-spec validator rejects them with a
  `missing required arguments` message. The corresponding `ansible.builtin.assert` tasks
  passed after checking `msg` contains the missing argument's name.
- **Invalid parent ext_id** — a fake but syntactically valid UUID is sent to the live API; the
  Nutanix SDK returned a `404 POLICY_NOT_FOUND` (`VMM-34060`) which the module surfaced as
  `failed=true` with `msg=Api Exception raised while fetching VmStartupPolicyDependencyConflictDependentVms info`
  and `status=404`. The follow-up `assert` passed.
- **Out-of-range limit** — `limit=101` triggered a live `400` schema-validation error
  (`Numeric instance is greater than the required maximum (maximum: 100, found: 101)`), which
  the module surfaced as `failed=true, status=400`. Assertion passed.
- **Idempotency + happy-path** — skipped because no policies exist on the target cluster.
  These tests are guarded by `when: have_fixtures` so the same target file can be re-run on a
  cluster that DOES have a computed dependency conflict without any edits.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
No config file found; using defaults

PLAY [Run VmStartupPolicyDependencyConflictDependentVm integration tests] ******

TASK [Start VmStartupPolicyDependencyConflictDependentVm info tests] ***********
ok: [localhost] => {
    "msg": "Start VmStartupPolicyDependencyConflictDependentVm info tests"
}

TASK [Generate a random 12-char hex suffix so fake UUIDs remain valid UUID v4 shape] ***
ok: [localhost] => {"ansible_facts": {"random_hex": "97ac7d900fd4"}, "changed": false}

TASK [Set placeholder fixtures for negative tests] *****************************
ok: [localhost] => {"ansible_facts": {"fake_dependency_conflict_ext_id": "11111111-1111-1111-1111-97ac7d900fd4", "fake_ext_id": "00000000-0000-0000-0000-97ac7d900fd4"}, "changed": false}

TASK [Attempt to discover a VM startup policy dependency conflict] *************
ok: [localhost] => {"ansible_facts": {"have_fixtures": false}, "changed": false}

TASK [Skip live-list tests when required fixtures are missing] *****************
ok: [localhost] => {
    "msg": "Skipping live-list tests because vm_startup_policy_ext_id and/or dependency_conflict_ext_id are not set. Provide them via the target vars to exercise the happy-path flows on a real cluster."
}

TASK [List all dependent VMs of the given dependency conflict] *****************
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

TASK [Assert LIST all dependent VMs succeeded] *********************************
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

TASK [Assert every list element carries an ext_id] *****************************
skipping: [localhost] => {"changed": false, "skipped_reason": "No items in the list"}

TASK [List dependent VMs with page=0 and limit=10] *****************************
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

TASK [Assert paged LIST honours the request] ***********************************
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

TASK [List dependent VMs with limit=1 (smallest positive limit)] ***************
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

TASK [Assert LIST with limit=1 respects the cap] *******************************
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

TASK [Set the first dependent VM ext_id from the LIST result (if any)] *********
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

TASK [Fetch dependent VM using its ext_id] *************************************
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

TASK [Assert GET-by-ext_id returned the expected single entry] *****************
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

TASK [Fetch dependent VM using a nonexistent ext_id] ***************************
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

TASK [Assert nonexistent ext_id yields a descriptive failure] ******************
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

TASK [List dependent VMs with a nonexistent vm_startup_policy_ext_id] **********
fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VmStartupPolicyDependencyConflictDependentVms info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"policy_uuid": "00000000-0000-0000-0000-97ac7d900fd4"}, "code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the policy with UUID '00000000-0000-0000-0000-97ac7d900fd4', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [Assert an invalid parent policy surfaced an API error] *******************
ok: [localhost] => {
    "changed": false,
    "msg": "Invalid vm_startup_policy_ext_id failed as expected"
}

TASK [List dependent VMs without vm_startup_policy_ext_id (must fail)] *********
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: vm_startup_policy_ext_id"}
...ignoring

TASK [Assert missing vm_startup_policy_ext_id is rejected] *********************
ok: [localhost] => {
    "changed": false,
    "msg": "Missing vm_startup_policy_ext_id was rejected as expected"
}

TASK [List dependent VMs without dependency_conflict_ext_id (must fail)] *******
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: dependency_conflict_ext_id"}
...ignoring

TASK [Assert missing dependency_conflict_ext_id is rejected] *******************
ok: [localhost] => {
    "changed": false,
    "msg": "Missing dependency_conflict_ext_id was rejected as expected"
}

TASK [List dependent VMs with limit=101 (out of allowed range)] ****************
fatal: [localhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching VmStartupPolicyDependencyConflictDependentVms info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "vmm.v4.error.SchemaValidationError", "$objectType": "vmm.v4.error.ErrorResponse", "error": {"$objectType": "vmm.v4.error.SchemaValidationError", "error": "Bad Request", "path": "/api/vmm/v4.2/ahv/policies/vm-startup-policies/00000000-0000-0000-0000-97ac7d900fd4/dependency-conflicts/11111111-1111-1111-1111-97ac7d900fd4/dependent-vms", "statusCode": 400, "timestamp": "2026-07-21T05:19:40.855097849Z", "validationErrorMessages": [{"$objectType": "vmm.v4.error.SchemaValidationErrorMessage", "location": "@query.$limit", "message": "Numeric instance is greater than the required maximum (maximum: 100, found: 101)"}]}}}, "status": 400}
...ignoring

TASK [Assert out-of-range limit fails] *****************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Out-of-range limit failed as expected"
}

TASK [Re-run LIST all dependent VMs] *******************************************
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

TASK [Assert LIST is idempotent (same total on identical inputs)] **************
skipping: [localhost] => {"changed": false, "false_condition": "have_fixtures", "skip_reason": "Conditional result was False"}

PLAY RECAP *********************************************************************
localhost                  : ok=13   changed=0    unreachable=0    failed=0    skipped=14   rescued=0    ignored=4   
```

</details>

## Example execution

The example playbook
(`examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependentVm/vm_startup_policy_dependency_conflict_dependent_vms_info_v2.yml`)
was executed against `10.44.76.28`. Since the cluster has **no VM startup policies**
configured, every list call correctly returned `404 POLICY_NOT_FOUND` — this is a genuine
live-API round trip (see `examples/.../examples_run.log` for the full JSON error body).
Response samples in the module `RETURN` docstring are labelled with plausible values based on
the SDK response schema; they will be backfilled with real API output on the first live run
against a cluster that has a computed dependency conflict.

## Lint & format

- `black --check` — clean.
- `isort --check` — clean.
- `flake8` — clean.
- `ansible-lint` (module + example + tests) — clean on production profile.
- `ansible-test sanity` — Not run: this environment's `ansible-test` refuses to detect targets
  even for existing modules (`FATAL: Target pattern not matched` / `All targets skipped`)
  because the collection is served through an installed `MANIFEST.json` tree. All other lint
  gates pass.

## Known issues

- **CRUD module not generated** — intentional; the entity is read-only in the v4.2 SDK (see
  *Design decisions*).
- **Happy-path tasks skipped in the test log** — the target Prism Central has no VM startup
  policies, so no dependency conflict exists to iterate on. Set
  `vm_startup_policy_ext_id` / `dependency_conflict_ext_id` (via extra-vars or
  `integration_config.yml`) on a cluster with a real conflict to exercise them.
- **`ansible-test integration` / `ansible-test sanity`** — the harness inside this workspace
  cannot enumerate targets because the collection is exposed via a symlinked
  `MANIFEST.json` layout. The equivalent flows were driven via a plain `ansible-playbook`
  driver that imports the same target's `tasks/dependent_vms.yml`.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
