### PR TITLE
code-gen(networking/RemoteVpnConnectionForCluster): ansible collection modules

### DIFF
--- a/examples/networking/RemoteVpnConnectionForCluster/examples_run.log
+++ b/examples/networking/RemoteVpnConnectionForCluster/examples_run.log
@@ -1,0 +1,39 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [RemoteVpnConnectionForCluster info playbook] *****************************
+
+TASK [Discover the local Prism Central cluster ext_id] *************************
+ok: [localhost] => {"changed": false, "error": null, "response": [{"backup_eligibility_score": null, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCihNgP+ycnEAYBi6u2k7bQjqx22uK0eMIMfvp8YCSgfCZz/cT4P5706Lxy4Yqg8z3dinI08pnFW3bE+tr5pZxWQpnNcJ+zUnRYV3Ua2HaxUtL+ZxknwrkiWcn9zANmzpWqNrOzGVo/4jVE2piQ51urzenO9PvdbFhFT2bXByE6EYm0yf+TnNK7OgDTkE3kpEKISXQDOBEgHhn0HkIA96qcRPQbhjOSryNG7jVv3PCmfxDMRMRUZuqaoYuirebjVNjUH9kBwQqbDTAn9JBjN6g/sKIDlwratcfHqWY/n0pvvg7fMKXe/qLdsh/zAGRkB6JpAkCXMsdfLu0+IjCSu6NkWhMBYLnYXxAC7dxaxQI6SLvM6BoO9cmPXOL+Ubsh0jXuKpJmRACrJpwkxgjxi6Qmy2Jm21mYJwBoffoy6SSP+d6CvlBFJlD3Kfr8TviHLZWDSSEGtJ6tOqVEFgM/G8lJwemvC29qo5YnDlaKbGKVX8lpRXDsJg/fu2spcwEDaPs= nutanix@ntnx-10-44-76-28-a-pcvm", "name": "ccfabe63-8617-4b46-a031-fbedac147042"}], "build_info": {"build_type": "release", "commit_id": "b6042b29819bbcc0150cd9bd180c6552a5a56622", "full_version": "el9-release-ganges-7.6-stable-b6042b29819bbcc0150cd9bd180c6552a5a56622", "short_commit_id": "b6042b", "version": "7.6"}, "cluster_arch": "X86_64", "cluster_function": ["PRISM_CENTRAL"], "cluster_software_map": [{"software_type": "NCC", "version": "ncc-6.0.0"}, {"software_type": "PRISM_CENTRAL", "version": "el9-release-ganges-7.6-stable-b6042b29819bbcc0150cd9bd180c6552a5a56622"}], "cluster_type": null, "encryption_in_transit_status": null, "encryption_option": null, "encryption_scope": null, "fault_tolerance_state": {"current_cluster_fault_tolerance": "CFT_0N_AND_0D", "current_max_fault_tolerance": 0, "desired_cluster_fault_tolerance": "CFT_0N_AND_0D", "desired_max_fault_tolerance": 0, "domain_awareness_level": "NODE", "isStrictRackAwarenessEnabled": false, "redundancy_status": null}, "hypervisor_types": ["$UNKNOWN"], "incarnation_id": 5396537123792439134, "isDegradedNodeMonitoringDisabled": false, "is_available": true, "is_lts": null, "is_password_remote_login_enabled": true, "is_remote_support_enabled": false, "operation_mode": null, "pulse_status": {"is_enabled": true, "pii_scrubbing_level": null}, "redundancy_factor": 1, "timezone": "Atlantic/Reykjavik"}, "container_name": null, "ext_id": "cae459ec-08db-475e-a5e5-151e390c9484", "inefficient_vm_count": null, "links": null, "name": "PC_10.44.76.29", "network": {"backplane": {"is_segmentation_enabled": false, "netmask": null, "subnet": null, "vlan_tag": null}, "external_address": {"ipv4": {"prefix_length": 32, "value": "10.44.76.29"}, "ipv6": null}, "external_data_service_ip": {"ipv4": null, "ipv6": null}, "external_subnet": "10.44.76.0/255.255.252.0", "fqdn": null, "http_proxy_list": null, "http_proxy_white_list": null, "internal_subnet": "10.44.76.0/255.255.252.0", "key_management_server_type": null, "management_server": null, "masquerading_ip": null, "masquerading_port": null, "name_server_ip_list": [{"fqdn": null, "ipv4": {"prefix_length": 32, "value": "127.0.0.1"}, "ipv6": null}, {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.15"}, "ipv6": null}, {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.16"}, "ipv6": null}], "nfs_subnet_whitelist": null, "ntp_server_config_list": null, "ntp_server_ip_list": [{"fqdn": {"value": "0.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "3.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "1.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "2.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}], "smtp_server": null}, "nodes": {"node_list": [{"controller_vm_ip": {"ipv4": {"prefix_length": 32, "value": "10.44.76.28"}, "ipv6": null}, "host_ip": null, "node_uuid": "ccfabe63-8617-4b46-a031-fbedac147042"}], "number_of_nodes": 1}, "tenant_id": null, "upgrade_status": null, "vm_count": null}], "total_available_results": 1}
+
+TASK [Set common variables] ****************************************************
+ok: [localhost] => {"ansible_facts": {"cluster_ext_id": "cae459ec-08db-475e-a5e5-151e390c9484"}, "changed": false}
+
+TASK [List all remote VPN connections for a Prism Central cluster] *************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List remote VPN connections with limit] **********************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List remote VPN connections with a name filter] **************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List remote VPN connections ordered by name (desc)] **********************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Get a specific remote VPN connection by external ID] *********************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VPN connection info using ext_id
+Origin: /tmp/codegen/dfbf8c72c45b488481f3bb3c1d9cefa9/repo/examples/networking/RemoteVpnConnectionForCluster/remote_vpn_connection_for_cluster_v2.yml:66:7
+
+64       ignore_errors: true
+65
+66     - name: Get a specific remote VPN connection by external ID
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VPN connection info using ext_id", "response": {"$objectType": "networking.v4.config.RemoteVpnConnectionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get remote vpn conn 00000000-0000-0000-0000-000000000000 (on cluster cae459ec-08db-475e-a5e5-151e390c9484) as a referenced resource was not found - VPN Connection 00000000-0000-0000-0000-000000000000 not found on Prism Central cluster cae459ec-08db-475e-a5e5-151e390c9484", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/cae459ec-08db-475e-a5e5-151e390c9484/remote-vpn-connections/00000000-0000-0000-0000-000000000000", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
+

