### PR TITLE
code-gen(virtual_machine_management/VmStartupPolicyDependencyConflictDependeeVm): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+

--- a/examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependeeVm/examples_run.log
+++ b/examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependeeVm/examples_run.log
@@ -1,0 +1,22 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+[WARNING]: Found variable using reserved name: port
+No config file found; using defaults
+
+PLAY [VmStartupPolicyDependencyConflictDependeeVm info playbook] ***************
+
+TASK [Set VM startup policy and dependency conflict external IDs] **************
+ok: [localhost] => {"ansible_facts": {"dependency_conflict_ext_id": "9f6141a0-4a34-46e3-a4cf-4fe25d05c8f7", "vm_startup_policy_ext_id": "e3d33be5-ea1e-4b6a-a30d-4f1f8d0a1b21"}, "changed": false}
+
+TASK [List all dependee VMs of a VM startup policy dependency conflict] ********
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VM startup policy dependency conflict dependee VMs info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"policy_uuid": "e3d33be5-ea1e-4b6a-a30d-4f1f8d0a1b21"}, "code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the policy with UUID 'e3d33be5-ea1e-4b6a-a30d-4f1f8d0a1b21', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [List dependee VMs of a dependency conflict with pagination] **************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VM startup policy dependency conflict dependee VMs info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"policy_uuid": "e3d33be5-ea1e-4b6a-a30d-4f1f8d0a1b21"}, "code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the policy with UUID 'e3d33be5-ea1e-4b6a-a30d-4f1f8d0a1b21', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=2   
+

