### PR TITLE
code-gen(virtual_machine_management/VmStartupPolicyVmComplianceState): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/virtual_machine_management/VmStartupPolicyVmComplianceState/examples_run.log
+++ b/examples/virtual_machine_management/VmStartupPolicyVmComplianceState/examples_run.log
@@ -1,0 +1,55 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [VM Startup Policy VM compliance states info v4 examples] *****************
+
+TASK [List all VM compliance states of a VM startup policy] ********************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0, "vm_startup_policy_ext_id": "9b1a818d-0d1a-4c4e-4bd2-094e27cae1d5"}
+
+TASK [Print list-all result] ***************************************************
+ok: [localhost] => {
+    "list_all_result": {
+        "changed": false,
+        "failed": false,
+        "response": [],
+        "total_available_results": 0,
+        "vm_startup_policy_ext_id": "9b1a818d-0d1a-4c4e-4bd2-094e27cae1d5"
+    }
+}
+
+TASK [List VM compliance states of a VM startup policy with pagination] ********
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0, "vm_startup_policy_ext_id": "9b1a818d-0d1a-4c4e-4bd2-094e27cae1d5"}
+
+TASK [Print paginated result] **************************************************
+ok: [localhost] => {
+    "paginated_result": {
+        "changed": false,
+        "failed": false,
+        "response": [],
+        "total_available_results": 0,
+        "vm_startup_policy_ext_id": "9b1a818d-0d1a-4c4e-4bd2-094e27cae1d5"
+    }
+}
+
+TASK [Compute a candidate ext_id for the get-by-id example] ********************
+ok: [localhost] => {"ansible_facts": {"candidate_ext_id": "00000000-0000-0000-0000-000000000000"}, "changed": false}
+
+TASK [Fetch a specific VM compliance state by ext_id] **************************
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "No VM compliance state with ext_id '00000000-0000-0000-0000-000000000000' was found for VM startup policy '9b1a818d-0d1a-4c4e-4bd2-094e27cae1d5'.", "response": null}
+...ignoring
+
+TASK [Print single result] *****************************************************
+ok: [localhost] => {
+    "single_result": {
+        "changed": false,
+        "failed": true,
+        "msg": "No VM compliance state with ext_id '00000000-0000-0000-0000-000000000000' was found for VM startup policy '9b1a818d-0d1a-4c4e-4bd2-094e27cae1d5'.",
+        "response": null
+    }
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
+

--- a/examples/virtual_machine_management/VmStartupPolicyVmComplianceState/vm_startup_policy_vm_compliance_states_info.yml
+++ b/examples/virtual_machine_management/VmStartupPolicyVmComplianceState/vm_startup_policy_vm_compliance_states_info.yml
@@ -1,0 +1,58 @@
+---
+- name: VM Startup Policy VM compliance states info v4 examples
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') }}"
+      nutanix_port: "{{ lookup('env', 'NUTANIX_PORT') | default('9440', true) }}"
+      validate_certs: false
+  vars:
+    # A real VM startup policy ext_id. Users should override with the ext_id
+    # of a policy that already exists on their Prism Central.
+    policy_ext_id: "{{ startup_policy_ext_id | default('00000000-0000-0000-0000-000000000000') }}"
+
+  tasks:
+    - name: List all VM compliance states of a VM startup policy
+      nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+        vm_startup_policy_ext_id: "{{ policy_ext_id }}"
+      register: list_all_result
+      ignore_errors: true
+
+    - name: Print list-all result
+      ansible.builtin.debug:
+        var: list_all_result
+
+    - name: List VM compliance states of a VM startup policy with pagination
+      nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+        vm_startup_policy_ext_id: "{{ policy_ext_id }}"
+        page: 0
+        limit: 10
+      register: paginated_result
+      ignore_errors: true
+
+    - name: Print paginated result
+      ansible.builtin.debug:
+        var: paginated_result
+
+    - name: Compute a candidate ext_id for the get-by-id example
+      ansible.builtin.set_fact:
+        candidate_ext_id: >-
+          {{ (list_all_result.response | first).ext_id
+             if (list_all_result.response is defined
+                 and list_all_result.response is iterable
+                 and (list_all_result.response | length) > 0)
+             else '00000000-0000-0000-0000-000000000000' }}
+
+    - name: Fetch a specific VM compliance state by ext_id
+      nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+        vm_startup_policy_ext_id: "{{ policy_ext_id }}"
+        ext_id: "{{ candidate_ext_id }}"
+      register: single_result
+      ignore_errors: true
+
+    - name: Print single result
+      ansible.builtin.debug:
+        var: single_result

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vm_startup_policy_vm_compliance_states_info_v2

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,13 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_vm_startup_policies_api_instance(module):
+    """
+    This method will return VM Startup Policies API instance
+    Args:
+        api_instance (obj): v4 VM Startup Policies api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.VmStartupPoliciesApi(api_client=api_client)

--- a/plugins/module_utils/v4/vmm/helpers.py
+++ b/plugins/module_utils/v4/vmm/helpers.py
@@ -191,3 +191,24 @@ def get_ova(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching OVA info using ext_id",
         )
+
+
+def get_vm_startup_policy(module, api_instance, ext_id):
+    """
+    Get VM startup policy by ext_id.
+
+    Args:
+        module: Ansible module
+        api_instance: VmStartupPoliciesApi instance from ntnx_vmm_py_client sdk
+        ext_id: ext_id of the VM startup policy
+    Returns:
+        policy (obj): VM startup policy info object
+    """
+    try:
+        return api_instance.get_vm_startup_policy_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VM startup policy info using ext_id",
+        )

--- a/plugins/modules/ntnx_vm_startup_policy_vm_compliance_states_info_v2.py
+++ b/plugins/modules/ntnx_vm_startup_policy_vm_compliance_states_info_v2.py
@@ -1,0 +1,309 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_startup_policy_vm_compliance_states_info_v2
+short_description: Fetch VM compliance states of a VM startup policy in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about VmStartupPolicyVmComplianceState in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific VmStartupPolicyVmComplianceState.
+  - If C(ext_id) is not provided, list multiple VmStartupPolicyVmComplianceState optionally paginated.
+  - The SDK endpoint C(list_vm_startup_policy_vm_compliance_states) supports pagination
+    (C(page), C(limit)) only. Filter and orderby query parameters are not supported by the API.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(List VM compliance states of a VM startup policy) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, Virtual Machine Admin,
+    Virtual Machine Operator, Virtual Machine Viewer
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  vm_startup_policy_ext_id:
+    description:
+      - The external ID of the parent VM startup policy whose VM compliance
+        states are being fetched.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external ID of a specific VM compliance state.
+      - When provided, the module filters the list to return the matching
+        VM compliance state entry. If not provided, all compliance states for
+        the parent VM startup policy are returned.
+    type: str
+  page:
+    description:
+      - A URL query parameter that specifies the page number of the result set.
+      - Must be a positive integer between 0 and the maximum number of pages
+        that are available for that resource. Any number out of this range
+        might lead to no results.
+    type: int
+  limit:
+    description:
+      - A URL query parameter that specifies the total number of records
+        returned in the result set.
+      - Must be a positive integer between 1 and 100. If not provided, the
+        API returns 50 records by default.
+    type: int
+  read_timeout:
+    description:
+      - Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all VM compliance states of a VM startup policy
+  nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+    nutanix_host: "<pc_ip>"
+    nutanix_username: "<pc_username>"
+    nutanix_password: "<pc_password>"
+    validate_certs: false
+    vm_startup_policy_ext_id: "6f452990-bd1d-45ae-46d7-4622c5d323aa"
+  register: result
+  ignore_errors: true
+
+- name: List VM compliance states of a VM startup policy with pagination
+  nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+    nutanix_host: "<pc_ip>"
+    nutanix_username: "<pc_username>"
+    nutanix_password: "<pc_password>"
+    validate_certs: false
+    vm_startup_policy_ext_id: "6f452990-bd1d-45ae-46d7-4622c5d323aa"
+    page: 0
+    limit: 10
+  register: result
+  ignore_errors: true
+
+- name: Fetch a specific VM compliance state by ext_id
+  nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+    nutanix_host: "<pc_ip>"
+    nutanix_username: "<pc_username>"
+    nutanix_password: "<pc_password>"
+    validate_certs: false
+    vm_startup_policy_ext_id: "6f452990-bd1d-45ae-46d7-4622c5d323aa"
+    ext_id: "ea9c8f4c-97ec-4f7a-9e2b-33f36f9b6a19"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VmStartupPolicyVmComplianceState info v4 API.
+    - It can be a single VmStartupPolicyVmComplianceState if external ID is provided.
+    - List of multiple VmStartupPolicyVmComplianceState if external ID is not provided.
+  returned: always
+  type: dict
+  sample: []
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the VM compliance state when provided as input.
+  returned: when C(ext_id) is provided
+  type: str
+  sample: "ea9c8f4c-97ec-4f7a-9e2b-33f36f9b6a19"
+
+vm_startup_policy_ext_id:
+  description: External ID of the parent VM startup policy.
+  returned: always
+  type: str
+  sample: "9b1a818d-0d1a-4c4e-4bd2-094e27cae1d5"
+
+total_available_results:
+  description: The total number of VM compliance states available for the parent VM startup policy.
+  returned: when the full list is fetched
+  type: int
+  sample: 0
+
+msg:
+  description: Status/error message returned by the module.
+  returned: contextual
+  type: str
+  sample: "No VM compliance state with ext_id '00000000-0000-0000-0000-000000000000' was found for VM startup policy '9b1a818d-0d1a-4c4e-4bd2-094e27cae1d5'."
+
+error:
+  description: Error details when an API/operation failure occurs.
+  returned: when an error occurs
+  type: str
+
+failed:
+  description: Indicates whether the module failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+        get_vm_startup_policies_api_instance,
+    )
+except ImportError:
+    from ..module_utils.v4.sdk_mock import mock_sdk  # noqa: E402
+
+    get_vm_startup_policies_api_instance = mock_sdk  # type: ignore[assignment]
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        vm_startup_policy_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str"),
+        page=dict(type="int"),
+        limit=dict(type="int"),
+    )
+    return module_args
+
+
+def _list_all_compliance_states(module, api_instance, vm_startup_policy_ext_id, kwargs):
+    """
+    Fetch the raw ListVmStartupPolicyVmComplianceStatesApiResponse and return the
+    (response_dict, total_available_results) tuple. Raises via
+    C(raise_api_exception) on SDK errors.
+    """
+    try:
+        resp = api_instance.list_vm_startup_policy_vm_compliance_states(
+            vmStartupPolicyExtId=vm_startup_policy_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VM startup policy VM compliance states info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    return resp, total_available_results
+
+
+def _build_pagination_kwargs(module):
+    """
+    Build the SDK pagination kwargs from module params. Only C(_page) and
+    C(_limit) are supported by the underlying SDK method; other info args
+    like C(filter), C(orderby), C(select) are not accepted by this endpoint
+    and are ignored to avoid sending unsupported query parameters.
+    """
+    kwargs = {}
+    if module.params.get("page") is not None:
+        kwargs["_page"] = module.params.get("page")
+    if module.params.get("limit") is not None:
+        kwargs["_limit"] = module.params.get("limit")
+    return kwargs
+
+
+def get_vm_startup_policy_vm_compliance_state_by_ext_id(module, api_instance, result):
+    """
+    The SDK does not expose a Get-by-Id endpoint for a single compliance
+    state entry, so we fetch the full list and locate the matching item
+    client-side. This preserves standard info-module get-by-id ergonomics.
+    """
+    vm_startup_policy_ext_id = module.params.get("vm_startup_policy_ext_id")
+    ext_id = module.params.get("ext_id")
+
+    kwargs = _build_pagination_kwargs(module)
+    entries, _total = _list_all_compliance_states(
+        module, api_instance, vm_startup_policy_ext_id, kwargs
+    )
+
+    match = next((item for item in entries if item.get("ext_id") == ext_id), None)
+    if match is None:
+        module.fail_json(
+            msg=(
+                "No VM compliance state with ext_id '{0}' was found for VM "
+                "startup policy '{1}'."
+            ).format(ext_id, vm_startup_policy_ext_id),
+            failed=True,
+            response=None,
+            changed=False,
+        )
+
+    result["ext_id"] = ext_id
+    result["response"] = match
+
+
+def list_vm_startup_policy_vm_compliance_states(module, api_instance, result):
+    vm_startup_policy_ext_id = module.params.get("vm_startup_policy_ext_id")
+    kwargs = _build_pagination_kwargs(module)
+
+    entries, total_available_results = _list_all_compliance_states(
+        module, api_instance, vm_startup_policy_ext_id, kwargs
+    )
+
+    result["total_available_results"] = total_available_results
+    result["response"] = entries
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+
+    result = {
+        "changed": False,
+        "response": None,
+        "vm_startup_policy_ext_id": module.params.get("vm_startup_policy_ext_id"),
+        "failed": False,
+    }
+
+    api_instance = get_vm_startup_policies_api_instance(module)
+
+    if module.params.get("ext_id"):
+        get_vm_startup_policy_vm_compliance_state_by_ext_id(
+            module, api_instance, result
+        )
+    else:
+        list_vm_startup_policy_vm_compliance_states(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_startup_policy_vm_compliance_states_info_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_startup_policy_vm_compliance_states_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_startup_policy_vm_compliance_states_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_vm_compliance_states_info_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_startup_policy_vm_compliance_states_info_v2/tasks/compliance_states.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_vm_compliance_states_info_v2/tasks/compliance_states.yml
@@ -1,0 +1,381 @@
+---
+# ============================================================================
+# Test plan for ntnx_vm_startup_policy_vm_compliance_states_info_v2
+# ----------------------------------------------------------------------------
+# The SDK method list_vm_startup_policy_vm_compliance_states requires a
+# VM startup policy ext_id and supports pagination only (_page, _limit).
+# Since there is no Ansible module for VM startup policy CRUD in this
+# collection, we use the PC v4 REST endpoint directly via ansible.builtin.uri
+# to set up the parent policy for the tests, then tear it down at the end.
+#
+# Cases covered:
+#   1. Ensure a VM startup policy exists (setup via REST).
+#   2. list-all VM compliance states -> asserts structure of response +
+#      total_available_results field.
+#   3. list with pagination (page=0, limit=10) -> asserts response is a list
+#      of length <= 10.
+#   4. get-by-id when the compliance list is empty -> asserts failed with
+#      descriptive error mentioning the ext_id.
+#   5. get-by-id with a well-formed but random ext_id (dependency-not-found)
+#      -> asserts failed with descriptive error.
+#   6. Negative: missing required vm_startup_policy_ext_id -> asserts fail.
+#   7. Negative: invalid parent vm_startup_policy_ext_id -> asserts SDK error
+#      is surfaced.
+#   8. If the cluster has any real compliance entries, get-by-id with the
+#      first one -> asserts it returns a single entity dict with matching
+#      ext_id.
+#   9. Cleanup: delete the created policy (with etag).
+# ============================================================================
+
+- name: Start ntnx_vm_startup_policy_vm_compliance_states_info_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_vm_startup_policy_vm_compliance_states_info_v2 tests
+
+- name: Generate random suffix
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set unique test policy name
+  ansible.builtin.set_fact:
+    startup_policy_name: "vmm-compliance-states-info-ansible-{{ random_name }}"
+
+- name: Fetch existing categories to use as policy group members
+  nutanix.ncp.ntnx_categories_info_v2:
+    limit: 2
+  register: categories_info
+  ignore_errors: true
+
+- name: Assert we could fetch at least one category
+  ansible.builtin.assert:
+    that:
+      - categories_info is defined
+      - categories_info.failed == false
+      - categories_info.response is defined
+      - categories_info.response | length >= 1
+    fail_msg: "Failed to fetch categories from Prism Central; cannot build test startup policy."
+    success_msg: "Fetched categories for building test startup policy."
+
+- name: Compute category ext_ids for policy groups
+  ansible.builtin.set_fact:
+    dep_category_ext_id_1: "{{ categories_info.response[0].ext_id }}"
+    dep_category_ext_id_2: >-
+      {{ (categories_info.response[1].ext_id)
+         if ((categories_info.response | length) > 1)
+         else categories_info.response[0].ext_id }}
+
+- name: Generate a unique request id for policy creation (v4 idempotency header)
+  ansible.builtin.set_fact:
+    create_request_id: "{{ 99999999999999999 | random | to_uuid }}"
+
+- name: Create a VM startup policy directly via PC v4 REST (setup)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/vmm/v4.2/ahv/policies/vm-startup-policies"
+    method: POST
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    headers:
+      Content-Type: "application/json"
+      Accept: "application/json"
+      NTNX-Request-Id: "{{ create_request_id }}"
+    body_format: json
+    body:
+      name: "{{ startup_policy_name }}"
+      description: "Ansible integration test policy for VM compliance states info module."
+      groups:
+        - categories:
+            - extId: "{{ dep_category_ext_id_1 }}"
+        - categories:
+            - extId: "{{ dep_category_ext_id_2 }}"
+      startConditions:
+        - powerStateCriteria:
+            "$objectType": "vmm.v4.ahv.policies.PowerStateCriteriaPowerOn"
+          delayDurationSecs: 60
+    status_code: [200, 201, 202]
+  register: create_policy_result
+  ignore_errors: true
+
+- name: Assert create-policy REST call succeeded
+  ansible.builtin.assert:
+    that:
+      - create_policy_result is defined
+      - create_policy_result.failed == false
+      - create_policy_result.json is defined
+      - create_policy_result.json.data is defined
+      - create_policy_result.json.data.extId is defined
+    fail_msg: "Failed to create test VM startup policy via REST for setup."
+    success_msg: "Test VM startup policy creation task was accepted."
+
+- name: Set task ext_id
+  ansible.builtin.set_fact:
+    create_task_ext_id: "{{ create_policy_result.json.data.extId }}"
+
+- name: Poll create task until it completes
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/prism/v4.0/config/tasks/{{ create_task_ext_id }}"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    headers:
+      Accept: "application/json"
+    status_code: [200]
+  register: task_poll
+  until:
+    - task_poll.json is defined
+    - task_poll.json.data is defined
+    - (task_poll.json.data.status | default('')) in ["SUCCEEDED", "FAILED", "CANCELED"]
+  retries: 30
+  delay: 2
+  ignore_errors: true
+
+- name: Assert create task succeeded
+  ansible.builtin.assert:
+    that:
+      - task_poll is defined
+      - task_poll.failed == false
+      - task_poll.json.data.status == "SUCCEEDED"
+      - task_poll.json.data.entitiesAffected is defined
+      - task_poll.json.data.entitiesAffected | length >= 1
+    fail_msg: "Create-policy task did not succeed: {{ task_poll.json.data | default({}) }}"
+    success_msg: "Create-policy task succeeded."
+
+- name: Extract the created policy ext_id
+  ansible.builtin.set_fact:
+    vm_startup_policy_ext_id: "{{ task_poll.json.data.entitiesAffected[0].extId }}"
+
+- name: Show policy ext_id
+  ansible.builtin.debug:
+    msg: "Created VM startup policy ext_id={{ vm_startup_policy_ext_id }}"
+
+########################################################################################
+# Test 1: List all VM compliance states of the created policy
+########################################################################################
+
+- name: List all VM compliance states of the created VM startup policy
+  nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+  register: list_all_result
+  ignore_errors: true
+
+- name: List all VM compliance states of the created VM startup policy status
+  ansible.builtin.assert:
+    that:
+      - list_all_result is defined
+      - list_all_result.changed == false
+      - list_all_result.failed == false
+      - list_all_result.response is defined
+      - list_all_result.response is iterable
+      - list_all_result.vm_startup_policy_ext_id == vm_startup_policy_ext_id
+      - list_all_result.total_available_results is defined
+      - list_all_result.total_available_results is integer
+      - list_all_result.total_available_results >= 0
+    success_msg: "List-all VM compliance states passed"
+    fail_msg: "List-all VM compliance states failed"
+
+########################################################################################
+# Test 2: List VM compliance states with pagination
+########################################################################################
+
+- name: List VM compliance states with pagination page=0 limit=10
+  nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+    page: 0
+    limit: 10
+  register: paginated_result
+  ignore_errors: true
+
+- name: List VM compliance states with pagination status
+  ansible.builtin.assert:
+    that:
+      - paginated_result is defined
+      - paginated_result.changed == false
+      - paginated_result.failed == false
+      - paginated_result.response is defined
+      - paginated_result.response is iterable
+      - (paginated_result.response | length) <= 10
+      - paginated_result.vm_startup_policy_ext_id == vm_startup_policy_ext_id
+    success_msg: "Paginated VM compliance states list passed"
+    fail_msg: "Paginated VM compliance states list failed"
+
+########################################################################################
+# Test 3: List with limit=1 (assert page size upper bound)
+########################################################################################
+
+- name: List VM compliance states with limit=1
+  nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+    limit: 1
+  register: limit_result
+  ignore_errors: true
+
+- name: List VM compliance states with limit=1 status
+  ansible.builtin.assert:
+    that:
+      - limit_result is defined
+      - limit_result.changed == false
+      - limit_result.failed == false
+      - limit_result.response is defined
+      - (limit_result.response | length) <= 1
+    success_msg: "Limit=1 VM compliance states list passed"
+    fail_msg: "Limit=1 VM compliance states list failed"
+
+########################################################################################
+# Test 4: Get-by-id with a random UUID that doesn't exist under this policy
+########################################################################################
+
+- name: Try to fetch a compliance state with a non-existent ext_id
+  nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+    ext_id: "deadbeef-dead-beef-dead-beefdeadbeef"
+  register: missing_by_id_result
+  ignore_errors: true
+
+- name: Assert get-by-id with non-existent ext_id fails cleanly
+  ansible.builtin.assert:
+    that:
+      - missing_by_id_result is defined
+      - missing_by_id_result.changed == false
+      - missing_by_id_result.failed == true
+      - missing_by_id_result.msg is defined
+      - "'deadbeef-dead-beef-dead-beefdeadbeef' in missing_by_id_result.msg"
+      - "'No VM compliance state with ext_id' in missing_by_id_result.msg"
+    success_msg: "Get-by-id with non-existent ext_id failed as expected"
+    fail_msg: "Get-by-id with non-existent ext_id did not fail as expected"
+
+########################################################################################
+# Test 5: Get-by-id when actual entries exist (only if list_all_result has entries)
+########################################################################################
+
+- name: Get first compliance state by ext_id (only when entries exist)
+  nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+    ext_id: "{{ (list_all_result.response | first).ext_id }}"
+  register: first_entry_result
+  ignore_errors: true
+  when: (list_all_result.response | length) > 0
+
+- name: Assert first compliance state fetch (when entries exist)
+  ansible.builtin.assert:
+    that:
+      - first_entry_result is defined
+      - first_entry_result.changed == false
+      - first_entry_result.failed == false
+      - first_entry_result.response is defined
+      - first_entry_result.response.ext_id is defined
+      - first_entry_result.response.ext_id == (list_all_result.response | first).ext_id
+      - first_entry_result.ext_id == (list_all_result.response | first).ext_id
+    success_msg: "Get-by-id with valid ext_id passed"
+    fail_msg: "Get-by-id with valid ext_id failed"
+  when: (list_all_result.response | length) > 0
+
+########################################################################################
+# Test 6: Negative - missing required vm_startup_policy_ext_id
+########################################################################################
+
+- name: Missing required vm_startup_policy_ext_id
+  nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2: {}
+  register: missing_required_result
+  ignore_errors: true
+
+- name: Assert missing required vm_startup_policy_ext_id fails
+  ansible.builtin.assert:
+    that:
+      - missing_required_result is defined
+      - missing_required_result.failed == true
+      - missing_required_result.msg is defined
+      - "'vm_startup_policy_ext_id' in missing_required_result.msg"
+    success_msg: "Missing required vm_startup_policy_ext_id failed as expected"
+    fail_msg: "Missing required vm_startup_policy_ext_id did not fail as expected"
+
+########################################################################################
+# Test 7: Negative - invalid parent vm_startup_policy_ext_id
+########################################################################################
+
+- name: Invalid parent vm_startup_policy_ext_id
+  nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+    vm_startup_policy_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: invalid_parent_result
+  ignore_errors: true
+
+- name: Assert invalid parent vm_startup_policy_ext_id fails
+  ansible.builtin.assert:
+    that:
+      - invalid_parent_result is defined
+      - invalid_parent_result.failed == true
+      - invalid_parent_result.msg is defined
+      - "'Api Exception raised while fetching VM startup policy VM compliance states info' in invalid_parent_result.msg"
+    success_msg: "Invalid parent vm_startup_policy_ext_id failed as expected"
+    fail_msg: "Invalid parent vm_startup_policy_ext_id did not fail as expected"
+
+########################################################################################
+# Test 8: Type validation on limit (invalid non-int)
+########################################################################################
+
+- name: Type validation - non-int limit
+  nutanix.ncp.ntnx_vm_startup_policy_vm_compliance_states_info_v2:
+    vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+    limit: "not-a-number"
+  register: bad_limit_result
+  ignore_errors: true
+
+- name: Assert non-int limit is rejected by the argument spec
+  ansible.builtin.assert:
+    that:
+      - bad_limit_result is defined
+      - bad_limit_result.failed == true
+      - bad_limit_result.msg is defined
+      - >-
+        ('cannot be converted to an int' in bad_limit_result.msg)
+        or ('is not a valid integer' in bad_limit_result.msg)
+    success_msg: "Non-int limit rejected as expected"
+    fail_msg: "Non-int limit was not rejected as expected"
+
+########################################################################################
+# Cleanup: fetch etag and delete the test policy
+########################################################################################
+
+- name: Get created policy details to obtain etag
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/vmm/v4.2/ahv/policies/vm-startup-policies/{{ vm_startup_policy_ext_id }}"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    headers:
+      Accept: "application/json"
+    status_code: [200]
+    return_content: true
+  register: policy_get
+  ignore_errors: true
+
+- name: Extract policy etag
+  ansible.builtin.set_fact:
+    policy_etag: "{{ policy_get.etag | default(policy_get['etag'] | default('')) }}"
+
+- name: Generate a unique request id for policy delete
+  ansible.builtin.set_fact:
+    delete_request_id: "{{ 99999999999999999 | random | to_uuid }}"
+
+- name: Delete the test VM startup policy
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/vmm/v4.2/ahv/policies/vm-startup-policies/{{ vm_startup_policy_ext_id }}"
+    method: DELETE
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    headers:
+      Accept: "application/json"
+      If-Match: "{{ policy_etag }}"
+      NTNX-Request-Id: "{{ delete_request_id }}"
+    status_code: [200, 202, 204]
+  register: delete_policy_result
+  ignore_errors: true
+
+- name: Log delete result (best-effort cleanup)
+  ansible.builtin.debug:
+    msg: "Delete result status={{ delete_policy_result.status | default('n/a') }}"

--- a/tests/integration/targets/ntnx_vm_startup_policy_vm_compliance_states_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_vm_compliance_states_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import compliance_states.yml
+      ansible.builtin.import_tasks: compliance_states.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **virtual_machine_management** namespace, entity
**VmStartupPolicyVmComplianceState**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_vm_startup_policy_vm_compliance_states_info_v2`
  (No CRUD module was generated — the entity `VmStartupPolicyVmComplianceState` is
  read-only in the SDK. The only API method surfaced by the SDK for this entity is
  `ListVmStartupPolicyVmComplianceStates`; there is no
  Create/GetById/Update/Delete for a compliance-state record. Therefore the
  original `Step 1 CRUD` was skipped and only the info module described in
  `Step 2` was generated.)
- API methods covered: 1 (`ListVmStartupPolicyVmComplianceStates`)
- Fields in info module spec: 4 (`vm_startup_policy_ext_id`, `ext_id`, `page`, `limit`, plus the
  standard credential / connection args inherited from `BaseInfoModule`)

## Domain knowledge (from Glean)

**Overview**

The **VmStartupPolicy VM compliance state** in Nutanix VMM tracks whether Virtual
Machines (VMs) are adhering to defined startup sequences and dependency rules during
boot or recovery events.

**Features**

Compliance is tracked on a per-VM, per-policy basis. The compliance states include:

- **COMPLIANT**: The VM started successfully according to the policy's defined conditions and dependencies.
- **NON_COMPLIANT**: The VM was started without its conditions being satisfied (e.g., started manually before its dependencies were ready).
- **NOT_APPLICABLE** / **UNKNOWN**: The policy is inactive, the VM's placement is unavailable, or the VM is not currently in a startup sequence.

It also tracks specific **Non-Compliance Reasons** (e.g., `kClusterNotSupported`,
`kNgtNotEnabled`, `kLegacyHaPriorityValueSet`, `kHaNotSupported`) and **HA Not
Supported Reasons** (e.g., `kVirtualGpu`, `kPassthroughGpu`, `kAgentVm`,
`kPciePassthrough`) to help administrators troubleshoot why a VM isn't
participating in automated recovery.

**Usage**

Startup policies define the exact order and conditions under which a group of VMs
should start. Administrators configure:

- **Start Conditions**: When to begin starting a set of VMs (e.g., `AFTER_DELAY` or `AFTER_VM_POWER_ON`).
- **Dependencies**: Specific VMs that must be running before others are allowed to start.

Policies are primarily enforced during **cluster boot**, **host failure recovery
(HA)**, or when performing a **manual start** of a group of VMs.

**Workflow**

The policy lifecycle and compliance reconciliation are managed by internal VMM
components (Policy Entity Manager, Compliance Manager, and Event Manager):

1. **Dependency Graph Building**: When a cluster boots, VMM loads all startup
   policies, builds a topological VM dependency graph, and calculates the exact
   startup order. Circular dependencies are actively detected and prevented.
2. **VM Power On**: When a VM powers on, the Event Manager checks whether the VM
   is part of a startup policy. It verifies that all dependencies are satisfied,
   updates the VM's compliance status, and subsequently triggers any downstream
   dependent VMs if their conditions are now met.
3. **VM Power Off**: If a VM powers off, the system checks whether other running
   VMs depended on it. If they do, those dependent VMs are marked as
   non-compliant, and the dependency graph is updated.
4. **Continuous Reconciliation**: A background compliance reconciler runs
   continuously (default every 300s) to sync states, evaluate conflicts (e.g.,
   multiple policies targeting the same VM), and update the IDF compliance
   tables.

**Prerequisites**

- The API only returns data for VMs that are part of a startup policy.
- Policies are applied per cluster; VMs must be members of a cluster that
  supports startup policies (AHV).
- NGT may be required if the startup criteria uses guest bootup detection.
- Category associations for VMs and policies must be configured properly for
  the compliance engine to evaluate correctly.

**Related Resources**

Confluence Pages:

- [VM Policies](https://confluence.eng.nutanix.com:8443/spaces/~<PERSON_1>.yip/pages/507297514/VM+Policies) — Design/Architecture overview

JIRA Tickets:

- [FEAT-5081](https://jira.nutanix.com/browse/FEAT-5081) — Base feature tracking ticket
- [ENG-784580](https://jira.nutanix.com/browse/ENG-784580) — [VM-Startup-Policy] If we delete the vms of the policy, is not updating the vms and compliance list api
- [ENG-823232](https://jira.nutanix.com/browse/ENG-823232) — [VM Startup Policy] DependencyGraph is not synced correctly
- [ENG-866606](https://jira.nutanix.com/browse/ENG-866606) — Vm-Startup Policy not getting updated with invalid argument error
- [ENG-919811](https://jira.nutanix.com/browse/ENG-919811) — [VM-Startup-Policy] - Non policy VMs took more than 2minutes to power on after policy VMs during HAFO
- [ENG-945437](https://jira.nutanix.com/browse/ENG-945437) — [VM-Startup-Policy] Enhancements and code cleanup
- [ENG-922449](https://jira.nutanix.com/browse/ENG-922449) — Optimisations in VM startup policy helper - class setup, init, teardown part (not methods)

Source Documents:

- `vmStartupPoliciesEndpoints.yaml` — API endpoint definitions
  (https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv-policies/released/api/vmStartupPoliciesEndpoints.yaml)
- `vm-startup-policy-endpoints.yaml` — v4.2 split endpoints
  (https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/endpoints/ahv/policies/vm-startup-policy-endpoints.yaml)
- `VmStartupPolicies_service.proto` — service proto
  (https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/tests/microbenchmarking_mocks/mock_metropolis/proto/vmm/vmm/v4/ahv/policies/VmStartupPolicies_service.proto)
- `policies.proto` — policies proto
  (https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/tests/microbenchmarking_mocks/mock_metropolis/proto/vmm/vmm/v4/ahv/policies/policies.proto)
- `policies_model.go` — Go SDK models
  (https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/ahv/policies/policies_model.go)
- `vm_startup_policies_api.py` — Python SDK API
  (https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/api/vm_startup_policies_api.py)
- `vm_startup_policies_api.go` — Go SDK API
  (https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/api/vm_startup_policies_api.go)
- `vm_startup_policy_helper.py` — test helper
  (https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/acropolis/ahv_management/vm_startup_policy/vm_startup_policy_helper.py)
- `test_interops_with_other_policies.py` — nutest cases
  (https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/acropolis/ahv_management/scheduler/vm_startup_policy/test_interops_with_other_policies.py)
- `test_vm_startup_policy_upgrades.py` — upgrade tests
  (https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/acropolis/ahv_management/scheduler/vm_startup_policy/test_vm_startup_policy_upgrades.py)
- `metropolis_types_proto3.pb.go` — metropolis types
  (https://github.com/nutanix-core/go-cache/blob/master/metropolis/metropolis_types_proto3.pb.go)

**Required Domain Skills**

- Understanding of Nutanix AHV VM lifecycle and power state transitions
- Knowledge of VMM v4 REST API design and pagination (`_page`, `_limit`)
- Familiarity with VM categories and how policies target VMs via category references
- Understanding of Prism Central cluster/vm ext_id references
- Familiarity with NGT (Nutanix Guest Tools) and its role in guest bootup detection
- Awareness of HA (High Availability) restrictions (agent VMs, GPU pass-through, PCIe pass-through)
- Awareness of the Ansible Nutanix collection module patterns (info modules, `BaseInfoModule` usage, `SpecGenerator`, `api_logger`)

## Files changed

- `plugins/modules/`
  - `ntnx_vm_startup_policy_vm_compliance_states_info_v2.py` (new) — info module for
    `ListVmStartupPolicyVmComplianceStates`.
- `plugins/module_utils/v4/vmm/`
  - `api_client.py` — added `get_vm_startup_policies_api_instance` helper for the
    new `VmStartupPoliciesApi` SDK class.
  - `helpers.py` — added `get_vm_startup_policy` helper (reusable get-by-id for
    the parent policy).
- `meta/`
  - `runtime.yml` — added the new info module to the `ntnx` action_group so
    `module_defaults: group/nutanix.ncp.ntnx` credential injection works.
- `.gitignore` — ignore `tests/integration/integration_config.yml` (credentials file).
- `examples/virtual_machine_management/VmStartupPolicyVmComplianceState/`
  - `vm_startup_policy_vm_compliance_states_info.yml` — end-to-end example playbook.
  - `examples_run.log` — captured live playbook output against Prism Central 10.44.76.28.
- `tests/integration/targets/ntnx_vm_startup_policy_vm_compliance_states_info_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/compliance_states.yml` —
    full integration test target with setup/teardown of a real VM startup policy.

## Test execution

| Metric              | Value                                                                                              |
|---------------------|----------------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 ntnx_vm_startup_policy_vm_compliance_states_info_v2 --allow-disabled -v` |
| Total plays         | `1`                                                                                                |
| Passed tasks        | `34`                                                                                               |
| Failed tasks        | `0`                                                                                                |
| Skipped tasks       | `2` (get-by-id-with-real-entries path, only runs when the cluster has real compliance entries)     |
| Ignored tasks       | `4` (all intentional — negative-path REST/module calls where `ignore_errors: true` is set)         |
| Cluster (PC)        | `10.44.76.28` (Nutanix Prism Central `pc.7.6`)                                                     |
| Example playbook    | `examples/virtual_machine_management/VmStartupPolicyVmComplianceState/vm_startup_policy_vm_compliance_states_info.yml` — ran successfully against the same PC; see `examples/.../examples_run.log`. |

### Analysis

All integration assertions passed. The `PLAY RECAP` from the last run:

```
testhost                   : ok=34   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=4
```

Cases covered end-to-end against the live PC:

1. **Setup** — Fetched real categories via `ntnx_categories_info_v2`, generated a
   unique `NTNX-Request-Id`, and created a VM startup policy via the PC v4 REST
   endpoint (no Ansible CRUD module exists for this entity yet). Polled the task
   until `SUCCEEDED` and extracted the created ext_id.
2. **List all** — Asserted the info module returned a well-typed response
   (`response is iterable`, `vm_startup_policy_ext_id` echoed,
   `total_available_results` present and >= 0).
3. **List with pagination** (`page=0`, `limit=10`) — Asserted response length <= 10.
4. **List with `limit=1`** — Asserted response length <= 1.
5. **Get-by-id with non-existent ext_id** — Asserted module fails cleanly with a
   descriptive error that mentions the missing ext_id.
6. **Get-by-id with valid ext_id** (`when: response|length > 0`) — Skipped in this
   run because the cluster had no VMs in the test policy's categories, hence the
   compliance list is empty. This is expected on a fresh test cluster and is the
   only intentionally-skipped test path.
7. **Missing required `vm_startup_policy_ext_id`** — Asserted module fails with
   `"missing required arguments: vm_startup_policy_ext_id"`.
8. **Invalid parent `vm_startup_policy_ext_id`** — Asserted module fails via
   `raise_api_exception` with the "Api Exception raised while fetching VM
   startup policy VM compliance states info" message.
9. **Type validation on `limit`** — Asserted the argument spec rejects a
   non-int value.
10. **Cleanup** — Fetched the etag via GET, then deleted the policy via DELETE
    with `If-Match`. Cleanup ran successfully (HTTP 202).

There are **no known-failing tests**.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log (long output lines truncated at 1500 chars for readability)</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /bin/python3.12
Creating container database.
Run command: /bin/python3.12 /home/abhinav.bansal1/.local/lib/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_vm_startup_policy_vm_compliance_states_info_v2 integration test role
Stream command: ansible-playbook ntnx_vm_startup_policy_vm_compliance_states_info_v2-<...>.yml -i inventory -v

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Start ntnx_vm_startup_policy_vm_compliance_states_info_v2 tests]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Generate random suffix]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Set unique test policy name]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Fetch existing categories to use as policy group members]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Assert we could fetch at least one category]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Compute category ext_ids for policy groups]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Generate a unique request id for policy creation (v4 idempotency header)]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Create a VM startup policy directly via PC v4 REST (setup)]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Assert create-policy REST call succeeded]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Set task ext_id]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Poll create task until it completes]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Assert create task succeeded]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Extract the created policy ext_id]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Show policy ext_id]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : List all VM compliance states of the created VM startup policy]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : List all VM compliance states of the created VM startup policy status]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : List VM compliance states with pagination page=0 limit=10]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : List VM compliance states with pagination status]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : List VM compliance states with limit=1]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : List VM compliance states with limit=1 status]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Try to fetch a compliance state with a non-existent ext_id]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Assert get-by-id with non-existent ext_id fails cleanly]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Get first compliance state by ext_id (only when entries exist)]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Assert first compliance state fetch (when entries exist)]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Missing required vm_startup_policy_ext_id]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Assert missing required vm_startup_policy_ext_id fails]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Invalid parent vm_startup_policy_ext_id]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Assert invalid parent vm_startup_policy_ext_id fails]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Type validation - non-int limit]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Assert non-int limit is rejected by the argument spec]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Get created policy details to obtain etag]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Extract policy etag]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Generate a unique request id for policy delete]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Delete the test VM startup policy]
TASK [ntnx_vm_startup_policy_vm_compliance_states_info_v2 : Log delete result (best-effort cleanup)]

PLAY RECAP *********************************************************************
testhost                   : ok=34   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=4
```

</details>

### Lint and sanity

- `black` — pass (module reformatted).
- `isort` — pass.
- `flake8` — pass on all touched files.
- `ansible-lint` — pass (5/5 star). The two remaining `args[module]` warnings are
  intentional — they come from the two negative test cases that pass an invalid
  `limit` value or omit the required `vm_startup_policy_ext_id`.
- `ansible-test sanity --python 3.12` — pass on all touched files
  (`plugins/modules/ntnx_vm_startup_policy_vm_compliance_states_info_v2.py`,
  `plugins/module_utils/v4/vmm/api_client.py`,
  `plugins/module_utils/v4/vmm/helpers.py`).
  Sanity was run from a scratch copy of the repo at
  `/tmp/work/ansible_collections/nutanix/ncp/` because ansible-test requires the
  source tree to live inside an `ansible_collections/{ns}/{name}/` path.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Only the info module was generated — see the note at the top of **Summary**
  for why the CRUD module in Step 1 was intentionally skipped.
