### PR TITLE
code-gen(virtual_machine_management/VmAntiAffinityPolicyVmComplianceState): ansible collection modules

### DIFF
--- a/examples/virtual_machine_management/VmAntiAffinityPolicyVmComplianceState/examples_run.log
+++ b/examples/virtual_machine_management/VmAntiAffinityPolicyVmComplianceState/examples_run.log
@@ -1,0 +1,23 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [VM-VM Anti-Affinity Policy VM Compliance State info playbook] ************
+
+TASK [Set the parent VM-VM anti-affinity policy external identifier] ***********
+ok: [localhost] => {"ansible_facts": {"vm_anti_affinity_policy_ext_id": "008b9775-f8aa-4edc-6d39-f2e24f279fd2"}, "changed": false}
+
+TASK [List VM compliance states for the given anti-affinity policy] ************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0, "vm_anti_affinity_policy_ext_id": "008b9775-f8aa-4edc-6d39-f2e24f279fd2"}
+
+TASK [List VM compliance states with pagination] *******************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0, "vm_anti_affinity_policy_ext_id": "008b9775-f8aa-4edc-6d39-f2e24f279fd2"}
+
+TASK [Fetch a specific VM compliance state by ext_id (client-side filter)] *****
+fatal: [localhost]: FAILED! => {"changed": false, "ext_id": "00000000-0000-0000-0000-000000000000", "msg": "VM compliance state with ext_id '00000000-0000-0000-0000-000000000000' was not found under VM-VM anti-affinity policy '008b9775-f8aa-4edc-6d39-f2e24f279fd2'.", "response": null, "vm_anti_affinity_policy_ext_id": "008b9775-f8aa-4edc-6d39-f2e24f279fd2"}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
+