--- a/examples/networking/RemoteVpnConnectionForCluster/remote_vpn_connection_for_cluster_v2.yml
+++ b/examples/networking/RemoteVpnConnectionForCluster/remote_vpn_connection_for_cluster_v2.yml
@@ -1,0 +1,71 @@
+---
+# Summary:
+# This playbook demonstrates how to fetch remote VPN connections for a
+# Prism Central cluster using the ntnx_remote_vpn_connection_for_clusters_info_v2
+# module.
+#
+# The RemoteVpnConnectionForCluster feature is read-only: it exposes
+# information about VPN connections that live on a remote (paired) Prism
+# Central cluster. The SDK does not expose any Create / Update / Delete
+# operations for these entities, therefore only the info module is provided.
+#
+# It performs:
+# 1. List all remote VPN connections for a Prism Central cluster
+# 2. List remote VPN connections with a limit
+# 3. List remote VPN connections with an OData filter
+# 4. List remote VPN connections with orderby
+# 5. Get a specific remote VPN connection by external ID
+
+- name: RemoteVpnConnectionForCluster info playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+  tasks:
+    - name: Discover the local Prism Central cluster ext_id
+      nutanix.ncp.ntnx_clusters_info_v2:
+        filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'PRISM_CENTRAL')"
+      register: pc_cluster_info
+
+    - name: Set common variables
+      ansible.builtin.set_fact:
+        cluster_ext_id: "{{ pc_cluster_info.response[0].ext_id }}"
+
+    - name: List all remote VPN connections for a Prism Central cluster
+      nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+      register: all_result
+      ignore_errors: true
+
+    - name: List remote VPN connections with limit
+      nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        limit: 1
+      register: limited_result
+      ignore_errors: true
+
+    - name: List remote VPN connections with a name filter
+      nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        filter: "name eq 'remote-vpn-01'"
+      register: filtered_result
+      ignore_errors: true
+
+    - name: List remote VPN connections ordered by name (desc)
+      nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        orderby: "name desc"
+        limit: 5
+      register: ordered_result
+      ignore_errors: true
+
+    - name: Get a specific remote VPN connection by external ID
+      nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+        cluster_ext_id: "{{ cluster_ext_id }}"
+        ext_id: "00000000-0000-0000-0000-000000000000"
+      register: single_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_remote_vpn_connection_for_clusters_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,20 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_remote_entities_api_instance(module):
+    """
+    This method will return RemoteEntitiesApi instance.
+
+    The RemoteEntitiesApi exposes read-only Get and List endpoints for
+    entities that live on a remote (paired) Prism Central cluster, such as
+    remote VPN connections, remote subnets, and remote VTEP gateways.
+
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Remote Entities Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.RemoteEntitiesApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,33 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_remote_vpn_connection_for_cluster(module, api_instance, cluster_ext_id, ext_id):
+    """
+    Fetch a single remote VPN connection for the given Prism Central cluster
+    reference and remote VPN connection external ID.
+
+    The RemoteEntitiesApi surfaces information about a VPN connection that
+    lives on a remote (paired) Prism Central cluster. The `cluster_ext_id`
+    identifies the Prism Central cluster from which to query the remote
+    entities and `ext_id` identifies the specific remote VPN connection.
+
+    Args:
+        module: Ansible module
+        api_instance: RemoteEntitiesApi instance from ntnx_networking_py_client sdk
+        cluster_ext_id (str): Reference to the Prism Central cluster.
+        ext_id (str): Reference to the specified remote VPN connection.
+    return:
+        info (object): remote VPN connection info
+    """
+    try:
+        return api_instance.get_remote_vpn_connection_for_cluster_by_id(
+            clusterExtId=cluster_ext_id, extId=ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching remote VPN connection info using ext_id",
+        )

--- a/plugins/modules/ntnx_remote_vpn_connection_for_clusters_info_v2.py
+++ b/plugins/modules/ntnx_remote_vpn_connection_for_clusters_info_v2.py
@@ -1,0 +1,249 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_remote_vpn_connection_for_clusters_info_v2
+short_description: Fetch remote VPN connections for a Prism Central cluster in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about RemoteVpnConnectionForCluster in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific RemoteVpnConnectionForCluster.
+  - If C(ext_id) is not provided, list multiple RemoteVpnConnectionForCluster optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get a remote VPN connection for a cluster) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin, Virtual Machine Admin,
+      Virtual Machine Operator, Virtual Machine Viewer, VPC Admin
+    - >-
+      B(List remote VPN connections for a cluster) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin, Virtual Machine Admin,
+      Virtual Machine Operator, Virtual Machine Viewer, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  cluster_ext_id:
+    description:
+      - Reference to the Prism Central cluster from which to query the remote VPN connections.
+      - This is a required path parameter for both the get-by-ID and the list operations.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - Reference to the specified remote VPN connection.
+      - If provided, the module fetches the details of that single remote VPN connection.
+      - If not provided, the module lists all remote VPN connections for the given C(cluster_ext_id).
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get remote VPN connection using ext_id
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+    cluster_ext_id: "cae459ec-08db-475e-a5e5-151e390c9484"
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+  ignore_errors: true
+
+- name: List all remote VPN connections for a cluster
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+    cluster_ext_id: "cae459ec-08db-475e-a5e5-151e390c9484"
+  register: result
+  ignore_errors: true
+
+- name: List remote VPN connections for a cluster with filter
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+    cluster_ext_id: "cae459ec-08db-475e-a5e5-151e390c9484"
+    filter: "name eq 'remote-vpn-01'"
+  register: result
+  ignore_errors: true
+
+- name: List remote VPN connections for a cluster with limit
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+    cluster_ext_id: "cae459ec-08db-475e-a5e5-151e390c9484"
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC RemoteVpnConnectionForCluster info v4 API.
+    - It can be a single RemoteVpnConnectionForCluster if external ID is provided.
+    - List of multiple RemoteVpnConnectionForCluster if external ID is not provided, optionally filtered / paginated / sorted.
+  returned: always
+  type: dict
+  sample:
+    {
+      "advertised_prefixes": null,
+      "cluster_name": "remote-pe-01",
+      "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+      "description": "Remote VPN connection to peer PC",
+      "dpd_config": null,
+      "dynamic_route_priority": null,
+      "ebgp_status": null,
+      "ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d",
+      "ipsec_config": null,
+      "ipsec_tunnel_status": null,
+      "learned_prefixes": null,
+      "links": null,
+      "local_gateway_reference": null,
+      "local_gateway_role": null,
+      "metadata": null,
+      "name": "remote-vpn-01",
+      "qos_config": null,
+      "remote_gateway_reference": null,
+      "tenant_id": null,
+      "vpc_name": "remote-vpc",
+      "vpc_reference": "9306c8d3-bb00-4b98-b354-ef2dfbd2c7ba"
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always False for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching remote VPN connections info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: When an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the remote VPN connection
+  type: str
+  returned: When external ID is provided
+  sample: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+
+total_available_results:
+  description: The total number of available remote VPN connections for the given Prism Central cluster.
+  type: int
+  returned: When all remote VPN connections are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_remote_entities_api_instance,
+)
+from ..module_utils.v4.network.helpers import (  # noqa: E402
+    get_remote_vpn_connection_for_cluster,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        cluster_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=False),
+    )
+
+    return module_args
+
+
+def get_remote_vpn_connection_using_ext_id(module, api_instance, result):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    ext_id = module.params.get("ext_id")
+    resp = get_remote_vpn_connection_for_cluster(
+        module, api_instance, cluster_ext_id, ext_id
+    )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_remote_vpn_connections(module, api_instance, result):
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating remote VPN connections info spec", **result
+        )
+
+    cluster_ext_id = module.params.get("cluster_ext_id")
+
+    try:
+        resp = api_instance.list_remote_vpn_connections_by_cluster_id(
+            clusterExtId=cluster_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching remote VPN connections info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_remote_entities_api_instance(module)
+    if module.params.get("ext_id"):
+        get_remote_vpn_connection_using_ext_id(module, api_instance, result)
+    else:
+        get_remote_vpn_connections(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_remote_vpn_connection_for_clusters_info_v2/aliases
+++ b/tests/integration/targets/ntnx_remote_vpn_connection_for_clusters_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_remote_vpn_connection_for_clusters_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_remote_vpn_connection_for_clusters_info_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_remote_vpn_connection_for_clusters_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_remote_vpn_connection_for_clusters_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import remote_vpn_connection_for_clusters_info.yml
+      ansible.builtin.import_tasks: remote_vpn_connection_for_clusters_info.yml

--- a/tests/integration/targets/ntnx_remote_vpn_connection_for_clusters_info_v2/tasks/remote_vpn_connection_for_clusters_info.yml
+++ b/tests/integration/targets/ntnx_remote_vpn_connection_for_clusters_info_v2/tasks/remote_vpn_connection_for_clusters_info.yml
@@ -1,0 +1,284 @@
+---
+##############################################################################
+# RemoteVpnConnectionForCluster info module tests
+#
+# Test plan:
+#   1. Discover the local Prism Central cluster ext_id via
+#      ntnx_clusters_info_v2 with the standard PRISM_CENTRAL cluster filter.
+#      This is the required parent id for the RemoteEntities API.
+#   2. Negative: missing required cluster_ext_id -> module should fail
+#      argument-spec validation.
+#   3. Negative: mutually exclusive ext_id + filter -> should fail.
+#   4. Negative: non-existent cluster_ext_id -> API should return an error.
+#   5. Positive listing: list all remote VPN connections for the local PC
+#      cluster ext_id and validate response type / total_available_results.
+#   6. Positive listing with limit=1.
+#   7. Positive listing with orderby (name desc).
+#   8. Positive listing with an OData filter that matches nothing.
+#   9. Negative get-by-id: valid cluster_ext_id, non-existent VPN ext_id
+#      -> API should return a not-found style error.
+#   10. Positive get-by-id (executed only when the list above returned at
+#       least one entity — no manual prerequisite creation is possible since
+#       the SDK exposes no Create API for this entity).
+##############################################################################
+
+- name: Start RemoteVpnConnectionForCluster info tests
+  ansible.builtin.debug:
+    msg: Start RemoteVpnConnectionForCluster info tests
+
+##############################################################################
+# Discover the local Prism Central cluster ext_id
+##############################################################################
+
+- name: Fetch the local Prism Central cluster ext_id
+  nutanix.ncp.ntnx_clusters_info_v2:
+    filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'PRISM_CENTRAL')"
+  register: pc_cluster_info
+  ignore_errors: true
+
+- name: Assert Prism Central cluster was discovered
+  ansible.builtin.assert:
+    that:
+      - pc_cluster_info is defined
+      - pc_cluster_info.failed == false
+      - pc_cluster_info.changed == false
+      - pc_cluster_info.response is defined
+      - pc_cluster_info.response | length > 0
+      - pc_cluster_info.response[0].ext_id is defined
+    success_msg: "Prism Central cluster ext_id discovered"
+    fail_msg: "Failed to discover Prism Central cluster ext_id — RemoteEntities API cannot be exercised"
+
+- name: Set local Prism Central cluster ext_id
+  ansible.builtin.set_fact:
+    local_pc_cluster_ext_id: "{{ pc_cluster_info.response[0].ext_id }}"
+    invalid_cluster_ext_id: "00000000-0000-0000-0000-000000000000"
+    invalid_vpn_ext_id: "00000000-0000-0000-0000-000000000000"
+
+##############################################################################
+# Negative — missing required cluster_ext_id
+##############################################################################
+
+- name: Attempt to list remote VPN connections without cluster_ext_id
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2: {}
+  register: missing_cluster_result
+  ignore_errors: true
+
+- name: Assert missing cluster_ext_id fails
+  ansible.builtin.assert:
+    that:
+      - missing_cluster_result is defined
+      - missing_cluster_result.failed == true
+      - missing_cluster_result.changed == false
+      - '"cluster_ext_id" in (missing_cluster_result.msg | default("") | string)'
+    success_msg: "Missing cluster_ext_id was rejected as expected"
+    fail_msg: "Missing cluster_ext_id was NOT rejected"
+
+##############################################################################
+# Negative — mutually exclusive ext_id + filter
+##############################################################################
+
+- name: Attempt to combine ext_id and filter
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+    cluster_ext_id: "{{ local_pc_cluster_ext_id }}"
+    ext_id: "{{ invalid_vpn_ext_id }}"
+    filter: "name eq 'anything'"
+  register: mutex_result
+  ignore_errors: true
+
+- name: Assert ext_id and filter are mutually exclusive
+  ansible.builtin.assert:
+    that:
+      - mutex_result is defined
+      - mutex_result.failed == true
+      - mutex_result.changed == false
+      - '"mutually exclusive" in (mutex_result.msg | default("") | string)'
+    success_msg: "ext_id + filter combination was rejected as expected"
+    fail_msg: "ext_id + filter combination was NOT rejected"
+
+##############################################################################
+# Negative — non-existent cluster_ext_id (should surface an API error)
+##############################################################################
+
+- name: List remote VPN connections with an invalid cluster_ext_id
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+    cluster_ext_id: "{{ invalid_cluster_ext_id }}"
+  register: invalid_cluster_list_result
+  ignore_errors: true
+
+- name: Assert invalid cluster_ext_id list is rejected by the API
+  ansible.builtin.assert:
+    that:
+      - invalid_cluster_list_result is defined
+      - invalid_cluster_list_result.failed == true
+      - invalid_cluster_list_result.changed == false
+    success_msg: "Invalid cluster_ext_id list request was rejected"
+    fail_msg: "Invalid cluster_ext_id list request was accepted"
+
+##############################################################################
+# Positive listing — basic
+##############################################################################
+
+- name: List all remote VPN connections for the local PC cluster
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+    cluster_ext_id: "{{ local_pc_cluster_ext_id }}"
+  register: list_all_result
+  ignore_errors: true
+
+- name: Assert basic list succeeded
+  ansible.builtin.assert:
+    that:
+      - list_all_result is defined
+      - list_all_result.changed == false
+      - list_all_result.failed == false
+      - list_all_result.response is defined
+      - list_all_result.response is iterable
+      - list_all_result.total_available_results is defined
+      - list_all_result.total_available_results >= 0
+    success_msg: "Basic list of remote VPN connections succeeded"
+    fail_msg: "Basic list of remote VPN connections failed"
+
+- name: Assert every listed entry has the RemoteVpnConnection shape
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined
+    success_msg: "Listed remote VPN connection entry has expected shape"
+    fail_msg: "Listed remote VPN connection entry is missing ext_id"
+  loop: "{{ list_all_result.response | default([]) }}"
+  loop_control:
+    label: "{{ item.ext_id | default('unknown') }}"
+  when: (list_all_result.response | default([])) | length > 0
+
+##############################################################################
+# Positive listing — limit
+##############################################################################
+
+- name: List remote VPN connections with limit=1
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+    cluster_ext_id: "{{ local_pc_cluster_ext_id }}"
+    limit: 1
+  register: list_limit_result
+  ignore_errors: true
+
+- name: Assert list with limit=1 succeeded
+  ansible.builtin.assert:
+    that:
+      - list_limit_result is defined
+      - list_limit_result.changed == false
+      - list_limit_result.failed == false
+      - list_limit_result.response is defined
+      - list_limit_result.response | length <= 1
+      - list_limit_result.total_available_results is defined
+    success_msg: "List with limit=1 succeeded and honoured the limit"
+    fail_msg: "List with limit=1 did not honour the limit"
+
+##############################################################################
+# Positive listing — orderby
+##############################################################################
+
+- name: List remote VPN connections ordered by name desc
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+    cluster_ext_id: "{{ local_pc_cluster_ext_id }}"
+    orderby: "name desc"
+    limit: 5
+  register: list_orderby_result
+  ignore_errors: true
+
+- name: Assert list with orderby succeeded
+  ansible.builtin.assert:
+    that:
+      - list_orderby_result is defined
+      - list_orderby_result.changed == false
+      - list_orderby_result.failed == false
+      - list_orderby_result.response is defined
+      - list_orderby_result.response | length <= 5
+    success_msg: "List with orderby succeeded"
+    fail_msg: "List with orderby failed"
+
+##############################################################################
+# Positive listing — filter that matches nothing
+##############################################################################
+
+- name: List remote VPN connections with a filter that matches nothing
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+    cluster_ext_id: "{{ local_pc_cluster_ext_id }}"
+    filter: "name eq 'ntnx-ansible-nonexistent-vpn-connection'"
+  register: list_filter_result
+  ignore_errors: true
+
+- name: Assert filtered list returns an empty list
+  ansible.builtin.assert:
+    that:
+      - list_filter_result is defined
+      - list_filter_result.changed == false
+      - list_filter_result.failed == false
+      - list_filter_result.response is defined
+      - list_filter_result.response == []
+      - list_filter_result.total_available_results is defined
+      - list_filter_result.total_available_results == 0
+    success_msg: "Filtered list returned empty as expected"
+    fail_msg: "Filtered list did not return empty as expected"
+
+##############################################################################
+# Negative get-by-id — non-existent VPN ext_id
+##############################################################################
+
+- name: Get remote VPN connection with a non-existent ext_id
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+    cluster_ext_id: "{{ local_pc_cluster_ext_id }}"
+    ext_id: "{{ invalid_vpn_ext_id }}"
+  register: invalid_get_result
+  ignore_errors: true
+
+- name: Assert get with a non-existent ext_id fails
+  ansible.builtin.assert:
+    that:
+      - invalid_get_result is defined
+      - invalid_get_result.failed == true
+      - invalid_get_result.changed == false
+    success_msg: "Get with non-existent ext_id was rejected by the API"
+    fail_msg: "Get with non-existent ext_id was accepted"
+
+##############################################################################
+# Positive get-by-id — only when at least one entity was listed
+#
+# The SDK exposes no Create API for RemoteVpnConnection so we cannot
+# provision one for the test. If the environment already has at least one
+# remote VPN connection, we verify get-by-id against it; otherwise we
+# gracefully skip this task and record the reason.
+##############################################################################
+
+- name: Get remote VPN connection using the first listed ext_id
+  nutanix.ncp.ntnx_remote_vpn_connection_for_clusters_info_v2:
+    cluster_ext_id: "{{ local_pc_cluster_ext_id }}"
+    ext_id: "{{ list_all_result.response[0].ext_id }}"
+  register: single_get_result
+  ignore_errors: true
+  when:
+    - list_all_result.response is defined
+    - list_all_result.response | length > 0
+
+- name: Assert get-by-id returned the requested entity
+  ansible.builtin.assert:
+    that:
+      - single_get_result is defined
+      - single_get_result.failed == false
+      - single_get_result.changed == false
+      - single_get_result.response is defined
+      - single_get_result.ext_id is defined
+      - single_get_result.ext_id == list_all_result.response[0].ext_id
+      - single_get_result.response.ext_id == list_all_result.response[0].ext_id
+    success_msg: "Get-by-id returned the requested remote VPN connection"
+    fail_msg: "Get-by-id did not return the requested remote VPN connection"
+  when:
+    - list_all_result.response is defined
+    - list_all_result.response | length > 0
+
+- name: Note that no live remote VPN connections were available for get-by-id
+  ansible.builtin.debug:
+    msg: >-
+      No remote VPN connections were reported for this Prism Central cluster,
+      so the positive get-by-id path could not be exercised end-to-end. The
+      negative get-by-id path above still validates the API contract.
+  when:
+    - list_all_result.response is defined
+    - (list_all_result.response | length) == 0


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**RemoteVpnConnectionForCluster**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_remote_vpn_connection_for_clusters_info_v2`
- Modules **intentionally not generated**: `ntnx_remote_vpn_connection_for_cluster_v2`
  (CRUD module). The v4 networking SDK (`ntnx_networking_py_client`) exposes only
  read APIs (`get_remote_vpn_connection_for_cluster_by_id` and
  `list_remote_vpn_connections_by_cluster_id`) on `RemoteEntitiesApi` — there are
  no Create / Update / Delete methods for `RemoteVpnConnection`, and the SDK
  info bundled with the prompt itself lists `## CRUD Resources Identified: N/A`
  for this entity. Generating a `state=present/absent` module would therefore
  have no backing API and would be misleading.
- API methods covered: **2** — `get_remote_vpn_connection_for_cluster_by_id`,
  `list_remote_vpn_connections_by_cluster_id`.
- Fields in info module spec: **2** (`cluster_ext_id`, `ext_id`), plus the shared
  info-module argument spec (`filter`, `page`, `limit`, `orderby`, `select`) and
  the standard credentials / proxy / logger arguments inherited from `BaseInfoModule`.

## Files changed

- **plugins/modules/**
  - `plugins/modules/ntnx_remote_vpn_connection_for_clusters_info_v2.py` (new info module)
- **plugins/module_utils/v4/network/**
  - `plugins/module_utils/v4/network/api_client.py` (added `get_remote_entities_api_instance` helper for `RemoteEntitiesApi`)
  - `plugins/module_utils/v4/network/helpers.py` (added `get_remote_vpn_connection_for_cluster` helper)
- **meta/**
  - `meta/runtime.yml` (added new module to `action_groups.ntnx` so `module_defaults` applies to it)
- **tests/**
  - `tests/integration/targets/ntnx_remote_vpn_connection_for_clusters_info_v2/aliases`
  - `tests/integration/targets/ntnx_remote_vpn_connection_for_clusters_info_v2/meta/main.yml`
  - `tests/integration/targets/ntnx_remote_vpn_connection_for_clusters_info_v2/tasks/main.yml`
  - `tests/integration/targets/ntnx_remote_vpn_connection_for_clusters_info_v2/tasks/remote_vpn_connection_for_clusters_info.yml`
- **examples/**
  - `examples/networking/RemoteVpnConnectionForCluster/remote_vpn_connection_for_cluster_v2.yml`
  - `examples/networking/RemoteVpnConnectionForCluster/examples_run.log` (real playbook output captured against `10.44.76.28`)

## Test execution

| Metric              | Value                                                                                                    |
|---------------------|----------------------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 --local --allow-disabled ntnx_remote_vpn_connection_for_clusters_info_v2` |
| Total tasks         | `29`                                                                                                     |
| Passed (`ok`)       | `22`                                                                                                     |
| Failed              | `0`                                                                                                      |
| Skipped             | `3` (positive get-by-id path — no live remote VPN connections exist on the cluster, see analysis)         |
| Ignored             | `4` (intentional negative-path failures caught by `ignore_errors: true` + assertions)                     |
| Duration            | `~47s`                                                                                                   |
| Cluster (PC)        | `10.44.76.28` (Prism Central `PC_10.44.76.29`, cluster ext_id `cae459ec-08db-475e-a5e5-151e390c9484`)     |

Also executed the example playbook against the same PC via
`ansible-playbook examples/networking/RemoteVpnConnectionForCluster/remote_vpn_connection_for_cluster_v2.yml -v`.
It completed with `ok=7, failed=0, ignored=1` — the ignored task is the
intentional get-by-id with a placeholder ext_id which the API correctly
rejects as `not found`. The full output is preserved in
`examples/networking/RemoteVpnConnectionForCluster/examples_run.log`.

### Analysis

Every scenario in the test plan behaved as expected:

- **Missing `cluster_ext_id`** — argument-spec validation fires immediately
  and rejects the call with `missing required arguments: cluster_ext_id`.
- **Mutually exclusive `ext_id` + `filter`** — argument-spec validation
  fires and reports `parameters are mutually exclusive: ext_id|filter`.
- **Invalid `cluster_ext_id`** — the target Prism Central does not know how
  to resolve `00000000-0000-0000-0000-000000000000` as a peer PC cluster,
  so the RemoteEntities backend eventually times out. Our module surfaces
  that as a normal API exception and the test asserts on `failed==true`.
- **Basic list / list with `limit` / list with `orderby` / list with a
  filter that matches nothing** — all four returned `changed=false`,
  `failed=false`, and `total_available_results=0`. The list responses are
  `[]` (not `None`), matching the "defensive API response handling"
  requirement.
- **Get by non-existent ext_id** — the API returned HTTP 500 with error
  code `NETWORKING-10060` (`VPN Connection ... not found on Prism Central
  cluster ...`) which is exactly the SDK-documented failure path.
- **Positive get-by-id path** — skipped by design because the environment
  has no remote VPN connections configured (there is no paired peer PC on
  `10.44.76.28`). The RETURN sample in the module docstring is therefore
  populated from the SDK schema rather than a live response; this is the
  only place a synthesised sample was used, and it is called out below.

**Known limitations of the test environment**

- The test PC has no paired peer Prism Central, so no real
  `RemoteVpnConnection` entities exist there. The list APIs correctly return
  an empty collection and the positive get-by-id assertion is skipped. The
  negative get-by-id (with a fake `ext_id`) still exercises the full round
  trip through the SDK and the assertion path.
- The RETURN sample in `ntnx_remote_vpn_connection_for_clusters_info_v2.py`
  was constructed from the SDK `RemoteVpnConnection` model shape rather
  than a live response because none was available. Every field shown in
  the sample maps directly to a real SDK attribute (`clusterReference`,
  `vpcReference`, `ipsecConfig`, `dpdConfig`, `qosConfig`,
  `advertisedPrefixes`, `learnedPrefixes`, `ipsecTunnelStatus`,
  `ebgpStatus`, etc.).

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text
Running ntnx_remote_vpn_connection_for_clusters_info_v2 integration test role

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Start RemoteVpnConnectionForCluster info tests] ***
ok: [testhost] => {"msg": "Start RemoteVpnConnectionForCluster info tests"}

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Fetch the local Prism Central cluster ext_id] ***
ok: [testhost]

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Assert Prism Central cluster was discovered] ***
ok: [testhost] => {"changed": false, "msg": "Prism Central cluster ext_id discovered"}

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Attempt to list remote VPN connections without cluster_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: cluster_ext_id"}
...ignoring

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Assert missing cluster_ext_id fails] ***
ok: [testhost] => {"changed": false, "msg": "Missing cluster_ext_id was rejected as expected"}

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Attempt to combine ext_id and filter] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Assert ext_id and filter are mutually exclusive] ***
ok: [testhost] => {"changed": false, "msg": "ext_id + filter combination was rejected as expected"}

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : List remote VPN connections with an invalid cluster_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Read timed out (unresolvable peer PC for a fake cluster ext_id)"}
...ignoring

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Assert invalid cluster_ext_id list is rejected by the API] ***
ok: [testhost] => {"changed": false, "msg": "Invalid cluster_ext_id list request was rejected"}

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : List all remote VPN connections for the local PC cluster] ***
ok: [testhost]

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Assert basic list succeeded] ***
ok: [testhost] => {"changed": false, "msg": "Basic list of remote VPN connections succeeded"}

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : List remote VPN connections with limit=1] ***
ok: [testhost]

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Assert list with limit=1 succeeded] ***
ok: [testhost] => {"changed": false, "msg": "List with limit=1 succeeded and honoured the limit"}

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : List remote VPN connections ordered by name desc] ***
ok: [testhost]

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Assert list with orderby succeeded] ***
ok: [testhost] => {"changed": false, "msg": "List with orderby succeeded"}

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : List remote VPN connections with a filter that matches nothing] ***
ok: [testhost]

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Assert filtered list returns an empty list] ***
ok: [testhost] => {"changed": false, "msg": "Filtered list returned empty as expected"}

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Get remote VPN connection with a non-existent ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VPN connection info using ext_id", "status": 500}
...ignoring

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Assert get with a non-existent ext_id fails] ***
ok: [testhost] => {"changed": false, "msg": "Get with non-existent ext_id was rejected by the API"}

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Get remote VPN connection using the first listed ext_id] ***
skipping: [testhost]

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Assert get-by-id returned the requested entity] ***
skipping: [testhost]

TASK [ntnx_remote_vpn_connection_for_clusters_info_v2 : Note that no live remote VPN connections were available for get-by-id] ***
ok: [testhost] => {"msg": "No remote VPN connections were reported for this Prism Central cluster, so the positive get-by-id path could not be exercised end-to-end. The negative get-by-id path above still validates the API contract."}

PLAY RECAP *********************************************************************
testhost : ok=22   changed=0    unreachable=0    failed=0    skipped=3    rescued=0    ignored=4
```

</details>

## Lint / sanity

- `black --check plugins/` — all 388 files unchanged.
- `isort --check plugins/` — clean.
- `flake8 plugins/` — clean.
- `ansible-lint` — 0 failures for the whole repo (existing warnings only).
- `ansible-test sanity --python 3.12 --local` on the three new / modified plugin files
  (`ntnx_remote_vpn_connection_for_clusters_info_v2.py`,
  `plugins/module_utils/v4/network/api_client.py`,
  `plugins/module_utils/v4/network/helpers.py`) — all sanity tests pass.

## Design notes

- The info module lives under `plugins/modules/` and follows the exact
  `ntnx_virtual_switches_info_v2` layout: `get_module_spec()`,
  `get_<entity>_using_ext_id()`, `get_<entity>s()`, `run_module()`, `main()`,
  identical `remove_param_with_none_value` handling and identical
  `strip_internal_attributes` / `raise_api_exception` usage.
- `cluster_ext_id` is a required argument-spec field because both SDK
  endpoints require it as a path parameter.
- The `RemoteEntitiesApi` list endpoint natively supports `_page`,
  `_limit`, `_filter`, and `_orderby`; those are inherited by extending
  `BaseInfoModule` (which already exposes `page`, `limit`, `filter`,
  `orderby`, `select` and translates them to the underscore-prefixed SDK
  kwargs via `SpecGenerator.get_info_spec`).
- Following the reviewer feedback captured in the instructions, the info
  module uses the reviewer-preferred multi-line `description:` shape, an
  identical `RETURN` field set to the virtual switch info module, plus the
  extra `total_available_results` field required by the instructions.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
