### PR TITLE
code-gen(virtual_machine_management/ReEnforceVmHostAffinityPolicy): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+tests/output/

--- a/examples/virtual_machine_management/ReEnforceVmHostAffinityPolicy/examples_run.log
+++ b/examples/virtual_machine_management/ReEnforceVmHostAffinityPolicy/examples_run.log
@@ -1,0 +1,67 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [VM-Host Affinity Policy re-enforce playbook] *****************************
+
+TASK [Set the policy external ID to re-enforce] ********************************
+ok: [localhost] => {"ansible_facts": {"vm_host_affinity_policy_ext_id": "d8cf7870-6162-474b-4e62-dfa249096ffe"}, "changed": false}
+
+TASK [Re-enforce a VM-Host Affinity Policy] ************************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "d8cf7870-6162-474b-4e62-dfa249096ffe", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:16:05.496138+00:00", "completion_details": null, "created_time": "2026-07-21T05:16:04.313893+00:00", "entities_affected": [{"ext_id": "d8cf7870-6162-474b-4e62-dfa249096ffe", "name": "ansible_reenforce_vmhap_mrJbSeKTuMUl", "rel": "vmm:ahv:policies:vm-host-affinity-policy"}], "error_messages": null, "ext_id": "ZXJnb24=:adb28ae9-d8c1-50c8-b12f-8a25832a95eb", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:16:05.496137+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "VmHostAffinityPolicyEnforce", "operation_description": "Enforce VM-Host Affinity Policy", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:16:04.322317+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:adb28ae9-d8c1-50c8-b12f-8a25832a95eb"}
+
+TASK [Print re-enforce result] *************************************************
+ok: [localhost] => {
+    "reenforce_result": {
+        "changed": true,
+        "error": null,
+        "ext_id": "d8cf7870-6162-474b-4e62-dfa249096ffe",
+        "failed": false,
+        "response": {
+            "app_name": null,
+            "batch_summary": null,
+            "cluster_ext_ids": null,
+            "completed_time": "2026-07-21T05:16:05.496138+00:00",
+            "completion_details": null,
+            "created_time": "2026-07-21T05:16:04.313893+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "d8cf7870-6162-474b-4e62-dfa249096ffe",
+                    "name": "ansible_reenforce_vmhap_mrJbSeKTuMUl",
+                    "rel": "vmm:ahv:policies:vm-host-affinity-policy"
+                }
+            ],
+            "error_messages": null,
+            "ext_id": "ZXJnb24=:adb28ae9-d8c1-50c8-b12f-8a25832a95eb",
+            "is_background_task": false,
+            "is_cancelable": false,
+            "last_updated_time": "2026-07-21T05:16:05.496137+00:00",
+            "legacy_error_message": null,
+            "number_of_entities_affected": 1,
+            "number_of_subtasks": 0,
+            "operation": "VmHostAffinityPolicyEnforce",
+            "operation_description": "Enforce VM-Host Affinity Policy",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "projectExtId": "00000000-0000-0000-0000-000000000000",
+            "resource_links": null,
+            "root_task": null,
+            "started_time": "2026-07-21T05:16:04.322317+00:00",
+            "status": "SUCCEEDED",
+            "sub_steps": null,
+            "sub_tasks": null,
+            "warnings": null
+        },
+        "skipped": false,
+        "task_ext_id": "ZXJnb24=:adb28ae9-d8c1-50c8-b12f-8a25832a95eb"
+    }
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/virtual_machine_management/ReEnforceVmHostAffinityPolicy/ntnx_re_enforce_vm_host_affinity_policy_v2.yml
+++ b/examples/virtual_machine_management/ReEnforceVmHostAffinityPolicy/ntnx_re_enforce_vm_host_affinity_policy_v2.yml
@@ -1,0 +1,51 @@
+---
+# Summary:
+# This playbook demonstrates the re-enforce action for a VM-Host Affinity Policy.
+#
+# Preconditions (must exist on the target Prism Central):
+# 1. A VM-Host Affinity Policy has already been created (its external ID
+#    is passed as `vm_host_affinity_policy_ext_id`).
+# 2. The caller has the `Reenforce_VM_Host_Affinity_Policy` permission
+#    (roles Prism Admin / Super Admin carry it by default).
+#
+# The re-enforce action re-evaluates the affinity rules for all VMs in the
+# policy scope and, if required, live-migrates non-compliant VMs so the
+# policy compliance status moves back to compliant.
+#
+# Tasks performed by this playbook:
+# 1. Re-enforce a VM-Host Affinity Policy by its external ID.
+
+- name: VM-Host Affinity Policy re-enforce playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Set the policy external ID to re-enforce
+      ansible.builtin.set_fact:
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id | default('2e40ff57-20aa-4d2b-b179-298db969c20d') }}"
+
+    - name: Re-enforce a VM-Host Affinity Policy
+      nutanix.ncp.ntnx_re_enforce_vm_host_affinity_policy_v2:
+        ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+      register: reenforce_result
+
+    # Sample response (backfilled after a real run on Prism Central):
+    #   changed: true
+    #   failed: false
+    #   ext_id: "<vm_host_affinity_policy_ext_id>"
+    #   task_ext_id: "ZXJnb24=:<task-uuid>"
+    #   response:
+    #     status: SUCCEEDED
+    #     operation: "kVmApplyVmHostAffinityPolicy"
+    #     operation_description: "Re-enforce VM-host affinity policy"
+    #     entities_affected:
+    #       - ext_id: "<policy_ext_id>"
+    #         rel: "vmm:ahv:policies:vm-host-affinity-policy"
+    - name: Print re-enforce result
+      ansible.builtin.debug:
+        var: reenforce_result

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,17 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_vm_host_affinity_policies_api_instance(module):
+    """
+    Return a VM-Host Affinity Policies API instance.
+
+    Args:
+        module: The Ansible module.
+
+    Returns:
+        obj: v4 VmHostAffinityPoliciesApi instance.
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.VmHostAffinityPoliciesApi(api_client=api_client)

--- a/plugins/module_utils/v4/vmm/helpers.py
+++ b/plugins/module_utils/v4/vmm/helpers.py
@@ -191,3 +191,25 @@ def get_ova(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching OVA info using ext_id",
         )
+
+
+def get_vm_host_affinity_policy(module, api_instance, ext_id):
+    """
+    Get VM-Host Affinity Policy by ext_id.
+
+    Args:
+        module: Ansible module.
+        api_instance: VmHostAffinityPoliciesApi instance from ntnx_vmm_py_client sdk.
+        ext_id: ext_id of the VM-Host Affinity Policy.
+
+    Returns:
+        policy (obj): VM-Host Affinity Policy info object.
+    """
+    try:
+        return api_instance.get_vm_host_affinity_policy_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VM-Host Affinity Policy info using ext_id",
+        )

--- a/plugins/modules/ntnx_re_enforce_vm_host_affinity_policy_v2.py
+++ b/plugins/modules/ntnx_re_enforce_vm_host_affinity_policy_v2.py
@@ -1,0 +1,266 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_re_enforce_vm_host_affinity_policy_v2
+short_description: Re-enforce a VM-Host Affinity Policy in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module re-enforces (re-applies) an existing VM-Host Affinity Policy against all
+    the VMs currently associated with the policy in Nutanix Prism Central.
+  - Re-enforcement re-evaluates the affinity/anti-affinity rules and, if required, live-migrates
+    non-compliant VMs to hosts that satisfy the policy so that the policy compliance status
+    moves back to compliant.
+  - The referenced VM-Host Affinity Policy is identified by its external ID (C(ext_id)) and
+    must already exist. This module does not create, update or delete the policy — it only
+    triggers the re-enforce action.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the Nutanix IAM permission
+    B(Reenforce_VM_Host_Affinity_Policy). The following roles carry this permission
+    by default - Prism Admin, Super Admin.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  ext_id:
+    description:
+      - The external ID (UUID) of the VM-Host Affinity Policy to re-enforce.
+    type: str
+    required: true
+  state:
+    description:
+      - Kept for consistency with other v2 modules; only C(present) is meaningful for
+        this action module and it triggers a re-enforce.
+    type: str
+    choices:
+      - present
+    default: present
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Re-enforce a VM-Host Affinity Policy
+  nutanix.ncp.ntnx_re_enforce_vm_host_affinity_policy_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for the VM-Host Affinity Policy re-enforce action.
+    - When C(wait) is true, contains the final Prism task details.
+    - When C(wait) is false, contains the task reference returned immediately by the API.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_ids": null,
+      "completed_time": "2026-07-21T05:16:05.496138+00:00",
+      "completion_details": null,
+      "created_time": "2026-07-21T05:16:04.313893+00:00",
+      "entities_affected": [
+        {
+          "ext_id": "d8cf7870-6162-474b-4e62-dfa249096ffe",
+          "name": "ansible_reenforce_vmhap_mrJbSeKTuMUl",
+          "rel": "vmm:ahv:policies:vm-host-affinity-policy"
+        }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:adb28ae9-d8c1-50c8-b12f-8a25832a95eb",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-21T05:16:05.496137+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 1,
+      "number_of_subtasks": 0,
+      "operation": "VmHostAffinityPolicyEnforce",
+      "operation_description": "Enforce VM-Host Affinity Policy",
+      "owned_by": {
+        "ext_id": "00000000-0000-0000-0000-000000000000",
+        "name": "admin"
+      },
+      "parent_task": null,
+      "progress_percentage": 100,
+      "root_task": null,
+      "started_time": "2026-07-21T05:16:04.322317+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+task_ext_id:
+  description:
+    - The external ID of the Prism task that was created for the re-enforce action.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:adb28ae9-d8c1-50c8-b12f-8a25832a95eb"
+ext_id:
+  description:
+    - The external ID of the VM-Host Affinity Policy that was re-enforced.
+  returned: always
+  type: str
+  sample: "d8cf7870-6162-474b-4e62-dfa249096ffe"
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+skipped:
+  description:
+    - This indicates whether the task was skipped (e.g. in check mode).
+  returned: when applicable
+  type: bool
+  sample: false
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, module is idempotent or in check mode.
+  type: str
+  sample: "VM-Host Affinity Policy with ext_id:d8cf7870-6162-474b-4e62-dfa249096ffe will be re-enforced."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_etag,
+    get_vm_host_affinity_policies_api_instance,
+)
+from ..module_utils.v4.vmm.helpers import get_vm_host_affinity_policy  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_vmm_py_client as vmm_sdk  # noqa: E402  # pylint: disable=unused-import
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402  # pylint: disable=unused-import
+        mock_sdk as vmm_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        state=dict(type="str", choices=["present"], default="present"),
+    )
+    return module_args
+
+
+def re_enforce_vm_host_affinity_policy(module, result, api_instance):
+    """Trigger the re-enforce action on an existing VM-Host Affinity Policy."""
+    validate_required_params(module, ["ext_id"])
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    current_policy = get_vm_host_affinity_policy(module, api_instance, ext_id)
+
+    if module.check_mode:
+        result["msg"] = (
+            "VM-Host Affinity Policy with ext_id:{0} will be re-enforced.".format(
+                ext_id
+            )
+        )
+        result["response"] = strip_internal_attributes(current_policy.to_dict())
+        return
+
+    etag = get_etag(data=current_policy)
+    kwargs = {}
+    if etag:
+        kwargs["if_match"] = etag
+
+    try:
+        resp = api_instance.re_enforce_vm_host_affinity_policy_by_id(
+            extId=ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while re-enforcing VM-Host Affinity Policy",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+        "failed": False,
+    }
+
+    api_instance = get_vm_host_affinity_policies_api_instance(module)
+    re_enforce_vm_host_affinity_policy(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_re_enforce_vm_host_affinity_policy_v2/aliases
+++ b/tests/integration/targets/ntnx_re_enforce_vm_host_affinity_policy_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_re_enforce_vm_host_affinity_policy_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_re_enforce_vm_host_affinity_policy_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_re_enforce_vm_host_affinity_policy_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_re_enforce_vm_host_affinity_policy_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults for ntnx_re_enforce_vm_host_affinity_policy_v2 tests
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import re_enforce_vm_host_affinity_policy.yml
+      ansible.builtin.import_tasks: re_enforce_vm_host_affinity_policy.yml

--- a/tests/integration/targets/ntnx_re_enforce_vm_host_affinity_policy_v2/tasks/re_enforce_vm_host_affinity_policy.yml
+++ b/tests/integration/targets/ntnx_re_enforce_vm_host_affinity_policy_v2/tasks/re_enforce_vm_host_affinity_policy.yml
@@ -1,0 +1,355 @@
+---
+# Test plan for ntnx_re_enforce_vm_host_affinity_policy_v2:
+#   1. Negative: missing required ext_id            -> module fails with required-arg error
+#   2. Negative: bogus ext_id (well-formed UUID)    -> API 404 raised through raise_api_exception
+#   3. Prerequisites: create two categories (host + VM) via ntnx_categories_v2
+#   4. Prerequisites: create a VM-Host Affinity Policy via the v4 REST API (uri module)
+#      because the collection does not yet ship a CRUD module for this entity.
+#   5. Check-mode re-enforce                        -> changed=False, response is current policy
+#   6. Live re-enforce                              -> changed=True, task SUCCEEDED
+#   7. Second live re-enforce (idempotency-of-action) -> re-enforce is idempotent from the
+#      caller's perspective; both calls should complete with changed=True and status SUCCEEDED
+#   8. Cleanup: delete the policy, delete the categories
+
+- name: Start ntnx_re_enforce_vm_host_affinity_policy_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_re_enforce_vm_host_affinity_policy_v2 tests
+
+- name: Compute PC base URL and auth header for direct v4 REST calls
+  ansible.builtin.set_fact:
+    pc_base_url: "https://{{ ip }}:{{ port | default(9440) }}"
+    pc_auth_header: "Basic {{ (username + ':' + password) | b64encode }}"
+
+- name: Generate random suffix for test resource names
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set names for policy and categories
+  ansible.builtin.set_fact:
+    policy_name: "ansible_reenforce_vmhap_{{ random_name }}"
+    host_cat_key: "ansible_reenforce_host_{{ random_name }}"
+    host_cat_value: "host_ansible"
+    vm_cat_key: "ansible_reenforce_vm_{{ random_name }}"
+    vm_cat_value: "vm_ansible"
+
+########################################################################################
+# 1. Negative: missing required ext_id
+########################################################################################
+
+- name: Re-enforce without ext_id (should fail)
+  nutanix.ncp.ntnx_re_enforce_vm_host_affinity_policy_v2: {}
+  register: result
+  ignore_errors: true
+
+- name: Assert missing ext_id fails as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: ext_id' in result.msg"
+    success_msg: "Re-enforce without ext_id failed as expected"
+    fail_msg: "Re-enforce without ext_id did NOT fail with the expected error"
+
+########################################################################################
+# 2. Negative: well-formed but non-existent ext_id
+########################################################################################
+
+- name: Re-enforce with a bogus ext_id (should fail with API 404)
+  nutanix.ncp.ntnx_re_enforce_vm_host_affinity_policy_v2:
+    ext_id: "00000000-0000-0000-0000-000000000001"
+  register: result
+  ignore_errors: true
+
+- name: Assert bogus ext_id fails as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg is defined
+      - "'Api Exception' in result.msg"
+    success_msg: "Re-enforce with bogus ext_id failed as expected"
+    fail_msg: "Re-enforce with bogus ext_id did NOT fail as expected"
+
+########################################################################################
+# 3. Prerequisites: create categories for host + VM
+########################################################################################
+
+- name: Create host category for affinity policy
+  nutanix.ncp.ntnx_categories_v2:
+    key: "{{ host_cat_key }}"
+    value: "{{ host_cat_value }}"
+    description: "host category for re-enforce integration test"
+  register: host_category_result
+  ignore_errors: true
+
+- name: Assert host category was created
+  ansible.builtin.assert:
+    that:
+      - host_category_result is defined
+      - host_category_result.failed == false
+      - host_category_result.changed == true
+      - host_category_result.response is defined
+      - host_category_result.response.ext_id is defined
+      - host_category_result.response.key == host_cat_key
+      - host_category_result.response.value == host_cat_value
+    success_msg: "Host category created successfully"
+    fail_msg: "Failed to create host category"
+
+- name: Set host category ext_id
+  ansible.builtin.set_fact:
+    host_category_ext_id: "{{ host_category_result.response.ext_id }}"
+
+- name: Create VM category for affinity policy
+  nutanix.ncp.ntnx_categories_v2:
+    key: "{{ vm_cat_key }}"
+    value: "{{ vm_cat_value }}"
+    description: "VM category for re-enforce integration test"
+  register: vm_category_result
+  ignore_errors: true
+
+- name: Assert VM category was created
+  ansible.builtin.assert:
+    that:
+      - vm_category_result is defined
+      - vm_category_result.failed == false
+      - vm_category_result.changed == true
+      - vm_category_result.response is defined
+      - vm_category_result.response.ext_id is defined
+      - vm_category_result.response.key == vm_cat_key
+      - vm_category_result.response.value == vm_cat_value
+    success_msg: "VM category created successfully"
+    fail_msg: "Failed to create VM category"
+
+- name: Set VM category ext_id
+  ansible.builtin.set_fact:
+    vm_category_ext_id: "{{ vm_category_result.response.ext_id }}"
+
+########################################################################################
+# 4. Prerequisites: create the VM-Host Affinity Policy via v4 REST API
+#    (no dedicated CRUD Ansible module ships with this collection yet).
+########################################################################################
+
+- name: Generate NTNX-Request-Id for policy create
+  ansible.builtin.set_fact:
+    policy_create_request_id: "{{ 99999999999999999999 | random | to_uuid }}"
+
+- name: Create VM-Host Affinity Policy via v4 REST API
+  ansible.builtin.uri:
+    url: "{{ pc_base_url }}/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies"
+    method: POST
+    headers:
+      Authorization: "{{ pc_auth_header }}"
+      Content-Type: "application/json"
+      Accept: "application/json"
+      NTNX-Request-Id: "{{ policy_create_request_id }}"
+    body_format: json
+    body:
+      name: "{{ policy_name }}"
+      description: "Policy created by ntnx_re_enforce_vm_host_affinity_policy_v2 integration tests"
+      hostCategories:
+        - extId: "{{ host_category_ext_id }}"
+      vmCategories:
+        - extId: "{{ vm_category_ext_id }}"
+    validate_certs: "{{ validate_certs }}"
+    status_code: [200, 201, 202]
+    return_content: true
+  register: policy_create_result
+  ignore_errors: true
+
+- name: Show policy create response
+  ansible.builtin.debug:
+    var: policy_create_result.json
+
+- name: Extract policy task ext_id (returned by POST)
+  ansible.builtin.set_fact:
+    policy_create_task_ext_id: "{{ policy_create_result.json.data.extId }}"
+  when:
+    - policy_create_result.json is defined
+    - policy_create_result.json.data is defined
+    - policy_create_result.json.data.extId is defined
+
+- name: Poll the create task until it completes
+  ansible.builtin.uri:
+    url: "{{ pc_base_url }}/api/prism/v4.0/config/tasks/{{ policy_create_task_ext_id }}"
+    method: GET
+    headers:
+      Authorization: "{{ pc_auth_header }}"
+      Accept: "application/json"
+    validate_certs: "{{ validate_certs }}"
+    status_code: [200]
+    return_content: true
+  register: policy_create_task
+  until:
+    - policy_create_task.json is defined
+    - policy_create_task.json.data is defined
+    - policy_create_task.json.data.status in ["SUCCEEDED", "FAILED"]
+  retries: 30
+  delay: 4
+  when: policy_create_task_ext_id is defined
+
+- name: Assert policy create task succeeded
+  ansible.builtin.assert:
+    that:
+      - policy_create_task.json is defined
+      - policy_create_task.json.data.status == "SUCCEEDED"
+    success_msg: "VM-Host Affinity Policy create task succeeded"
+    fail_msg: "VM-Host Affinity Policy create task did not succeed"
+
+- name: Extract created policy ext_id from task entities
+  ansible.builtin.set_fact:
+    policy_ext_id: >-
+      {{
+        (policy_create_task.json.data.entitiesAffected
+        | selectattr('rel', 'search', 'vm-host-affinity-policy')
+        | list)[0].extId
+      }}
+
+- name: Confirm policy ext_id resolved
+  ansible.builtin.assert:
+    that:
+      - policy_ext_id is defined
+      - policy_ext_id | length > 0
+    success_msg: "Resolved created policy ext_id: {{ policy_ext_id }}"
+    fail_msg: "Could not resolve created policy ext_id from task"
+
+- name: Wait for the new policy to become readable via GET (eventual consistency)
+  ansible.builtin.uri:
+    url: "{{ pc_base_url }}/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies/{{ policy_ext_id }}"
+    method: GET
+    headers:
+      Authorization: "{{ pc_auth_header }}"
+      Accept: "application/json"
+    validate_certs: "{{ validate_certs }}"
+    status_code: [200]
+    return_content: true
+  register: policy_get_after_create
+  until:
+    - policy_get_after_create.json is defined
+    - policy_get_after_create.json.data is defined
+    - policy_get_after_create.json.data.extId == policy_ext_id
+  retries: 30
+  delay: 2
+
+########################################################################################
+# 5. Check-mode re-enforce (returns current policy without calling re-enforce)
+########################################################################################
+
+- name: Re-enforce policy in check mode
+  nutanix.ncp.ntnx_re_enforce_vm_host_affinity_policy_v2:
+    ext_id: "{{ policy_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check-mode re-enforce did NOT change state
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == policy_ext_id
+      - result.response is defined
+      - result.response.name == policy_name
+      - "'will be re-enforced' in result.msg"
+    success_msg: "Check-mode re-enforce behaved correctly"
+    fail_msg: "Check-mode re-enforce did NOT behave as expected"
+
+########################################################################################
+# 6. Live re-enforce
+########################################################################################
+
+- name: Re-enforce policy (live)
+  nutanix.ncp.ntnx_re_enforce_vm_host_affinity_policy_v2:
+    ext_id: "{{ policy_ext_id }}"
+  register: reenforce_result
+  ignore_errors: true
+
+- name: Assert live re-enforce succeeded
+  ansible.builtin.assert:
+    that:
+      - reenforce_result is defined
+      - reenforce_result.changed == true
+      - reenforce_result.failed == false
+      - reenforce_result.ext_id == policy_ext_id
+      - reenforce_result.task_ext_id is defined
+      - reenforce_result.task_ext_id | length > 0
+      - reenforce_result.response is defined
+      - reenforce_result.response.status == "SUCCEEDED"
+    success_msg: "Live re-enforce succeeded"
+    fail_msg: "Live re-enforce did NOT succeed"
+
+########################################################################################
+# 7. Second re-enforce (action is safe to repeat)
+########################################################################################
+
+- name: Re-enforce policy a second time
+  nutanix.ncp.ntnx_re_enforce_vm_host_affinity_policy_v2:
+    ext_id: "{{ policy_ext_id }}"
+  register: reenforce_result_2
+  ignore_errors: true
+
+- name: Assert second re-enforce also completes cleanly
+  ansible.builtin.assert:
+    that:
+      - reenforce_result_2 is defined
+      - reenforce_result_2.failed == false
+      - reenforce_result_2.changed == true
+      - reenforce_result_2.ext_id == policy_ext_id
+      - reenforce_result_2.task_ext_id is defined
+      - reenforce_result_2.response.status == "SUCCEEDED"
+    success_msg: "Repeated re-enforce completed cleanly"
+    fail_msg: "Repeated re-enforce failed unexpectedly"
+
+########################################################################################
+# 8. Cleanup: delete policy + categories
+########################################################################################
+
+- name: Fetch the policy to obtain its ETag for delete
+  ansible.builtin.uri:
+    url: "{{ pc_base_url }}/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies/{{ policy_ext_id }}"
+    method: GET
+    headers:
+      Authorization: "{{ pc_auth_header }}"
+      Accept: "application/json"
+    validate_certs: "{{ validate_certs }}"
+    status_code: [200]
+    return_content: true
+  register: policy_pre_delete
+  ignore_errors: true
+
+- name: Delete the VM-Host Affinity Policy via v4 REST API
+  ansible.builtin.uri:
+    url: "{{ pc_base_url }}/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies/{{ policy_ext_id }}"
+    method: DELETE
+    headers:
+      Authorization: "{{ pc_auth_header }}"
+      Accept: "application/json"
+      NTNX-Request-Id: "{{ 99999999999999999999 | random | to_uuid }}"
+      If-Match: "{{ policy_pre_delete.etag | default(omit) }}"
+    validate_certs: "{{ validate_certs }}"
+    status_code: [200, 202, 204]
+  register: policy_delete_result
+  ignore_errors: true
+
+- name: Delete VM category
+  nutanix.ncp.ntnx_categories_v2:
+    ext_id: "{{ vm_category_ext_id }}"
+    state: absent
+  register: vm_cat_delete
+  ignore_errors: true
+
+- name: Delete host category
+  nutanix.ncp.ntnx_categories_v2:
+    ext_id: "{{ host_category_ext_id }}"
+    state: absent
+  register: host_cat_delete
+  ignore_errors: true
+
+- name: Report cleanup outcome (non-fatal — best-effort)
+  ansible.builtin.debug:
+    msg:
+      policy_delete_status: "{{ policy_delete_result.status | default('unknown') }}"
+      vm_category_deleted: "{{ vm_cat_delete.changed | default(false) }}"
+      host_category_deleted: "{{ host_cat_delete.changed | default(false) }}"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection module for the **virtual_machine_management**
namespace, entity **ReEnforceVmHostAffinityPolicy**, based on the inline
`sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_re_enforce_vm_host_affinity_policy_v2` (action
  module; no `_info` companion because `ReEnforceVmHostAffinityPolicy` is a
  single action endpoint, not a queryable entity)
- API methods covered: `1` — `re_enforce_vm_host_affinity_policy_by_id`
  (`POST /api/vmm/v4.x/ahv/policies/vm-host-affinity-policies/{extId}/$actions/re-enforce`)
- Fields in CRUD module spec: `2` (`ext_id`, `state`; plus inherited base v2
  connection args and `wait`)
- Fields in info module spec: `0` (not applicable — action-type entity)

## Domain knowledge (from Glean)

**Query:** Nutanix VMM v4 `ReEnforceVmHostAffinityPolicy` API — purpose,
workflow, prerequisites, RBAC, backend orchestration, related tickets and
design/spec docs.

**Glean answer (verbatim):**

In Nutanix, a **VM-Host Affinity Policy** dictates which hosts a specific
virtual machine (or group of VMs) is allowed to run on within a cluster.
This is typically managed via Categories in Prism Central.

### What is "Re-enforce" for a VM-Host Affinity Policy?

The **Re-enforce** action is used to re-evaluate and re-apply a VM-Host
Affinity policy across all VMs associated with it.

You typically use the re-enforce action when:

1. **Resolving Non-Compliance:** A VM has fallen out of compliance with its
   assigned policy, and you have rectified the underlying issue (e.g.,
   adding resources, removing a conflicting legacy policy, or upgrading
   Prism Element versions). Re-enforcing tells the system to try applying
   the rules again.
2. **System Upgrades:** If a policy could not be enforced because Prism
   Element (AOS) was on an older, unsupported version, you can click
   "Re-enforce" after upgrading to a supported version.
3. **State Syncing:** To force Prism Central to push the affinity rules
   down to Prism Element (AOS/Lazan) again and update the compliance
   status widget in the UI.

### Compliance States

When a policy is evaluated or re-enforced, a VM can fall into one of the
following compliance states:

- **Compliant:** The VM is currently running on an allowed host and
  satisfies all HA (High Availability) and affinity rules.
- **Non-compliant:** The VM cannot satisfy the policy. Reasons include:
    - **Not Enough Resources:** The affined hosts do not have the
      CPU/memory capacity to run the VM.
    - **No Hosts:** The host category assigned to the policy currently
      has no hosts in it.
    - **Conflicting Policy:** Another policy with an earlier creation time
      is already applied to the VM, or a legacy Prism Element affinity
      rule is blocking it.
    - **PE Not Capable:** The cluster's AOS version is too old to support
      category-based VM-Host Affinity policies.
- **Pending:** The policy enforcement is still in progress.

### How to Re-enforce a Policy

**Via Prism Central UI:**

1. Navigate to the **VM-Host Affinity Policies** page.
2. Click on the target policy to open its Summary/Details page.
3. In the upper-right actions menu (or by selecting the policy in the
   list), click **Re-enforce**.

**Via API (v4):**

You can trigger a re-enforce programmatically using the Nutanix v4 API:

```http
POST /api/vmm/v4.0/ahv/policies/vm-host-affinity-policies/{extId}/$actions/re-enforce
```

Where `{extId}` is the UUID of the VM-Host Affinity policy.

### Note on High Availability (HA) Constraints

When utilizing single-host affinity policies on clusters with VM HA enabled,
ensure the VM is marked as an **Agent VM** if it is affined to only one
host. A standard (non-agent) HA-protected VM requires at least two hosts to
tolerate a single host failure. If a single-host affinity rule is applied
to an HA-protected VM, enforcement may fail or silently violate HA
constraints.

### Related tickets and reference docs (from Glean search)

**JIRA / ENG tickets:**

- **[ENG-861205]** Re-enforce of VM-Host Affinity policy fails —
  <https://jira.nutanix.com/browse/ENG-861205>
- **[ENG-952014]** VM High Availability shows compliant in PC even when
  agent-VM setting is disabled with single node selected for affinity
  policy — <https://jira.nutanix.com/browse/ENG-952014>
- **[ENG-923540]** VM–Host Affinity compliance status displays unexpected
  hyphenated format — <https://jira.nutanix.com/browse/ENG-923540>
- **[ENG-929620]** [PC UI] Test failure caused by recent product change:
  compliance status text updated from "Non Compliant" to
  "Non-compliant" in the VM–Host Affinity page —
  <https://jira.nutanix.com/browse/ENG-929620>
- **[ENG-896845]** Sp: VM Anti-Affinity policy section is missing from UI
  for Tenants — <https://jira.nutanix.com/browse/ENG-896845>

**API definitions / SDK / spec references:**

- `hostAffinityPolicyDescriptions.yaml` (VMM API descriptions) —
  <https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/etc/resources/documentation/bundles/en_US/hostAffinityPolicyDescriptions.yaml>
- `re_enforce_vm_host_affinity_policy_by_id_request.go` (Go client) —
  <https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmhostaffinitypolicies/re_enforce_vm_host_affinity_policy_by_id_request.go>
- `VmHostAffinityPolicies_service.proto` —
  <https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/tests/microbenchmarking_mocks/mock_metropolis/proto/vmm/vmm/v4/ahv/policies/VmHostAffinityPolicies_service.proto>
- `vm-host-affinity-policy-vm-compliance-state.yaml` —
  <https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/models/ahv/policies/vm-host-affinity-policy-vm-compliance-state.yaml>
- `vm_host_affinity_policies_api.go` (Go SDK) —
  <https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_client/github.com/vendor/github.com/nutanix-core/ntnx-api-golang-sdk-internal/vmm-go-client/v17/api/vm_host_affinity_policies_api.go>
- `ReEnforceVmHostAffinityPolicyApiResponse.py` (Python SDK) —
  <https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/policies/ReEnforceVmHostAffinityPolicyApiResponse.py>
- `PeNotCapableForVmHostAffinityPolicy.py` (Python SDK) —
  <https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/policies/PeNotCapableForVmHostAffinityPolicy.py>
- `vm-host-affinity-policy-endpoints.yaml` —
  <https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split-module-tree/definitions/endpoints/ahv/policies/vm-host-affinity-policy-endpoints.yaml>

**Test / workflow references:**

- `test_vm_host_affinity.py` (nutest) —
  <https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/acropolis/ahv_management/v4/test_vm_host_affinity.py>
- `vm_host_affinity_workflows.py` (nutest) —
  <https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/acropolis/ahv_management/ahv_ui/pc/ui_workflows/vm_host_affinity_workflows.py>
- `host_affinity_policy_summary_page.py` (nutest) —
  <https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/acropolis/ahv_management/ahv_ui/pc/pages/policies/host_affinity_policy_summary_page.py>

### Required domain skills (for reviewers)

- Nutanix AHV VM management and VM/Host category model in Prism Central.
- Understanding of VM-Host Affinity vs. VM-VM Affinity, agent-VM semantics
  and their interaction with VM HA on AHV.
- Familiarity with Nutanix Prism Central v4 REST APIs and the
  `ntnx-vmm-py-client` SDK (`VmHostAffinityPoliciesApi`, Ergon tasks,
  `if_match`/ETag semantics, `NTNX-Request-Id` idempotency header).
- IAM / RBAC on PC — the `Reenforce_VM_Host_Affinity_Policy` operation
  required on the invoking role (default in Prism Admin / Super Admin).
- Ansible module conventions for the `nutanix.ncp` collection (v4 base
  module, `wait_for_completion`, action-type module pattern like
  `ntnx_vm_revert_v2`).

## Files changed

**`plugins/modules/`**

- `ntnx_re_enforce_vm_host_affinity_policy_v2.py` — new action module.
  Wraps `VmHostAffinityPoliciesApi.re_enforce_vm_host_affinity_policy_by_id`,
  supports `check_mode` (no-op — only fetches the policy), waits on the
  Prism task via `wait_for_completion`, populates `ext_id`, `task_ext_id`,
  and full task response in the module result.

**`plugins/module_utils/v4/vmm/`**

- `api_client.py` — added `get_vm_host_affinity_policies_api_instance()`
  helper (mirrors the existing per-entity API helpers).
- `helpers.py` — added `get_vm_host_affinity_policy()` helper that fetches
  a policy by `ext_id` and normalizes API errors via `raise_api_exception`.

**`tests/integration/targets/ntnx_re_enforce_vm_host_affinity_policy_v2/`**

- `aliases` — disabled (test drives live PC and is not part of
  `ansible-test integration` auto-discovery).
- `meta/main.yml` — declares dependency on the `prepare_env` target.
- `tasks/main.yml` — sets `module_defaults` and imports the test tasks.
- `tasks/re_enforce_vm_host_affinity_policy.yml` — full test plan (see
  next section).

**`examples/virtual_machine_management/ReEnforceVmHostAffinityPolicy/`**

- `ntnx_re_enforce_vm_host_affinity_policy_v2.yml` — example playbook.
- `examples_run.log` — captured live PC output from running the example.

**`.gitignore`**

- Ignore `tests/integration/integration_config.yml` (contains secrets) and
  `tests/output/` (ansible-test artefacts).

## Test execution

| Metric              | Value                                                                 |
|---------------------|-----------------------------------------------------------------------|
| Command             | `ansible-playbook -v $ARTIFACTS/run_tests_wrapper.yml` (wrapper play imports `tests/integration/targets/ntnx_re_enforce_vm_host_affinity_policy_v2/tasks/main.yml`) |
| Total tasks         | `34`                                                                  |
| Passed (`ok`)       | `34`                                                                  |
| Changed             | `6` (category + policy create/delete + 2 live re-enforce actions)     |
| Failed              | `0`                                                                   |
| Skipped             | `0`                                                                   |
| Ignored (negative)  | `2` (missing-`ext_id` and bogus-`ext_id` intentional failures)        |
| Duration            | `~0:00:24` (`23858 ms` per shell timing)                              |
| Cluster (PC)        | `10.44.76.28:9440` (`pc.7.6`)                                         |
| Lint                | `black`, `isort`, `flake8`, `ansible-lint` — all clean                |
| Sanity              | `ansible-test sanity --python 3.12` on the new module and
                       `plugins/module_utils/v4/vmm/{api_client,helpers}.py` — all 32 tests pass |
| Example playbook    | `PLAY RECAP: ok=3 changed=1 unreachable=0 failed=0` against the same PC |

### Test plan covered

Test IDs in `tasks/re_enforce_vm_host_affinity_policy.yml`:

1. **Negative — missing `ext_id`**: module fails with the standard
   `missing required arguments` message (asserted via `ansible.builtin.assert`).
2. **Negative — bogus `ext_id`**: API returns 404 (`VMM-34060` /
   `POLICY_NOT_FOUND`); module surfaces it through `raise_api_exception`.
3. **Prereqs**: creates one host category and one VM category via
   `nutanix.ncp.ntnx_categories_v2`, and creates a VM-Host Affinity Policy
   via the v4 REST API (`ansible.builtin.uri`) because the collection
   does not (yet) ship a CRUD module for this entity. Uses the
   `NTNX-Request-Id` idempotency header and polls the Prism task to
   completion, then polls the entity itself until it is GET-readable
   (eventual-consistency guard).
4. **Check-mode re-enforce**: module returns `changed=False`, no task is
   created, and `response` contains the current policy snapshot.
5. **Live re-enforce**: task `VmHostAffinityPolicyEnforce` reaches
   `status=SUCCEEDED`, `changed=True`, `ext_id` echoed.
6. **Idempotency — second live re-enforce**: succeeds again cleanly, which
   is the semantics of this action (re-evaluate + re-apply is always safe
   to repeat).
7. **Cleanup**: deletes the policy (fetching its `ETag` and passing
   `If-Match`), then deletes both categories.

### Analysis

No test failures. Two `ignore_errors: true` tasks are intentional negative
tests whose failure is asserted immediately after by
`ansible.builtin.assert`.

### Test logs (tail)

<details>
<summary>tail -n 50 integration_run.log</summary>

```text
TASK [Assert check-mode re-enforce did NOT change state] ***********************
ok: [localhost] => { "changed": false, "msg": "Check-mode re-enforce behaved correctly" }

TASK [Re-enforce policy (live)] ************************************************
changed: [localhost] => {"changed": true, "ext_id": "1903c136-2902-4eb1-61b0-439498cf7e01",
  "response": {"operation": "VmHostAffinityPolicyEnforce", "status": "SUCCEEDED",
              "progress_percentage": 100,
              "entities_affected": [{"ext_id": "1903c136-2902-4eb1-61b0-439498cf7e01",
                                     "name": "ansible_reenforce_vmhap_vMutrcGcOxZs",
                                     "rel": "vmm:ahv:policies:vm-host-affinity-policy"}],
              "task_ext_id": "ZXJnb24=:e1d506d6-a41f-5ba4-80ae-3d5bdcbc833a"}}

TASK [Assert live re-enforce succeeded] ****************************************
ok: [localhost] => { "changed": false, "msg": "Live re-enforce succeeded" }

TASK [Re-enforce policy a second time] *****************************************
changed: [localhost] => {"changed": true, "ext_id": "1903c136-2902-4eb1-61b0-439498cf7e01",
  "response": {"operation": "VmHostAffinityPolicyEnforce", "status": "SUCCEEDED",
              "task_ext_id": "ZXJnb24=:6248eb63-31ea-5c06-a3f8-81c2625af053"}}

TASK [Assert second re-enforce also completes cleanly] *************************
ok: [localhost] => { "changed": false, "msg": "Repeated re-enforce completed cleanly" }

TASK [Fetch the policy to obtain its ETag for delete] **************************
ok: [localhost] => {"status": 200, "etag": "YXBwbGljYXRpb24vanNvbg==:MQ==", ...}

TASK [Delete the VM-Host Affinity Policy via v4 REST API] **********************
ok: [localhost] => {"status": 202, ...}

TASK [Delete VM category] ******************************************************
changed: [localhost] => {"changed": true, "ext_id": "8879bbea-27a3-4e19-50b5-4b118c2b9c3c"}

TASK [Delete host category] ****************************************************
changed: [localhost] => {"changed": true, "ext_id": "584ed50f-8ab9-459a-6464-78c389f8f678"}

TASK [Report cleanup outcome (non-fatal — best-effort)] ************************
ok: [localhost] => { "msg": { "host_category_deleted": true,
                              "policy_delete_status": "202",
                              "vm_category_deleted": true } }

PLAY RECAP *********************************************************************
localhost                  : ok=34   changed=6    unreachable=0    failed=0    skipped=0    rescued=0    ignored=2
```

</details>

### Example playbook (live)

<details>
<summary>examples/virtual_machine_management/ReEnforceVmHostAffinityPolicy/examples_run.log — tail</summary>

```text
TASK [Re-enforce a VM-Host Affinity Policy] ************************************
changed: [localhost] => {
  "changed": true,
  "ext_id": "d8cf7870-6162-474b-4e62-dfa249096ffe",
  "task_ext_id": "ZXJnb24=:adb28ae9-d8c1-50c8-b12f-8a25832a95eb",
  "response": {
    "operation": "VmHostAffinityPolicyEnforce",
    "operation_description": "Enforce VM-Host Affinity Policy",
    "status": "SUCCEEDED",
    "progress_percentage": 100,
    "entities_affected": [{
      "ext_id": "d8cf7870-6162-474b-4e62-dfa249096ffe",
      "name": "ansible_reenforce_vmhap_mrJbSeKTuMUl",
      "rel": "vmm:ahv:policies:vm-host-affinity-policy"
    }]
  }
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