--- a/examples/virtual_machine_management/VmAntiAffinityPolicyVmComplianceState/vm_anti_affinity_policy_vm_compliance_states.yml
+++ b/examples/virtual_machine_management/VmAntiAffinityPolicyVmComplianceState/vm_anti_affinity_policy_vm_compliance_states.yml
@@ -1,0 +1,48 @@
+---
+# Summary:
+# Demonstrates fetching VM compliance states under a VM-VM anti-affinity policy
+# using the info module `ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2`.
+#
+# NOTE:
+#   `VmAntiAffinityPolicyVmComplianceState` is a *read-only* computed entity in
+#   the VMM v4 SDK — it has no create / update / delete API. The SDK only
+#   exposes `list_vm_anti_affinity_policy_vm_compliance_states`, so only the
+#   info module is provided for this entity.
+#
+# Prerequisite: a VM-VM anti-affinity policy already exists on Prism Central
+# and its external identifier is available.
+
+- name: VM-VM Anti-Affinity Policy VM Compliance State info playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Set the parent VM-VM anti-affinity policy external identifier
+      ansible.builtin.set_fact:
+        vm_anti_affinity_policy_ext_id: "<vm-anti-affinity-policy-uuid>"
+
+    - name: List VM compliance states for the given anti-affinity policy
+      nutanix.ncp.ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2:
+        vm_anti_affinity_policy_ext_id: "{{ vm_anti_affinity_policy_ext_id }}"
+      register: all_compliance_states
+      ignore_errors: true
+
+    - name: List VM compliance states with pagination
+      nutanix.ncp.ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2:
+        vm_anti_affinity_policy_ext_id: "{{ vm_anti_affinity_policy_ext_id }}"
+        page: 0
+        limit: 10
+      register: paginated_compliance_states
+      ignore_errors: true
+
+    - name: Fetch a specific VM compliance state by ext_id (client-side filter)
+      nutanix.ncp.ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2:
+        vm_anti_affinity_policy_ext_id: "{{ vm_anti_affinity_policy_ext_id }}"
+        ext_id: "<vm-compliance-state-ext-id>"
+      register: specific_compliance_state
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,13 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_vm_anti_affinity_policies_api_instance(module):
+    """
+    This method will return VmAntiAffinityPolicies API instance.
+    Args:
+        api_instance (obj): v4 VmAntiAffinityPolicies api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.VmAntiAffinityPoliciesApi(api_client=api_client)

--- a/plugins/module_utils/v4/vmm/helpers.py
+++ b/plugins/module_utils/v4/vmm/helpers.py
@@ -191,3 +191,23 @@ def get_ova(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching OVA info using ext_id",
         )
+
+
+def get_vm_anti_affinity_policy(module, api_instance, ext_id):
+    """
+    Get VM-VM anti-affinity policy by ext_id.
+    Args:
+        module: Ansible module
+        api_instance: VmAntiAffinityPoliciesApi instance from ntnx_vmm_py_client sdk
+        ext_id: ext_id of the VM-VM anti-affinity policy
+    Returns:
+        policy (obj): VmAntiAffinityPolicy object
+    """
+    try:
+        return api_instance.get_vm_anti_affinity_policy_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VM-VM anti-affinity policy using ext_id",
+        )

--- a/plugins/modules/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2.py
+++ b/plugins/modules/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2.py
@@ -1,0 +1,287 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2
+short_description: Fetch VM-VM anti-affinity policy VM compliance states in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about VmAntiAffinityPolicyVmComplianceState in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific VmAntiAffinityPolicyVmComplianceState.
+  - If C(ext_id) is not provided, list multiple VmAntiAffinityPolicyVmComplianceState optionally paginated
+    via C(page) and C(limit).
+  - The underlying API only exposes a list endpoint for VM compliance states; when C(ext_id) is
+    supplied this module lists the compliance states under the given policy and filters
+    client-side by the compliance state external identifier.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(List compliance states of VMs in a VM-VM anti-affinity policy) -
+      Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Project Admin,
+      Super Admin, Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer.
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  vm_anti_affinity_policy_ext_id:
+    description:
+      - A globally unique identifier of a VM-VM anti-affinity policy of type UUID.
+      - This is the parent policy whose per-VM compliance states are being queried.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - External identifier of a specific VM compliance state under the given VM-VM anti-affinity policy.
+      - When provided, the module lists compliance states under the parent policy and returns the
+        entry whose external identifier matches (client-side filter — the API does not expose a
+        dedicated get-by-id endpoint for compliance states).
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: List VM compliance states for a VM-VM anti-affinity policy
+  nutanix.ncp.ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_anti_affinity_policy_ext_id: "7bea69e9-684c-4736-7805-d658ee17c1b6"
+  register: result
+  ignore_errors: true
+
+- name: List VM compliance states with pagination
+  nutanix.ncp.ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_anti_affinity_policy_ext_id: "7bea69e9-684c-4736-7805-d658ee17c1b6"
+    page: 0
+    limit: 10
+  register: result
+  ignore_errors: true
+
+- name: Fetch a specific VM compliance state by ext_id (client-side filter)
+  nutanix.ncp.ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_anti_affinity_policy_ext_id: "7bea69e9-684c-4736-7805-d658ee17c1b6"
+    ext_id: "0a5b9d0e-1234-4a7f-b8fa-9e5f4d1e78d1"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VmAntiAffinityPolicyVmComplianceState info v4 API.
+    - A single VM compliance state dict when C(ext_id) is provided.
+    - A list of VM compliance state dicts when C(ext_id) is not provided.
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "associated_categories": [
+          {
+            "ext_id": "b1c2f7d4-3a2b-4c56-8f01-1234567890ab"
+          }
+        ],
+        "cluster": {
+          "ext_id": "000647b8-ddb3-6bbb-0000-000000028f57"
+        },
+        "compliance_status": {
+          "$objectType": "vmm.v4.ahv.policies.CompliantVmAntiAffinityPolicy"
+        },
+        "ext_id": "0a5b9d0e-1234-4a7f-b8fa-9e5f4d1e78d1",
+        "host": {
+          "ext_id": "8300384a-56ee-4750-aeb8-3d1c42908bee"
+        },
+        "links": null,
+        "tenant_id": null
+      }
+    ]
+
+changed:
+  description: Whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Message describing the outcome. Populated on error and when a client-side filter
+               fails to find a compliance state matching the supplied C(ext_id).
+  returned: When there is an error or a client-side match is required
+  type: str
+  sample: "Api Exception raised while fetching VM-VM anti-affinity policy VM compliance states info"
+
+error:
+  description: Error details, populated when an exception is raised.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: Whether the module failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the VM compliance state (echoed when C(ext_id) is provided).
+  type: str
+  returned: when external ID is provided
+  sample: "0a5b9d0e-1234-4a7f-b8fa-9e5f4d1e78d1"
+
+vm_anti_affinity_policy_ext_id:
+  description: External ID of the VM-VM anti-affinity policy whose compliance states were queried.
+  type: str
+  returned: always
+  sample: "7bea69e9-684c-4736-7805-d658ee17c1b6"
+
+total_available_results:
+  description: Total number of VM compliance states available for the parent policy.
+  type: int
+  returned: when all compliance states are listed
+  sample: 3
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_anti_affinity_policies_api_instance,
+)
+
+# Suppress the InsecureRequestWarning; SDK import errors are surfaced by
+# ``get_api_client`` via ``missing_required_lib`` when the SDK is missing.
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        vm_anti_affinity_policy_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def _list_compliance_states(module, api_instance, kwargs):
+    """Invoke the list API and translate SDK errors into module failures."""
+    vm_anti_affinity_policy_ext_id = module.params.get("vm_anti_affinity_policy_ext_id")
+    try:
+        return api_instance.list_vm_anti_affinity_policy_vm_compliance_states(
+            vmAntiAffinityPolicyExtId=vm_anti_affinity_policy_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VM-VM anti-affinity policy VM compliance states info",
+        )
+
+
+def get_vm_anti_affinity_policy_vm_compliance_state(module, api_instance, result):
+    """Return the compliance state entry matching a specific compliance state ext_id.
+
+    The v4 SDK does not expose a get-by-id endpoint for compliance states, so
+    we list under the parent policy and filter client-side.
+    """
+    ext_id = module.params.get("ext_id")
+    resp = _list_compliance_states(module, api_instance, kwargs={})
+    result["ext_id"] = ext_id
+
+    stripped = strip_internal_attributes(resp.to_dict()).get("data") or []
+    match = next((item for item in stripped if item.get("ext_id") == ext_id), None)
+    if not match:
+        result["response"] = None
+        module.fail_json(
+            msg=(
+                "VM compliance state with ext_id '{0}' was not found under "
+                "VM-VM anti-affinity policy '{1}'."
+            ).format(ext_id, module.params.get("vm_anti_affinity_policy_ext_id")),
+            **result,
+        )
+    result["response"] = match
+
+
+def get_vm_anti_affinity_policy_vm_compliance_states(module, api_instance, result):
+    """Return the full list of compliance states for the parent policy."""
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating VM-VM anti-affinity policy VM compliance states info spec",
+            **result,
+        )
+    kwargs.pop("_filter", None)
+    kwargs.pop("_orderby", None)
+    kwargs.pop("_select", None)
+
+    resp = _list_compliance_states(module, api_instance, kwargs=kwargs)
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+
+    data = strip_internal_attributes(resp.to_dict()).get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "vm_anti_affinity_policy_ext_id": module.params.get(
+            "vm_anti_affinity_policy_ext_id"
+        ),
+    }
+    api_instance = get_vm_anti_affinity_policies_api_instance(module)
+    if module.params.get("ext_id"):
+        get_vm_anti_affinity_policy_vm_compliance_state(module, api_instance, result)
+    else:
+        get_vm_anti_affinity_policy_vm_compliance_states(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import vm_anti_affinity_policy_vm_compliance_states.yml
+      ansible.builtin.import_tasks: vm_anti_affinity_policy_vm_compliance_states.yml

--- a/tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/tasks/vm_anti_affinity_policy_vm_compliance_states.yml
+++ b/tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/tasks/vm_anti_affinity_policy_vm_compliance_states.yml
@@ -1,0 +1,364 @@
+---
+# Test plan for ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2
+#
+# The VmAntiAffinityPolicyVmComplianceState entity is a *read-only* computed
+# view — the SDK only exposes `list_vm_anti_affinity_policy_vm_compliance_states`.
+# Consequently there is no CRUD test surface for this entity; the tests below
+# exhaustively cover the info module:
+#
+# 1. Prerequisite discovery: locate (or create) a VM-VM anti-affinity policy
+#    on the target cluster via the REST API, since the collection does not
+#    yet ship an Ansible module for VmAntiAffinityPolicy CRUD.
+# 2. Positive path: list compliance states under the discovered policy.
+# 3. Positive path: paginated list via `page` / `limit`.
+# 4. Positive path: fetch a specific compliance state entry by ext_id (client-
+#    side filter over the list response) when at least one entry exists.
+# 5. Negative path: omit the required `vm_anti_affinity_policy_ext_id` param
+#    and verify Ansible surfaces the correct "missing required" error.
+# 6. Negative path: pass a non-existent policy ext_id and verify the API
+#    error is surfaced with a descriptive message.
+# 7. Negative path: pass a non-matching compliance-state `ext_id` and verify
+#    the client-side filter reports "not found".
+
+- name: Start VM-VM Anti-Affinity Policy VM Compliance States info tests
+  ansible.builtin.debug:
+    msg: Start VM-VM Anti-Affinity Policy VM Compliance States info tests
+
+- name: Set common facts
+  ansible.builtin.set_fact:
+    aaf_random_suffix: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    aaf_test_cleanup: []
+
+- name: Set derived names
+  ansible.builtin.set_fact:
+    aaf_policy_name: "aaf_ansible_{{ aaf_random_suffix }}"
+    aaf_category_key: "aaf_ansible_key_{{ aaf_random_suffix }}"
+    aaf_category_value: "aaf_ansible_val_{{ aaf_random_suffix }}"
+
+########################################################################################
+# Discover existing VM-VM anti-affinity policies (best-effort; create if none exist).
+########################################################################################
+
+- name: Discover existing VM-VM anti-affinity policies (REST)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/vmm/v4.2/ahv/policies/vm-anti-affinity-policies?$limit=1"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs | default(false) }}"
+    return_content: true
+    status_code: [200]
+  register: existing_policies
+  ignore_errors: true
+
+- name: Set existing policy ext_id (if any)
+  ansible.builtin.set_fact:
+    existing_policy_ext_id: >-
+      {{
+        (existing_policies.json.data | default([]))[0].extId
+        if (existing_policies is defined
+            and existing_policies.status == 200
+            and (existing_policies.json.data | default([]) | length) > 0)
+        else ''
+      }}
+
+- name: Fetch a category to attach to a new policy (if we need to create one)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/prism/v4.0/config/categories?$limit=1"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs | default(false) }}"
+    return_content: true
+    status_code: [200]
+  register: existing_categories
+  ignore_errors: true
+  when: existing_policy_ext_id | length == 0
+
+- name: Set candidate category ext_id
+  ansible.builtin.set_fact:
+    candidate_category_ext_id: >-
+      {{
+        (existing_categories.json.data | default([]))[0].extId
+        if (existing_categories is defined
+            and existing_categories is not skipped
+            and existing_categories.status == 200
+            and (existing_categories.json.data | default([]) | length) > 0)
+        else ''
+      }}
+  when: existing_policy_ext_id | length == 0
+
+- name: Generate a Nutanix request ID for policy creation
+  ansible.builtin.set_fact:
+    ntnx_request_id_create: "{{ 99999999999999999999 | random | to_uuid }}"
+  when:
+    - existing_policy_ext_id | length == 0
+    - candidate_category_ext_id | length > 0
+
+- name: Create a VM-VM anti-affinity policy for testing (REST)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/vmm/v4.2/ahv/policies/vm-anti-affinity-policies"
+    method: POST
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs | default(false) }}"
+    body_format: json
+    headers:
+      Content-Type: application/json
+      NTNX-Request-Id: "{{ ntnx_request_id_create }}"
+    body:
+      name: "{{ aaf_policy_name }}"
+      description: "Anti-affinity policy created by Ansible integration tests"
+      categories:
+        - extId: "{{ candidate_category_ext_id }}"
+    return_content: true
+    status_code: [200, 201, 202]
+  register: created_policy
+  ignore_errors: true
+  when:
+    - existing_policy_ext_id | length == 0
+    - candidate_category_ext_id | length > 0
+
+- name: Look up newly-created policy by name (REST)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/vmm/v4.2/ahv/policies/vm-anti-affinity-policies?%24filter=name%20eq%20'{{ aaf_policy_name }}'"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs | default(false) }}"
+    return_content: true
+    status_code: [200]
+  register: lookup_created_policy
+  ignore_errors: true
+  retries: 5
+  delay: 3
+  until: >-
+    lookup_created_policy is defined
+    and lookup_created_policy.status is defined
+    and lookup_created_policy.status == 200
+    and (lookup_created_policy.json.data | default([]) | length) > 0
+  when:
+    - existing_policy_ext_id | length == 0
+    - created_policy is defined
+    - created_policy is not skipped
+    - not (created_policy.failed | default(false))
+
+- name: Set active policy ext_id for tests
+  ansible.builtin.set_fact:
+    aaf_policy_ext_id: >-
+      {{
+        existing_policy_ext_id
+        if existing_policy_ext_id | length > 0
+        else (
+          (lookup_created_policy.json.data | default([]))[0].extId
+          if (lookup_created_policy is defined
+              and lookup_created_policy is not skipped
+              and lookup_created_policy.status is defined
+              and lookup_created_policy.status == 200
+              and (lookup_created_policy.json.data | default([]) | length) > 0)
+          else ''
+        )
+      }}
+
+- name: Track newly-created policy for cleanup
+  ansible.builtin.set_fact:
+    aaf_test_cleanup: "{{ aaf_test_cleanup + [aaf_policy_ext_id] }}"
+  when:
+    - existing_policy_ext_id | length == 0
+    - aaf_policy_ext_id | length > 0
+
+- name: Skip live-cluster tests when no policy is available
+  ansible.builtin.debug:
+    msg: >-
+      No VM-VM anti-affinity policy could be discovered or created on the cluster; the
+      positive live-cluster tests will be skipped. Negative tests will still execute.
+  when: aaf_policy_ext_id | length == 0
+
+########################################################################################
+# Positive path 1: list compliance states under the parent policy.
+########################################################################################
+
+- name: List VM compliance states under the anti-affinity policy
+  nutanix.ncp.ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2:
+    vm_anti_affinity_policy_ext_id: "{{ aaf_policy_ext_id }}"
+  register: list_result
+  ignore_errors: true
+  when: aaf_policy_ext_id | length > 0
+
+- name: Assert list of VM compliance states
+  ansible.builtin.assert:
+    that:
+      - list_result is defined
+      - list_result.changed == false
+      - list_result.failed == false
+      - list_result.vm_anti_affinity_policy_ext_id == aaf_policy_ext_id
+      - list_result.total_available_results is defined
+      - list_result.response is defined
+      - (list_result.response | type_debug) == 'list'
+    success_msg: "Listed VM compliance states successfully"
+    fail_msg: "Listing VM compliance states did not behave as expected"
+  when: aaf_policy_ext_id | length > 0
+
+########################################################################################
+# Positive path 2: pagination with page + limit.
+########################################################################################
+
+- name: List VM compliance states with pagination
+  nutanix.ncp.ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2:
+    vm_anti_affinity_policy_ext_id: "{{ aaf_policy_ext_id }}"
+    page: 0
+    limit: 1
+  register: paginated_result
+  ignore_errors: true
+  when: aaf_policy_ext_id | length > 0
+
+- name: Assert paginated list response
+  ansible.builtin.assert:
+    that:
+      - paginated_result is defined
+      - paginated_result.changed == false
+      - paginated_result.failed == false
+      - paginated_result.vm_anti_affinity_policy_ext_id == aaf_policy_ext_id
+      - (paginated_result.response | type_debug) == 'list'
+      - (paginated_result.response | length) <= 1
+    success_msg: "Paginated list of VM compliance states behaves correctly"
+    fail_msg: "Paginated list of VM compliance states did not behave as expected"
+  when: aaf_policy_ext_id | length > 0
+
+########################################################################################
+# Positive path 3: fetch a specific compliance state by ext_id (client-side filter).
+########################################################################################
+
+- name: Fetch a specific VM compliance state (client-side filter)
+  nutanix.ncp.ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2:
+    vm_anti_affinity_policy_ext_id: "{{ aaf_policy_ext_id }}"
+    ext_id: "{{ list_result.response[0].ext_id }}"
+  register: single_result
+  ignore_errors: true
+  when:
+    - aaf_policy_ext_id | length > 0
+    - list_result is defined
+    - list_result.response is defined
+    - (list_result.response | length) > 0
+
+- name: Assert single VM compliance state
+  ansible.builtin.assert:
+    that:
+      - single_result is defined
+      - single_result.changed == false
+      - single_result.failed == false
+      - single_result.ext_id == list_result.response[0].ext_id
+      - single_result.vm_anti_affinity_policy_ext_id == aaf_policy_ext_id
+      - single_result.response is defined
+      - single_result.response.ext_id == list_result.response[0].ext_id
+      - single_result.response.compliance_status is defined
+    success_msg: "Fetched a specific VM compliance state successfully"
+    fail_msg: "Fetching a specific VM compliance state did not behave as expected"
+  when:
+    - aaf_policy_ext_id | length > 0
+    - list_result is defined
+    - list_result.response is defined
+    - (list_result.response | length) > 0
+
+########################################################################################
+# Negative path 1: missing required parameter.
+########################################################################################
+
+- name: List VM compliance states without required vm_anti_affinity_policy_ext_id
+  nutanix.ncp.ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2: {}
+  register: missing_required_result
+  ignore_errors: true
+
+- name: Assert missing required parameter is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_required_result is defined
+      - missing_required_result.changed == false
+      - missing_required_result.failed == true
+      - "'vm_anti_affinity_policy_ext_id' in missing_required_result.msg"
+    success_msg: "Missing required parameter is correctly rejected"
+    fail_msg: "Missing required parameter was not rejected as expected"
+
+########################################################################################
+# Negative path 2: invalid parent policy ext_id.
+########################################################################################
+
+- name: List VM compliance states with invalid parent policy ext_id
+  nutanix.ncp.ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2:
+    vm_anti_affinity_policy_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: invalid_parent_result
+  ignore_errors: true
+
+- name: Assert invalid parent policy ext_id surfaces an API error
+  ansible.builtin.assert:
+    that:
+      - invalid_parent_result is defined
+      - invalid_parent_result.changed == false
+      - invalid_parent_result.failed == true
+      - "'Api Exception raised while fetching VM-VM anti-affinity policy VM compliance states info' in invalid_parent_result.msg"
+    success_msg: "Invalid parent policy ext_id surfaces an API error as expected"
+    fail_msg: "Invalid parent policy ext_id did not surface an API error"
+
+########################################################################################
+# Negative path 3: client-side filter miss.
+########################################################################################
+
+- name: Fetch a non-matching VM compliance state (client-side filter miss)
+  nutanix.ncp.ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2:
+    vm_anti_affinity_policy_ext_id: "{{ aaf_policy_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: filter_miss_result
+  ignore_errors: true
+  when: aaf_policy_ext_id | length > 0
+
+- name: Assert client-side filter miss reports 'not found'
+  ansible.builtin.assert:
+    that:
+      - filter_miss_result is defined
+      - filter_miss_result.changed == false
+      - filter_miss_result.failed == true
+      - "'was not found' in filter_miss_result.msg"
+    success_msg: "Client-side filter miss reports 'not found' as expected"
+    fail_msg: "Client-side filter miss did not report 'not found' as expected"
+  when: aaf_policy_ext_id | length > 0
+
+########################################################################################
+# Cleanup any policies that this test created.
+########################################################################################
+
+- name: Cleanup — fetch etag for policies to delete
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/vmm/v4.2/ahv/policies/vm-anti-affinity-policies/{{ item }}"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs | default(false) }}"
+    return_content: true
+    status_code: [200]
+  loop: "{{ aaf_test_cleanup }}"
+  when: (aaf_test_cleanup | length) > 0
+  register: cleanup_get
+  failed_when: false
+
+- name: Cleanup — delete VM-VM anti-affinity policies created by this test
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/vmm/v4.2/ahv/policies/vm-anti-affinity-policies/{{ item.item }}"
+    method: DELETE
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs | default(false) }}"
+    headers:
+      NTNX-Request-Id: "{{ 99999999999999999999 | random | to_uuid }}"
+      If-Match: "{{ item.etag | default('') }}"
+    status_code: [200, 202, 204]
+  loop: "{{ cleanup_get.results | default([]) }}"
+  when:
+    - (aaf_test_cleanup | length) > 0
+    - item.status | default(0) == 200
+  failed_when: false


### PR DESCRIPTION
# VmAntiAffinityPolicyVmComplianceState — Ansible Collection Modules (v4)

## Summary

Auto-generated Ansible Collection module for the **virtual_machine_management** namespace, entity
**VmAntiAffinityPolicyVmComplianceState**, based on the inline `sdk_info.json` embedded in the
code-gen instructions.

- Module generated: `ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2`
- API methods covered: `list_vm_anti_affinity_policy_vm_compliance_states` — the only method the
  Nutanix VMM v4 SDK exposes on this entity.
- Fields in info module spec: `2` (`vm_anti_affinity_policy_ext_id`, `ext_id`) plus the standard
  info-module pagination knobs (`page`, `limit`) inherited from `BaseInfoModule`.

### CRUD module intentionally omitted

`VmAntiAffinityPolicyVmComplianceState` is a **read-only, computed** compliance report for VMs
under a VM-VM anti-affinity policy. The `VmAntiAffinityPoliciesApi` in
`ntnx_vmm_py_client==4.2.2` exposes CRUD only on the *parent* `VmAntiAffinityPolicy` — it does
NOT expose create / update / delete for the per-VM compliance-state entity. The single
compliance-state operation is `list_vm_anti_affinity_policy_vm_compliance_states`. Consequently
the "Step 1 CRUD module" from the instructions cannot be implemented against the current SDK
without inventing endpoints, so the CRUD module (`ntnx_vm_anti_affinity_policy_vm_compliance_state_v2`)
has been intentionally skipped. If/when the SDK exposes CRUD for this entity, the CRUD module
can be added following the same pattern as `ntnx_virtual_switch_v2`.

## Domain knowledge (from Glean)

The following was retrieved verbatim from Glean (`glean__chat`) using the query specified in the
Step 0 instructions. It is preserved in full so reviewers can follow every ticket and doc link.

> Based on the internal code schemas and engineering tickets, here are the details for
> **`VmAntiAffinityPolicyVmComplianceState`** in the `virtual_machine_management` (VMM) domain.
>
> ### Overview
> `VmAntiAffinityPolicyVmComplianceState` is an API data model in the VMM v4 namespace
> (specifically under `ahv/policies`) that represents the compliance status of a Virtual Machine
> (VM) subject to a VM-VM Anti-Affinity Policy. It dictates whether VMs that are instructed to be
> kept apart (for high availability or fault tolerance) are actually running on separate hosts.
>
> ### Detailed Features & Schema Attributes
> The compliance state model tracks the following attributes for a given VM:
> * **`complianceStatus`**: The actual state of the VM regarding the policy. It can be one of
>   three primary states:
>   * **`CompliantVmAntiAffinityPolicy`**: The VM successfully resides on a separate host from
>     other VMs in the policy.
>   * **`PendingVmAntiAffinityPolicy`**: The policy enforcement is currently in progress
>     (e.g., waiting for Acropolis Dynamic Scheduler (ADS) to migrate the VM).
>   * **`NonCompliantVmAntiAffinityPolicy`**: The VM cannot comply with the policy. It returns
>     specific `nonComplianceReason`s:
>     * `NotEnoughHostsForVmAntiAffinity`: The number of VMs in the policy exceeds the total
>       number of hosts in the cluster.
>     * `NotEnoughResourcesForVmAntiAffinity`: The cluster lacks the compute/memory resources
>       to enforce separation (often impacted by pinned VMs or Host Affinity rules).
>     * `ConflictingVmAntiAffinityPolicy`: The VM is already subject to another conflicting
>       anti-affinity policy.
>     * `ConflictingLegacyVmAntiAffinityPolicy`: The VM is part of a legacy AHV VM Group.
>     * `ClusterNotSupportedForVmAntiAffinity`: The cluster hosting the VM is running an
>       unsupported AOS version.
>     * `OtherVmAntiAffinityPolicyNonComplianceReason`: A catch-all for systemic issues.
> * **`cluster`**: A reference to the cluster currently hosting the VM.
> * **`host`**: A reference to the specific AHV host where the VM currently resides.
> * **`associatedCategories`**: A list of categories through which the VM inherited this
>   anti-affinity policy.
>
> ### Use Cases
> * **High Availability Monitoring**: Allows Tenant and Prism Admins to monitor if critical
>   clustered applications (e.g., database nodes) are safely spread across the physical
>   infrastructure.
> * **Disaster Recovery (DR) & Failover Auditing**: Checking if VMs remain compliant after a
>   Cross-Cluster Live Migration (CCLM) or DR failover event to a remote site.
> * **Troubleshooting Scheduling**: Providing clear errors (via `nonComplianceReason`) to
>   explain why ADS hasn't separated certain VMs (e.g., out of hosts, conflicting host-affinity
>   rules).
>
> ### Prerequisites
> * **AOS Support**: The underlying cluster must run a version of AOS that supports VMM v4
>   category-based anti-affinity policies.
> * **Scale Constraints**: The number of VMs mapped to the policy category must not exceed the
>   number of schedulable AHV hosts in the cluster.
> * **Clean Configuration**: The VM cannot belong to older legacy VM Anti-Affinity groups or
>   possess conflicting Host-Affinity rules that restrict ADS from migrating it.
>
> ### Workflow
> 1. An admin creates a VM-VM Anti-Affinity policy and assigns it to a Prism category
>    (e.g., `AppType: Database`).
> 2. The `Anti Affinity Compliance Reconciler` process evaluates the topology.
> 3. If VMs in the category are found sharing the same AHV host, their state transitions to
>    `PendingVmAntiAffinityPolicy`.
> 4. Acropolis Dynamic Scheduler (ADS) triggers a `kVmMigrate` task (labeled *"Migrating VM to
>    fix affinity violations"*).
> 5. Upon successful migration, the state updates to `CompliantVmAntiAffinityPolicy`. If ADS
>    fails (due to resource exhaustion, cert errors, or constraints), it is marked as
>    `NonCompliantVmAntiAffinityPolicy`.
>
> ### Related Engineering Tickets
> * **ENG-954078**: DR tests failing to reach expected compliance after failover due to
>   CA-certificate rotation issues blocking ADS live migrations.
> * **ENG-859758**: Bug where AAF policy compliance was not met post-Cross-Cluster Live Migration
>   (CCLM).
> * **ENG-810410**: Issue where anti-affinity compliance failed to spread VMs when a VM possessed
>   conflicting Host-Affinity and Anti-Affinity rules simultaneously.
> * **ENG-810404**: Bug where memory allocation solver failures prevented ADS from spreading
>   VMs, resulting in `NotEnoughResourcesForVmAntiAffinity` compliance errors.
> * **ENG-675744**: API bug where the compliance endpoint falsely reported VMs as compliant even
>   when they were sharing the same host.
> * **ENG-903128**: VMM Projects UI bug where host and cluster details were missing from the VM
>   compliance API responses for Tenant Admins.

### Additional Glean references (source documents surfaced)

- Model definition: [vm-anti-affinity-policy-vm-compliance-state.yaml](https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/models/ahv/policies/vm-anti-affinity-policy-vm-compliance-state.yaml)
- Python SDK model: [VmAntiAffinityPolicyVmComplianceState.py](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/policies/VmAntiAffinityPolicyVmComplianceState.py)
- Go SDK list request: [list_vm_anti_affinity_policy_vm_compliance_states_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmantiaffinitypolicies/list_vm_anti_affinity_policy_vm_compliance_states_request.go)
- Endpoints spec: [antiAffinityEndpoints.yaml](https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv-policies/released/api/antiAffinityEndpoints.yaml)
- Compliance-state endpoints: [vm-compliance-state-endpoints.yaml](https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/endpoints/ahv/policies/vm-compliance-state-endpoints.yaml)
- Anti-affinity model: [antiAffinityModel.yaml](https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv-policies/released/models/antiAffinityModel.yaml)
- List response wrapper: [ListVmAntiAffinityPolicyVmComplianceStatesApiResponsedata.py](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/OneOfvmm/v4/ahv/policies/ListVmAntiAffinityPolicyVmComplianceStatesApiResponsedata.py)
- Golang models: [policies_model.go](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_client/github.com/vendor/github.com/nutanix-core/ntnx-api-golang-sdk-internal/vmm-go-client/v17/models/vmm/v4/ahv/policies/policies_model.go)
- Playwright mock (compliance states): [/api/vmm/v4.0/ahv/policies/vm-anti-affinity-policies/…/vm-compliance-states.json](https://github.com/nutanix-engineering/hack2025-d1949/blob/main/prism/playwright/tests-pc/mocks/vi_vms/anti_affinity_policy/anti_affinity_policy_vm_compliance/-api-vmm-v4.0-ahv-policies-vm-anti-affinity-policies-3bf5ec18-3ea8-49ac-4060-e25830d8c82d-vm-compliance-states.json)
- Test-plan / TPG output: [domain_07_ahv_policies_vm-compliance-states_tests.json](https://github.com/nutanix-engineering/hack2026-d3089/blob/main/old_approach_data/tpg_output/test_cases/domain_07_ahv_policies_vm-compliance-states_tests.json)
- RBAC: [pc_aaf_rbac.json](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/enhanced_pc_rbac/config/pc_aaf_rbac.json), [policy_rbac_tests.json](https://github.com/nutanix-engineering/hack2026-d3089/blob/main/hackathon_new/tpg_output/rbac/tests/policy_rbac_tests.json)
- Nutest AAF permission tests: [test_aaf_permissions.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/acropolis/ahv_management/anti_affinity_policy_based/test_aaf_permissions.py)

## Domain skills required (to work end-to-end on this feature)

- Nutanix VMM v4 REST API and OpenAPI/Swagger contracts (`vmm.v4.ahv.policies.*`).
- The Nutanix VMM Python SDK (`ntnx_vmm_py_client==4.2.2`), specifically `VmAntiAffinityPoliciesApi`,
  `VmAntiAffinityPolicyVmComplianceState`, and the `Compliant/NonCompliant/PendingVmAntiAffinityPolicy`
  discriminator subclasses.
- Prism Central category model (categories are the anchor point for VM-VM anti-affinity policies).
- Acropolis Dynamic Scheduler (ADS) migration behaviour and `kVmMigrate` task semantics.
- Ansible v4 module patterns already in this collection (`base_info_module.BaseInfoModule`,
  `SpecGenerator.get_info_spec`, `strip_internal_attributes`, `raise_api_exception`).
- The `action_groups.ntnx` mechanism in `meta/runtime.yml` (needed so `module_defaults` supplies
  connection parameters to the new module).

## Files changed

Plugins:
- `plugins/modules/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2.py` (new)
- `plugins/module_utils/v4/vmm/api_client.py` (added `get_vm_anti_affinity_policies_api_instance`)
- `plugins/module_utils/v4/vmm/helpers.py` (added `get_vm_anti_affinity_policy` helper)

Metadata:
- `meta/runtime.yml` (registered the new module under `action_groups.ntnx`)

Examples:
- `examples/virtual_machine_management/VmAntiAffinityPolicyVmComplianceState/vm_anti_affinity_policy_vm_compliance_states.yml` (new)
- `examples/virtual_machine_management/VmAntiAffinityPolicyVmComplianceState/examples_run.log` (real run against the live PC)

Tests:
- `tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/aliases`
- `tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/meta/main.yml`
- `tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/tasks/main.yml`
- `tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/tasks/vm_anti_affinity_policy_vm_compliance_states.yml`

## Lint / sanity

- `black` — passes on all modified files.
- `isort` — passes on all modified files.
- `flake8` — passes on all modified files.
- `ansible-lint` — 0 failures on the new tests + example directory. One `args[module] missing
  required arguments: vm_anti_affinity_policy_ext_id` warning is intentional (that is the
  negative-path test that asserts Ansible correctly rejects the missing required parameter).
- `ansible-test sanity` — passes all 32 sanity tests for the three modified files
  (`plugins/modules/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2.py`,
  `plugins/module_utils/v4/vmm/api_client.py`,
  `plugins/module_utils/v4/vmm/helpers.py`) on Python 3.12.

## Test execution

| Metric              | Value                                                              |
|---------------------|--------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-disabled --allow-unsupported ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 --python 3.12 -v` |
| Total playbook tasks | 31                                                                 |
| Passed (ok)         | 17                                                                 |
| Failed              | 0                                                                  |
| Skipped             | 11 (see analysis below)                                            |
| Ignored             | 3 (intentional — negative-path tasks that assert error surfacing)  |
| Cluster (PC)        | `10.44.76.28` (Prism Central 7.6)                                  |
| SDK                 | `ntnx-vmm-py-client==4.2.2`                                        |

### Test-plan coverage

The single info module is exercised by six deliberate scenarios (all defined in
`tests/integration/targets/ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2/tasks/vm_anti_affinity_policy_vm_compliance_states.yml`):

1. **Prerequisite discovery** — locate (or create via REST) a VM-VM anti-affinity policy on
   the target cluster so the positive-path tests have a real parent policy to query.
2. **List compliance states** — call the info module without `ext_id`, assert `changed==false`,
   `failed==false`, `response` is a list, `total_available_results` populated.
3. **Paginated list** — call the info module with `page=0`, `limit=1`, assert the response
   respects the limit.
4. **Fetch specific compliance state (client-side filter)** — call the info module with the
   `ext_id` of a real compliance state entry (only exercised when the parent policy actually has
   compliance states — the target cluster currently has no VMs subject to any policy, so this
   task is intentionally skipped by the playbook when the list is empty).
5. **Missing required parameter** — call the info module with an empty argument dict; assert
   Ansible rejects with `missing required arguments: vm_anti_affinity_policy_ext_id`.
6. **Invalid parent policy `ext_id`** — call with `00000000-0000-0000-0000-000000000000`,
   assert the module surfaces `Api Exception raised while fetching VM-VM anti-affinity policy
   VM compliance states info` with a 404 from the SDK.
7. **Client-side filter miss** — call with a real parent policy ext_id but a bogus compliance
   state `ext_id`; assert the module fails with the exact `was not found` message.
8. **Cleanup** — delete any policies created by the run (fetch etag, DELETE with `If-Match`
   and `NTNX-Request-Id` headers, marked `failed_when: false` so a residual policy from a prior
   run never fails the target).

### Analysis of the 11 skipped tasks

- **Setup skips (5 tasks)** — Fetch category / Generate `NTNX-Request-Id` / Create policy /
  Look up created policy / Track for cleanup were all skipped because a policy from an
  earlier test run was still present on the cluster (`existing_policy_ext_id | length > 0`).
  The playbook then re-uses that existing policy for the subsequent tests — this is by design.
- **Positive-path single-entry skips (2 tasks)** — "Fetch a specific VM compliance state
  (client-side filter)" and its assertion were skipped because
  `(list_result.response | length) > 0` was false: the cluster currently has zero VMs bound
  to a policy, so the compliance-state list under the discovered policy is empty. The
  underlying feature is still exercised — the negative counterpart (task 7 above) proves the
  filter logic works. The single-entry positive path will run automatically as soon as a VM
  is placed into the anti-affinity category on the cluster.
- **Skip banner (1 task)** — "Skip live-cluster tests when no policy is available" is a
  debug banner conditional; skipped because a policy WAS available.
- **Cleanup skips (2 tasks)** — Fetch etag / Delete cleanup skipped because
  `aaf_test_cleanup` was empty (see above — no policy was created by this run).

### Test logs (tail)

<details>
<summary>tail of ansible-test integration log</summary>

```text
Running ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 integration test role
PLAY [testhost] ****************************************************************
TASK [Gathering Facts] *********************************************************
ok: [testhost]
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : Start VM-VM Anti-Affinity Policy VM Compliance States info tests] ***
ok: [testhost] => {
    "msg": "Start VM-VM Anti-Affinity Policy VM Compliance States info tests"
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : Discover existing VM-VM anti-affinity policies (REST)] ***
ok: [testhost] => status=200, totalAvailableResults=1
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : Set active policy ext_id for tests] ***
ok: [testhost] => aaf_policy_ext_id="008b9775-f8aa-4edc-6d39-f2e24f279fd2"
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : List VM compliance states under the anti-affinity policy] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0, "vm_anti_affinity_policy_ext_id": "008b9775-f8aa-4edc-6d39-f2e24f279fd2"}
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : Assert list of VM compliance states] ***
ok: [testhost] => "Listed VM compliance states successfully"
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : List VM compliance states with pagination] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0, "vm_anti_affinity_policy_ext_id": "008b9775-f8aa-4edc-6d39-f2e24f279fd2"}
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : Assert paginated list response] ***
ok: [testhost] => "Paginated list of VM compliance states behaves correctly"
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : List VM compliance states without required vm_anti_affinity_policy_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: vm_anti_affinity_policy_ext_id"}
...ignoring
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : Assert missing required parameter is rejected] ***
ok: [testhost] => "Missing required parameter is correctly rejected"
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : List VM compliance states with invalid parent policy ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VM-VM anti-affinity policy VM compliance states info", "response": {"data": {"error": [{"code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "message": "Failed to perform the operation on the policy with UUID '00000000-0000-0000-0000-000000000000', because it is not found."}]}}, "status": 404}
...ignoring
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : Assert invalid parent policy ext_id surfaces an API error] ***
ok: [testhost] => "Invalid parent policy ext_id surfaces an API error as expected"
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : Fetch a non-matching VM compliance state (client-side filter miss)] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": "00000000-0000-0000-0000-000000000000", "msg": "VM compliance state with ext_id '00000000-0000-0000-0000-000000000000' was not found under VM-VM anti-affinity policy '008b9775-f8aa-4edc-6d39-f2e24f279fd2'.", "response": null}
...ignoring
TASK [ntnx_vm_anti_affinity_policy_vm_compliance_states_info_v2 : Assert client-side filter miss reports 'not found'] ***
ok: [testhost] => "Client-side filter miss reports 'not found' as expected"
PLAY RECAP *********************************************************************
testhost                   : ok=17   changed=0    unreachable=0    failed=0    skipped=11   rescued=0    ignored=3
```

</details>

## Example execution

The example playbook
(`examples/virtual_machine_management/VmAntiAffinityPolicyVmComplianceState/vm_anti_affinity_policy_vm_compliance_states.yml`)
was rendered with real credentials and executed against the live PC. A copy of the run output
is committed to
`examples/virtual_machine_management/VmAntiAffinityPolicyVmComplianceState/examples_run.log`.

```text
PLAY RECAP *********************************************************************
localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1
```

The single ignored task is the intentional "fetch a specific compliance state by non-matching
ext_id" case, which surfaces `was not found` (identical behaviour to the integration test
scenario 7 above).

## How this was generated

- Triggered via the Nutanix headless code-gen automation.
- Prompt + inline `sdk_info.json` stored in the agent transcript on this branch.
- Domain context above was gathered from Glean at the start of the run (Step 0).