--- a/examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependeeVm/vm_startup_policy_dependency_conflict_dependee_vms_info_v2.yml
+++ b/examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependeeVm/vm_startup_policy_dependency_conflict_dependee_vms_info_v2.yml
@@ -1,0 +1,56 @@
+---
+# Summary:
+# This playbook demonstrates fetching the dependee VMs of a VM startup policy's
+# dependency conflict via the info module
+# `ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2`.
+#
+# The endpoint under test is a LIST-only endpoint on the Nutanix VMM v4 API:
+#   GET /vmm/v4.2/ahv/policies/vm-startup-policies/{vmStartupPolicyExtId}/
+#       dependency-conflicts/{dependencyConflictExtId}/dependee-vms
+#
+# A "dependee" VM is a VM that other VMs in the startup policy depend on
+# (i.e. it must be running before its dependents can start). A dependency
+# conflict exists when Prism Central detects an ordering/consistency issue
+# with the startup graph (e.g. a missing VM, a circular dependency, or a
+# category with no member VMs).
+#
+# Prerequisites (see also the domain knowledge block in the PR body):
+#   1. A VM Startup Policy exists on the cluster.
+#   2. The policy currently has at least one dependency conflict — use
+#      `list_vm_startup_policy_dependency_conflicts` (or the parent info
+#      module once available) to discover the conflict UUIDs.
+#
+# The playbook covers:
+#   1. Listing ALL dependee VMs of a specific dependency conflict.
+#   2. Listing dependee VMs with pagination (page/limit).
+
+- name: VmStartupPolicyDependencyConflictDependeeVm info playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username }}"
+      nutanix_password: "{{ password }}"
+      validate_certs: false
+  tasks:
+    - name: Set VM startup policy and dependency conflict external IDs
+      ansible.builtin.set_fact:
+        vm_startup_policy_ext_id: "e3d33be5-ea1e-4b6a-a30d-4f1f8d0a1b21"
+        dependency_conflict_ext_id: "9f6141a0-4a34-46e3-a4cf-4fe25d05c8f7"
+
+    - name: List all dependee VMs of a VM startup policy dependency conflict
+      nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2:
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        dependency_conflict_ext_id: "{{ dependency_conflict_ext_id }}"
+      register: all_dependee_vms
+      ignore_errors: true
+
+    - name: List dependee VMs of a dependency conflict with pagination
+      nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2:
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        dependency_conflict_ext_id: "{{ dependency_conflict_ext_id }}"
+        page: 0
+        limit: 5
+      register: paginated_dependee_vms
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,13 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_vm_startup_policies_api_instance(module):
+    """
+    This method will return VM Startup Policies API instance
+    Args:
+        api_instance (obj): v4 VM Startup Policies api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.VmStartupPoliciesApi(api_client=api_client)

--- a/plugins/modules/ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2.py
+++ b/plugins/modules/ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2.py
@@ -1,0 +1,231 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2
+short_description: Fetch dependee VMs of a VM startup policy dependency conflict in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about VmStartupPolicyDependencyConflictDependeeVm in Nutanix Prism Central.
+  - Lists the dependee VMs (VMs that other VMs depend on) that are involved in a specific dependency conflict of a VM startup policy.
+  - A dependee VM is a VM referenced as a prerequisite by other VMs in a startup policy's dependency graph.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(List dependee VMs of a VM startup policy dependency conflict) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  vm_startup_policy_ext_id:
+    description:
+      - The external ID (UUID) of the VM startup policy whose dependency conflict's dependee VMs need to be listed.
+      - This is a path parameter required by the underlying v4 API.
+    type: str
+    required: true
+  dependency_conflict_ext_id:
+    description:
+      - The external ID (UUID) of the dependency conflict of the specified VM startup policy.
+      - This is a path parameter required by the underlying v4 API.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all dependee VMs of a VM startup policy dependency conflict
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_startup_policy_ext_id: "e3d33be5-ea1e-4b6a-a30d-4f1f8d0a1b21"
+    dependency_conflict_ext_id: "9f6141a0-4a34-46e3-a4cf-4fe25d05c8f7"
+  register: result
+  ignore_errors: true
+
+- name: List dependee VMs of a dependency conflict with pagination
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_startup_policy_ext_id: "e3d33be5-ea1e-4b6a-a30d-4f1f8d0a1b21"
+    dependency_conflict_ext_id: "9f6141a0-4a34-46e3-a4cf-4fe25d05c8f7"
+    page: 0
+    limit: 10
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VmStartupPolicyDependencyConflictDependeeVm info v4 API.
+    - It is a list of dependee VMs of the given VM startup policy dependency conflict.
+    - Each entry is a VM reference containing the external ID of the dependee VM.
+    - The list can be paginated using the C(page) and C(limit) parameters.
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "ext_id": "3ac9fb37-3c9d-4a11-b3f7-4f9e05c26e0a"
+      },
+      {
+        "ext_id": "7b4c4f27-06a5-4a72-9d55-6b8e6acdbfa4"
+      }
+    ]
+
+total_available_results:
+  description:
+    - The total number of dependee VMs available for the specified dependency conflict.
+  type: int
+  returned: always
+  sample: 2
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching VM startup policy dependency conflict dependee VMs info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task has failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_startup_policies_api_instance,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        vm_startup_policy_ext_id=dict(type="str", required=True),
+        dependency_conflict_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def list_vm_startup_policy_dependency_conflict_dependee_vms(
+    module, api_instance, result
+):
+    """
+    List the dependee VMs of a VM startup policy dependency conflict.
+
+    Args:
+        module: The AnsibleModule instance.
+        api_instance: VmStartupPoliciesApi instance from ntnx_vmm_py_client.
+        result: The result dict to populate.
+    """
+    vm_startup_policy_ext_id = module.params.get("vm_startup_policy_ext_id")
+    dependency_conflict_ext_id = module.params.get("dependency_conflict_ext_id")
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg=(
+                "Failed generating VM startup policy dependency conflict "
+                "dependee VMs info spec"
+            ),
+            **result,
+        )
+
+    # Drop unsupported query params — this list API only supports _page/_limit.
+    for key in list(kwargs.keys()):
+        if key not in ("_page", "_limit"):
+            kwargs.pop(key)
+
+    try:
+        resp = api_instance.list_vm_startup_policy_dependency_conflict_dependee_vms(
+            vmStartupPolicyExtId=vm_startup_policy_ext_id,
+            dependencyConflictExtId=dependency_conflict_ext_id,
+            **kwargs,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching VM startup policy "
+                "dependency conflict dependee VMs info"
+            ),
+        )
+
+    total_available_results = 0
+    if resp.metadata is not None:
+        total_available_results = (
+            getattr(resp.metadata, "total_available_results", None) or 0
+        )
+    result["total_available_results"] = total_available_results
+
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_vm_startup_policies_api_instance(module)
+    list_vm_startup_policy_dependency_conflict_dependee_vms(
+        module, api_instance, result
+    )
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2/tasks/dependee_vms_info.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2/tasks/dependee_vms_info.yml
@@ -1,0 +1,238 @@
+---
+###############################################################################
+# Integration tests for
+#   nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2
+#
+# Test plan (LIST-only endpoint, path params are required):
+#   1. Negative: missing `vm_startup_policy_ext_id` -> module must fail with
+#      a "missing required arguments" error and MUST NOT reach the API.
+#   2. Negative: missing `dependency_conflict_ext_id` -> same as (1).
+#   3. Negative: both required params provided but neither exists on the
+#      cluster -> API returns a 404-style error and the module surfaces a
+#      descriptive failure message.
+#   4. Positive: when a real VM startup policy with a dependency conflict is
+#      discovered on the live cluster, list its dependee VMs and validate the
+#      response shape (list of VmReference dicts each with `ext_id`). If no
+#      policy or no conflict is present, mark that step as skipped since it
+#      requires cluster-side setup that this module cannot perform.
+#   5. Positive: pagination via `page` / `limit` returns a truncated list
+#      when the underlying set is large enough; otherwise the response is
+#      returned unchanged.
+###############################################################################
+
+- name: Start VmStartupPolicyDependencyConflictDependeeVm info tests
+  ansible.builtin.debug:
+    msg: >-
+      Start testing
+      ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2
+
+- name: Generate random ext_ids used for negative tests
+  ansible.builtin.set_fact:
+    random_policy_ext_id: "{{ 99999999 | random | to_uuid }}"
+    random_conflict_ext_id: "{{ 99999999 | random | to_uuid }}"
+
+###############################################################################
+# 1. Negative: missing vm_startup_policy_ext_id
+###############################################################################
+- name: Fail when vm_startup_policy_ext_id is missing
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2:
+    dependency_conflict_ext_id: "{{ random_conflict_ext_id }}"
+  register: missing_policy_result
+  ignore_errors: true
+
+- name: Assert failure when vm_startup_policy_ext_id is missing
+  ansible.builtin.assert:
+    that:
+      - missing_policy_result is defined
+      - missing_policy_result.failed == true
+      - missing_policy_result.changed == false
+      - "'vm_startup_policy_ext_id' in (missing_policy_result.msg | default(''))"
+    success_msg: "Module correctly failed when vm_startup_policy_ext_id was missing"
+    fail_msg: "Module did not fail with a descriptive message when vm_startup_policy_ext_id was missing"
+
+###############################################################################
+# 2. Negative: missing dependency_conflict_ext_id
+###############################################################################
+- name: Fail when dependency_conflict_ext_id is missing
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ random_policy_ext_id }}"
+  register: missing_conflict_result
+  ignore_errors: true
+
+- name: Assert failure when dependency_conflict_ext_id is missing
+  ansible.builtin.assert:
+    that:
+      - missing_conflict_result is defined
+      - missing_conflict_result.failed == true
+      - missing_conflict_result.changed == false
+      - "'dependency_conflict_ext_id' in (missing_conflict_result.msg | default(''))"
+    success_msg: "Module correctly failed when dependency_conflict_ext_id was missing"
+    fail_msg: "Module did not fail with a descriptive message when dependency_conflict_ext_id was missing"
+
+###############################################################################
+# 3. Negative: non-existent ext_ids -> API returns a not-found style error
+###############################################################################
+- name: Call info module with non-existent ext_ids
+  nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ random_policy_ext_id }}"
+    dependency_conflict_ext_id: "{{ random_conflict_ext_id }}"
+  register: not_found_result
+  ignore_errors: true
+
+- name: Assert the API surfaces a descriptive error for unknown ext_ids
+  ansible.builtin.assert:
+    that:
+      - not_found_result is defined
+      - not_found_result.failed == true
+      - not_found_result.changed == false
+    success_msg: "Module correctly surfaced an API error for unknown ext_ids"
+    fail_msg: "Module did not fail as expected for unknown ext_ids"
+
+###############################################################################
+# 4. Domain-level end-to-end: discover real dependency conflicts on the cluster
+#    and, for every one found, exercise the info module against it. Uses the
+#    raw v4 REST endpoint to enumerate startup policies and their dependency
+#    conflicts since a dedicated info module for the parent entities is not
+#    yet part of this collection.
+###############################################################################
+- name: Enumerate VM startup policies on the cluster via the v4 REST endpoint
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default(9440) }}/api/vmm/v4.2/ahv/policies/vm-startup-policies?$limit=100"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    status_code: [200]
+    return_content: true
+  register: startup_policies_raw
+  ignore_errors: true
+
+- name: Set discovered startup policy IDs
+  ansible.builtin.set_fact:
+    discovered_policy_ext_ids: >-
+      {{
+        (startup_policies_raw.json.data | default([]))
+        | map(attribute='extId') | list
+      }}
+  when: startup_policies_raw is defined and not (startup_policies_raw.failed | default(false))
+
+- name: Enumerate dependency conflicts for each policy
+  ansible.builtin.uri:
+    url: >-
+      https://{{ ip }}:{{ port | default(9440) }}/api/vmm/v4.2/ahv/policies/vm-startup-policies/{{ item }}/dependency-conflicts?$limit=100
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    status_code: [200]
+    return_content: true
+  loop: "{{ discovered_policy_ext_ids | default([]) }}"
+  register: dependency_conflicts_raw
+  ignore_errors: true
+  loop_control:
+    label: "{{ item }}"
+
+- name: Initialise the conflict pair list
+  ansible.builtin.set_fact:
+    conflict_pairs: []
+
+- name: Build the list of (policy_ext_id, conflict_ext_id) pairs discovered on the cluster
+  ansible.builtin.set_fact:
+    conflict_pairs: >-
+      {{
+        conflict_pairs +
+        (
+          (((item.json | default({})).get('data')) | default([]) | default([], true))
+          | map(attribute='extId')
+          | map('community.general.dict_kv', 'conflict_ext_id')
+          | map('combine', {'policy_ext_id': item.item})
+          | list
+        )
+      }}
+  loop: "{{ dependency_conflicts_raw.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item | default('unknown') }}"
+  when: dependency_conflicts_raw is defined
+
+- name: Report how many conflicts were discovered on the live cluster
+  ansible.builtin.debug:
+    msg: >-
+      Discovered
+      {{ (conflict_pairs | default([])) | length }} dependency conflict(s)
+      across
+      {{ (discovered_policy_ext_ids | default([])) | length }} startup policy/policies.
+
+- name: Positive-path — list dependee VMs for every discovered conflict
+  when: (conflict_pairs | default([])) | length > 0
+  block:
+    - name: List dependee VMs for every discovered dependency conflict
+      nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2:
+        vm_startup_policy_ext_id: "{{ pair.policy_ext_id }}"
+        dependency_conflict_ext_id: "{{ pair.conflict_ext_id }}"
+      register: real_dependee_vms_batch
+      loop: "{{ conflict_pairs }}"
+      loop_control:
+        loop_var: pair
+        label: "{{ pair.policy_ext_id }}/{{ pair.conflict_ext_id }}"
+      ignore_errors: true
+
+    - name: Assert the info module returned a well-formed response for every conflict
+      ansible.builtin.assert:
+        that:
+          - item.failed == false
+          - item.changed == false
+          - item.response is defined
+          - item.response | type_debug in ['list', 'NoneType']
+          - item.total_available_results is defined
+        success_msg: "Info module returned OK for {{ item.pair.policy_ext_id }}/{{ item.pair.conflict_ext_id }}"
+        fail_msg: "Info module failed for {{ item.pair.policy_ext_id }}/{{ item.pair.conflict_ext_id }}: {{ item.msg | default('') }}"
+      loop: "{{ real_dependee_vms_batch.results | default([]) }}"
+      loop_control:
+        label: "{{ item.pair.policy_ext_id }}/{{ item.pair.conflict_ext_id }}"
+
+    - name: Every dependee VM entry MUST expose a non-empty ext_id
+      ansible.builtin.assert:
+        that:
+          - item.ext_id is defined
+          - item.ext_id | length > 0
+        success_msg: "Dependee VM {{ item.ext_id }} is valid"
+        fail_msg: "Dependee VM entry {{ item }} is missing ext_id"
+      loop: >-
+        {{
+          (real_dependee_vms_batch.results | default([]))
+          | map(attribute='response', default=[])
+          | flatten
+        }}
+      loop_control:
+        label: "{{ item.ext_id | default('unknown') }}"
+
+    - name: Exercise pagination — first page with limit=1 for the first conflict
+      nutanix.ncp.ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2:
+        vm_startup_policy_ext_id: "{{ conflict_pairs[0].policy_ext_id }}"
+        dependency_conflict_ext_id: "{{ conflict_pairs[0].conflict_ext_id }}"
+        page: 0
+        limit: 1
+      register: paginated_dependee_vms
+      ignore_errors: true
+
+    - name: Assert paginated response has at most `limit` entries
+      ansible.builtin.assert:
+        that:
+          - paginated_dependee_vms is defined
+          - paginated_dependee_vms.failed == false
+          - paginated_dependee_vms.changed == false
+          - paginated_dependee_vms.response is defined
+          - (paginated_dependee_vms.response | length) <= 1
+        success_msg: "Paginated dependee VMs list respected the limit"
+        fail_msg: "Paginated dependee VMs list did not respect the limit"
+
+- name: Skip note when no real dependency conflicts are available on the cluster
+  when: (conflict_pairs | default([])) | length == 0
+  ansible.builtin.debug:
+    msg: >-
+      No real VM startup policy dependency conflicts were found on this
+      cluster; skipping the positive-path assertions. The negative-path and
+      not-found-ext_id tests above have already validated argument handling
+      and API error surfacing against the live API.

--- a/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import dependee_vms_info.yml
+      ansible.builtin.import_tasks: dependee_vms_info.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **virtual_machine_management** namespace, entity **VmStartupPolicyDependencyConflictDependeeVm**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2`
- API methods covered: 1 of 12 (`list_vm_startup_policy_dependency_conflict_dependee_vms`).
  The entity **VmStartupPolicyDependencyConflictDependeeVm** exposes only a LIST endpoint on the v4 API — there is no Create / Read-by-ID / Update / Delete operation for this resource. A CRUD module is therefore intentionally NOT generated; the info module is the complete surface for this entity.
- Fields in CRUD module spec: N/A (no CRUD API exists)
- Fields in info module spec: 2 required path params (`vm_startup_policy_ext_id`, `dependency_conflict_ext_id`) plus the inherited base-info-module query params (`page`, `limit`).

## Domain knowledge (from Glean)

## Glean query
"What is VmStartupPolicyDependencyConflictDependeeVm in Nutanix VMM (virtual machine management) v4 API? Describe the dependee-vms endpoint under vm-startup-policies dependency-conflicts, its purpose, workflow, prerequisites, related engineering tickets, design documents, and documentation URLs."

## Glean response

The **VmStartupPolicyDependencyConflictDependeeVm** (and its corresponding `dependee-vms` endpoint) in the Nutanix VMM (Virtual Machine Management) v4 API is used to manage and retrieve information about the "dependee" virtual machines that are involved in a dependency conflict within a VM Startup Policy.

In a VM Startup Policy, VMs or categories of VMs can be configured to depend on each other (e.g., VM 'B' cannot start until VM 'A' has started). A "dependee" VM is the underlying VM that others rely upon. A dependency conflict occurs when there are configuration issues, circular dependencies, or missing entities preventing the policy from safely executing.

### Endpoint Details
- HTTP Method: GET
- Path: `/api/vmm/v4.x/ahv/policies/vm-startup-policies/{vmStartupPolicyExtId}/dependency-conflicts/{dependencyConflictExtId}/dependee-vms`
- Purpose: Returns a paginated list of dependee VMs (as `VmReference` objects) that are part of a specific dependency conflict within a given VM startup policy.
- Operation ID: `listVmStartupPolicyDependencyConflictDependeeVms`
- Query Parameters: Supports pagination via `$page` (default `0`) and `$limit` (default `50`, max `100`).

### Prerequisites & Workflow
1. Identify the Policy: You must first know the UUID (`vmStartupPolicyExtId`) of the target VM Startup Policy.
2. Identify the Conflict: You need the specific conflict UUID (`dependencyConflictExtId`). This is typically found by first calling the parent endpoint: `GET /vmm/v4.x/ahv/policies/vm-startup-policies/{vmStartupPolicyExtId}/dependency-conflicts`.
3. Query Dependee VMs: Make the GET request to the `dependee-vms` endpoint using both UUIDs to see exactly which dependee VMs are causing or involved in that specific conflict. (There is also a companion `dependent-vms` endpoint to see the VMs that rely on them).

### Related Engineering Tickets
Several bugs have been identified and resolved during the qualification of the VM Startup Policy feature (FEAT-5081) related to this exact endpoint:
- ENG-795868: Addressed a `500 Internal Server Error` (PLAT-10006) that occurred when attempting to fetch the list of dependent/dependee VMs for a conflict. https://jira.nutanix.com/browse/ENG-795868
- ENG-796441 (Critical): Fixed a bug where the API returned an incorrect list of dependee VMs (e.g., returning 0 available results or showing the wrong VMs in the dependee list) for a dependency conflict. https://jira.nutanix.com/browse/ENG-796441
- ENG-796440 (Critical): Addressed an issue where hitting the parent GET `dependency-conflicts` endpoint caused a `panic: runtime error: invalid memory address or nil pointer dereference` which crashed the metropolis service. https://jira.nutanix.com/browse/ENG-796440

### Design & Documentation References
The schema, endpoint definitions, and descriptions for this API are defined and tracked in the following files across the internal SDK and API definition repositories:
- Endpoint Definitions: `vmStartupPoliciesEndpoints.yaml` — https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv-policies/released/api/vmStartupPoliciesEndpoints.yaml
- Descriptions: `vmStartupPolicyDescriptions.yaml` — https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/etc/resources/documentation/bundles/en_US/vmStartupPolicyDescriptions.yaml
- Python SDK: `ListVmStartupPolicyDependencyConflictDependeeVmsApiResponse.py` — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/policies/ListVmStartupPolicyDependencyConflictDependeeVmsApiResponse.py
- Golang SDK request: `list_vm_startup_policy_dependency_conflict_dependee_vms_request.go` — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmstartuppolicies/list_vm_startup_policy_dependency_conflict_dependee_vms_request.go
- Golang SDK API: `vm_startup_policies_api.go` — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/api/vm_startup_policies_api.go
- Protobuf Definitions: `VmStartupPolicies_service.proto` — https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/tests/microbenchmarking_mocks/mock_metropolis/proto/vmm/vmm/v4/ahv/policies/VmStartupPolicies_service.proto
- Golang model: `policies_model.go` — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/ahv/policies/policies_model.go
- OASIS test data (endpoints): `dependee-vm-endpoints.yaml` — https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/endpoints/ahv/policies/dependee-vm-endpoints.yaml
- OASIS test data (models orphan): `_orphan.yaml` — https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split-module-tree/definitions/models/ahv-policies/_orphan.yaml
- Proto policies definition: `policies.proto` — https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/tests/microbenchmarking_mocks/mock_metropolis/proto/vmm/vmm/v4/ahv/policies/policies.proto
- Domain mapping (hack2026): `domain_mapping.md` — https://github.com/nutanix-engineering/hack2026-d3089/blob/main/old_approach_data/tpg_output/domain_mapping.md
- Domain 05 tests: `domain_05_ahv_policies_dependency-conflicts_tests.json` — https://github.com/nutanix-engineering/hack2026-d3089/blob/main/old_approach_data/tpg_output/test_cases/domain_05_ahv_policies_dependency-conflicts_tests.json
- Endpoints schema: `endpoints.json` — https://github.com/nutanix-engineering/hack2026-d3089/blob/main/old_approach_data/tpg_output/schemas/domain_05_ahv_policies_dependency-conflicts/endpoints.json

### Required domain skills to learn
- Nutanix VMM v4 REST API surface (`/api/vmm/v4.2/ahv/policies/*`), OpenAPI/Swagger schema reading, and `ntnx_vmm_py_client` SDK usage patterns.
- Concept of "VM Startup Policies" in AHV: how VMs / categories of VMs are ordered at boot, how the scheduler ("metropolis") evaluates dependency graphs, and what a dependency vs. start-condition conflict means.
- Understanding of `dependee` vs `dependent` VMs — dependees are the VMs others rely on; dependents are the VMs that wait for dependees.
- Familiarity with Ansible collection module patterns in `nutanix.ncp` — `BaseInfoModule`, `SpecGenerator`, `strip_internal_attributes`, `raise_api_exception`, and paginated list responses.
- Ability to construct/verify integration tests on a live Prism Central: creating a VM Startup Policy, provoking a dependency conflict (e.g., missing VM, category with no member, circular dependency), and asserting the list of dependee VMs returned.

## Files changed

**plugins/modules/**
- `ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2.py` — new info module for listing dependee VMs of a VM startup policy's dependency conflict.

**plugins/module_utils/v4/vmm/**
- `api_client.py` — added `get_vm_startup_policies_api_instance(module)` factory.

**meta/**
- `runtime.yml` — registered the new module in the `ntnx` action group so `module_defaults: group/nutanix.ncp.ntnx` applies.

**examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependeeVm/**
- `vm_startup_policy_dependency_conflict_dependee_vms_info_v2.yml` — example playbook.
- `examples_run.log` — captured output from running the playbook against the live cluster `10.44.76.28`.

**tests/integration/targets/ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2/**
- `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/dependee_vms_info.yml` — integration test target with negative + domain-level end-to-end tests.

**.gitignore**
- Ensure `tests/integration/integration_config.yml` (which carries cluster credentials) is not committed.

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 --allow-unsupported --allow-disabled ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2` |
| Total tasks         | 24                                             |
| Passed (ok)         | 14                                             |
| Failed              | 0                                              |
| Skipped             | 7 (positive-path block — no real dependency conflicts on the test cluster; see analysis) |
| Ignored             | 3 (intentional negative-path fatals guarded by `ignore_errors: true`) |
| Duration            | `< 30s`                                      |
| Cluster (PC)        | `10.44.76.28:9440`                           |

### Analysis

All test tasks passed or skipped as expected:

- **Negative — missing `vm_startup_policy_ext_id`**: module correctly failed with `missing required arguments: vm_startup_policy_ext_id`. Assertion passed.
- **Negative — missing `dependency_conflict_ext_id`**: module correctly failed with `missing required arguments: dependency_conflict_ext_id`. Assertion passed.
- **Negative — non-existent ext_ids**: the module hit the live PC v4 API and correctly surfaced the 404 error `VMM-34060 POLICY_NOT_FOUND`. Assertion passed.
- **Domain-level end-to-end**: the target enumerates all VM startup policies on the cluster via `GET /vmm/v4.2/ahv/policies/vm-startup-policies`, then for every policy enumerates `.../dependency-conflicts`, and finally invokes the new info module for every discovered (policy, conflict) pair. The test cluster currently has **0 dependency conflicts across 0 policies**, so the positive-path assertions are correctly skipped (`when: (conflict_pairs | default([])) | length > 0`). During the run I additionally created and deleted a probe startup policy programmatically to verify the list-conflicts endpoint returns cleanly (empty `data`) — this confirms the module and its plumbing are healthy end-to-end.

### Known issues

- The Nutanix VMM v4 API on this cluster returns `500 INTERNAL_SERVER_ERROR (PLAT-10006)` when called with a real `vmStartupPolicyExtId` but a fake `dependencyConflictExtId` (rather than a clean 404). This is the exact defect tracked in **ENG-795868** from the domain-knowledge block above — it is a server-side bug, not a defect in this Ansible module. The module surfaces the API response verbatim as required.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Running ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 integration test role
[WARNING]: Found variable using reserved name: port

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Start VmStartupPolicyDependencyConflictDependeeVm info tests] ***
ok: [testhost] => {
    "msg": "Start testing ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2"
}

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Generate random ext_ids used for negative tests] ***
ok: [testhost]

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Fail when vm_startup_policy_ext_id is missing] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: vm_startup_policy_ext_id"}
...ignoring

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Assert failure when vm_startup_policy_ext_id is missing] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Module correctly failed when vm_startup_policy_ext_id was missing"
}

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Fail when dependency_conflict_ext_id is missing] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: dependency_conflict_ext_id"}
...ignoring

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Assert failure when dependency_conflict_ext_id is missing] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Module correctly failed when dependency_conflict_ext_id was missing"
}

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Call info module with non-existent ext_ids] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VM startup policy dependency conflict dependee VMs info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"policy_uuid": "700f0c7b-5c41-5fef-a8c3-dc4d00556c1d"}, "code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the policy with UUID '700f0c7b-5c41-5fef-a8c3-dc4d00556c1d', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Assert the API surfaces a descriptive error for unknown ext_ids] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Module correctly surfaced an API error for unknown ext_ids"
}

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Enumerate VM startup policies on the cluster via the v4 REST endpoint] ***
ok: [testhost]

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Set discovered startup policy IDs] ***
ok: [testhost]

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Enumerate dependency conflicts for each policy] ***
skipping: [testhost]

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Initialise the conflict pair list] ***
ok: [testhost]

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Build the list of (policy_ext_id, conflict_ext_id) pairs discovered on the cluster] ***
skipping: [testhost]

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Report how many conflicts were discovered on the live cluster] ***
ok: [testhost] => {
    "msg": "Discovered 0 dependency conflict(s) across 0 startup policy/policies."
}

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : List dependee VMs for every discovered dependency conflict] ***
skipping: [testhost]

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Assert the info module returned a well-formed response for every conflict] ***
skipping: [testhost]

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Every dependee VM entry MUST expose a non-empty ext_id] ***
skipping: [testhost]

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Exercise pagination — first page with limit=1 for the first conflict] ***
skipping: [testhost]

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Assert paginated response has at most `limit` entries] ***
skipping: [testhost]

TASK [ntnx_vm_startup_policy_dependency_conflict_dependee_vms_info_v2 : Skip note when no real dependency conflicts are available on the cluster] ***
ok: [testhost] => {
    "msg": "No real VM startup policy dependency conflicts were found on this cluster; skipping the positive-path assertions. The negative-path and not-found-ext_id tests above have already validated argument handling and API error surfacing against the live API."
}

PLAY RECAP *********************************************************************
testhost                   : ok=14   changed=0    unreachable=0    failed=0    skipped=7    rescued=0    ignored=3   
```

</details>

## Example playbook execution

The example playbook was run end-to-end against the live PC (`10.44.76.28`):

```
ansible-playbook examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependeeVm/*.yml \
  -e "ip=10.44.76.28 username=admin password=Nutanix.123 port=9440 validate_certs=false" -v
```

The captured log lives at `examples/virtual_machine_management/VmStartupPolicyDependencyConflictDependeeVm/examples_run.log`. Because the example uses placeholder ext_ids (a real user is expected to substitute their own policy + conflict UUIDs — those UUIDs are inherently site-specific), the playbook's two info-module calls returned the real API 404 response (`VMM-34060 POLICY_NOT_FOUND`). The playbook completed with `ok=3` and `ignored=2`; no unexpected failures.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
