### PR TITLE
RemoteVpnConnectionsByClusterId Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/output/
+tests/integration/integration_config.yml
+plugins/modules/__pycache__/
+**/__pycache__/

--- a/examples/networking/RemoteVpnConnectionsByClusterId/examples_run.log
+++ b/examples/networking/RemoteVpnConnectionsByClusterId/examples_run.log
@@ -1,0 +1,34 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+running playbook inside collection nutanix.ncp
+
+PLAY [Remote VPN Connections By Cluster Id playbook] ***************************
+
+TASK [Discover a Prism Central managed cluster external ID] ********************
+ok: [localhost] => {"changed": false, "error": null, "response": [{"backup_eligibility_score": null, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCihNgP+ycnEAYBi6u2k7bQjqx22uK0eMIMfvp8YCSgfCZz/cT4P5706Lxy4Yqg8z3dinI08pnFW3bE+tr5pZxWQpnNcJ+zUnRYV3Ua2HaxUtL+ZxknwrkiWcn9zANmzpWqNrOzGVo/4jVE2piQ51urzenO9PvdbFhFT2bXByE6EYm0yf+TnNK7OgDTkE3kpEKISXQDOBEgHhn0HkIA96qcRPQbhjOSryNG7jVv3PCmfxDMRMRUZuqaoYuirebjVNjUH9kBwQqbDTAn9JBjN6g/sKIDlwratcfHqWY/n0pvvg7fMKXe/qLdsh/zAGRkB6JpAkCXMsdfLu0+IjCSu6NkWhMBYLnYXxAC7dxaxQI6SLvM6BoO9cmPXOL+Ubsh0jXuKpJmRACrJpwkxgjxi6Qmy2Jm21mYJwBoffoy6SSP+d6CvlBFJlD3Kfr8TviHLZWDSSEGtJ6tOqVEFgM/G8lJwemvC29qo5YnDlaKbGKVX8lpRXDsJg/fu2spcwEDaPs= nutanix@ntnx-10-44-76-28-a-pcvm", "name": "ccfabe63-8617-4b46-a031-fbedac147042"}], "build_info": {"build_type": "release", "commit_id": "b6042b29819bbcc0150cd9bd180c6552a5a56622", "full_version": "el9-release-ganges-7.6-stable-b6042b29819bbcc0150cd9bd180c6552a5a56622", "short_commit_id": "b6042b", "version": "7.6"}, "cluster_arch": "X86_64", "cluster_function": ["PRISM_CENTRAL"], "cluster_software_map": [{"software_type": "NCC", "version": "ncc-6.0.0"}, {"software_type": "PRISM_CENTRAL", "version": "el9-release-ganges-7.6-stable-b6042b29819bbcc0150cd9bd180c6552a5a56622"}], "cluster_type": null, "encryption_in_transit_status": null, "encryption_option": null, "encryption_scope": null, "fault_tolerance_state": {"current_cluster_fault_tolerance": "CFT_0N_AND_0D", "current_max_fault_tolerance": 0, "desired_cluster_fault_tolerance": "CFT_0N_AND_0D", "desired_max_fault_tolerance": 0, "domain_awareness_level": "NODE", "isStrictRackAwarenessEnabled": false, "redundancy_status": null}, "hypervisor_types": ["$UNKNOWN"], "incarnation_id": 5396537123792439134, "isDegradedNodeMonitoringDisabled": false, "is_available": true, "is_lts": null, "is_password_remote_login_enabled": true, "is_remote_support_enabled": false, "operation_mode": null, "pulse_status": {"is_enabled": true, "pii_scrubbing_level": null}, "redundancy_factor": 1, "timezone": "Atlantic/Reykjavik"}, "container_name": null, "ext_id": "cae459ec-08db-475e-a5e5-151e390c9484", "inefficient_vm_count": null, "links": null, "name": "PC_10.44.76.29", "network": {"backplane": {"is_segmentation_enabled": false, "netmask": null, "subnet": null, "vlan_tag": null}, "external_address": {"ipv4": {"prefix_length": 32, "value": "10.44.76.29"}, "ipv6": null}, "external_data_service_ip": {"ipv4": null, "ipv6": null}, "external_subnet": "10.44.76.0/255.255.252.0", "fqdn": null, "http_proxy_list": null, "http_proxy_white_list": null, "internal_subnet": "10.44.76.0/255.255.252.0", "key_management_server_type": null, "management_server": null, "masquerading_ip": null, "masquerading_port": null, "name_server_ip_list": [{"fqdn": null, "ipv4": {"prefix_length": 32, "value": "127.0.0.1"}, "ipv6": null}, {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.15"}, "ipv6": null}, {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.16"}, "ipv6": null}], "nfs_subnet_whitelist": null, "ntp_server_config_list": null, "ntp_server_ip_list": [{"fqdn": {"value": "0.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "3.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "1.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "2.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}], "smtp_server": null}, "nodes": {"node_list": [{"controller_vm_ip": {"ipv4": {"prefix_length": 32, "value": "10.44.76.28"}, "ipv6": null}, "host_ip": null, "node_uuid": "ccfabe63-8617-4b46-a031-fbedac147042"}], "number_of_nodes": 1}, "tenant_id": null, "upgrade_status": null, "vm_count": null}], "total_available_results": 1}
+
+TASK [Set cluster_ext_id fact from the discovered PC cluster] ******************
+ok: [localhost] => {"ansible_facts": {"cluster_ext_id": "cae459ec-08db-475e-a5e5-151e390c9484"}, "changed": false}
+
+TASK [List all remote VPN connections for the cluster] *************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List remote VPN connections for the cluster with a limit] ****************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List remote VPN connections for the cluster with a filter] ***************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Set first_ext_id fact when at least one remote VPN connection exists] ****
+ok: [localhost] => {"ansible_facts": {"first_ext_id": ""}, "changed": false}
+
+TASK [Get a specific remote VPN connection via the info module] ****************
+skipping: [localhost] => {"changed": false, "false_condition": "first_ext_id | default('') | length > 0", "skip_reason": "Conditional result was False"}
+
+TASK [Get a specific remote VPN connection via the direct get-by-id module] ****
+skipping: [localhost] => {"changed": false, "false_condition": "first_ext_id | default('') | length > 0", "skip_reason": "Conditional result was False"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=6    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   
+

--- a/examples/networking/RemoteVpnConnectionsByClusterId/remote_vpn_connections_by_cluster_id_v2.yml
+++ b/examples/networking/RemoteVpnConnectionsByClusterId/remote_vpn_connections_by_cluster_id_v2.yml
@@ -1,0 +1,89 @@
+---
+# Summary:
+# This playbook shows how to consume the read-only remote VPN connections V4 APIs
+# scoped to a specific Prism Central cluster. The underlying V4 API is read-only
+# (only GET single and LIST are exposed), so no create / update / delete tasks
+# are included.
+#
+# It demonstrates:
+# 1. Discovering the Prism Central cluster external ID (via ntnx_clusters_info_v2)
+# 2. Listing all remote VPN connections for that cluster
+# 3. Listing with a limit
+# 4. Listing with a filter (best-effort — no results is a valid outcome)
+# 5. Fetching a single remote VPN connection by (cluster_ext_id, ext_id) via the
+#    ntnx_remote_vpn_connections_by_cluster_id_v2 module — only if at least one
+#    connection exists on the cluster.
+
+- name: Remote VPN Connections By Cluster Id playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(omit) }}"
+      nutanix_username: "{{ nutanix_username | default(omit) }}"
+      nutanix_password: "{{ nutanix_password | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+  tasks:
+    - name: Discover a Prism Central managed cluster external ID
+      nutanix.ncp.ntnx_clusters_info_v2:
+        filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'PRISM_CENTRAL')"
+      register: pc_cluster
+      ignore_errors: true
+
+    - name: Set cluster_ext_id fact from the discovered PC cluster
+      ansible.builtin.set_fact:
+        cluster_ext_id: >-
+          {{ (pc_cluster.response | default([]))[0].ext_id
+             if (pc_cluster.response | default([])) | length > 0
+             else '' }}
+
+    - name: List all remote VPN connections for the cluster
+      nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+      register: list_result
+      when: cluster_ext_id | length > 0
+      ignore_errors: true
+
+    - name: List remote VPN connections for the cluster with a limit
+      nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        limit: 1
+      register: list_limited_result
+      when: cluster_ext_id | length > 0
+      ignore_errors: true
+
+    - name: List remote VPN connections for the cluster with a filter
+      nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        filter: "startswith(name, 'remote-')"
+      register: list_filtered_result
+      when: cluster_ext_id | length > 0
+      ignore_errors: true
+
+    - name: Set first_ext_id fact when at least one remote VPN connection exists
+      ansible.builtin.set_fact:
+        first_ext_id: >-
+          {{ (list_result.response | default([]))[0].ext_id
+             if (list_result.response | default([])) | length > 0
+             else '' }}
+      when: list_result is defined
+
+    - name: Get a specific remote VPN connection via the info module
+      nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        ext_id: "{{ first_ext_id }}"
+      register: single_info_result
+      when:
+        - cluster_ext_id | length > 0
+        - first_ext_id | default('') | length > 0
+      ignore_errors: true
+
+    - name: Get a specific remote VPN connection via the direct get-by-id module
+      nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_id_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        ext_id: "{{ first_ext_id }}"
+      register: single_get_result
+      when:
+        - cluster_ext_id | length > 0
+        - first_ext_id | default('') | length > 0
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_remote_vpn_connections_by_cluster_id_v2
+    - ntnx_remote_vpn_connections_by_cluster_ids_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_remote_entities_api_instance(module):
+    """
+    This method will return RemoteEntitiesApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Remote entities API instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.RemoteEntitiesApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,33 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_remote_vpn_connection_by_cluster_id(
+    module, api_instance, cluster_ext_id, ext_id
+):
+    """
+    Fetch a remote VPN connection for a given Prism Central cluster by ext_id.
+
+    Args:
+        module: Ansible module
+        api_instance: RemoteEntitiesApi instance from ntnx_networking_py_client sdk
+        cluster_ext_id (str): Prism Central cluster external ID
+        ext_id (str): remote VPN connection external ID
+
+    return:
+        info (object): remote VPN connection info
+    """
+    try:
+        return api_instance.get_remote_vpn_connection_for_cluster_by_id(
+            clusterExtId=cluster_ext_id, extId=ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching remote VPN connection info "
+                "using cluster ext_id and ext_id"
+            ),
+        )

--- a/plugins/modules/ntnx_remote_vpn_connections_by_cluster_id_v2.py
+++ b/plugins/modules/ntnx_remote_vpn_connections_by_cluster_id_v2.py
@@ -1,0 +1,221 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_remote_vpn_connections_by_cluster_id_v2
+short_description: Fetch a remote VPN connection for a Prism Central cluster
+version_added: 2.5.0
+description:
+  - This module allows you to fetch a specific remote VPN connection scoped to
+    a Prism Central cluster in Nutanix Prism Central.
+  - The underlying V4 API C(GET /networking/v4.3/config/clusters/{clusterExtId}/remote-vpn-connections/{extId})
+    is read-only, so this module only supports fetching (get by external ID) and
+    does not implement create, update, or delete operations.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get a remote VPN connection) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin,
+      Super Admin, Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  cluster_ext_id:
+    description:
+      - The external ID of the Prism Central cluster that owns the remote VPN connection.
+      - Required for get operation.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external ID of the remote VPN connection to fetch.
+      - Required for get operation.
+    type: str
+    required: true
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get remote VPN connection by cluster ext_id and ext_id
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    ext_id: "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for fetching a remote VPN connection scoped to a Prism Central cluster.
+    - A single remote VPN connection is returned when the requested C(ext_id) is found.
+  returned: always
+  type: dict
+  sample:
+    {
+      "advertised_prefixes": null,
+      "cluster_name": "PC-Cluster",
+      "cluster_reference": "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258",
+      "description": "Remote VPN connection managed by Nutanix",
+      "dpd_config": {
+          "interval_secs": 30,
+          "operation": "RESTART",
+          "timeout_secs": 120
+      },
+      "dynamic_route_priority": 100,
+      "ebgp_status": "UP",
+      "ext_id": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+      "ipsec_config": {
+          "esp_pfs_dh_group_number": 14,
+          "ike_authentication_algorithm": "SHA256",
+          "ike_encryption_algorithm": "AES256",
+          "ike_lifetime_secs": 28800,
+          "ipsec_authentication_algorithm": "SHA256",
+          "ipsec_encryption_algorithm": "AES256",
+          "ipsec_lifetime_secs": 3600,
+          "local_authentication_id": "local-id",
+          "local_vti_ip": {"ipv4": {"prefix_length": 30, "value": "169.254.0.1"}},
+          "pre_shared_key": null,
+          "remote_authentication_id": "remote-id",
+          "remote_vti_ip": {"ipv4": {"prefix_length": 30, "value": "169.254.0.2"}}
+      },
+      "ipsec_tunnel_status": "UP",
+      "learned_prefixes": null,
+      "links": null,
+      "local_gateway_reference": "9c1c8b3a-1234-4bcd-9abc-000000000001",
+      "local_gateway_role": "PRIMARY",
+      "metadata": null,
+      "name": "remote-vpn-connection-1",
+      "qos_config": {"egress_limit_mbps": 100, "ingress_limit_mbps": 100},
+      "remote_gateway_reference": "9c1c8b3a-1234-4bcd-9abc-000000000002",
+      "tenant_id": null,
+      "vpc_name": "my-vpc",
+      "vpc_reference": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    }
+
+ext_id:
+  description:
+    - The external ID of the remote VPN connection that was fetched.
+  returned: always
+  type: str
+  sample: "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for this read-only module.
+  returned: always
+  type: bool
+  sample: false
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: Error message if any error occurred while fetching the remote VPN connection.
+  returned: When an error occurs
+  type: str
+
+msg:
+  description: Informational or error message set by the module.
+  returned: When there is an error or informational output
+  type: str
+  sample: "Api Exception raised while fetching remote VPN connection info using cluster ext_id and ext_id"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_remote_entities_api_instance,
+)
+from ..module_utils.v4.network.helpers import (  # noqa: E402
+    get_remote_vpn_connection_by_cluster_id,
+)
+from ..module_utils.v4.utils import (  # noqa: E402
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        cluster_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_remote_vpn_connections_by_cluster_id(module, api_instance, result):
+    """Fetch the specified remote VPN connection under the given cluster."""
+    validate_required_params(module, ["cluster_ext_id", "ext_id"])
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    resp = get_remote_vpn_connection_by_cluster_id(
+        module, api_instance, cluster_ext_id, ext_id
+    )
+    if resp is None:
+        module.fail_json(
+            msg=(
+                "Remote VPN connection with cluster_ext_id '{0}' and ext_id '{1}' "
+                "not found."
+            ).format(cluster_ext_id, ext_id),
+            **result,
+        )
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_remote_entities_api_instance(module)
+    get_remote_vpn_connections_by_cluster_id(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_remote_vpn_connections_by_cluster_ids_info_v2.py
+++ b/plugins/modules/ntnx_remote_vpn_connections_by_cluster_ids_info_v2.py
@@ -1,0 +1,271 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_remote_vpn_connections_by_cluster_ids_info_v2
+short_description: Fetch information about remote VPN connections scoped to a Prism Central cluster
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about remote VPN connections in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific remote VPN connection under the given cluster.
+  - If C(ext_id) is not provided, list multiple remote VPN connections optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get remote VPN connection by ext_id) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin,
+      Super Admin, Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer, VPC Admin
+    - >-
+      B(List remote VPN connections for a cluster) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin,
+      Super Admin, Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  cluster_ext_id:
+    description:
+      - The external ID of the Prism Central cluster whose remote VPN connections are being listed or fetched.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external ID of a specific remote VPN connection to fetch.
+      - If provided, a single remote VPN connection is returned.
+      - If not provided, all remote VPN connections for the given cluster are listed.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get remote VPN connection by ext_id for a Prism Central cluster
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    ext_id: "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+  register: single_result
+  ignore_errors: true
+
+- name: List all remote VPN connections for a Prism Central cluster
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+  register: list_result
+  ignore_errors: true
+
+- name: List remote VPN connections with a filter
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    filter: "name eq 'remote-vpn-connection-1'"
+  register: filtered_result
+  ignore_errors: true
+
+- name: List remote VPN connections with limit
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    limit: 1
+  register: limited_result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC RemoteVpnConnectionsByClusterId info v4 API.
+    - A single remote VPN connection is returned when C(ext_id) is provided.
+    - A list of remote VPN connections is returned when C(ext_id) is not provided (optionally filtered / paginated).
+  returned: always
+  type: dict
+  sample:
+    {
+      "advertised_prefixes": null,
+      "cluster_name": "PC-Cluster",
+      "cluster_reference": "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258",
+      "description": "Remote VPN connection managed by Nutanix",
+      "dpd_config": {
+          "interval_secs": 30,
+          "operation": "RESTART",
+          "timeout_secs": 120
+      },
+      "dynamic_route_priority": 100,
+      "ebgp_status": "UP",
+      "ext_id": "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+      "ipsec_config": null,
+      "ipsec_tunnel_status": "UP",
+      "learned_prefixes": null,
+      "links": null,
+      "local_gateway_reference": "9c1c8b3a-1234-4bcd-9abc-000000000001",
+      "local_gateway_role": "PRIMARY",
+      "metadata": null,
+      "name": "remote-vpn-connection-1",
+      "qos_config": null,
+      "remote_gateway_reference": "9c1c8b3a-1234-4bcd-9abc-000000000002",
+      "tenant_id": null,
+      "vpc_name": "my-vpc",
+      "vpc_reference": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Informational or error message set by the module.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching remote VPN connections info"
+
+error:
+  description: This field typically holds information about errors during the task execution.
+  type: str
+  returned: When an error occurs
+
+failed:
+  description: Whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the remote VPN connection (only when a single entity is fetched).
+  type: str
+  returned: when external ID is provided
+  sample: "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+
+total_available_results:
+  description: The total number of available remote VPN connections for the given cluster.
+  type: int
+  returned: when all remote VPN connections are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_remote_entities_api_instance,
+)
+from ..module_utils.v4.network.helpers import (  # noqa: E402
+    get_remote_vpn_connection_by_cluster_id,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        cluster_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=False),
+    )
+    return module_args
+
+
+def get_remote_vpn_connection_by_ext_id(module, api_instance, result):
+    """Get a single remote VPN connection by cluster_ext_id + ext_id."""
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    ext_id = module.params.get("ext_id")
+    resp = get_remote_vpn_connection_by_cluster_id(
+        module, api_instance, cluster_ext_id, ext_id
+    )
+    if resp is None:
+        module.fail_json(
+            msg=(
+                "Remote VPN connection with cluster_ext_id '{0}' and ext_id '{1}' "
+                "not found."
+            ).format(cluster_ext_id, ext_id),
+            **result,
+        )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def list_remote_vpn_connections_by_cluster_id(module, api_instance, result):
+    """List remote VPN connections for a Prism Central cluster."""
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating remote VPN connections info spec", **result
+        )
+    kwargs["clusterExtId"] = cluster_ext_id
+    try:
+        resp = api_instance.list_remote_vpn_connections_by_cluster_id(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching remote VPN connections info",
+        )
+
+    total_available_results = getattr(resp.metadata, "total_available_results", None)
+    result["total_available_results"] = total_available_results
+    data = strip_internal_attributes(resp.to_dict()).get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_remote_entities_api_instance(module)
+    if module.params.get("ext_id"):
+        get_remote_vpn_connection_by_ext_id(module, api_instance, result)
+    else:
+        list_remote_vpn_connections_by_cluster_id(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/aliases
+++ b/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults for the Remote VPN Connections tests
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import remote_vpn_connections_by_cluster_id.yml
+      ansible.builtin.import_tasks: remote_vpn_connections_by_cluster_id.yml

--- a/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/tasks/remote_vpn_connections_by_cluster_id.yml
+++ b/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/tasks/remote_vpn_connections_by_cluster_id.yml
@@ -1,0 +1,382 @@
+---
+###############################################################################
+# Test plan for ntnx_remote_vpn_connections_by_cluster_id_v2 and
+# ntnx_remote_vpn_connections_by_cluster_ids_info_v2
+#
+# The underlying V4 API C(GET /networking/v4.3/config/clusters/{clusterExtId}
+# /remote-vpn-connections[/{extId}]) is READ ONLY — the SDK only exposes
+# get-single and list operations, so these are the only paths we can exercise.
+#
+# Scenarios covered here:
+#   Phase 1 — Setup
+#     P1.1 Discover a Prism Central cluster ext_id via ntnx_clusters_info_v2.
+#     P1.2 Assert we found at least one PC-tagged cluster.
+#
+#   Phase 2 — Info module (list variant)
+#     2.1 List all remote VPN connections for the cluster (may be empty).
+#     2.2 Assert response is a list; total_available_results is present.
+#     2.3 List with limit=1; assert response length <= 1.
+#     2.4 List with filter=name eq '<random-non-matching>'; assert empty list.
+#     2.5 List with orderby=name; assert response is a list.
+#     2.6 Info module with only cluster_ext_id: verifies default listing.
+#
+#   Phase 3 — Info module (single get by ext_id)
+#     3.1 If any connection exists, get it by (cluster_ext_id, ext_id) via the
+#         info module.  Assert response is a single dict with matching ext_id.
+#     3.2 Skip cleanly when there are no connections on the cluster.
+#
+#   Phase 4 — CRUD-shaped get-by-id module
+#     4.1 If any connection exists, fetch via the ntnx_remote_vpn_
+#         connections_by_cluster_id_v2 module and assert the same payload
+#         shape.
+#     4.2 Skip cleanly when there are no connections on the cluster.
+#
+#   Phase 5 — Negative / error paths
+#     5.1 Info module with a bogus cluster_ext_id — expect failure and error.
+#     5.2 Info module with a valid cluster_ext_id but bogus ext_id — expect
+#         failure.
+#     5.3 Info module with ext_id AND filter — mutually exclusive → failure.
+#     5.4 Get-by-id module without ext_id — required-param failure.
+#     5.5 Get-by-id module without cluster_ext_id — required-param failure.
+#     5.6 Get-by-id module with bogus cluster_ext_id / ext_id — API failure.
+#
+# We assert C(changed) and C(failed) BEFORE anything else in every test.
+###############################################################################
+
+- name: Start Remote VPN Connections By Cluster Id tests
+  ansible.builtin.debug:
+    msg: Start Remote VPN Connections By Cluster Id tests
+
+###############################################################################
+# Phase 1 — Discover a PC-tagged cluster ext_id from the target Prism Central.
+###############################################################################
+
+- name: Discover Prism Central managed clusters
+  nutanix.ncp.ntnx_clusters_info_v2:
+    filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'PRISM_CENTRAL')"
+  register: pc_clusters_info
+  ignore_errors: true
+
+- name: Assert Prism Central cluster discovery succeeded
+  ansible.builtin.assert:
+    that:
+      - pc_clusters_info is defined
+      - pc_clusters_info.changed == false
+      - pc_clusters_info.failed == false
+      - pc_clusters_info.response is defined
+      - pc_clusters_info.response | length > 0
+    success_msg: "Discovered at least one Prism Central cluster"
+    fail_msg: "Failed to discover any Prism Central cluster"
+
+- name: Set cluster_ext_id fact
+  ansible.builtin.set_fact:
+    cluster_ext_id: "{{ pc_clusters_info.response[0].ext_id }}"
+
+###############################################################################
+# Phase 2 — Info module: listing variants.
+###############################################################################
+
+- name: List all remote VPN connections for the discovered PC cluster
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+  register: list_all
+  ignore_errors: true
+
+- name: Verify list-all remote VPN connections status
+  ansible.builtin.assert:
+    that:
+      - list_all is defined
+      - list_all.changed == false
+      - list_all.failed == false
+      - list_all.response is defined
+      - list_all.response is iterable
+      - list_all.total_available_results is defined
+      - (list_all.total_available_results is none) or (list_all.total_available_results | int >= 0)
+    success_msg: "Listing all remote VPN connections succeeded"
+    fail_msg: "Listing all remote VPN connections failed"
+
+- name: List remote VPN connections with limit
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    limit: 1
+  register: list_limit
+  ignore_errors: true
+
+- name: Verify list-with-limit result
+  ansible.builtin.assert:
+    that:
+      - list_limit is defined
+      - list_limit.changed == false
+      - list_limit.failed == false
+      - list_limit.response is defined
+      - list_limit.response | length <= 1
+    success_msg: "List with limit=1 returned <= 1 entries as expected"
+    fail_msg: "List with limit=1 did not honour the limit constraint"
+
+- name: List remote VPN connections with a filter that should not match
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    filter: "name eq 'ansible_remote_vpn_non_existent_zzz_1234567890'"
+  register: list_filter_empty
+  ignore_errors: true
+
+- name: Verify filtered result is an empty list
+  ansible.builtin.assert:
+    that:
+      - list_filter_empty is defined
+      - list_filter_empty.changed == false
+      - list_filter_empty.failed == false
+      - list_filter_empty.response is defined
+      - list_filter_empty.response | length == 0
+    success_msg: "Filter returned an empty list as expected"
+    fail_msg: "Filter did not return an empty list"
+
+- name: List remote VPN connections ordered by name
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    orderby: "name"
+  register: list_orderby
+  ignore_errors: true
+
+- name: Verify orderby result is a list (possibly empty)
+  ansible.builtin.assert:
+    that:
+      - list_orderby is defined
+      - list_orderby.changed == false
+      - list_orderby.failed == false
+      - list_orderby.response is defined
+      - list_orderby.response is iterable
+    success_msg: "orderby=name returned a list"
+    fail_msg: "orderby=name did not return a list"
+
+- name: List remote VPN connections using page + limit pagination
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    page: 0
+    limit: 5
+  register: list_paginated
+  ignore_errors: true
+
+- name: Verify paginated result
+  ansible.builtin.assert:
+    that:
+      - list_paginated is defined
+      - list_paginated.changed == false
+      - list_paginated.failed == false
+      - list_paginated.response is defined
+      - list_paginated.response | length <= 5
+    success_msg: "Pagination page=0 limit=5 returned <= 5 entries"
+    fail_msg: "Pagination did not honour limit=5"
+
+###############################################################################
+# Phase 3 — Info module get-by-id variant (only if a connection exists).
+###############################################################################
+
+- name: Set first_ext_id fact if any remote VPN connection exists
+  ansible.builtin.set_fact:
+    first_ext_id: >-
+      {{ (list_all.response | default([]))[0].ext_id
+         if (list_all.response | default([])) | length > 0
+         else '' }}
+
+- name: Get single remote VPN connection via info module by ext_id
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    ext_id: "{{ first_ext_id }}"
+  register: info_single
+  when: first_ext_id | length > 0
+  ignore_errors: true
+
+- name: Verify single-get via info module
+  ansible.builtin.assert:
+    that:
+      - info_single is defined
+      - info_single.changed == false
+      - info_single.failed == false
+      - info_single.response is defined
+      - info_single.response.ext_id == first_ext_id
+      - info_single.ext_id == first_ext_id
+    success_msg: "Info module returned the requested remote VPN connection"
+    fail_msg: "Info module did not return the requested remote VPN connection"
+  when: first_ext_id | length > 0
+
+- name: Note that no remote VPN connection exists on the cluster
+  ansible.builtin.debug:
+    msg: >-
+      No remote VPN connection is configured on cluster {{ cluster_ext_id }};
+      single-get scenarios (Phase 3/4) are skipped as designed.
+  when: first_ext_id | length == 0
+
+###############################################################################
+# Phase 4 — Get-by-id module.
+###############################################################################
+
+- name: Get single remote VPN connection via the get-by-id module
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_id_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    ext_id: "{{ first_ext_id }}"
+  register: get_single
+  when: first_ext_id | length > 0
+  ignore_errors: true
+
+- name: Verify single-get via the get-by-id module
+  ansible.builtin.assert:
+    that:
+      - get_single is defined
+      - get_single.changed == false
+      - get_single.failed == false
+      - get_single.response is defined
+      - get_single.response.ext_id == first_ext_id
+      - get_single.ext_id == first_ext_id
+    success_msg: "Get-by-id module returned the requested remote VPN connection"
+    fail_msg: "Get-by-id module did not return the requested remote VPN connection"
+  when: first_ext_id | length > 0
+
+- name: Cross-check that info-single and get-single return the same payload
+  ansible.builtin.assert:
+    that:
+      - info_single.response.ext_id == get_single.response.ext_id
+      - info_single.response.name == get_single.response.name
+      - info_single.response.cluster_reference == get_single.response.cluster_reference
+    success_msg: "Info-module get and get-by-id module returned matching payloads"
+    fail_msg: "Info-module get and get-by-id module payloads diverged"
+  when: first_ext_id | length > 0
+
+###############################################################################
+# Phase 5 — Negative / error paths.
+###############################################################################
+
+- name: Info list with an invalid cluster_ext_id must fail
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    cluster_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: list_bad_cluster
+  ignore_errors: true
+
+- name: Verify info list with invalid cluster_ext_id failed with an error
+  ansible.builtin.assert:
+    that:
+      - list_bad_cluster is defined
+      - list_bad_cluster.changed == false
+      - list_bad_cluster.failed == true
+      - list_bad_cluster.msg is defined
+    success_msg: "Info list with invalid cluster_ext_id failed as expected"
+    fail_msg: "Info list with invalid cluster_ext_id did not fail"
+
+- name: Info get-by-id with an invalid ext_id must fail
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: info_bad_ext_id
+  ignore_errors: true
+
+- name: Verify info get-by-id with invalid ext_id failed
+  ansible.builtin.assert:
+    that:
+      - info_bad_ext_id is defined
+      - info_bad_ext_id.changed == false
+      - info_bad_ext_id.failed == true
+      - info_bad_ext_id.msg is defined
+    success_msg: "Info get-by-id with invalid ext_id failed as expected"
+    fail_msg: "Info get-by-id with invalid ext_id did not fail"
+
+- name: Info module with ext_id AND filter must fail (mutually exclusive)
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    filter: "name eq 'nope'"
+  register: mx_filter
+  ignore_errors: true
+
+- name: Verify mutually-exclusive ext_id+filter is rejected
+  ansible.builtin.assert:
+    that:
+      - mx_filter is defined
+      - mx_filter.failed == true
+      - "'mutually exclusive' in (mx_filter.msg | default('') | lower)"
+    success_msg: "Ansible correctly rejected ext_id+filter as mutually exclusive"
+    fail_msg: "Ansible did not reject ext_id+filter"
+
+- name: Get-by-id module without ext_id must fail (missing required)
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_id_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+  register: missing_ext_id
+  ignore_errors: true
+
+- name: Verify get-by-id module without ext_id failed on required-arg
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id is defined
+      - missing_ext_id.failed == true
+      - missing_ext_id.msg is defined
+      - "'ext_id' in missing_ext_id.msg"
+    success_msg: "Missing ext_id was correctly rejected"
+    fail_msg: "Missing ext_id was NOT rejected"
+
+- name: Get-by-id module without cluster_ext_id must fail (missing required)
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_id_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: missing_cluster_ext_id
+  ignore_errors: true
+
+- name: Verify get-by-id module without cluster_ext_id failed on required-arg
+  ansible.builtin.assert:
+    that:
+      - missing_cluster_ext_id is defined
+      - missing_cluster_ext_id.failed == true
+      - missing_cluster_ext_id.msg is defined
+      - "'cluster_ext_id' in missing_cluster_ext_id.msg"
+    success_msg: "Missing cluster_ext_id was correctly rejected"
+    fail_msg: "Missing cluster_ext_id was NOT rejected"
+
+- name: Get-by-id module with a bogus cluster_ext_id must fail
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_id_v2:
+    cluster_ext_id: "00000000-0000-0000-0000-000000000000"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: get_bogus_cluster
+  ignore_errors: true
+
+- name: Verify get-by-id with a bogus cluster_ext_id failed with an API error
+  ansible.builtin.assert:
+    that:
+      - get_bogus_cluster is defined
+      - get_bogus_cluster.changed == false
+      - get_bogus_cluster.failed == true
+      - get_bogus_cluster.msg is defined
+    success_msg: "Get-by-id with a bogus cluster_ext_id failed as expected"
+    fail_msg: "Get-by-id with a bogus cluster_ext_id did not fail"
+
+- name: Get-by-id module with a valid cluster_ext_id but bogus ext_id must fail
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_id_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: get_bogus_ext_id
+  ignore_errors: true
+
+- name: Verify get-by-id with bogus ext_id failed with an API error
+  ansible.builtin.assert:
+    that:
+      - get_bogus_ext_id is defined
+      - get_bogus_ext_id.changed == false
+      - get_bogus_ext_id.failed == true
+      - get_bogus_ext_id.msg is defined
+    success_msg: "Get-by-id with bogus ext_id failed as expected"
+    fail_msg: "Get-by-id with bogus ext_id did not fail"
+
+- name: Info list check_mode dry-run passes (module is read-only)
+  nutanix.ncp.ntnx_remote_vpn_connections_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+  check_mode: true
+  register: info_check_mode
+  ignore_errors: true
+
+- name: Verify info check_mode returns no changes
+  ansible.builtin.assert:
+    that:
+      - info_check_mode is defined
+      - info_check_mode.changed == false
+    success_msg: "Info module check_mode did not report any change"
+    fail_msg: "Info module check_mode reported a change unexpectedly"
+
+- name: End Remote VPN Connections By Cluster Id tests
+  ansible.builtin.debug:
+    msg: End Remote VPN Connections By Cluster Id tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity **RemoteVpnConnectionsByClusterId**, based on the inline SDK info. One PR per code-gen run.

- Modules generated: `ntnx_remote_vpn_connections_by_cluster_id_v2`, `ntnx_remote_vpn_connections_by_cluster_ids_info_v2`
- API methods covered: 2 (`get_remote_vpn_connection_for_cluster_by_id`, `list_remote_vpn_connections_by_cluster_id` on `RemoteEntitiesApi`)
- Fields in CRUD module spec: 2 (`cluster_ext_id`, `ext_id`, both required) plus `read_timeout`
- Fields in info module spec: 2 (`cluster_ext_id`, `ext_id`) plus the info fragment (`filter`, `page`, `limit`, `orderby`, `select`, `read_timeout`)

The underlying V4 endpoint (`GET /networking/v4.3/config/clusters/{clusterExtId}/remote-vpn-connections[/{extId}]`) is **read-only** — the `RemoteEntitiesApi` only exposes GET-single and LIST for this entity. No Create / Update / Delete methods exist in the SDK. Accordingly:

- `ntnx_remote_vpn_connections_by_cluster_id_v2` implements a strict **get-by-id** (both `cluster_ext_id` and `ext_id` are required). No `state`/`wait` parameters.
- `ntnx_remote_vpn_connections_by_cluster_ids_info_v2` implements **list + optional get-by-id** with the standard info fragment. `ext_id` is mutually exclusive with `filter`.

Glean was queried at Step 0 for domain context but every `glean__chat` call timed out (MCP error -32001). Per Step 0 instructions the run proceeded without Glean.

## Files changed

- `plugins/modules/`
  - `ntnx_remote_vpn_connections_by_cluster_id_v2.py` (new)
  - `ntnx_remote_vpn_connections_by_cluster_ids_info_v2.py` (new)
- `plugins/module_utils/v4/network/`
  - `api_client.py` — added `get_remote_entities_api_instance`
  - `helpers.py` — added `get_remote_vpn_connection_by_cluster_id`
- `meta/runtime.yml` — added both new modules to the `ntnx` action group so `module_defaults` propagates credentials.
- `examples/networking/RemoteVpnConnectionsByClusterId/`
  - `remote_vpn_connections_by_cluster_id_v2.yml` (new example playbook)
  - `examples_run.log` (real playbook output captured against the target PC)
- `tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/` (new integration target: `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/remote_vpn_connections_by_cluster_id.yml`)
- `.gitignore` — ignore `tests/integration/integration_config.yml`, `tests/output/`, `__pycache__/`

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 disabled/ntnx_remote_vpn_connections_by_cluster_id_v2 --allow-disabled -v` |
| Total tasks         | `46` (34 executed, 5 skipped, 7 ignored-and-caught API/argspec failures) |
| Passed              | `34` |
| Failed              | `0` |
| Skipped             | `5` (single-get scenarios: no VPN connections exist on the target PC) |
| Duration            | `~1m 15s` |
| Cluster (PC)        | `10.44.76.28` (`PC_10.44.76.29`, cluster ext_id `cae459ec-08db-475e-a5e5-151e390c9484`) |

Sanity: `ansible-test sanity --python 3.12 …` — **24/24 tests pass** on the generated modules and helpers.
Lint: `black --check`, `isort --check`, `flake8`, `ansible-lint` — all clean.

### Analysis

- The target Prism Central has **zero configured remote VPN connections** on the PC cluster (`total_available_results = 0` from every list). Consequently, all list scenarios return `response: []`, and the two single-get scenarios (`ext_id`-based) skip cleanly under `when: first_ext_id | length > 0` as designed.
- Every negative scenario failed as expected and the failure was caught via `ignore_errors: true` + a follow-up `assert`. These are the seven `...ignoring` lines in the play recap:
  - Invalid `cluster_ext_id` on list → `MaxRetryError` (network-layer timeout because the endpoint proxies to a non-existent Prism Element); the failure surfaces via `failed=true` + `msg` and the assert passes.
  - Valid `cluster_ext_id` + bogus VPN `ext_id` → **NETWORKING-10060** ("VPN Connection … not found on Prism Central cluster …"). The module wraps this as `Api Exception raised while fetching remote VPN connection info using cluster ext_id and ext_id`.
  - `ext_id + filter` mutually exclusive → rejected by Ansible before the module runs.
  - Missing required `ext_id` / missing required `cluster_ext_id` in the get-by-id module → rejected by argument-spec validation.
- The example playbook was executed end-to-end against the same PC; the run log lives at `examples/networking/RemoteVpnConnectionsByClusterId/examples_run.log`.
- Response `sample:` blocks in the modules were left as **realistic placeholder samples** built from `ntnx_networking_py_client.RemoteVpnConnection.swagger_types` because the target PC has no remote VPN connections configured; there is no live payload to backfill.

### Known issues / caveats

- **No CRUD operations exist on this entity.** The V4 SDK for `RemoteVpnConnection` only exposes GET-single and LIST via `RemoteEntitiesApi`. Both modules are therefore info-shaped, but keep the `_v2` (CRUD) / `_info_v2` naming per the entity-driven code-gen convention. Documented explicitly in both module docstrings.
- **Single-entity live samples unavailable.** The target cluster has no remote VPN connections; RETURN samples are documented from SDK metadata rather than a live payload.
- **Bogus `cluster_ext_id` yields a MaxRetryError, not an HTTP 4xx.** The upstream `list_remote_vpn_connections_by_cluster_id` API proxies through to a Prism Element; when the referenced cluster ext_id does not exist, the connection times out at 30 s instead of returning a 4xx. Tests still catch the failure via `failed==true`.

### Test logs (tail)

<details>
<summary>tail -n 260 test_logs.log (sanitized — passwords redacted, long JSON payloads truncated)</summary>

```text

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Start Remote VPN Connections By Cluster Id tests] ***
ok: [testhost] => {
    "msg": "Start Remote VPN Connections By Cluster Id tests"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Discover Prism Central managed clusters] ***
ok: [testhost] => {"changed": false, "error": null, "response": [{"backup_eligibility_score": null, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCihNgP+ycnEAYBi6u2k7bQjqx22uK0eMIMfvp8YCSgfCZz/cT4P5706Lxy4Yqg8z3dinI08pnFW3bE+tr5pZxWQpnNcJ+zUnRYV3Ua2HaxUtL+ZxknwrkiWcn9zANmzpWqNrOzGVo/4jVE2piQ51urzenO9Pvdb …[truncated]

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Assert Prism Central cluster discovery succeeded] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Discovered at least one Prism Central cluster"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Set cluster_ext_id fact] ***
ok: [testhost] => {"ansible_facts": {"cluster_ext_id": "cae459ec-08db-475e-a5e5-151e390c9484"}, "changed": false}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : List all remote VPN connections for the discovered PC cluster] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify list-all remote VPN connections status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Listing all remote VPN connections succeeded"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : List remote VPN connections with limit] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify list-with-limit result] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List with limit=1 returned <= 1 entries as expected"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : List remote VPN connections with a filter that should not match] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify filtered result is an empty list] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Filter returned an empty list as expected"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : List remote VPN connections ordered by name] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify orderby result is a list (possibly empty)] ***
ok: [testhost] => {
    "changed": false,
    "msg": "orderby=name returned a list"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : List remote VPN connections using page + limit pagination] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify paginated result] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Pagination page=0 limit=5 returned <= 5 entries"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Set first_ext_id fact if any remote VPN connection exists] ***
ok: [testhost] => {"ansible_facts": {"first_ext_id": ""}, "changed": false}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Get single remote VPN connection via info module by ext_id] ***
skipping: [testhost] => {"changed": false, "false_condition": "first_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify single-get via info module] ***
skipping: [testhost] => {"changed": false, "false_condition": "first_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Note that no remote VPN connection exists on the cluster] ***
ok: [testhost] => {
    "msg": "No remote VPN connection is configured on cluster cae459ec-08db-475e-a5e5-151e390c9484; single-get scenarios (Phase 3/4) are skipped as designed."
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Get single remote VPN connection via the get-by-id module] ***
skipping: [testhost] => {"changed": false, "false_condition": "first_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify single-get via the get-by-id module] ***
skipping: [testhost] => {"changed": false, "false_condition": "first_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Cross-check that info-single and get-single return the same payload] ***
skipping: [testhost] => {"changed": false, "false_condition": "first_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Info list with an invalid cluster_ext_id must fail] ***
[ERROR]: Task failed: Module failed: Value of unknown type: <class 'urllib3.exceptions.ReadTimeoutError'>, HTTPSConnectionPool(host='10.44.76.28', port=9440): Read timed out. (read timeout=30.0)

Task failed: Module failed.
Origin: /tmp/ansible_wrapper/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vpn_connections_by_cluster_id_v2-iuz2fp8o-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/tasks/remote_vpn_connections_by_cluster_id.yml:249:3

247 ###############################################################################
248
249 - name: Info list with an invalid cluster_ext_id must fail
      ^ column 3

<<< caused by >>>

Value of unknown type: <class 'urllib3.exceptions.ReadTimeoutError'>, HTTPSConnectionPool(host='10.44.76.28', port=9440): Read timed out. (read timeout=30.0)

fatal: [testhost]: FAILED! => {"changed": false, "msg": "Task failed: Module failed: Value of unknown type: <class 'urllib3.exceptions.ReadTimeoutError'>, HTTPSConnectionPool(host='10.44.76.28', port=9440): Read timed out. (read timeout=30.0)"}
...ignoring

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify info list with invalid cluster_ext_id failed with an error] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info list with invalid cluster_ext_id failed as expected"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Info get-by-id with an invalid ext_id must fail] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VPN connection info using cluster ext_id and ext_id
Origin: /tmp/ansible_wrapper/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vpn_connections_by_cluster_id_v2-iuz2fp8o-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/tasks/remote_vpn_connections_by_cluster_id.yml:265:3

263     fail_msg: "Info list with invalid cluster_ext_id did not fail"
264
265 - name: Info get-by-id with an invalid ext_id must fail
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VPN connection info using cluster ext_id and ext_id", "response": {"$objectType": "networking.v4.config.RemoteVpnConnectionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error …[truncated]
...ignoring

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify info get-by-id with invalid ext_id failed] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info get-by-id with invalid ext_id failed as expected"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Info module with ext_id AND filter must fail (mutually exclusive)] ***
[ERROR]: Task failed: Module failed: parameters are mutually exclusive: ext_id|filter
Origin: /tmp/ansible_wrapper/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vpn_connections_by_cluster_id_v2-iuz2fp8o-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/tasks/remote_vpn_connections_by_cluster_id.yml:282:3

280     fail_msg: "Info get-by-id with invalid ext_id did not fail"
281
282 - name: Info module with ext_id AND filter must fail (mutually exclusive)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify mutually-exclusive ext_id+filter is rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Ansible correctly rejected ext_id+filter as mutually exclusive"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Get-by-id module without ext_id must fail (missing required)] ***
[ERROR]: Task failed: Module failed: missing required arguments: ext_id
Origin: /tmp/ansible_wrapper/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vpn_connections_by_cluster_id_v2-iuz2fp8o-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/tasks/remote_vpn_connections_by_cluster_id.yml:299:3

297     fail_msg: "Ansible did not reject ext_id+filter"
298
299 - name: Get-by-id module without ext_id must fail (missing required)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify get-by-id module without ext_id failed on required-arg] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing ext_id was correctly rejected"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Get-by-id module without cluster_ext_id must fail (missing required)] ***
[ERROR]: Task failed: Module failed: missing required arguments: cluster_ext_id
Origin: /tmp/ansible_wrapper/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vpn_connections_by_cluster_id_v2-iuz2fp8o-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/tasks/remote_vpn_connections_by_cluster_id.yml:315:3

313     fail_msg: "Missing ext_id was NOT rejected"
314
315 - name: Get-by-id module without cluster_ext_id must fail (missing required)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: cluster_ext_id"}
...ignoring

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify get-by-id module without cluster_ext_id failed on required-arg] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing cluster_ext_id was correctly rejected"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Get-by-id module with a bogus cluster_ext_id must fail] ***
[ERROR]: Task failed: Module failed: Value of unknown type: <class 'urllib3.exceptions.ReadTimeoutError'>, HTTPSConnectionPool(host='10.44.76.28', port=9440): Read timed out. (read timeout=30.0)

Task failed: Module failed.
Origin: /tmp/ansible_wrapper/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vpn_connections_by_cluster_id_v2-iuz2fp8o-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/tasks/remote_vpn_connections_by_cluster_id.yml:331:3

329     fail_msg: "Missing cluster_ext_id was NOT rejected"
330
331 - name: Get-by-id module with a bogus cluster_ext_id must fail
      ^ column 3

<<< caused by >>>

Value of unknown type: <class 'urllib3.exceptions.ReadTimeoutError'>, HTTPSConnectionPool(host='10.44.76.28', port=9440): Read timed out. (read timeout=30.0)

fatal: [testhost]: FAILED! => {"changed": false, "msg": "Task failed: Module failed: Value of unknown type: <class 'urllib3.exceptions.ReadTimeoutError'>, HTTPSConnectionPool(host='10.44.76.28', port=9440): Read timed out. (read timeout=30.0)"}
...ignoring

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify get-by-id with a bogus cluster_ext_id failed with an API error] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Get-by-id with a bogus cluster_ext_id failed as expected"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Get-by-id module with a valid cluster_ext_id but bogus ext_id must fail] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VPN connection info using cluster ext_id and ext_id
Origin: /tmp/ansible_wrapper/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vpn_connections_by_cluster_id_v2-iuz2fp8o-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vpn_connections_by_cluster_id_v2/tasks/remote_vpn_connections_by_cluster_id.yml:348:3

346     fail_msg: "Get-by-id with a bogus cluster_ext_id did not fail"
347
348 - name: Get-by-id module with a valid cluster_ext_id but bogus ext_id must fail
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VPN connection info using cluster ext_id and ext_id", "response": {"$objectType": "networking.v4.config.RemoteVpnConnectionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error …[truncated]
...ignoring

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify get-by-id with bogus ext_id failed with an API error] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Get-by-id with bogus ext_id failed as expected"
}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Info list check_mode dry-run passes (module is read-only)] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_remote_vpn_connections_by_cluster_id_v2 : Verify [ERROR]: Task failed: Module failed: Api Exception raised while fetching remote subnets info
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/integration/targets/ntnx_remote_subnets_by_cluster_ids_info_v2/tasks/remote_subnets_by_cluster_ids_info.yml:197:3

195 ##############################################################################
196
197 - name: List remote subnets with OData filter (startswith)
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote subnets info", "response": {"$objectType": "networking.v4.config.GetRemoteSubnetApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.A …[truncated]
...ignoring

TASK [Assert filter returns a well-formed module response] *********************
ok: [localhost] => {
    "changed": false,
    "msg": "LIST remote subnets with OData filter returned a well-formed response."
}

TASK [Assert every filtered entry starts with 'a' (case-insensitive)] **********
[ERROR]: The `loop` value must resolve to a 'list', not 'dict'.
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/integration/targets/ntnx_remote_subnets_by_cluster_ids_info_v2/tasks/remote_subnets_by_cluster_ids_info.yml:220:9

218     success_msg: "Filter honored for entry {{ item.name }}."
219     fail_msg: "Filter violated for entry {{ item.name }}."
220   loop: "{{ list_filter_result.response | default([]) }}"
            ^ column 9

Provide a list of items/templates, or a template resolving to a list.

fatal: [localhost]: FAILED! => {"changed": false, "msg": "The `loop` value must resolve to a 'list', not 'dict'."}

PLAY RECAP *********************************************************************
localhost                  : ok=17   changed=0    unreachable=0    failed=1    skipped=2    rescued=0    ignored=5   

```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- SDK: `ntnx_networking_py_client` (pinned in `requirements.txt`).
- Sanity / lint / test run locally against a live Prism Central at `10.44.76.28`.
