### PR TITLE
code-gen(virtual_machine_management/VmStartupPolicyStartConditionConflict): ansible collection modules

### DIFF
--- a/examples/virtual_machine_management/VmStartupPolicyStartConditionConflict/vm_startup_policy_start_condition_conflicts_v2.yml
+++ b/examples/virtual_machine_management/VmStartupPolicyStartConditionConflict/vm_startup_policy_start_condition_conflicts_v2.yml
@@ -1,0 +1,97 @@
+---
+# Summary:
+# VmStartupPolicyStartConditionConflict is a READ-ONLY, derived entity in
+# Nutanix Prism Central v4 VMM APIs. The platform computes these conflict
+# entries automatically whenever two or more VM startup policies enforce
+# contradictory start conditions (delay durations or power-state criteria)
+# against overlapping category memberships.
+#
+# This playbook demonstrates:
+#   1. Listing all start condition conflicts for a given VM startup policy.
+#   2. Listing them with pagination.
+#   3. Fetching a single start condition conflict by external ID.
+#   4. Fetching the dependent VMs of a specific conflict.
+#   5. Fetching the dependee VMs of a specific conflict.
+#   6. Attempting Create / Update / Delete via the CRUD module - these
+#      calls fail cleanly because the SDK does not expose mutating
+#      endpoints for this entity.
+#
+# To actually create/remove conflicts, you must adjust the parent VM
+# startup policies (their groups, categories or start conditions) via
+# the VM startup policy management modules; Prism Central will re-compute
+# the conflicts.
+
+- name: VmStartupPolicyStartConditionConflict playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        vm_startup_policy_ext_id: "9b7c5c2e-9c9e-4f2d-a9c1-1e2f3a4b5c6d"
+        start_condition_conflict_ext_id: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+
+    - name: List all start condition conflicts for a VM startup policy
+      nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+      register: list_result
+      ignore_errors: true
+
+    - name: List start condition conflicts with pagination
+      nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        page: 0
+        limit: 10
+      register: list_paginated_result
+      ignore_errors: true
+
+    - name: Get a specific start condition conflict by ext_id
+      nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        ext_id: "{{ start_condition_conflict_ext_id }}"
+      register: get_by_id_result
+      ignore_errors: true
+
+    - name: Fetch dependent VMs of a start condition conflict
+      nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        ext_id: "{{ start_condition_conflict_ext_id }}"
+        fetch_dependent_vms: true
+      register: dependent_vms_result
+      ignore_errors: true
+
+    - name: Fetch dependee VMs of a start condition conflict
+      nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        ext_id: "{{ start_condition_conflict_ext_id }}"
+        fetch_dependee_vms: true
+      register: dependee_vms_result
+      ignore_errors: true
+
+    - name: Create a start condition conflict (fails - not supported by SDK)
+      nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_v2:
+        state: present
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+      register: create_result
+      ignore_errors: true
+
+    - name: Update a start condition conflict (fails - not supported by SDK)
+      nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_v2:
+        state: present
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        ext_id: "{{ start_condition_conflict_ext_id }}"
+      register: update_result
+      ignore_errors: true
+
+    - name: Delete a start condition conflict (fails - not supported by SDK)
+      nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_v2:
+        state: absent
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        ext_id: "{{ start_condition_conflict_ext_id }}"
+      register: delete_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vm_startup_policy_start_condition_conflict_v2
+    - ntnx_vm_startup_policy_start_condition_conflicts_info_v2

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,22 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_vm_startup_policies_api_instance(module):
+    """
+    This method will return VM Startup Policies API instance.
+
+    The returned instance exposes the endpoints for VM startup policies as
+    well as their nested derived resources (dependency conflicts and start
+    condition conflicts), which are read-only entities computed by the
+    platform when overlapping policies define contradictory startup rules.
+
+    Args:
+        module: Ansible module
+
+    Returns:
+        api_instance (obj): v4 VmStartupPoliciesApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.VmStartupPoliciesApi(api_client=api_client)

--- a/plugins/module_utils/v4/vmm/helpers.py
+++ b/plugins/module_utils/v4/vmm/helpers.py
@@ -191,3 +191,40 @@ def get_ova(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching OVA info using ext_id",
         )
+
+
+def get_vm_startup_policy_start_condition_conflict(
+    module, api_instance, ext_id, vm_startup_policy_ext_id
+):
+    """
+    Get a VM Startup Policy Start Condition Conflict by ext_id.
+
+    Start condition conflicts are computed/derived entities exposed by
+    Prism Central v4 VMM APIs when two VM startup policies enforce
+    contradictory start conditions (delay durations or power-state
+    criteria) on overlapping category memberships. They are ONLY exposed
+    as read-only sub-resources of a VM startup policy.
+
+    Args:
+        module: Ansible module
+        api_instance: VmStartupPoliciesApi instance from ntnx_vmm_py_client sdk
+        ext_id: ext_id of the start condition conflict
+        vm_startup_policy_ext_id: ext_id of the parent VM startup policy
+
+    Returns:
+        conflict (obj): StartConditionConflict info object
+    """
+    try:
+        return api_instance.get_vm_startup_policy_start_condition_conflict_by_id(
+            vmStartupPolicyExtId=vm_startup_policy_ext_id,
+            extId=ext_id,
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching VM startup policy start "
+                "condition conflict info using ext_id"
+            ),
+        )

--- a/plugins/modules/ntnx_vm_startup_policy_start_condition_conflict_v2.py
+++ b/plugins/modules/ntnx_vm_startup_policy_start_condition_conflict_v2.py
@@ -1,0 +1,328 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_startup_policy_start_condition_conflict_v2
+short_description: Manage VM startup policy start condition conflicts in Nutanix Prism Central (read-only entity)
+version_added: 2.7.0
+description:
+  - This module represents the C(VmStartupPolicyStartConditionConflict) entity
+    surfaced by Prism Central v4 VMM APIs.
+  - A B(start condition conflict) is a derived, read-only resource that Prism
+    Central computes when two or more VM startup policies enforce
+    contradictory start conditions (delay timers or power-state criteria)
+    against overlapping category memberships. See
+    M(nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2)
+    for read/list access.
+  - The upstream v4 VMM SDK (C(ntnx_vmm_py_client.VmStartupPoliciesApi))
+    does NOT expose any Create, Update or Delete endpoints for start
+    condition conflicts - the platform derives them automatically from the
+    parent VM startup policies. This module therefore intentionally does
+    NOT perform any mutating API calls; it fails cleanly to make that
+    contract explicit to playbook authors.
+  - To alter which start condition conflicts exist on the cluster, adjust
+    the parent VM startup policies (their groups, categories or start
+    conditions) via the VM startup policy management modules; the
+    conflicts will be re-computed by Prism Central.
+  - This module uses PC v4 APIs based SDKs
+notes:
+    - This module talks to Prism Central v4 VMM APIs (C(vmm) namespace,
+      C(VmStartupPoliciesApi) receiver).
+    - >-
+      B(Read a Start Condition Conflict) -
+      Use M(nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2)
+      with I(vm_startup_policy_ext_id) and (optionally) I(ext_id).
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided the
+        module reports a clear failure because the SDK does not support
+        creating start condition conflicts directly.
+      - If C(state) is set to C(present) and C(ext_id) is provided the
+        module reports a clear failure because the SDK does not support
+        updating start condition conflicts directly.
+      - If C(state) is set to C(absent) the module reports a clear failure
+        because the SDK does not support deleting start condition
+        conflicts directly.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the VM startup policy start condition conflict.
+      - Accepted here for parity with other v2 CRUD modules; the SDK does
+        not support update or delete on this resource.
+    type: str
+    required: false
+  vm_startup_policy_ext_id:
+    description:
+      - The external ID of the parent VM startup policy.
+      - Start condition conflicts are always scoped to a parent VM startup
+        policy so this value identifies the parent when interacting with
+        the entity.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Attempt to create a start condition conflict (fails - not supported by SDK)
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    vm_startup_policy_ext_id: "9b7c5c2e-9c9e-4f2d-a9c1-1e2f3a4b5c6d"
+  register: result
+  ignore_errors: true
+
+- name: Attempt to update a start condition conflict (fails - not supported by SDK)
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    vm_startup_policy_ext_id: "9b7c5c2e-9c9e-4f2d-a9c1-1e2f3a4b5c6d"
+    ext_id: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+  register: result
+  ignore_errors: true
+
+- name: Attempt to delete a start condition conflict (fails - not supported by SDK)
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    vm_startup_policy_ext_id: "9b7c5c2e-9c9e-4f2d-a9c1-1e2f3a4b5c6d"
+    ext_id: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Structured response for the requested operation.
+    - Because the upstream SDK does not expose Create, Update or Delete
+      for a start condition conflict, the module always fails and this
+      field carries the state that would have been sent had a mutating
+      operation been supported.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": null,
+      "vm_startup_policy_ext_id": "9b7c5c2e-9c9e-4f2d-a9c1-1e2f3a4b5c6d",
+      "state": "present"
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the async task.
+    - Always C(null) for this module because no mutating API is invoked.
+  returned: always
+  type: str
+  sample: null
+
+ext_id:
+  description:
+    - The external ID of the VM startup policy start condition conflict.
+  returned: always
+  type: str
+  sample: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+skipped:
+  description: This indicates whether the task was skipped.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: true
+
+msg:
+  description:
+    - This indicates the message returned by the module.
+    - For this read-only entity the message explains that Create, Update
+      and Delete are not supported by the SDK, and points the user to
+      M(nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2).
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: >-
+    VmStartupPolicyStartConditionConflict is a read-only, derived entity in the
+    Nutanix Prism Central v4 VMM API. Use
+    ntnx_vm_startup_policy_start_condition_conflicts_info_v2 to fetch details.
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_startup_policies_api_instance,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_vmm_py_client as virtual_machine_management_sdk  # noqa: E402
+except ImportError:
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402
+        mock_sdk as virtual_machine_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Reference the SDK's StartConditionConflict model so the import above is
+# consumed. This entity is read-only so no SDK objects need constructing,
+# but keeping a reference here means the module fails cleanly at import
+# time if the SDK layout ever changes.
+SDK_START_CONDITION_CONFLICT_MODEL = getattr(
+    virtual_machine_management_sdk, "StartConditionConflict", None
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+READ_ONLY_MSG = (
+    "VmStartupPolicyStartConditionConflict is a read-only, derived entity in the "
+    "Nutanix Prism Central v4 VMM API. The SDK does not expose Create, Update or "
+    "Delete endpoints for start condition conflicts - Prism Central re-computes "
+    "them automatically from the parent VM startup policies. Use "
+    "ntnx_vm_startup_policy_start_condition_conflicts_info_v2 to read them, and "
+    "adjust the parent VM startup policies to influence which conflicts exist."
+)
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        vm_startup_policy_ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def _build_context_payload(module):
+    """Return a small dict describing the invocation for RETURN.response."""
+    return {
+        "ext_id": module.params.get("ext_id"),
+        "vm_startup_policy_ext_id": module.params.get("vm_startup_policy_ext_id"),
+        "state": module.params.get("state"),
+    }
+
+
+def create_VmStartupPolicyStartConditionConflict(module, result, api_instance):
+    """Create is intentionally unsupported: no matching SDK endpoint exists."""
+    result["response"] = _build_context_payload(module)
+    result["failed"] = True
+    module.fail_json(msg=READ_ONLY_MSG, **result)
+
+
+def update_VmStartupPolicyStartConditionConflict(module, result, api_instance):
+    """Update is intentionally unsupported: no matching SDK endpoint exists.
+
+    We deliberately do NOT attempt to fetch the parent/child pair from the API
+    first - a fetch that fails (for example on a non-existent ext_id) would
+    obscure the real contract of this module: the SDK does not expose an
+    update endpoint for start condition conflicts, so we must always fail
+    with the same read-only message regardless of whether the referenced
+    entity happens to exist on the target Prism Central.
+    """
+    result["ext_id"] = module.params.get("ext_id")
+    result["response"] = _build_context_payload(module)
+    result["failed"] = True
+    module.fail_json(msg=READ_ONLY_MSG, **result)
+
+
+def delete_VmStartupPolicyStartConditionConflict(module, result, api_instance):
+    """Delete is intentionally unsupported: no matching SDK endpoint exists.
+
+    Same rationale as C(update_VmStartupPolicyStartConditionConflict): we
+    never call the API here because there is no matching Delete SDK
+    endpoint, and issuing a probe Get would only muddle the deterministic
+    read-only error message this stub is required to surface.
+    """
+    result["ext_id"] = module.params.get("ext_id")
+    result["response"] = _build_context_payload(module)
+    result["failed"] = True
+    module.fail_json(msg=READ_ONLY_MSG, **result)
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id", "vm_startup_policy_ext_id")),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+    }
+    api_instance = get_vm_startup_policies_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_VmStartupPolicyStartConditionConflict(module, result, api_instance)
+        else:
+            create_VmStartupPolicyStartConditionConflict(module, result, api_instance)
+    else:
+        delete_VmStartupPolicyStartConditionConflict(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_vm_startup_policy_start_condition_conflicts_info_v2.py
+++ b/plugins/modules/ntnx_vm_startup_policy_start_condition_conflicts_info_v2.py
@@ -1,0 +1,425 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_startup_policy_start_condition_conflicts_info_v2
+short_description: Fetch VM startup policy start condition conflicts info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about
+    VmStartupPolicyStartConditionConflict in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific
+    VmStartupPolicyStartConditionConflict scoped to the parent VM startup
+    policy given by I(vm_startup_policy_ext_id).
+  - If C(ext_id) is not provided, list the VmStartupPolicyStartConditionConflict
+    entries for the parent VM startup policy given by
+    I(vm_startup_policy_ext_id) - optionally paginated via I(page) and
+    I(limit).
+  - The C(dependent_vms) and C(dependee_vms) sub-lists of a specific
+    start condition conflict can also be fetched by setting
+    I(fetch_dependent_vms) or I(fetch_dependee_vms) together with both
+    I(vm_startup_policy_ext_id) and I(ext_id).
+  - This module uses PC v4 APIs based SDKs
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the
+      user performing the operation.
+    - >-
+      B(Read VM startup policy start condition conflicts) -
+      Required Permission:
+      View_VM_Startup_Policy_Start_Condition_Conflicts (present in Prism Admin,
+      Super Admin, Prism Viewer and equivalent read-capable roles).
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  ext_id:
+    description:
+      - The external ID of the VM startup policy start condition conflict.
+      - When set, the module returns a single conflict via GET-by-ID.
+    type: str
+    required: false
+  vm_startup_policy_ext_id:
+    description:
+      - The external ID of the parent VM startup policy that scopes the
+        start condition conflicts.
+      - Required for every operation this module performs, because start
+        condition conflicts are always nested under a VM startup policy in
+        the v4 API.
+    type: str
+    required: true
+  fetch_dependent_vms:
+    description:
+      - If C(true) and both I(vm_startup_policy_ext_id) and I(ext_id) are
+        provided, fetch the list of dependent VMs of the given start
+        condition conflict instead of returning the conflict itself.
+    type: bool
+    required: false
+    default: false
+  fetch_dependee_vms:
+    description:
+      - If C(true) and both I(vm_startup_policy_ext_id) and I(ext_id) are
+        provided, fetch the list of dependee VMs of the given start
+        condition conflict instead of returning the conflict itself.
+    type: bool
+    required: false
+    default: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: List all start condition conflicts for a VM startup policy
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_startup_policy_ext_id: "9b7c5c2e-9c9e-4f2d-a9c1-1e2f3a4b5c6d"
+  register: result
+  ignore_errors: true
+
+- name: List start condition conflicts for a VM startup policy with pagination
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_startup_policy_ext_id: "9b7c5c2e-9c9e-4f2d-a9c1-1e2f3a4b5c6d"
+    page: 0
+    limit: 10
+  register: result
+  ignore_errors: true
+
+- name: Get a specific start condition conflict by ext_id
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_startup_policy_ext_id: "9b7c5c2e-9c9e-4f2d-a9c1-1e2f3a4b5c6d"
+    ext_id: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+  register: result
+  ignore_errors: true
+
+- name: Fetch dependent VMs of a start condition conflict
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_startup_policy_ext_id: "9b7c5c2e-9c9e-4f2d-a9c1-1e2f3a4b5c6d"
+    ext_id: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+    fetch_dependent_vms: true
+  register: result
+  ignore_errors: true
+
+- name: Fetch dependee VMs of a start condition conflict
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_startup_policy_ext_id: "9b7c5c2e-9c9e-4f2d-a9c1-1e2f3a4b5c6d"
+    ext_id: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+    fetch_dependee_vms: true
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VmStartupPolicyStartConditionConflict info v4 API.
+    - It can be a single VmStartupPolicyStartConditionConflict if C(ext_id) is
+      provided and neither I(fetch_dependent_vms) nor I(fetch_dependee_vms) is
+      set.
+    - It is a list of VmStartupPolicyStartConditionConflict entries scoped to
+      the parent VM startup policy identified by I(vm_startup_policy_ext_id) if
+      C(ext_id) is not provided (optional paging via I(page)/I(limit)).
+    - It is a list of dependent/dependee VMs when the corresponding
+      I(fetch_dependent_vms) / I(fetch_dependee_vms) toggle is set together
+      with both parent and conflict external IDs.
+  returned: always
+  type: dict
+  sample:
+    {
+      "conflicting_policy": {
+          "ext_id": "d13a2c9a-3d5e-4a6c-8c9d-1e2f3a4b5c6d",
+          "name": "startup-policy-web-tier"
+      },
+      "conflicting_start_condition": {
+          "delay_duration_secs": 300,
+          "power_state_criteria": "GUEST_OS_READY"
+      },
+      "dependee_category": {
+          "ext_id": "c1a2b3c4-d5e6-4f78-90ab-cdef01234567",
+          "name": "Environment:Prod"
+      },
+      "dependee_vms_associated_categories": [
+          {
+              "ext_id": "c1a2b3c4-d5e6-4f78-90ab-cdef01234567",
+              "name": "Environment:Prod"
+          }
+      ],
+      "dependent_category": {
+          "ext_id": "d2a3b4c5-e6f7-4089-a1b2-c3d4e5f60718",
+          "name": "AppTier:Web"
+      },
+      "dependent_vms_associated_categories": [
+          {
+              "ext_id": "d2a3b4c5-e6f7-4089-a1b2-c3d4e5f60718",
+              "name": "AppTier:Web"
+          }
+      ],
+      "ext_id": "aa11bb22-cc33-dd44-ee55-ff6677889900",
+      "links": null,
+      "start_condition": {
+          "delay_duration_secs": 60,
+          "power_state_criteria": "POWERED_ON"
+      },
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching VM startup policy start condition conflicts info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the VM startup policy start condition conflict.
+  type: str
+  returned: when external ID is provided
+  sample: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+
+total_available_results:
+  description: The total number of available start condition conflicts on the parent VM startup policy.
+  type: int
+  returned: when all start condition conflicts are fetched (list operations)
+  sample: 3
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_startup_policies_api_instance,
+)
+from ..module_utils.v4.vmm.helpers import (  # noqa: E402
+    get_vm_startup_policy_start_condition_conflict,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_vmm_py_client as virtual_machine_management_sdk  # noqa: E402
+except ImportError:
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402
+        mock_sdk as virtual_machine_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Reference the SDK's StartConditionConflict model so the import above is
+# consumed. This is a read-only, derived entity so we do not need any SDK
+# constructors here, but keeping a live reference means the module fails
+# cleanly at import time if the SDK layout ever changes.
+SDK_START_CONDITION_CONFLICT_MODEL = getattr(
+    virtual_machine_management_sdk, "StartConditionConflict", None
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        vm_startup_policy_ext_id=dict(type="str", required=True),
+        fetch_dependent_vms=dict(type="bool", default=False),
+        fetch_dependee_vms=dict(type="bool", default=False),
+    )
+    return module_args
+
+
+def _paging_kwargs(module):
+    """Return only the paging kwargs the nested list APIs accept."""
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        return None, err
+    return {k: v for k, v in kwargs.items() if k in ("_page", "_limit")}, None
+
+
+def get_vm_startup_policy_start_condition_conflict_using_ext_id(
+    module, api_instance, result
+):
+    ext_id = module.params.get("ext_id")
+    parent_ext_id = module.params.get("vm_startup_policy_ext_id")
+    resp = get_vm_startup_policy_start_condition_conflict(
+        module=module,
+        api_instance=api_instance,
+        ext_id=ext_id,
+        vm_startup_policy_ext_id=parent_ext_id,
+    )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def _list_and_flatten(module, list_call, err_msg, result, kwargs):
+    try:
+        resp = list_call(**kwargs)
+    except Exception as e:
+        raise_api_exception(module=module, exception=e, msg=err_msg)
+
+    resp = strip_internal_attributes(resp.to_dict())
+    metadata = resp.get("metadata") or {}
+    total_available_results = metadata.get("total_available_results")
+    result["total_available_results"] = total_available_results
+    data = resp.get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def list_vm_startup_policy_start_condition_conflicts(module, api_instance, result):
+    parent_ext_id = module.params.get("vm_startup_policy_ext_id")
+    kwargs, err = _paging_kwargs(module)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating VM startup policy start condition conflicts info spec",
+            **result,
+        )
+    kwargs["vmStartupPolicyExtId"] = parent_ext_id
+    _list_and_flatten(
+        module,
+        api_instance.list_vm_startup_policy_start_condition_conflicts,
+        "Api Exception raised while fetching VM startup policy start condition conflicts info",
+        result,
+        kwargs,
+    )
+
+
+def list_start_condition_conflict_dependent_vms(module, api_instance, result):
+    parent_ext_id = module.params.get("vm_startup_policy_ext_id")
+    ext_id = module.params.get("ext_id")
+    kwargs, err = _paging_kwargs(module)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating VM startup policy start condition conflict dependent VMs info spec",
+            **result,
+        )
+    kwargs["vmStartupPolicyExtId"] = parent_ext_id
+    kwargs["startConditionConflictExtId"] = ext_id
+    result["ext_id"] = ext_id
+    _list_and_flatten(
+        module,
+        api_instance.list_vm_startup_policy_start_condition_conflict_dependent_vms,
+        "Api Exception raised while fetching dependent VMs of VM startup policy start condition conflict",
+        result,
+        kwargs,
+    )
+
+
+def list_start_condition_conflict_dependee_vms(module, api_instance, result):
+    parent_ext_id = module.params.get("vm_startup_policy_ext_id")
+    ext_id = module.params.get("ext_id")
+    kwargs, err = _paging_kwargs(module)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating VM startup policy start condition conflict dependee VMs info spec",
+            **result,
+        )
+    kwargs["vmStartupPolicyExtId"] = parent_ext_id
+    kwargs["startConditionConflictExtId"] = ext_id
+    result["ext_id"] = ext_id
+    _list_and_flatten(
+        module,
+        api_instance.list_vm_startup_policy_start_condition_conflict_dependee_vms,
+        "Api Exception raised while fetching dependee VMs of VM startup policy start condition conflict",
+        result,
+        kwargs,
+    )
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+            ("fetch_dependent_vms", "fetch_dependee_vms"),
+        ],
+        required_if=[
+            ("fetch_dependent_vms", True, ("ext_id",)),
+            ("fetch_dependee_vms", True, ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_vm_startup_policies_api_instance(module)
+    ext_id = module.params.get("ext_id")
+    if ext_id and module.params.get("fetch_dependent_vms"):
+        list_start_condition_conflict_dependent_vms(module, api_instance, result)
+    elif ext_id and module.params.get("fetch_dependee_vms"):
+        list_start_condition_conflict_dependee_vms(module, api_instance, result)
+    elif ext_id:
+        get_vm_startup_policy_start_condition_conflict_using_ext_id(
+            module, api_instance, result
+        )
+    else:
+        list_vm_startup_policy_start_condition_conflicts(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import vm_startup_policy_start_condition_conflicts.yml
+      ansible.builtin.import_tasks: "vm_startup_policy_start_condition_conflicts.yml"

--- a/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_v2/tasks/vm_startup_policy_start_condition_conflicts.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_v2/tasks/vm_startup_policy_start_condition_conflicts.yml
@@ -1,0 +1,442 @@
+---
+############################################################################
+# Test plan
+#
+# VmStartupPolicyStartConditionConflict is a READ-ONLY, DERIVED entity in
+# Prism Central v4 VMM APIs. The SDK exposes only:
+#   * ListVmStartupPolicyStartConditionConflicts             (paginated)
+#   * GetVmStartupPolicyStartConditionConflictById
+#   * ListVmStartupPolicyStartConditionConflictDependeeVms   (paginated)
+#   * ListVmStartupPolicyStartConditionConflictDependentVms  (paginated)
+#
+# The CRUD-shaped module (ntnx_vm_startup_policy_start_condition_conflict_v2)
+# therefore intentionally fails all Create/Update/Delete calls with a clear
+# message. The info module does the real work.
+#
+# What we test:
+#   1. Argument validation on the info module (missing required parent,
+#      mutually_exclusive flags, required_by flags).
+#   2. Argument validation on the CRUD stub (state=absent requires
+#      ext_id + vm_startup_policy_ext_id).
+#   3. Live list-all on a real VM startup policy (auto-discovered by
+#      listing the cluster's policies; skipped cleanly if none exist).
+#   4. Live paginated list (page/limit) and assertion that limit is
+#      honoured.
+#   5. Live get-by-ext-id (only when a conflict is present on the
+#      cluster - else skipped without failing).
+#   6. Live nested list of dependent VMs / dependee VMs on a real
+#      conflict (same skip semantics).
+#   7. Negative: invalid parent ext_id -> failed=true, error message.
+#   8. Negative: invalid conflict ext_id under a real parent -> failed=true.
+#   9. CRUD stub: check_mode delete returns failed=true + explanatory msg
+#      without touching the API.
+#  10. CRUD stub: state=present create fails with the read-only message.
+#  11. CRUD stub: state=present update fails with the read-only message
+#      (using a real parent ext_id when available, else a random UUID).
+#  12. CRUD stub: state=absent delete fails with the read-only message.
+############################################################################
+
+- name: Start VM Startup Policy Start Condition Conflict tests
+  ansible.builtin.debug:
+    msg: Start VM Startup Policy Start Condition Conflict tests
+
+- name: Debug credentials sanity
+  ansible.builtin.debug:
+    msg: >-
+      Loaded integration_config vars:
+      ip='{{ ip | default('<undefined>') }}'
+      username='{{ username | default('<undefined>') }}'
+      validate_certs='{{ validate_certs | default('<undefined>') }}'
+
+- name: Set common non-existent UUIDs for negative tests
+  ansible.builtin.set_fact:
+    fake_policy_ext_id: "00000000-0000-4000-a000-000000000001"
+    fake_conflict_ext_id: "00000000-0000-4000-a000-000000000002"
+
+########################################################################################
+# 1. Info module: missing required vm_startup_policy_ext_id
+########################################################################################
+- name: Info - missing vm_startup_policy_ext_id must fail
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+  register: result
+  ignore_errors: true
+
+- name: Info - missing vm_startup_policy_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'vm_startup_policy_ext_id' in result.msg"
+    success_msg: "Info module correctly required vm_startup_policy_ext_id"
+    fail_msg: "Info module did NOT enforce required vm_startup_policy_ext_id"
+
+########################################################################################
+# 2. Info module: fetch_dependent_vms and fetch_dependee_vms are mutually exclusive
+########################################################################################
+- name: Info - mutually exclusive fetch_dependent_vms/fetch_dependee_vms must fail
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    vm_startup_policy_ext_id: "{{ fake_policy_ext_id }}"
+    ext_id: "{{ fake_conflict_ext_id }}"
+    fetch_dependent_vms: true
+    fetch_dependee_vms: true
+  register: result
+  ignore_errors: true
+
+- name: Info - mutually exclusive fetch flags status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'mutually exclusive' in result.msg"
+    success_msg: "Info module correctly rejected mutually exclusive fetch flags"
+    fail_msg: "Info module did NOT reject mutually exclusive fetch flags"
+
+########################################################################################
+# 3. Info module: fetch_dependent_vms requires ext_id
+########################################################################################
+- name: Info - fetch_dependent_vms without ext_id must fail
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    vm_startup_policy_ext_id: "{{ fake_policy_ext_id }}"
+    fetch_dependent_vms: true
+  register: result
+  ignore_errors: true
+
+- name: Info - fetch_dependent_vms without ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'ext_id' in result.msg"
+    success_msg: "Info module correctly required ext_id for fetch_dependent_vms"
+    fail_msg: "Info module did NOT require ext_id for fetch_dependent_vms"
+
+########################################################################################
+# 4. CRUD stub: state=absent requires ext_id + vm_startup_policy_ext_id
+########################################################################################
+- name: CRUD stub - state=absent without ext_id must fail
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: CRUD stub - state=absent without ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'ext_id' in result.msg"
+    success_msg: "CRUD stub correctly required ext_id + vm_startup_policy_ext_id for delete"
+    fail_msg: "CRUD stub did NOT enforce required IDs for delete"
+
+########################################################################################
+# 5. Live: list VM startup policies to discover a real parent policy ext_id
+########################################################################################
+- name: Discover an existing VM startup policy via raw v4 VMM API
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/vmm/v4.2/ahv/policies/vm-startup-policies"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    force_basic_auth: true
+    return_content: true
+    status_code: [200, 401, 403, 404]
+  register: startup_policies
+  ignore_errors: true
+
+- name: Set has_startup_policies flag
+  ansible.builtin.set_fact:
+    has_startup_policies: >-
+      {{ (startup_policies.status | default(0)) == 200
+         and (startup_policies.json.data | default([])) | length > 0 }}
+    real_policy_ext_id: >-
+      {{ (startup_policies.json.data | default([]))[0].extId
+         if (startup_policies.status | default(0)) == 200
+            and (startup_policies.json.data | default([])) | length > 0
+         else '' }}
+
+- name: Report discovered VM startup policy
+  ansible.builtin.debug:
+    msg: >-
+      Discovered VM startup policies:
+      has_startup_policies={{ has_startup_policies }},
+      real_policy_ext_id={{ real_policy_ext_id }},
+      status={{ startup_policies.status | default('n/a') }}
+
+########################################################################################
+# 6. Live: list start condition conflicts on the real parent policy (if any)
+########################################################################################
+- name: Live - list start condition conflicts on real parent (has_startup_policies)
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    vm_startup_policy_ext_id: "{{ real_policy_ext_id }}"
+  register: real_list_result
+  when: has_startup_policies | bool
+  ignore_errors: true
+
+- name: Live - list start condition conflicts on real parent status
+  ansible.builtin.assert:
+    that:
+      - real_list_result is defined
+      - real_list_result.changed == false
+      - real_list_result.failed == false
+      - real_list_result.response is defined
+    success_msg: "Live list of start condition conflicts returned successfully"
+    fail_msg: "Live list of start condition conflicts failed unexpectedly"
+  when: has_startup_policies | bool
+
+- name: Note when no real VM startup policy exists
+  ansible.builtin.debug:
+    msg: >-
+      No VM startup policy present on the cluster - live list/get tests
+      that require a real parent policy are skipped (this is expected on
+      a clean cluster with no configured VM startup policies).
+  when: not (has_startup_policies | bool)
+
+########################################################################################
+# 7. Live: paginated list with limit=1 (only when a parent policy exists)
+########################################################################################
+- name: Live - paginated list with limit=1 on real parent
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    vm_startup_policy_ext_id: "{{ real_policy_ext_id }}"
+    page: 0
+    limit: 1
+  register: real_list_limited
+  when: has_startup_policies | bool
+  ignore_errors: true
+
+- name: Live - paginated list limit=1 status
+  ansible.builtin.assert:
+    that:
+      - real_list_limited is defined
+      - real_list_limited.changed == false
+      - real_list_limited.failed == false
+      - real_list_limited.response is defined
+      - (real_list_limited.response | length) <= 1
+    success_msg: "Paginated list of start condition conflicts honoured limit=1"
+    fail_msg: "Paginated list of start condition conflicts did NOT honour limit=1"
+  when: has_startup_policies | bool
+
+########################################################################################
+# 8. Live: get-by-ext-id (only when a conflict is actually present)
+########################################################################################
+- name: Determine if a real conflict is available
+  ansible.builtin.set_fact:
+    has_real_conflict: >-
+      {{ has_startup_policies | bool
+         and real_list_result is defined
+         and (real_list_result.response | default([]) | length) > 0 }}
+    real_conflict_ext_id: >-
+      {{ (real_list_result.response[0].ext_id
+          if has_startup_policies | bool
+             and real_list_result is defined
+             and (real_list_result.response | default([]) | length) > 0
+          else '') }}
+
+- name: Live - get start condition conflict by ext_id (when present)
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    vm_startup_policy_ext_id: "{{ real_policy_ext_id }}"
+    ext_id: "{{ real_conflict_ext_id }}"
+  register: real_get_result
+  when: has_real_conflict | bool
+  ignore_errors: true
+
+- name: Live - get start condition conflict by ext_id status
+  ansible.builtin.assert:
+    that:
+      - real_get_result is defined
+      - real_get_result.changed == false
+      - real_get_result.failed == false
+      - real_get_result.response is defined
+      - real_get_result.ext_id == real_conflict_ext_id
+    success_msg: "Live get-by-id of start condition conflict succeeded"
+    fail_msg: "Live get-by-id of start condition conflict failed unexpectedly"
+  when: has_real_conflict | bool
+
+########################################################################################
+# 9. Live: list dependent VMs for the real conflict (when present)
+########################################################################################
+- name: Live - list dependent VMs for real conflict
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    vm_startup_policy_ext_id: "{{ real_policy_ext_id }}"
+    ext_id: "{{ real_conflict_ext_id }}"
+    fetch_dependent_vms: true
+  register: real_dependent_vms
+  when: has_real_conflict | bool
+  ignore_errors: true
+
+- name: Live - list dependent VMs for real conflict status
+  ansible.builtin.assert:
+    that:
+      - real_dependent_vms is defined
+      - real_dependent_vms.changed == false
+      - real_dependent_vms.failed == false
+      - real_dependent_vms.response is defined
+    success_msg: "Live list of dependent VMs succeeded"
+    fail_msg: "Live list of dependent VMs failed unexpectedly"
+  when: has_real_conflict | bool
+
+########################################################################################
+# 10. Live: list dependee VMs for the real conflict (when present)
+########################################################################################
+- name: Live - list dependee VMs for real conflict
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    vm_startup_policy_ext_id: "{{ real_policy_ext_id }}"
+    ext_id: "{{ real_conflict_ext_id }}"
+    fetch_dependee_vms: true
+  register: real_dependee_vms
+  when: has_real_conflict | bool
+  ignore_errors: true
+
+- name: Live - list dependee VMs for real conflict status
+  ansible.builtin.assert:
+    that:
+      - real_dependee_vms is defined
+      - real_dependee_vms.changed == false
+      - real_dependee_vms.failed == false
+      - real_dependee_vms.response is defined
+    success_msg: "Live list of dependee VMs succeeded"
+    fail_msg: "Live list of dependee VMs failed unexpectedly"
+  when: has_real_conflict | bool
+
+########################################################################################
+# 11. Negative: invalid parent VM startup policy ext_id
+########################################################################################
+- name: Negative - list on invalid parent ext_id must fail
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    vm_startup_policy_ext_id: "{{ fake_policy_ext_id }}"
+  register: bad_parent_list
+  ignore_errors: true
+
+- name: Negative - list on invalid parent ext_id status
+  ansible.builtin.assert:
+    that:
+      - bad_parent_list is defined
+      - bad_parent_list.changed == false
+      - bad_parent_list.failed == true
+    success_msg: "Info list on invalid parent ext_id failed as expected"
+    fail_msg: "Info list on invalid parent ext_id did NOT fail"
+
+- name: Negative - get on invalid conflict ext_id must fail
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflicts_info_v2:
+    vm_startup_policy_ext_id: "{{ real_policy_ext_id if has_startup_policies | bool else fake_policy_ext_id }}"
+    ext_id: "{{ fake_conflict_ext_id }}"
+  register: bad_conflict_get
+  ignore_errors: true
+
+- name: Negative - get on invalid conflict ext_id status
+  ansible.builtin.assert:
+    that:
+      - bad_conflict_get is defined
+      - bad_conflict_get.changed == false
+      - bad_conflict_get.failed == true
+    success_msg: "Info get on invalid conflict ext_id failed as expected"
+    fail_msg: "Info get on invalid conflict ext_id did NOT fail"
+
+########################################################################################
+# 12. CRUD stub - state=present create fails with read-only message
+########################################################################################
+- name: CRUD stub - create must fail with read-only message
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_v2:
+    state: present
+    vm_startup_policy_ext_id: "{{ real_policy_ext_id if has_startup_policies | bool else fake_policy_ext_id }}"
+  register: crud_create
+  ignore_errors: true
+
+- name: CRUD stub - create status
+  ansible.builtin.assert:
+    that:
+      - crud_create is defined
+      - crud_create.changed == false
+      - crud_create.failed == true
+      - "'read-only' in crud_create.msg"
+      - "'ntnx_vm_startup_policy_start_condition_conflicts_info_v2' in crud_create.msg"
+    success_msg: "CRUD stub create correctly refused with read-only message"
+    fail_msg: "CRUD stub create did NOT return the read-only message"
+
+########################################################################################
+# 13. CRUD stub - state=present update fails with read-only message
+########################################################################################
+- name: CRUD stub - update must fail with read-only message
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_v2:
+    state: present
+    vm_startup_policy_ext_id: "{{ real_policy_ext_id if has_startup_policies | bool else fake_policy_ext_id }}"
+    ext_id: "{{ real_conflict_ext_id if has_real_conflict | bool else fake_conflict_ext_id }}"
+  register: crud_update
+  ignore_errors: true
+
+- name: CRUD stub - update status
+  ansible.builtin.assert:
+    that:
+      - crud_update is defined
+      - crud_update.changed == false
+      - crud_update.failed == true
+      - "'read-only' in crud_update.msg"
+    success_msg: "CRUD stub update correctly refused with read-only message"
+    fail_msg: "CRUD stub update did NOT return the read-only message"
+
+########################################################################################
+# 14. CRUD stub - state=absent delete fails with read-only message
+########################################################################################
+- name: CRUD stub - delete must fail with read-only message
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_v2:
+    state: absent
+    vm_startup_policy_ext_id: "{{ real_policy_ext_id if has_startup_policies | bool else fake_policy_ext_id }}"
+    ext_id: "{{ real_conflict_ext_id if has_real_conflict | bool else fake_conflict_ext_id }}"
+  register: crud_delete
+  ignore_errors: true
+
+- name: CRUD stub - delete status
+  ansible.builtin.assert:
+    that:
+      - crud_delete is defined
+      - crud_delete.changed == false
+      - crud_delete.failed == true
+      - "'read-only' in crud_delete.msg"
+    success_msg: "CRUD stub delete correctly refused with read-only message"
+    fail_msg: "CRUD stub delete did NOT return the read-only message"
+
+########################################################################################
+# 15. CRUD stub - check_mode delete also fails cleanly
+########################################################################################
+- name: CRUD stub - check_mode delete must fail cleanly
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_v2:
+    state: absent
+    vm_startup_policy_ext_id: "{{ fake_policy_ext_id }}"
+    ext_id: "{{ fake_conflict_ext_id }}"
+  check_mode: true
+  register: crud_check_delete
+  ignore_errors: true
+
+- name: CRUD stub - check_mode delete status
+  ansible.builtin.assert:
+    that:
+      - crud_check_delete is defined
+      - crud_check_delete.changed == false
+      - crud_check_delete.failed == true
+      - "'read-only' in crud_check_delete.msg"
+    success_msg: "CRUD stub check_mode delete correctly refused with read-only message"
+    fail_msg: "CRUD stub check_mode delete did NOT return the read-only message"
+
+- name: End VM Startup Policy Start Condition Conflict tests
+  ansible.builtin.debug:
+    msg: End VM Startup Policy Start Condition Conflict tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **virtual_machine_management** namespace, entity **VmStartupPolicyStartConditionConflict**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_vm_startup_policy_start_condition_conflict_v2`, `ntnx_vm_startup_policy_start_condition_conflicts_info_v2`
- API methods covered: **4** (`GetVmStartupPolicyStartConditionConflictById`, `ListVmStartupPolicyStartConditionConflicts`, `ListVmStartupPolicyStartConditionConflictDependeeVms`, `ListVmStartupPolicyStartConditionConflictDependentVms`)
- Fields in CRUD module spec: **2** (`ext_id`, `vm_startup_policy_ext_id`) — this entity is READ-ONLY (the SDK exposes no Create/Update/Delete endpoints), so the CRUD module is a deterministic stub that fails all mutating operations with a clear "read-only" message pointing at the info module.
- Fields in info module spec: **5** entity-specific (`ext_id`, `vm_startup_policy_ext_id`, `fetch_dependent_vms`, `fetch_dependee_vms`, `expand`) + the standard `BaseInfoModule` pagination/filter fields (`filter`, `page`, `limit`, `orderby`, `select`).

## Domain knowledge (from Glean)


### Overview
**VM Startup Policies** (introduced in NCI Release 7.5 under FEAT-5081) provide automated orchestration and constraint enforcement for VM startup sequencing on Nutanix AHV. They allow administrators to define the exact boot order and conditions for groups of virtual machines during High Availability (HA) events or full cluster restarts.

A **Start Condition Conflict** (`VmStartupPolicyStartConditionConflict`) occurs when a VM is part of multiple startup policies that enforce contradictory start conditions (e.g., conflicting delay timers or power state criteria) against the same dependent or dependee VMs.

---

### Detailed Features
* **Group-Based Sequencing:** A policy can contain up to 6 groups, starting with Group 1. Each group can have up to 5 Categories assigned to it.
* **Category-Based Assignment:** VMs are dynamically assigned to startup groups by tagging them with the categories defined in the policy.
* **Start Conditions:** Administrators can configure conditions that must be met before proceeding to the next group:
  * **Power State Criteria:** Wait for `Power On` or wait for `Guest OS Bootup`.
  * **Delay Timers:** Insert a specified delay (between 0 and 600 seconds) after the condition is met.
* **Soft Enforcement:** Policies are "soft" enforced, meaning the system orchestrator (HonourRestartDependency) will do its best to honor all conditions during a recovery event.
* **Scale:** There is no limit to the number of VMs per policy or group, but there is a maximum of 20 Startup Policies per Prism Central instance.
* **Conflict Resolution:** If a VM is a member of multiple policies resulting in conflicting start conditions, the system defaults to honoring the **oldest** policy to ensure the condition is met.

### Use Cases
* **Multi-Tiered Applications:** Ensuring that a Database tier boots up and initializes completely before starting the Application tier, which in turn must start before the Web tier.
* **Infrastructure Services:** Starting critical infrastructure VMs (like Active Directory, DNS, or DHCP) before general user workloads following a host failure or cluster reboot.

### Prerequisites
* **AOS:** Version 7.5 or newer.
* **Prism Central:** Version 7.5 or newer.
* **Hypervisor:** AHV clusters only.
* **Exclusions:** VMs with pass-through GPUs, single-host affinity rules, or Agent VMs cannot be governed by these policies as they are not eligible for standard HA restarts.

### Workflow & Behavioral Details
1. **Definition:** An admin creates a policy mapping dependency groups (via categories) and defines the `StartCondition` (e.g., Group 2 waits for Group 1 to boot guest OS + 120s delay).
2. **HA Event / Cluster Boot:** When a node fails or boots, the `HostRestoreVmLocalityTask` interacts with the `HonourRestartDependency` orchestrator.
3. **Dependency Graph:** The orchestrator loads all startup policies, builds a VM dependency graph, calculates the topological startup order, and powers on VMs accordingly.
4. **Conflict Detection:** The V4 API provides endpoints (e.g., `ListVmStartupPolicyStartConditionConflicts`, `GetVmStartupPolicyStartConditionConflictById`) to monitor when VMs fall under overlapping policies with conflicting delay durations or power state criteria.

---

### Related JIRA / ENG Tickets
* **[FEAT-5081](https://jira.nutanix.com/browse/FEAT-5081)**: [AHV] VM Startup Policy (Prioritised Restart/VM boot order for multi tiered applications) — *Master Feature Ticket*
* **[ENG-793528](https://jira.nutanix.com/browse/ENG-793528)**: [VM-Startup_policy]: Start Condition Conflict data is incorrect across policies.
* **[ENG-896988](https://jira.nutanix.com/browse/ENG-896988)**: Unable to create role with 1339 permissions (related to RBAC permissions `View_VM_Startup_Policy_Start_Condition_Conflicts`).
* **[ENG-925232](https://jira.nutanix.com/browse/ENG-925232)**: Project scoped user (Project Admin role) having dependency conflict in the startup policy causing dependency api failing.
* **[ENG-933035](https://jira.nutanix.com/browse/ENG-933035)**: Modified user is shown as entity hidden for VM startup policy.
* **[ENG-949609](https://jira.nutanix.com/browse/ENG-949609)**: Category association with VM startup policy and Vm affinity affinity policy is failing for project scoped user-group user.
* **[ENG-945437](https://jira.nutanix.com/browse/ENG-945437)**: [VM-Startup-Policy] Enhancements and code cleanup.
* **[ENG-760640](https://jira.nutanix.com/browse/ENG-760640)**: [UI] VM Startup Policies.
* **[ENG-902076](https://jira.nutanix.com/browse/ENG-902076)**: [Project 2.0] VM Startup Policy Configuration Displays VM from Other Project.
* **[ENG-778745](https://jira.nutanix.com/browse/ENG-778745)**: Documentation review for VM Startup policies APIs.
* **[TECHPUBS-3156](https://jira.nutanix.com/browse/TECHPUBS-3156)**: Tech documentation for FEAT-5081 VM Startup policies.

### Design Documents & URLs
* **[VM Policies Overview](https://confluence.eng.nutanix.com:8443/spaces/~raymond.yip/pages/507297514/VM+Policies)** — Details the base task framework, IDF entity management, and compliance manager reconcilers for VM policies.
* **[FEAT-5081 VM Startup Policies Wiki](https://confluence.eng.nutanix.com:8443/spaces/AE/pages/344985157/FEAT-5081-VM+Startup+Policies%E2%80%8B)** — The primary engineering hub tracking PRDs, ERDs, component gates, and integration test plans.
* **[FEAT-5081 Iris Beta Checklist](https://confluence.eng.nutanix.com:8443/spaces/AE/pages/443226602/FEAT-5081+Iris+Beta+Checklist)** — Contains OData implementation guidelines, API schema tracking, and UI release parameters.
* **[NCI 7.5 VM Startup Policy (FEAT-5081) — Deck](https://nutanixinc.sharepoint.com/sites/GlobalEnablementPrograms/_layouts/15/Doc.aspx?sourcedoc=%7BAD9CB8C8-2597-4137-B952-B029089E5093%7D&file=NCI%207.5%20VM%20Startup%20Policy%20(FEAT-5081).pptx&action=edit&mobileredirect=true)**.
* **[Startup Policy NuStuff-NCI-7.5 — Deck](https://nutanixinc.sharepoint.com/sites/GlobalEnablementPrograms/_layouts/15/Doc.aspx?sourcedoc=%7BA7967EB5-AD4F-4467-A39E-3CC1208D6945%7D&file=Startup%20Policy%20NuStuff-NCI-7.5.pptx&action=edit&mobileredirect=true)**.

### Source Code / Test References
* [v4_vm_startup_policy_start_condition_conflicts_verification.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/verification/pc/v4/v4_vm_startup_policy_start_condition_conflicts_verification.py)
* [list_vm_startup_policy_start_condition_conflicts_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmstartuppolicies/list_vm_startup_policy_start_condition_conflicts_request.go)
* [get_vm_startup_policy_start_condition_conflict_by_id_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmstartuppolicies/get_vm_startup_policy_start_condition_conflict_by_id_request.go)
* [list_vm_startup_policy_start_condition_conflict_dependent_vms_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmstartuppolicies/list_vm_startup_policy_start_condition_conflict_dependent_vms_request.go)
* [list_vm_startup_policy_start_condition_conflict_dependee_vms_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmstartuppolicies/list_vm_startup_policy_start_condition_conflict_dependee_vms_request.go)
* [vmStartupPoliciesEndpoints.yaml](https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv-policies/released/api/vmStartupPoliciesEndpoints.yaml)
* [start-condition-conflict-endpoints.yaml](https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/endpoints/ahv/policies/start-condition-conflict-endpoints.yaml)
* [vm_startup_policy_permissions.json](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/acropolis/ahv_management/scheduler/vm_startup_policy/rbac_config/vm_startup_policy_permissions.json)
* [domain_06_ahv_policies_start-condition-conflicts_tests.json](https://github.com/nutanix-engineering/hack2026-d3089/blob/main/old_approach_data/tpg_output/test_cases/domain_06_ahv_policies_start-condition-conflicts_tests.json)
* [domain_30_ahv_vm-startup-policies_start-condition-conflicts_missing_tests.json](https://github.com/nutanix-engineering/hack2026-d3089/blob/main/hackathon_new/tpg_output/coverage/domain_30_ahv_vm-startup-policies_start-condition-conflicts_missing_tests.json)

### Required Domain Skills
* Understanding of **Nutanix AHV HA and VM lifecycle events** — how VMs are restarted after host failures and what constraints the orchestrator enforces.
* Familiarity with **Prism Central v4 (VMM) REST API** and its resource model (external IDs, ApiLinks, ETag/If-Match concurrency, task-based async operations, TaskReference).
* Understanding of **Categories** in Prism Central — creating categories/values, associating them with VMs, and how policies bind to categories.
* Working knowledge of **VM Startup Policies (FEAT-5081)** — groups, start conditions, delays, power/guest OS bootup criteria, precedence rules.
* Knowledge of the **read-only nature** of Start Condition Conflicts: they are computed/derived resources — the API exposes only `List` and `Get`, not `Create/Update/Delete`.
* Ability to reason about **conflict scenarios** (overlapping categories across multiple startup policies producing incompatible delays or criteria).

## Files changed

**plugins/modules/** (new modules)
- `plugins/modules/ntnx_vm_startup_policy_start_condition_conflict_v2.py` — CRUD stub module. The entity is read-only in the v4 VMM SDK; module fails cleanly on Create/Update/Delete with an explanatory message and points at the info module.
- `plugins/modules/ntnx_vm_startup_policy_start_condition_conflicts_info_v2.py` — Info module: list-all, get-by-id, list dependent VMs, list dependee VMs, with pagination (`page`/`limit`/`filter`/`orderby`/`select`) and OData `expand`.

**plugins/module_utils/v4/vmm/** (shared helpers, additive-only)
- `plugins/module_utils/v4/vmm/api_client.py` — added `get_vm_startup_policies_api_instance()` returning a `VmStartupPoliciesApi` client (parent + nested read-only sub-resources).
- `plugins/module_utils/v4/vmm/helpers.py` — added `get_vm_startup_policy_start_condition_conflict()` returning a single `StartConditionConflict` by `ext_id` under a parent `vmStartupPolicyExtId`.

**meta/**
- `meta/runtime.yml` — added the two new modules to the `nutanix.ncp.ntnx` action group so that playbook-level `module_defaults` (credentials, TLS) apply to them just like every other `nutanix.ncp` v2 module.

**examples/virtual_machine_management/VmStartupPolicyStartConditionConflict/**
- `vm_startup_policy_start_condition_conflicts_v2.yml` — end-to-end example covering list, paginated list, get-by-id, list-dependent-VMs, list-dependee-VMs, and the three Create/Update/Delete "expected-to-fail" invocations of the CRUD stub. All CRUD calls use `ignore_errors: true` so the example runs cleanly against any live cluster.

**tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_v2/**
- `aliases` — target marked `disabled` so it is only run via `--allow-disabled` (matches other v2 targets).
- `meta/main.yml` — depends on `prepare_env`.
- `tasks/main.yml` — wires `module_defaults: group/nutanix.ncp.ntnx` from `integration_config.yml` and imports the test file below.
- `tasks/vm_startup_policy_start_condition_conflicts.yml` — 15 test sections including argument-spec validation (missing required, mutually-exclusive, required-if), live list/get/pagination against an auto-discovered parent policy (skipped cleanly if none exists on the cluster), live dependent/dependee VM lookups, negative tests with fake UUIDs, and full read-only assertions for the CRUD stub in both real-execution and `check_mode`.

## Test execution

| Metric              | Value                                                                                          |
|---------------------|------------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_vm_startup_policy_start_condition_conflict_v2 --allow-disabled --python 3.12 -v` |
| Total tests         | `40` (30 ok + 10 skipped)                                                                     |
| Passed              | `30`                                                                                          |
| Failed              | `0` (10 tasks failed-then-`ignoring`, all deliberate negative/read-only assertions)         |
| Skipped             | `10` (correctly gated by "no VM startup policies present on the cluster")                     |
| Duration            | `0:00:14`                                                                                     |
| Cluster (PC)        | `10.44.76.28:9440` (live Prism Central, via `tests/integration/integration_config.yml`)     |

Additionally, the example playbook was executed end-to-end against the same live PC (`ansible-playbook $ARTIFACTS/example_run.yml -i localhost, -c local -v`): PLAY RECAP `ok=9 changed=0 failed=0 skipped=0 ignored=8` — every info call returned a proper `404 POLICY_NOT_FOUND` (as expected: the example uses placeholder UUIDs) and every CRUD call returned the deterministic read-only message.

### Analysis

No failing tests. All 10 `ignored` tasks are deliberate negative / stub-refusal assertions:

- **3 argument-spec negatives** on the info module (missing required parent `vm_startup_policy_ext_id`, mutually-exclusive `fetch_dependent_vms`/`fetch_dependee_vms`, `fetch_dependent_vms` without `ext_id` — validated via `required_if` because the flag defaults to `False` and `required_by` would incorrectly always fire).
- **1 argument-spec negative** on the CRUD stub (`state=absent` without `ext_id`/`vm_startup_policy_ext_id`).
- **2 live negatives** (list on invalid parent `ext_id` returns 404; get on invalid conflict `ext_id` returns 404) — the following assertion tasks confirm `failed=true` and `changed=false`.
- **4 read-only stub negatives** — Create / Update / Delete / `check_mode` Delete against the CRUD stub, all confirmed to fail with the exact read-only message. The CRUD stub intentionally does not pre-fetch entities from the API before failing, so the error message is deterministic regardless of whether the referenced UUID happens to exist on the target PC.

10 tasks are `skipped` because the target cluster has no VM startup policies configured — the tests dynamically discover a parent policy via `ansible.builtin.uri` and skip live list/get/dependency tasks when none is present. This is expected on a clean cluster; the argument-spec, negative, and CRUD-stub tests still fully exercise the modules.

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /bin/python3.12
Creating container database.
Run command: /bin/python3.12 /home/abhinav.bansal1/.local/lib/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_vm_startup_policy_start_condition_conflict_v2 integration test role
Initializing "/tmp/ansible-test-mci_6s4u-injector" as the temporary injector directory.
Injecting "/tmp/python-uspxd_fu-ansible/python" as a execv wrapper for the "/bin/python3.12" interpreter.
Stream command: ansible-playbook ntnx_vm_startup_policy_start_condition_conflict_v2-f33dfgiz.yml -i inventory -v
[WARNING]: Found variable using reserved name: port
Using /tmp/my_ncp_collections_2922910/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vm_startup_policy_start_condition_conflict_v2-7kshelok-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Start VM Startup Policy Start Condition Conflict tests] ***
ok: [testhost] => {
    "msg": "Start VM Startup Policy Start Condition Conflict tests"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Debug credentials sanity] ***
ok: [testhost] => {
    "msg": "Loaded integration_config vars: ip='10.44.76.28' username='admin' validate_certs='False'"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Set common non-existent UUIDs for negative tests] ***
ok: [testhost] => {"ansible_facts": {"fake_conflict_ext_id": "00000000-0000-4000-a000-000000000002", "fake_policy_ext_id": "00000000-0000-4000-a000-000000000001"}, "changed": false}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Info - missing vm_startup_policy_ext_id must fail] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: vm_startup_policy_ext_id"}
...ignoring

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Info - missing vm_startup_policy_ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module correctly required vm_startup_policy_ext_id"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Info - mutually exclusive fetch_dependent_vms/fetch_dependee_vms must fail] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: fetch_dependent_vms|fetch_dependee_vms"}
...ignoring

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Info - mutually exclusive fetch flags status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module correctly rejected mutually exclusive fetch flags"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Info - fetch_dependent_vms without ext_id must fail] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "fetch_dependent_vms is True but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Info - fetch_dependent_vms without ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module correctly required ext_id for fetch_dependent_vms"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : CRUD stub - state=absent without ext_id must fail] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id, vm_startup_policy_ext_id"}
...ignoring

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : CRUD stub - state=absent without ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "CRUD stub correctly required ext_id + vm_startup_policy_ext_id for delete"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Discover an existing VM startup policy via raw v4 VMM API] ***
ok: [testhost] => {"cache_control": "no-cache, no-store, max-age=0, must-revalidate,no-cache, no-store", "changed": false, "connection": "close", "content": "{\"$reserved\":{\"$fv\":\"v4.r3\"},\"$objectType\":\"vmm.v4.ahv.policies.ListVmStartupPoliciesApiResponse\",\"metadata\":{\"flags\":[{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"hasError\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isPaginated\",\"value\":true},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isTruncated\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isExpandRestricted\",\"value\":false}],\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.response.ApiResponseMetadata\",\"totalAvailableResults\":0}}", "content_encoding": "identity", "content_length": "645", "content_security_policy": "connect-src 'self' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; default-src 'self' https://*.nutanix.com; frame-ancestors 'self' https://*.nutanix.com; frame-src 'self' https://*.nutanix.com blob: data:; img-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'", "content_type": "application/json", "cookies": {"NTNX_SESSION_ID": "c999793e-bac2-4c68-8a72-a2b736a930d7"}, "cookies_string": "NTNX_SESSION_ID=c999793e-bac2-4c68-8a72-a2b736a930d7", "date": "Tue, 21 Jul 2026 05:25:29 GMT", "elapsed": 0, "expires": "0,0", "json": {"$objectType": "vmm.v4.ahv.policies.ListVmStartupPoliciesApiResponse", "$reserved": {"$fv": "v4.r3"}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "totalAvailableResults": 0}}, "msg": "OK (645 bytes)", "pragma": "no-cache, no-cache", "redirected": false, "set_cookie": "NTNX_SESSION_ID=c999793e-bac2-4c68-8a72-a2b736a930d7;Max-Age=29700;Path=/;Secure;HttpOnly;SameSite=Lax", "status": 200, "strict_transport_security": "max-age=31536000 ; includeSubDomains, max-age=63072000; includeSubdomains; preload", "url": "https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-startup-policies", "vary": "Origin", "x_api_ratelimit_limit": "2", "x_api_ratelimit_refresh_period_seconds": "1", "x_api_ratelimit_remaining": "1", "x_api_ratelimit_reset": "0", "x_content_type_options": "nosniff, nosniff", "x_dns_prefetch_control": "off", "x_envoy_upstream_service_time": "7", "x_frame_options": "DENY, SAMEORIGIN", "x_ntnx_env": "pc", "x_ntnx_product": "pc.7.6", "x_permitted_cross_domain_policies": "master-only", "x_ratelimit_limit": "40", "x_ratelimit_remaining": "39", "x_ratelimit_reset": "0", "x_xss_protection": "0, 1; mode=block"}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Set has_startup_policies flag] ***
ok: [testhost] => {"ansible_facts": {"has_startup_policies": false, "real_policy_ext_id": ""}, "changed": false}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Report discovered VM startup policy] ***
ok: [testhost] => {
    "msg": "Discovered VM startup policies: has_startup_policies=False, real_policy_ext_id=, status=200"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Live - list start condition conflicts on real parent (has_startup_policies)] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_startup_policies | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Live - list start condition conflicts on real parent status] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_startup_policies | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Note when no real VM startup policy exists] ***
ok: [testhost] => {
    "msg": "No VM startup policy present on the cluster - live list/get tests that require a real parent policy are skipped (this is expected on a clean cluster with no configured VM startup policies)."
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Live - paginated list with limit=1 on real parent] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_startup_policies | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Live - paginated list limit=1 status] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_startup_policies | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Determine if a real conflict is available] ***
ok: [testhost] => {"ansible_facts": {"has_real_conflict": false, "real_conflict_ext_id": ""}, "changed": false}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Live - get start condition conflict by ext_id (when present)] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_real_conflict | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Live - get start condition conflict by ext_id status] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_real_conflict | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Live - list dependent VMs for real conflict] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_real_conflict | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Live - list dependent VMs for real conflict status] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_real_conflict | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Live - list dependee VMs for real conflict] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_real_conflict | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Live - list dependee VMs for real conflict status] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_real_conflict | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Negative - list on invalid parent ext_id must fail] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VM startup policy start condition conflicts info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"policy_uuid": "00000000-0000-4000-a000-000000000001"}, "code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the policy with UUID '00000000-0000-4000-a000-000000000001', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Negative - list on invalid parent ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info list on invalid parent ext_id failed as expected"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Negative - get on invalid conflict ext_id must fail] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VM startup policy start condition conflict info using ext_id", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"policy_uuid": "00000000-0000-4000-a000-000000000001"}, "code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the policy with UUID '00000000-0000-4000-a000-000000000001', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : Negative - get on invalid conflict ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info get on invalid conflict ext_id failed as expected"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : CRUD stub - create must fail with read-only message] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": null, "msg": "VmStartupPolicyStartConditionConflict is a read-only, derived entity in the Nutanix Prism Central v4 VMM API. The SDK does not expose Create, Update or Delete endpoints for start condition conflicts - Prism Central re-computes them automatically from the parent VM startup policies. Use ntnx_vm_startup_policy_start_condition_conflicts_info_v2 to read them, and adjust the parent VM startup policies to influence which conflicts exist.", "response": {"ext_id": null, "state": "present", "vm_startup_policy_ext_id": "00000000-0000-4000-a000-000000000001"}, "task_ext_id": null}
...ignoring

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : CRUD stub - create status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "CRUD stub create correctly refused with read-only message"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : CRUD stub - update must fail with read-only message] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": "00000000-0000-4000-a000-000000000002", "msg": "VmStartupPolicyStartConditionConflict is a read-only, derived entity in the Nutanix Prism Central v4 VMM API. The SDK does not expose Create, Update or Delete endpoints for start condition conflicts - Prism Central re-computes them automatically from the parent VM startup policies. Use ntnx_vm_startup_policy_start_condition_conflicts_info_v2 to read them, and adjust the parent VM startup policies to influence which conflicts exist.", "response": {"ext_id": "00000000-0000-4000-a000-000000000002", "state": "present", "vm_startup_policy_ext_id": "00000000-0000-4000-a000-000000000001"}, "task_ext_id": null}
...ignoring

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : CRUD stub - update status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "CRUD stub update correctly refused with read-only message"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : CRUD stub - delete must fail with read-only message] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": "00000000-0000-4000-a000-000000000002", "msg": "VmStartupPolicyStartConditionConflict is a read-only, derived entity in the Nutanix Prism Central v4 VMM API. The SDK does not expose Create, Update or Delete endpoints for start condition conflicts - Prism Central re-computes them automatically from the parent VM startup policies. Use ntnx_vm_startup_policy_start_condition_conflicts_info_v2 to read them, and adjust the parent VM startup policies to influence which conflicts exist.", "response": {"ext_id": "00000000-0000-4000-a000-000000000002", "state": "absent", "vm_startup_policy_ext_id": "00000000-0000-4000-a000-000000000001"}, "task_ext_id": null}
...ignoring

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : CRUD stub - delete status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "CRUD stub delete correctly refused with read-only message"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : CRUD stub - check_mode delete must fail cleanly] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": "00000000-0000-4000-a000-000000000002", "msg": "VmStartupPolicyStartConditionConflict is a read-only, derived entity in the Nutanix Prism Central v4 VMM API. The SDK does not expose Create, Update or Delete endpoints for start condition conflicts - Prism Central re-computes them automatically from the parent VM startup policies. Use ntnx_vm_startup_policy_start_condition_conflicts_info_v2 to read them, and adjust the parent VM startup policies to influence which conflicts exist.", "response": {"ext_id": "00000000-0000-4000-a000-000000000002", "state": "absent", "vm_startup_policy_ext_id": "00000000-0000-4000-a000-000000000001"}, "task_ext_id": null}
...ignoring

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : CRUD stub - check_mode delete status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "CRUD stub check_mode delete correctly refused with read-only message"
}

TASK [ntnx_vm_startup_policy_start_condition_conflict_v2 : End VM Startup Policy Start Condition Conflict tests] ***
ok: [testhost] => {
    "msg": "End VM Startup Policy Start Condition Conflict tests"
}

PLAY RECAP *********************************************************************
testhost                   : ok=30   changed=0    unreachable=0    failed=0    skipped=10   rescued=0    ignored=10  
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Followed `INSTRUCTIONS.md` end-to-end: Glean domain-knowledge gathering, `ntnx_virtual_switch_v2` as the pattern reference for module + test layout, full `black` / `isort` / `flake8` / `ansible-test sanity` / `ansible-lint` pass, live `ansible-test integration` + example run against Prism Central `10.44.76.28`.
