### PR TITLE
code-gen(virtual_machine_management/VmHostAffinityPolicyVmComplianceState): ansible collection modules

### DIFF
--- a/examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/examples_run.log
+++ b/examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/examples_run.log
@@ -1,0 +1,40 @@
+# ============================================================================
+# examples_run.log for ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2
+# ============================================================================
+# Command:
+#   ansible-playbook -i localhost, --connection=local \
+#     examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/vm_host_affinity_policy_vm_compliance_states.yml \
+#     -e vm_host_affinity_policy_ext_id=2bee42ba-d853-4967-6149-7f0b69e211f4 -v
+#
+# Environment:
+#   NUTANIX_HOST=10.44.76.28
+#   NUTANIX_USERNAME=admin
+#   NUTANIX_PORT=9440
+#   Parent VM-host affinity policy ext_id (bootstrapped for this run,
+#   then torn down afterwards): 2bee42ba-d853-4967-6149-7f0b69e211f4
+#
+# NB: because the parent policy was freshly created for this example run,
+# no VMs had been placed against it yet, so the compliance state list is
+# empty ([]). That is the correct API behavior for a policy with no matched
+# VMs; the module still returns the response list, total_available_results
+# and vm_host_affinity_policy_ext_id fields, and changed is false.
+# ============================================================================
+No config file found; using defaults
+
+PLAY [VmHostAffinityPolicyVmComplianceState info playbook] *********************
+
+TASK [Setting variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"vm_host_affinity_policy_ext_id": "2bee42ba-d853-4967-6149-7f0b69e211f4"}, "changed": false}
+
+TASK [List all VM compliance states of a VM-host affinity policy] **************
+ok: [localhost] => {"ansible_facts": {"discovered_interpreter_python": "/usr/libexec/platform-python"}, "changed": false, "response": [], "total_available_results": 0, "vm_host_affinity_policy_ext_id": "2bee42ba-d853-4967-6149-7f0b69e211f4"}
+
+TASK [Paginate the VM compliance states of a VM-host affinity policy] **********
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0, "vm_host_affinity_policy_ext_id": "2bee42ba-d853-4967-6149-7f0b69e211f4"}
+
+TASK [Fetch a specific VM compliance state by ext_id] **************************
+skipping: [localhost] => {"changed": false, "false_condition": "(all_compliance_states.response | length) > 0", "skip_reason": "Conditional result was False"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
+

--- a/examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/vm_host_affinity_policy_vm_compliance_states.yml
+++ b/examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/vm_host_affinity_policy_vm_compliance_states.yml
@@ -1,0 +1,52 @@
+---
+# Summary:
+# This playbook demonstrates the ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2
+# module. VmHostAffinityPolicyVmComplianceState is a read-only view surfaced by the
+# Prism Central v4.2 VMM API — it is populated by the AHV placement engine and
+# describes, per-VM, whether each VM matched by the parent VM-host affinity policy
+# is currently compliant with the policy (i.e. the VM lives on one of the host
+# categories the policy allows). Because it is server-computed there is no
+# create/update/delete API; the only supported operations are:
+#   1. List all VM compliance states of a VM-host affinity policy
+#   2. Paginate the list using page / limit
+#   3. Fetch a specific compliance state entry by ext_id (client-side filtered)
+
+- name: VmHostAffinityPolicyVmComplianceState info playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Setting variables
+      ansible.builtin.set_fact:
+        # Replace with a real VM-host affinity policy ext_id present on the cluster.
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id | default('00000000-0000-0000-0000-000000000000') }}"
+
+    - name: List all VM compliance states of a VM-host affinity policy
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+      register: all_compliance_states
+      ignore_errors: true
+
+    - name: Paginate the VM compliance states of a VM-host affinity policy
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+        page: 0
+        limit: 1
+      register: paginated_compliance_states
+      ignore_errors: true
+
+    - name: Fetch a specific VM compliance state by ext_id
+      when:
+        - all_compliance_states is defined
+        - all_compliance_states.response is defined
+        - (all_compliance_states.response | length) > 0
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+        ext_id: "{{ all_compliance_states.response[0].ext_id }}"
+      register: single_compliance_state
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,20 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_vm_host_affinity_policies_api_instance(module):
+    """
+    This method will return VmHostAffinityPolicies API instance which owns
+    both the parent VM-host affinity policy CRUD endpoints and the read-only
+    ``list_vm_host_affinity_policy_vm_compliance_states`` list endpoint used
+    by the VmHostAffinityPolicyVmComplianceState info module.
+
+    Args:
+        module: Ansible module object
+
+    Returns:
+        api_instance (obj): v4 VmHostAffinityPoliciesApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.VmHostAffinityPoliciesApi(api_client=api_client)

--- a/plugins/modules/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2.py
+++ b/plugins/modules/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2.py
@@ -1,0 +1,288 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2
+short_description: Fetch VM compliance states of a VM-host affinity policy in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about VmHostAffinityPolicyVmComplianceState in Nutanix Prism Central.
+  - The compliance states are always scoped under a parent VM-host affinity policy, therefore
+    C(vm_host_affinity_policy_ext_id) is required.
+  - If C(ext_id) is not provided, list all VM compliance states of the given VM-host affinity policy
+    optionally paginated using C(page) and C(limit).
+  - If C(ext_id) is provided, filter the listed VM compliance states client-side and return the
+    single matching entry (the underlying v4.2 SDK does not expose a get-by-id endpoint for
+    compliance states).
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(List VM compliance states of a VM-host affinity policy) -
+      Required Roles: Prism Admin, Super Admin, Virtual Machine Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  vm_host_affinity_policy_ext_id:
+    description:
+      - The external ID (UUID) of the parent VM-host affinity policy whose VM
+        compliance states are being fetched.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external ID (UUID) of a specific VM compliance state entry.
+      - When provided, the module lists all compliance states of the parent policy
+        and returns the single entry whose C(ext_id) matches.
+      - When not provided, the module returns the full list.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Nutanix (@nutanix)
+"""
+
+EXAMPLES = r"""
+- name: List all VM compliance states of a VM-host affinity policy
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_host_affinity_policy_ext_id: "b8f4e94b-1234-4567-8b19-6c3f2d1e8a90"
+  register: all_compliance_states
+
+- name: Paginate VM compliance states of a VM-host affinity policy
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_host_affinity_policy_ext_id: "b8f4e94b-1234-4567-8b19-6c3f2d1e8a90"
+    page: 0
+    limit: 10
+  register: paginated_compliance_states
+
+- name: Fetch a single VM compliance state by ext_id
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_host_affinity_policy_ext_id: "b8f4e94b-1234-4567-8b19-6c3f2d1e8a90"
+    ext_id: "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+  register: single_compliance_state
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VmHostAffinityPolicyVmComplianceState info v4 API.
+    - When C(ext_id) is provided, this is a single VmHostAffinityPolicyVmComplianceState entry.
+    - When C(ext_id) is not provided, this is the list of VmHostAffinityPolicyVmComplianceState
+      entries for the parent VM-host affinity policy (optionally paginated by C(page)/C(limit)).
+  returned: always
+  type: dict
+  sample:
+    [
+        {
+            "associated_categories": [
+                {
+                    "ext_id": "eb8b02f8-9dc8-5f2e-bc5b-4a1c0c2b6c93"
+                }
+            ],
+            "cluster": {
+                "ext_id": "000647b8-ddb3-6bbb-0000-000000028f57"
+            },
+            "compliance_status": {
+                "$objectType": "vmm.v4.ahv.policies.CompliantVmHostAffinityPolicy"
+            },
+            "ext_id": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+            "host": {
+                "ext_id": "f28e7475-f835-42ef-ac35-ecbc48d5421e"
+            },
+            "links": null,
+            "tenant_id": null
+        }
+    ]
+
+changed:
+  description: This indicates whether the task resulted in any changes. Info modules never change cluster state.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, or when a specific ext_id was requested but not found.
+  type: str
+  sample: "Api Exception raised while fetching VM host affinity policy VM compliance states info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task has failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: The external ID of the VM compliance state entry, echoed back when a specific one is requested.
+  type: str
+  returned: when C(ext_id) is provided
+  sample: "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+
+vm_host_affinity_policy_ext_id:
+  description: The external ID of the parent VM-host affinity policy.
+  type: str
+  returned: always
+  sample: "b8f4e94b-1234-4567-8b19-6c3f2d1e8a90"
+
+total_available_results:
+  description: The total number of VM compliance state entries available under the parent policy.
+  type: int
+  returned: when C(ext_id) is not provided
+  sample: 3
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_host_affinity_policies_api_instance,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    """Argument spec for the info module.
+
+    The underlying SDK method ``list_vm_host_affinity_policy_vm_compliance_states``
+    only accepts ``vmHostAffinityPolicyExtId``, ``_page`` and ``_limit``. It does
+    NOT accept ``filter``, ``orderby`` or ``select`` — those come from
+    :class:`BaseInfoModule` for the sake of the shared documentation fragment
+    but are ignored by this module (see ``run_module``).
+    """
+    module_args = dict(
+        vm_host_affinity_policy_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=False),
+    )
+    return module_args
+
+
+def _list_compliance_states(module, api_instance, kwargs):
+    vm_host_affinity_policy_ext_id = module.params.get("vm_host_affinity_policy_ext_id")
+    try:
+        return api_instance.list_vm_host_affinity_policy_vm_compliance_states(
+            vmHostAffinityPolicyExtId=vm_host_affinity_policy_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching VM host affinity policy VM "
+                "compliance states info"
+            ),
+        )
+
+
+def get_vm_host_affinity_policy_vm_compliance_state(module, api_instance, result):
+    """Return a single compliance state entry that matches C(ext_id).
+
+    The v4.2 SDK does not expose a get-by-id endpoint for VM compliance states,
+    so this helper lists all entries for the parent policy and filters
+    client-side. This keeps the module's UX consistent with other v4 info
+    modules while remaining honest about the API surface.
+    """
+    ext_id = module.params.get("ext_id")
+    resp = _list_compliance_states(module, api_instance, kwargs={})
+    data = strip_internal_attributes(resp.to_dict()).get("data") or []
+    match = next((item for item in data if item.get("ext_id") == ext_id), None)
+    if match is None:
+        result["response"] = None
+        result["failed"] = True
+        module.fail_json(
+            msg=(
+                "VM host affinity policy VM compliance state with ext_id "
+                "'{0}' was not found under parent policy '{1}'".format(
+                    ext_id, module.params.get("vm_host_affinity_policy_ext_id")
+                )
+            ),
+            **result,
+        )
+    result["response"] = match
+
+
+def list_vm_host_affinity_policy_vm_compliance_states(module, api_instance, result):
+    """List compliance states, honoring the SDK-supported pagination options."""
+    kwargs = {}
+    page = module.params.get("page")
+    if page is not None:
+        kwargs["_page"] = page
+    limit = module.params.get("limit")
+    if limit is not None:
+        kwargs["_limit"] = limit
+
+    resp = _list_compliance_states(module, api_instance, kwargs)
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "vm_host_affinity_policy_ext_id": module.params.get(
+            "vm_host_affinity_policy_ext_id"
+        ),
+    }
+    api_instance = get_vm_host_affinity_policies_api_instance(module)
+    if module.params.get("ext_id"):
+        result["ext_id"] = module.params.get("ext_id")
+        get_vm_host_affinity_policy_vm_compliance_state(module, api_instance, result)
+    else:
+        list_vm_host_affinity_policy_vm_compliance_states(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import vm_host_affinity_policy_vm_compliance_states.yml
+      ansible.builtin.import_tasks: vm_host_affinity_policy_vm_compliance_states.yml

--- a/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2/tasks/vm_host_affinity_policy_vm_compliance_states.yml
+++ b/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2/tasks/vm_host_affinity_policy_vm_compliance_states.yml
@@ -1,0 +1,405 @@
+---
+###############################################################################
+# Test plan
+#
+# Entity under test:
+#   ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2
+#
+# The compliance state is a *read-only* server-computed view of a VM-host
+# affinity policy — the AHV placement engine populates it as VMs are matched
+# against the policy's VM/host category filters. The v4.2 VMM SDK exposes
+# only a single endpoint for it:
+#
+#   list_vm_host_affinity_policy_vm_compliance_states(
+#       vmHostAffinityPolicyExtId, _page=None, _limit=None)
+#
+# There is no create/update/delete API surface, so this info module is the
+# only Ansible surface area for the entity.
+#
+# The tests cover:
+#   Setup
+#     - Create two random USER categories (a VM-side and a host-side) needed
+#       to build a valid VM-host affinity policy.
+#     - Create the parent VM-host affinity policy via the raw v4.2 API using
+#       `ansible.builtin.uri` (there is no ntnx_vm_host_affinity_policy_v2
+#       module in this collection yet).
+#   Positive tests
+#     1. List all compliance states of the parent policy (module returns a
+#        list — usually empty for a freshly created policy with no matching
+#        VMs — plus total_available_results and changed=false).
+#     2. Paginate the list using page=0, limit=1.
+#     3. When at least one entry is returned, fetch it by ext_id.
+#   Negative tests
+#     4. Missing required `vm_host_affinity_policy_ext_id` — argument spec
+#        validation error.
+#     5. Non-existent parent policy ext_id — SDK 4xx surfaced through
+#        raise_api_exception (result.failed == true, response has a body).
+#     6. Non-existent VM compliance state ext_id under a valid parent —
+#        module returns failed=true with the "was not found" message.
+#   Cleanup
+#     - Delete the parent policy via the raw v4.2 API.
+#     - Delete the two categories.
+###############################################################################
+
+- name: Start VM host affinity policy VM compliance states info tests
+  ansible.builtin.debug:
+    msg: Start VM host affinity policy VM compliance states info tests
+
+- name: Generate random suffix
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set names for categories and policy
+  ansible.builtin.set_fact:
+    vm_category_key: "vm_ansible_key_{{ random_name }}"
+    vm_category_value: "vm_ansible_value_{{ random_name }}"
+    host_category_key: "host_ansible_key_{{ random_name }}"
+    host_category_value: "host_ansible_value_{{ random_name }}"
+    policy_name: "vhap_ansible_{{ random_name }}"
+
+- name: Build base v4.2 VM-host affinity policies URL and headers
+  ansible.builtin.set_fact:
+    vhap_url: "https://{{ ip }}:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies"
+    # The v4.2 VMM API rejects create requests without the NTNX-Request-Id
+    # idempotency header (VMM-34040) — mint a fresh UUID for this test run.
+    vhap_headers:
+      Content-Type: application/json
+      Accept: application/json
+      NTNX-Request-Id: "{{ 999999999999 | random | to_uuid }}"
+
+########################################################################################
+# Setup: create categories that the affinity policy will reference
+########################################################################################
+
+- name: Create VM-side category
+  nutanix.ncp.ntnx_categories_v2:
+    key: "{{ vm_category_key }}"
+    value: "{{ vm_category_value }}"
+    description: "VM category for vm-host affinity policy compliance state tests"
+  register: vm_category_result
+  ignore_errors: true
+
+- name: VM-side category create status
+  ansible.builtin.assert:
+    that:
+      - vm_category_result is defined
+      - vm_category_result.failed == false
+      - vm_category_result.changed == true
+      - vm_category_result.response is defined
+      - vm_category_result.response.ext_id is defined
+      - vm_category_result.response.key == vm_category_key
+      - vm_category_result.response.value == vm_category_value
+    success_msg: "VM category created successfully"
+    fail_msg: "Failed to create VM category"
+
+- name: Set vm_category_ext_id
+  ansible.builtin.set_fact:
+    vm_category_ext_id: "{{ vm_category_result.response.ext_id }}"
+
+- name: Create host-side category
+  nutanix.ncp.ntnx_categories_v2:
+    key: "{{ host_category_key }}"
+    value: "{{ host_category_value }}"
+    description: "Host category for vm-host affinity policy compliance state tests"
+  register: host_category_result
+  ignore_errors: true
+
+- name: Host-side category create status
+  ansible.builtin.assert:
+    that:
+      - host_category_result is defined
+      - host_category_result.failed == false
+      - host_category_result.changed == true
+      - host_category_result.response is defined
+      - host_category_result.response.ext_id is defined
+      - host_category_result.response.key == host_category_key
+      - host_category_result.response.value == host_category_value
+    success_msg: "Host category created successfully"
+    fail_msg: "Failed to create host category"
+
+- name: Set host_category_ext_id
+  ansible.builtin.set_fact:
+    host_category_ext_id: "{{ host_category_result.response.ext_id }}"
+
+########################################################################################
+# Setup: create parent VM-host affinity policy via raw v4.2 API
+# There is no ntnx_vm_host_affinity_policy_v2 module yet in this collection,
+# so we bootstrap the parent using ansible.builtin.uri.
+########################################################################################
+
+- name: Create parent VM-host affinity policy via raw v4.2 API
+  ansible.builtin.uri:
+    url: "{{ vhap_url }}"
+    method: POST
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: false
+    body_format: json
+    body:
+      name: "{{ policy_name }}"
+      description: "Ansible integration test parent policy"
+      vmCategories:
+        - extId: "{{ vm_category_ext_id }}"
+      hostCategories:
+        - extId: "{{ host_category_ext_id }}"
+    headers: "{{ vhap_headers }}"
+    status_code: [200, 201, 202]
+    return_content: true
+  register: vhap_create_result
+  ignore_errors: true
+
+- name: Parent VM-host affinity policy create response status
+  ansible.builtin.assert:
+    that:
+      - vhap_create_result is defined
+      - vhap_create_result.failed == false
+      - vhap_create_result.status in [200, 201, 202]
+      - vhap_create_result.json is defined
+      - vhap_create_result.json.data is defined
+      - vhap_create_result.json.data.extId is defined
+    success_msg: "Parent VM-host affinity policy task submitted successfully"
+    fail_msg: "Failed to submit create for parent VM-host affinity policy"
+
+- name: Extract create task ext_id and poll it to get the policy ext_id
+  ansible.builtin.set_fact:
+    create_task_ext_id: "{{ vhap_create_result.json.data.extId }}"
+
+- name: Fetch create task details
+  nutanix.ncp.ntnx_pc_tasks_info_v2:
+    ext_id: "{{ create_task_ext_id }}"
+  register: create_task_info
+  until:
+    - create_task_info is defined
+    - create_task_info.response is defined
+    - create_task_info.response.status in ["SUCCEEDED", "FAILED"]
+  retries: 30
+  delay: 5
+  ignore_errors: true
+
+- name: Confirm create task succeeded and resolve policy ext_id
+  ansible.builtin.assert:
+    that:
+      - create_task_info is defined
+      - create_task_info.response is defined
+      - create_task_info.response.status == "SUCCEEDED"
+      - create_task_info.response.entities_affected is defined
+      - create_task_info.response.entities_affected | length > 0
+    success_msg: "Parent VM-host affinity policy created successfully"
+    fail_msg: "Parent VM-host affinity policy create task did not succeed"
+
+- name: Set parent policy ext_id
+  ansible.builtin.set_fact:
+    parent_policy_ext_id: >-
+      {{ (create_task_info.response.entities_affected
+          | selectattr('rel', 'equalto', 'vmm:ahv:policies:vm-host-affinity-policies')
+          | list
+          | first
+          | default(create_task_info.response.entities_affected[0])
+         ).ext_id }}
+
+########################################################################################
+# Positive tests
+########################################################################################
+
+- name: List all VM compliance states of the parent policy
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    vm_host_affinity_policy_ext_id: "{{ parent_policy_ext_id }}"
+  register: list_all_result
+  ignore_errors: true
+
+- name: List-all response status
+  ansible.builtin.assert:
+    that:
+      - list_all_result is defined
+      - list_all_result.changed == false
+      - list_all_result.failed == false
+      - list_all_result.response is defined
+      - list_all_result.response is iterable
+      - list_all_result.total_available_results is defined
+      - list_all_result.total_available_results >= 0
+      - list_all_result.vm_host_affinity_policy_ext_id == parent_policy_ext_id
+    success_msg: "List-all of VM compliance states passed"
+    fail_msg: "List-all of VM compliance states failed"
+
+- name: List VM compliance states with pagination (page=0, limit=1)
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    vm_host_affinity_policy_ext_id: "{{ parent_policy_ext_id }}"
+    page: 0
+    limit: 1
+  register: list_paginated_result
+  ignore_errors: true
+
+- name: Paginated list response status
+  ansible.builtin.assert:
+    that:
+      - list_paginated_result is defined
+      - list_paginated_result.changed == false
+      - list_paginated_result.failed == false
+      - list_paginated_result.response is defined
+      - list_paginated_result.response | length <= 1
+      - list_paginated_result.total_available_results is defined
+      - list_paginated_result.vm_host_affinity_policy_ext_id == parent_policy_ext_id
+    success_msg: "Paginated list of VM compliance states passed"
+    fail_msg: "Paginated list of VM compliance states failed"
+
+- name: Fetch a specific VM compliance state by ext_id
+  when:
+    - list_all_result is defined
+    - list_all_result.response is defined
+    - (list_all_result.response | length) > 0
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    vm_host_affinity_policy_ext_id: "{{ parent_policy_ext_id }}"
+    ext_id: "{{ list_all_result.response[0].ext_id }}"
+  register: get_by_id_result
+  ignore_errors: true
+
+- name: Fetch-by-ext_id response status
+  when:
+    - list_all_result is defined
+    - list_all_result.response is defined
+    - (list_all_result.response | length) > 0
+  ansible.builtin.assert:
+    that:
+      - get_by_id_result is defined
+      - get_by_id_result.changed == false
+      - get_by_id_result.failed == false
+      - get_by_id_result.response is defined
+      - get_by_id_result.response.ext_id == list_all_result.response[0].ext_id
+      - get_by_id_result.ext_id == list_all_result.response[0].ext_id
+      - get_by_id_result.vm_host_affinity_policy_ext_id == parent_policy_ext_id
+    success_msg: "Fetch-by-ext_id of VM compliance state passed"
+    fail_msg: "Fetch-by-ext_id of VM compliance state failed"
+
+########################################################################################
+# Negative tests
+########################################################################################
+
+- name: List with missing required vm_host_affinity_policy_ext_id
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2: {}
+  register: missing_parent_result
+  ignore_errors: true
+
+- name: Missing required parameter status
+  ansible.builtin.assert:
+    that:
+      - missing_parent_result is defined
+      - missing_parent_result.changed == false
+      - missing_parent_result.failed == true
+      - "'vm_host_affinity_policy_ext_id' in missing_parent_result.msg"
+    success_msg: "Missing required parameter correctly rejected"
+    fail_msg: "Missing required parameter was not rejected"
+
+- name: List against a non-existent parent policy ext_id
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    vm_host_affinity_policy_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: invalid_parent_result
+  ignore_errors: true
+
+- name: Non-existent parent policy status
+  ansible.builtin.assert:
+    that:
+      - invalid_parent_result is defined
+      - invalid_parent_result.changed == false
+      - invalid_parent_result.failed == true
+      - invalid_parent_result.msg is defined
+    success_msg: "Non-existent parent policy correctly returned an error"
+    fail_msg: "Non-existent parent policy did not return an error"
+
+- name: Fetch a non-existent VM compliance state under a valid parent
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    vm_host_affinity_policy_ext_id: "{{ parent_policy_ext_id }}"
+    ext_id: "deadbeef-dead-beef-dead-beefdeadbeef"
+  register: invalid_child_result
+  ignore_errors: true
+
+- name: Non-existent VM compliance state status
+  ansible.builtin.assert:
+    that:
+      - invalid_child_result is defined
+      - invalid_child_result.changed == false
+      - invalid_child_result.failed == true
+      - "'was not found' in invalid_child_result.msg"
+    success_msg: "Non-existent VM compliance state correctly reported not-found"
+    fail_msg: "Non-existent VM compliance state did not report not-found"
+
+########################################################################################
+# Cleanup: delete parent policy + categories
+########################################################################################
+
+- name: Fetch parent policy to capture ETag for delete
+  ansible.builtin.uri:
+    url: "{{ vhap_url }}/{{ parent_policy_ext_id }}"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: false
+    headers:
+      Accept: application/json
+    status_code: [200]
+    return_content: true
+  register: vhap_get_before_delete
+  ignore_errors: true
+
+- name: Delete parent VM-host affinity policy via raw v4.2 API
+  when:
+    - vhap_get_before_delete is defined
+    - vhap_get_before_delete.status is defined
+    - vhap_get_before_delete.status == 200
+  ansible.builtin.uri:
+    url: "{{ vhap_url }}/{{ parent_policy_ext_id }}"
+    method: DELETE
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: false
+    headers:
+      Content-Type: application/json
+      Accept: application/json
+      NTNX-Request-Id: "{{ 999999999999 | random | to_uuid }}"
+      # ansible.builtin.uri returns response headers as top-level keys
+      # (lower-cased), so we use vhap_get_before_delete.etag directly. The v4.2
+      # policy DELETE endpoint requires this If-Match header per PLAT-10004.
+      If-Match: "{{ vhap_get_before_delete.etag }}"
+    status_code: [200, 202, 204]
+  register: vhap_delete_result
+  ignore_errors: true
+
+- name: Parent policy delete status
+  ansible.builtin.assert:
+    that:
+      - vhap_delete_result is defined
+      - (vhap_delete_result.status | default(0)) in [200, 202, 204]
+    success_msg: "Parent VM-host affinity policy deletion submitted"
+    fail_msg: "Failed to submit parent VM-host affinity policy delete"
+
+- name: Delete VM-side category
+  nutanix.ncp.ntnx_categories_v2:
+    ext_id: "{{ vm_category_ext_id }}"
+    state: absent
+  register: vm_category_delete_result
+  ignore_errors: true
+
+- name: VM-side category delete status
+  ansible.builtin.assert:
+    that:
+      - vm_category_delete_result is defined
+      - vm_category_delete_result.failed == false
+    success_msg: "VM category deleted"
+    fail_msg: "Failed to delete VM category"
+
+- name: Delete host-side category
+  nutanix.ncp.ntnx_categories_v2:
+    ext_id: "{{ host_category_ext_id }}"
+    state: absent
+  register: host_category_delete_result
+  ignore_errors: true
+
+- name: Host-side category delete status
+  ansible.builtin.assert:
+    that:
+      - host_category_delete_result is defined
+      - host_category_delete_result.failed == false
+    success_msg: "Host category deleted"
+    fail_msg: "Failed to delete host category"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection module for the **virtual_machine_management**
namespace, entity **VmHostAffinityPolicyVmComplianceState**, based on the
inline `sdk_info.json` embedded in the task instructions.

- Modules generated: `ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2` (info)
- API methods covered from the SDK (1 of 1 relevant to this entity): `list_vm_host_affinity_policy_vm_compliance_states`
- Fields in info module spec: 2 (`vm_host_affinity_policy_ext_id`, `ext_id`) + the shared `page`/`limit`/`filter`/`orderby`/`select` from the `ntnx_info_v2` fragment
- Fields in CRUD module spec: n/a — see below

> **Why only an info module?** The `VmHostAffinityPolicyVmComplianceState`
> entity is a **read-only, server-computed view**. The v4.2 VMM SDK ships
> a single method for it — `list_vm_host_affinity_policy_vm_compliance_states`
> — and no create/update/delete/get-by-id endpoint. Generating a CRUD
> module would be misleading; the info module fully covers the API surface.
> The parent-policy CRUD (`create_vm_host_affinity_policy`,
> `update_vm_host_affinity_policy_by_id`,
> `delete_vm_host_affinity_policy_by_id`, `get_vm_host_affinity_policy_by_id`,
> `re_enforce_vm_host_affinity_policy_by_id`) belongs to a different
> entity (`VmHostAffinityPolicy`) and is out of scope for this code-gen
> task.

## Domain knowledge (from Glean)

Glean was unavailable — the MCP `glean__chat` tool timed out twice on this
run — so this section is written from the SDK/domain evidence collected
directly from the cluster and the SDK swagger types. What we know about
VmHostAffinityPolicyVmComplianceState:

- It is the per-VM compliance-status view of a parent `VmHostAffinityPolicy`.
  Each entry describes one VM matched by the parent policy's `vmCategories`
  filter and reports whether the VM is running on a host that belongs to the
  policy's `hostCategories` (compliant), whether it is running on a host
  outside those categories (non-compliant), or another status like pending,
  conflicting, or "no hosts for the policy".
- The SDK response type `VmHostAffinityPolicyVmComplianceState` carries:
  `cluster` (ClusterReference), `host` (HostReference),
  `associated_categories` (list[CategoryReference]),
  `compliance_status` (OneOf: CompliantVmHostAffinityPolicy,
  ConflictingVmHostAffinityPolicy, ConflictingLegacyVmHostAffinityPolicy,
  NoHostsForVmHostAffinityPolicy, NonCompliantVmHostAffinityPolicy,
  NotEnoughResourcesForVmHostAffinityPolicy, OtherVmHostAffinityPolicyVmNonComplianceReason,
  PeNotCapableForVmHostAffinityPolicy, PendingVmHostAffinityPolicy),
  `ext_id`, `links`, and `tenant_id`.
- The SDK only exposes a LIST endpoint at
  `/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies/{vmHostAffinityPolicyExtId}/vm-compliance-states`
  with pagination via `_page` and `_limit`. There is no filter/orderby/select.
- The read-only nature is confirmed by the AHV placement engine populating
  these entries on the server; the parent policy exposes counters
  (`num_vms`, `num_hosts`, `num_compliant_vms`, `num_non_compliant_vms`) but
  the individual compliance entries are only enumerable through this LIST.
- Prerequisites for any non-empty response: (a) a parent VM-host affinity
  policy referencing at least one VM category and one host category, and
  (b) at least one VM tagged with the referenced VM category actually
  running in the cluster. On a freshly created policy with no matching VMs
  the list is legitimately empty (this run confirmed `total_available_results=0`).
- Confirmed on-cluster behavior for this run (PC 10.44.76.28,
  `x-ntnx-product: pc.7.6`): `POST` on the policy requires an
  `NTNX-Request-Id` idempotency header (`VMM-34040 POLICY_MISSING_REQUEST_ID_HEADER`);
  `DELETE` requires an `If-Match: <etag>` header
  (`PLAT-10004 MISSING_ETAG_HEADER`); `GET`-by-id on a non-existent policy
  returns HTTP 404 with `VMM-34060 POLICY_NOT_FOUND`.
- Related public reference:
  U(https://developers.nutanix.com/api-reference?namespace=vmm).

If a reviewer wants the specific engineering tickets / Confluence design
docs / spec pages, please re-run this task in an environment where the
Glean MCP is reachable and I will paste them verbatim.

## Files changed

- `plugins/modules/`
  - `ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2.py` (new)
- `plugins/module_utils/v4/vmm/`
  - `api_client.py` — added `get_vm_host_affinity_policies_api_instance` helper
- `meta/`
  - `runtime.yml` — added the new module to the `ntnx` action group
- `examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/`
  - `vm_host_affinity_policy_vm_compliance_states.yml` (new)
  - `examples_run.log` (new — real playbook output against 10.44.76.28)
- `tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`,
    `tasks/vm_host_affinity_policy_vm_compliance_states.yml` (new)

## Test execution

| Metric              | Value                                                                                     |
|---------------------|-------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-unsupported --allow-disabled --python 3.12 ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 -v` |
| Total tasks         | 36                                                                                        |
| OK                  | 34 (27 pure OK + 4 changed + 3 intentionally-failed but ignored)                          |
| Failed              | 0                                                                                         |
| Skipped             | 2 (the "fetch specific compliance state ext_id" tasks — the policy had no matched VMs)    |
| Ignored             | 3 (deliberate negative tests: missing required param, invalid parent, invalid child)      |
| Duration            | ~13s                                                                                      |
| Cluster (PC)        | `10.44.76.28` (`x-ntnx-product: pc.7.6`)                                                  |

### Example playbook execution

The example playbook was also executed end-to-end against the same PC:

```
$ ansible-playbook -i localhost, --connection=local \
    examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/vm_host_affinity_policy_vm_compliance_states.yml \
    -e vm_host_affinity_policy_ext_id=<bootstrapped> -v
PLAY RECAP: localhost : ok=3  changed=0  unreachable=0  failed=0  skipped=1
```

The parent policy was bootstrapped for the run and torn down afterwards
(all cleanup verified). Real output is committed at
`examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/examples_run.log`.

### Analysis

No test failures. The 2 skipped tasks are guarded by
`(list_all_result.response | length) > 0` — since the freshly-created
parent policy did not have any VMs matched to its VM category, the
compliance-states list is legitimately empty, so the "fetch specific
ext_id" positive path did not exercise. All negative paths (missing
required param, non-existent parent, non-existent child ext_id) were
triggered as expected and their assertions passed against the module's
observable behavior:

- **Missing required param** → `"missing required arguments: vm_host_affinity_policy_ext_id"`
- **Non-existent parent** → SDK 404 surfaced via `raise_api_exception`,
  `"Api Exception raised while fetching VM host affinity policy VM compliance states info"`
- **Non-existent child** → module-level not-found message
  `"VM host affinity policy VM compliance state with ext_id '<ext_id>' was not found under parent policy '<parent>'"`

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /bin/python3.12
Creating container database.
Run command: /bin/python3.12 /home/abhinav.bansal1/.local/lib/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 integration test role
Initializing "/tmp/ansible-test-y1c07mef-injector" as the temporary injector directory.
Injecting "/tmp/python-nzml3vt5-ansible/python" as a execv wrapper for the "/bin/python3.12" interpreter.
Stream command: ansible-playbook ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2-e50wzhk8.yml -i inventory -v
[WARNING]: Found variable using reserved name: port
Using /tmp/ac2/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2-d17_kw0l-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Start VM host affinity policy VM compliance states info tests] ***
ok: [testhost] => {
    "msg": "Start VM host affinity policy VM compliance states info tests"
}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Generate random suffix] ***
[WARNING]: Collection community.general does not support Ansible version 2.16.0
ok: [testhost] => {"ansible_facts": {"random_name": "KzZlpQcJmYFu"}, "changed": false}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Set names for categories and policy] ***
ok: [testhost] => {"ansible_facts": {"host_category_key": "host_ansible_key_KzZlpQcJmYFu", "host_category_value": "host_ansible_value_KzZlpQcJmYFu", "policy_name": "vhap_ansible_KzZlpQcJmYFu", "vm_category_key": "vm_ansible_key_KzZlpQcJmYFu", "vm_category_value": "vm_ansible_value_KzZlpQcJmYFu"}, "changed": false}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Build base v4.2 VM-host affinity policies URL and headers] ***
ok: [testhost] => {"ansible_facts": {"vhap_headers": {"Accept": "application/json", "Content-Type": "application/json", "NTNX-Request-Id": "b90e5b51-dae1-56fe-b1f5-f538c1338eab"}, "vhap_url": "https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies"}, "changed": false}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Create VM-side category] ***
changed: [testhost] => {"changed": true, "error": null, "ext_id": "9d9840b2-06c6-490d-4f53-7a1015080b23", "response": {"associations": null, "description": "VM category for vm-host affinity policy compliance state tests", "detailed_associations": null, "ext_id": "9d9840b2-06c6-490d-4f53-7a1015080b23", "isSharedWithAllProjects": false, "key": "vm_ansible_key_KzZlpQcJmYFu", "links": null, "owner_uuid": "00000000-0000-0000-0000-000000000000", "projectExtId": "00000000-0000-0000-0000-000000000000", "tenant_id": null, "type": "USER", "value": "vm_ansible_value_KzZlpQcJmYFu"}}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : VM-side category create status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "VM category created successfully"
}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Set vm_category_ext_id] ***
ok: [testhost] => {"ansible_facts": {"vm_category_ext_id": "9d9840b2-06c6-490d-4f53-7a1015080b23"}, "changed": false}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Create host-side category] ***
changed: [testhost] => {"changed": true, "error": null, "ext_id": "eec2bf79-941d-43d0-5953-a04081def914", "response": {"associations": null, "description": "Host category for vm-host affinity policy compliance state tests", "detailed_associations": null, "ext_id": "eec2bf79-941d-43d0-5953-a04081def914", "isSharedWithAllProjects": false, "key": "host_ansible_key_KzZlpQcJmYFu", "links": null, "owner_uuid": "00000000-0000-0000-0000-000000000000", "projectExtId": "00000000-0000-0000-0000-000000000000", "tenant_id": null, "type": "USER", "value": "host_ansible_value_KzZlpQcJmYFu"}}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Host-side category create status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Host category created successfully"
}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Set host_category_ext_id] ***
ok: [testhost] => {"ansible_facts": {"host_category_ext_id": "eec2bf79-941d-43d0-5953-a04081def914"}, "changed": false}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Create parent VM-host affinity policy via raw v4.2 API] ***
ok: [testhost] => {"cache_control": "no-cache, no-store, max-age=0, must-revalidate,no-cache, no-store", "changed": false, "connection": "close", "content": "{\"data\":{\"$reserved\":{\"$fv\":\"v4.r2\"},\"$objectType\":\"prism.v4.config.TaskReference\",\"extId\":\"ZXJnb24=:4fb57fbf-7012-5979-89c1-21d4ca4fd6c9\"},\"$reserved\":{\"$fv\":\"v4.r3\"},\"$objectType\":\"vmm.v4.ahv.policies.CreateVmHostAffinityPolicyApiResponse\"}", "content_encoding": "identity", "content_length": "242", "content_security_policy": "connect-src 'self' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; default-src 'self' https://*.nutanix.com; frame-ancestors 'self' https://*.nutanix.com; frame-src 'self' https://*.nutanix.com blob: data:; img-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'", "content_type": "application/json", "cookies": {"NTNX_SESSION_ID": "0680cb55-ac27-4dc1-a5e2-ce0ba4fc76ff"}, "cookies_string": "NTNX_SESSION_ID=0680cb55-ac27-4dc1-a5e2-ce0ba4fc76ff", "date": "Tue, 21 Jul 2026 05:23:49 GMT", "elapsed": 0, "expires": "0,0", "json": {"$objectType": "vmm.v4.ahv.policies.CreateVmHostAffinityPolicyApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "prism.v4.config.TaskReference", "$reserved": {"$fv": "v4.r2"}, "extId": "ZXJnb24=:4fb57fbf-7012-5979-89c1-21d4ca4fd6c9"}}, "msg": "OK (242 bytes)", "pragma": "no-cache, no-cache", "redirected": false, "set_cookie": "NTNX_SESSION_ID=0680cb55-ac27-4dc1-a5e2-ce0ba4fc76ff;Max-Age=29700;Path=/;Secure;HttpOnly;SameSite=Lax", "status": 202, "strict_transport_security": "max-age=31536000 ; includeSubDomains, max-age=63072000; includeSubdomains; preload", "url": "https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies", "vary": "Origin", "x_api_ratelimit_limit": "2", "x_api_ratelimit_refresh_period_seconds": "1", "x_api_ratelimit_remaining": "1", "x_api_ratelimit_reset": "0", "x_content_type_options": "nosniff, nosniff", "x_dns_prefetch_control": "off", "x_envoy_upstream_service_time": "20", "x_frame_options": "DENY, SAMEORIGIN", "x_ntnx_env": "pc", "x_ntnx_product": "pc.7.6", "x_permitted_cross_domain_policies": "master-only", "x_ratelimit_limit": "40", "x_ratelimit_remaining": "39", "x_ratelimit_reset": "0", "x_xss_protection": "0, 1; mode=block"}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Parent VM-host affinity policy create response status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Parent VM-host affinity policy task submitted successfully"
}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Extract create task ext_id and poll it to get the policy ext_id] ***
ok: [testhost] => {"ansible_facts": {"create_task_ext_id": "ZXJnb24=:4fb57fbf-7012-5979-89c1-21d4ca4fd6c9"}, "changed": false}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Fetch create task details] ***
ok: [testhost] => {"attempts": 1, "changed": false, "ext_id": "ZXJnb24=:4fb57fbf-7012-5979-89c1-21d4ca4fd6c9", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:23:49.681203+00:00", "completion_details": null, "created_time": "2026-07-21T05:23:49.613372+00:00", "entities_affected": [{"ext_id": "a48e8d3d-4264-4d2f-786f-490f31b434c9", "name": "vhap_ansible_KzZlpQcJmYFu", "rel": "vmm:ahv:policies:vm-host-affinity-policy"}], "error_messages": null, "ext_id": "ZXJnb24=:4fb57fbf-7012-5979-89c1-21d4ca4fd6c9", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:23:49.681202+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "VmHostAffinityPolicyCreate", "operation_description": "Create VM-Host Affinity Policy", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:23:49.620445+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Confirm create task succeeded and resolve policy ext_id] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Parent VM-host affinity policy created successfully"
}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Set parent policy ext_id] ***
ok: [testhost] => {"ansible_facts": {"parent_policy_ext_id": "a48e8d3d-4264-4d2f-786f-490f31b434c9"}, "changed": false}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : List all VM compliance states of the parent policy] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0, "vm_host_affinity_policy_ext_id": "a48e8d3d-4264-4d2f-786f-490f31b434c9"}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : List-all response status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List-all of VM compliance states passed"
}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : List VM compliance states with pagination (page=0, limit=1)] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0, "vm_host_affinity_policy_ext_id": "a48e8d3d-4264-4d2f-786f-490f31b434c9"}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Paginated list response status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Paginated list of VM compliance states passed"
}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Fetch a specific VM compliance state by ext_id] ***
skipping: [testhost] => {"changed": false, "false_condition": "(list_all_result.response | length) > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Fetch-by-ext_id response status] ***
skipping: [testhost] => {"changed": false, "false_condition": "(list_all_result.response | length) > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : List with missing required vm_host_affinity_policy_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: vm_host_affinity_policy_ext_id"}
...ignoring

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Missing required parameter status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing required parameter correctly rejected"
}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : List against a non-existent parent policy ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VM host affinity policy VM compliance states info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"policy_uuid": "00000000-0000-0000-0000-000000000000"}, "code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the policy with UUID '00000000-0000-0000-0000-000000000000', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Non-existent parent policy status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Non-existent parent policy correctly returned an error"
}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Fetch a non-existent VM compliance state under a valid parent] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": "deadbeef-dead-beef-dead-beefdeadbeef", "msg": "VM host affinity policy VM compliance state with ext_id 'deadbeef-dead-beef-dead-beefdeadbeef' was not found under parent policy 'a48e8d3d-4264-4d2f-786f-490f31b434c9'", "response": null, "vm_host_affinity_policy_ext_id": "a48e8d3d-4264-4d2f-786f-490f31b434c9"}
...ignoring

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Non-existent VM compliance state status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Non-existent VM compliance state correctly reported not-found"
}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Fetch parent policy to capture ETag for delete] ***
ok: [testhost] => {"cache_control": "no-cache, no-store, max-age=0, must-revalidate,no-cache, no-store", "changed": false, "connection": "close", "content": "{\"data\":{\"$reserved\":{\"$fv\":\"v4.r3\"},\"$objectType\":\"vmm.v4.ahv.policies.VmHostAffinityPolicy\",\"extId\":\"a48e8d3d-4264-4d2f-786f-490f31b434c9\",\"createTime\":\"2026-07-21T05:23:49.635869Z\",\"updateTime\":\"2026-07-21T05:23:49.635869Z\",\"numVms\":0,\"numHosts\":0,\"numCompliantVms\":0,\"numNonCompliantVms\":0,\"name\":\"vhap_ansible_KzZlpQcJmYFu\",\"description\":\"Ansible integration test parent policy\",\"createdBy\":{\"$reserved\":{\"$fv\":\"v4.r3\"},\"$objectType\":\"vmm.v4.ahv.policies.UserReference\",\"extId\":\"00000000-0000-0000-0000-000000000000\"},\"lastUpdatedBy\":{\"$reserved\":{\"$fv\":\"v4.r3\"},\"$objectType\":\"vmm.v4.ahv.policies.UserReference\",\"extId\":\"00000000-0000-0000-0000-000000000000\"},\"vmCategories\":[{\"$reserved\":{\"$fv\":\"v4.r3\"},\"$objectType\":\"vmm.v4.ahv.policies.CategoryReference\",\"extId\":\"9d9840b2-06c6-490d-4f53-7a1015080b23\"}],\"hostCategories\":[{\"$reserved\":{\"$fv\":\"v4.r3\"},\"$objectType\":\"vmm.v4.ahv.policies.CategoryReference\",\"extId\":\"eec2bf79-941d-43d0-5953-a04081def914\"}]},\"$reserved\":{\"$fv\":\"v4.r3\"},\"$objectType\":\"vmm.v4.ahv.policies.GetVmHostAffinityPolicyApiResponse\",\"metadata\":{\"flags\":[{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"hasError\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isPaginated\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isTruncated\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isExpandRestricted\",\"value\":false}],\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.response.ApiResponseMetadata\",\"links\":[{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.response.ApiLink\",\"href\":\"https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies/a48e8d3d-4264-4d2f-786f-490f31b434c9\",\"rel\":\"self\"},{\"href\":\"https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies/a48e8d3d-4264-4d2f-786f-490f31b434c9/vm-compliance-states\",\"rel\":\"vm-compliance-states\"}]}}", "content_encoding": "identity", "content_length": "1980", "content_security_policy": "connect-src 'self' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; default-src 'self' https://*.nutanix.com; frame-ancestors 'self' https://*.nutanix.com; frame-src 'self' https://*.nutanix.com blob: data:; img-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'", "content_type": "application/json", "cookies": {"NTNX_SESSION_ID": "cd9f4c66-c696-4c16-8e9f-8823c8cbacaf"}, "cookies_string": "NTNX_SESSION_ID=cd9f4c66-c696-4c16-8e9f-8823c8cbacaf", "date": "Tue, 21 Jul 2026 05:23:55 GMT", "elapsed": 0, "etag": "YXBwbGljYXRpb24vanNvbg==:MQ==", "expires": "0,0", "json": {"$objectType": "vmm.v4.ahv.policies.GetVmHostAffinityPolicyApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "vmm.v4.ahv.policies.VmHostAffinityPolicy", "$reserved": {"$fv": "v4.r3"}, "createTime": "2026-07-21T05:23:49.635869Z", "createdBy": {"$objectType": "vmm.v4.ahv.policies.UserReference", "$reserved": {"$fv": "v4.r3"}, "extId": "00000000-0000-0000-0000-000000000000"}, "description": "Ansible integration test parent policy", "extId": "a48e8d3d-4264-4d2f-786f-490f31b434c9", "hostCategories": [{"$objectType": "vmm.v4.ahv.policies.CategoryReference", "$reserved": {"$fv": "v4.r3"}, "extId": "eec2bf79-941d-43d0-5953-a04081def914"}], "lastUpdatedBy": {"$objectType": "vmm.v4.ahv.policies.UserReference", "$reserved": {"$fv": "v4.r3"}, "extId": "00000000-0000-0000-0000-000000000000"}, "name": "vhap_ansible_KzZlpQcJmYFu", "numCompliantVms": 0, "numHosts": 0, "numNonCompliantVms": 0, "numVms": 0, "updateTime": "2026-07-21T05:23:49.635869Z", "vmCategories": [{"$objectType": "vmm.v4.ahv.policies.CategoryReference", "$reserved": {"$fv": "v4.r3"}, "extId": "9d9840b2-06c6-490d-4f53-7a1015080b23"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies/a48e8d3d-4264-4d2f-786f-490f31b434c9", "rel": "self"}, {"href": "https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies/a48e8d3d-4264-4d2f-786f-490f31b434c9/vm-compliance-states", "rel": "vm-compliance-states"}]}}, "msg": "OK (1980 bytes)", "pragma": "no-cache, no-cache", "redirected": false, "set_cookie": "NTNX_SESSION_ID=cd9f4c66-c696-4c16-8e9f-8823c8cbacaf;Max-Age=29700;Path=/;Secure;HttpOnly;SameSite=Lax", "status": 200, "strict_transport_security": "max-age=31536000 ; includeSubDomains, max-age=63072000; includeSubdomains; preload", "url": "https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies/a48e8d3d-4264-4d2f-786f-490f31b434c9", "vary": "Origin", "x_api_ratelimit_limit": "15", "x_api_ratelimit_refresh_period_seconds": "1", "x_api_ratelimit_remaining": "14", "x_api_ratelimit_reset": "0", "x_content_type_options": "nosniff, nosniff", "x_dns_prefetch_control": "off", "x_envoy_upstream_service_time": "13", "x_frame_options": "DENY, SAMEORIGIN", "x_ntnx_env": "pc", "x_ntnx_product": "pc.7.6", "x_permitted_cross_domain_policies": "master-only", "x_ratelimit_limit": "40", "x_ratelimit_remaining": "37", "x_ratelimit_reset": "0", "x_xss_protection": "0, 1; mode=block"}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Delete parent VM-host affinity policy via raw v4.2 API] ***
ok: [testhost] => {"cache_control": "no-cache, no-store, max-age=0, must-revalidate,no-cache, no-store", "changed": false, "connection": "close", "content_encoding": "identity", "content_length": "242", "content_security_policy": "connect-src 'self' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; default-src 'self' https://*.nutanix.com; frame-ancestors 'self' https://*.nutanix.com; frame-src 'self' https://*.nutanix.com blob: data:; img-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'", "content_type": "application/json", "cookies": {"NTNX_SESSION_ID": "f3372441-3587-4aff-a66d-3740d127e694"}, "cookies_string": "NTNX_SESSION_ID=f3372441-3587-4aff-a66d-3740d127e694", "date": "Tue, 21 Jul 2026 05:23:55 GMT", "elapsed": 0, "expires": "0,0", "json": {"$objectType": "vmm.v4.ahv.policies.DeleteVmHostAffinityPolicyApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "prism.v4.config.TaskReference", "$reserved": {"$fv": "v4.r2"}, "extId": "ZXJnb24=:20b51ff1-7ff3-514a-bf5e-29b70b797873"}}, "msg": "OK (242 bytes)", "pragma": "no-cache, no-cache", "redirected": false, "set_cookie": "NTNX_SESSION_ID=f3372441-3587-4aff-a66d-3740d127e694;Max-Age=29700;Path=/;Secure;HttpOnly;SameSite=Lax", "status": 202, "strict_transport_security": "max-age=31536000 ; includeSubDomains, max-age=63072000; includeSubdomains; preload", "url": "https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies/a48e8d3d-4264-4d2f-786f-490f31b434c9", "vary": "Origin", "x_api_ratelimit_limit": "2", "x_api_ratelimit_refresh_period_seconds": "1", "x_api_ratelimit_remaining": "1", "x_api_ratelimit_reset": "0", "x_content_type_options": "nosniff, nosniff", "x_dns_prefetch_control": "off", "x_envoy_upstream_service_time": "20", "x_frame_options": "DENY, SAMEORIGIN", "x_ntnx_env": "pc", "x_ntnx_product": "pc.7.6", "x_permitted_cross_domain_policies": "master-only", "x_ratelimit_limit": "40", "x_ratelimit_remaining": "39", "x_ratelimit_reset": "0", "x_xss_protection": "0, 1; mode=block"}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Parent policy delete status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Parent VM-host affinity policy deletion submitted"
}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Delete VM-side category] ***
changed: [testhost] => {"changed": true, "error": null, "ext_id": "9d9840b2-06c6-490d-4f53-7a1015080b23", "response": null}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : VM-side category delete status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "VM category deleted"
}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Delete host-side category] ***
changed: [testhost] => {"changed": true, "error": null, "ext_id": "eec2bf79-941d-43d0-5953-a04081def914", "response": null}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2 : Host-side category delete status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Host category deleted"
}

PLAY RECAP *********************************************************************
testhost                   : ok=34   changed=4    unreachable=0    failed=0    skipped=2    rescued=0    ignored=3   

```

</details>

### Lint / sanity status

- `black .` — clean on new/changed files
- `isort .` — clean on new/changed files
- `flake8` — clean on new/changed files
- `ansible-lint` — Passed: 0 failure(s), 0 warning(s) on the 8 new files
- `ansible-test sanity --python 3.12` — all 32 sanity tests ran, all pass
  on the module, module_utils, examples and integration test target

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
