### PR TITLE
code-gen(networking/ReserveIpsBySubnetId): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+tests/integration/inventory
+tests/output/

--- a/examples/networking/ReserveIpsBySubnetId/examples_run.log
+++ b/examples/networking/ReserveIpsBySubnetId/examples_run.log
@@ -1,0 +1,21 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Reserve IPs by Subnet Id playbook] ***************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"first_reserved_ip": "192.168.214.21", "reserve_client_context": "ansible_example_reserve", "second_reserved_ip": "192.168.214.22", "subnet_ext_id": "6be3e46b-794a-43f9-ab3e-04b94acf9f2e"}, "changed": false}
+
+TASK [Reserve IPs on a managed subnet (all attributes)] ************************
+changed: [localhost] => {"changed": true, "ext_id": "6be3e46b-794a-43f9-ab3e-04b94acf9f2e", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:51:41.861959+00:00", "completion_details": [{"name": "reserved_or_unreserved_ips", "value": "{\"reserved_ips\": [\"192.168.214.21\", \"192.168.214.22\"]}"}], "created_time": "2026-07-21T05:51:41.730026+00:00", "entities_affected": [{"ext_id": "6be3e46b-794a-43f9-ab3e-04b94acf9f2e", "name": null, "rel": "networking:config:subnet"}], "error_messages": null, "ext_id": "ZXJnb24=:b7d0e296-5968-43b1-a14e-10480ba7191b", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:51:41.861958+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kSubnetReserveIp", "operation_description": "Reserve or Unreserve IP on Managed Subnet", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:51:41.739554+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:b7d0e296-5968-43b1-a14e-10480ba7191b"}
+
+TASK [List reserved IPs on the subnet] *****************************************
+ok: [localhost] => {"changed": false, "ext_id": "6be3e46b-794a-43f9-ab3e-04b94acf9f2e", "response": [{"client_context": "ansible_example_reserve", "ext_id": null, "ipv4_address": "192.168.214.22", "links": null, "tenant_id": null}, {"client_context": "ansible_example_reserve", "ext_id": null, "ipv4_address": "192.168.214.21", "links": null, "tenant_id": null}], "total_available_results": 2}
+
+TASK [Unreserve IPs on the subnet (all attributes)] ****************************
+changed: [localhost] => {"changed": true, "ext_id": "6be3e46b-794a-43f9-ab3e-04b94acf9f2e", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:51:45.880382+00:00", "completion_details": [{"name": "reserved_or_unreserved_ips", "value": "{\"unreserved_ips\": [\"192.168.214.22\", \"192.168.214.21\"]}"}], "created_time": "2026-07-21T05:51:45.784359+00:00", "entities_affected": [{"ext_id": "6be3e46b-794a-43f9-ab3e-04b94acf9f2e", "name": null, "rel": "networking:config:subnet"}], "error_messages": null, "ext_id": "ZXJnb24=:61c184e1-d811-4d04-91d7-1119479d82df", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:51:45.880380+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kSubnetReserveIp", "operation_description": "Reserve or Unreserve IP on Managed Subnet", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:51:45.794160+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:61c184e1-d811-4d04-91d7-1119479d82df"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/networking/ReserveIpsBySubnetId/reserve_ips_by_subnet_id_v2.yml
+++ b/examples/networking/ReserveIpsBySubnetId/reserve_ips_by_subnet_id_v2.yml
@@ -1,0 +1,62 @@
+---
+# Summary:
+# This playbook demonstrates the ntnx_reserve_ips_by_subnet_id_v2 and
+# ntnx_reserve_ips_by_subnet_ids_info_v2 modules end-to-end.
+#
+# It exercises exactly one representative call per operation:
+#   1. Reserve IPs on a managed subnet (with ALL supported attributes).
+#   2. List reserved IPs on the subnet (info module).
+#   3. Unreserve IPs on the same subnet (with ALL supported attributes).
+#
+# Prerequisites (must exist on the target Prism Central):
+#   * A VLAN or overlay subnet with IPAM configured (i.e. the subnet has an
+#     IP address pool). The subnet ext_id is passed via `subnet_ext_id`.
+#   * The Ansible user must have Network Infra Admin / Prism Admin permissions.
+
+- name: Reserve IPs by Subnet Id playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        subnet_ext_id: "{{ subnet_ext_id | default('<managed-subnet-uuid>') }}"
+        reserve_client_context: "ansible_example_reserve"
+        first_reserved_ip: "{{ first_reserved_ip | default('192.168.214.21') }}"
+        second_reserved_ip: "{{ second_reserved_ip | default('192.168.214.22') }}"
+
+    - name: Reserve IPs on a managed subnet (all attributes)
+      nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+        state: present
+        ext_id: "{{ subnet_ext_id }}"
+        reserve_type: IP_ADDRESS_LIST
+        ip_addresses:
+          - ipv4:
+              value: "{{ first_reserved_ip }}"
+              prefix_length: 32
+          - ipv4:
+              value: "{{ second_reserved_ip }}"
+              prefix_length: 32
+        client_context: "{{ reserve_client_context }}"
+      register: reserve_result
+      ignore_errors: true
+
+    - name: List reserved IPs on the subnet
+      nutanix.ncp.ntnx_reserve_ips_by_subnet_ids_info_v2:
+        ext_id: "{{ subnet_ext_id }}"
+      register: list_result
+      ignore_errors: true
+
+    - name: Unreserve IPs on the subnet (all attributes)
+      nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+        state: absent
+        ext_id: "{{ subnet_ext_id }}"
+        unreserve_type: CONTEXT
+        client_context: "{{ reserve_client_context }}"
+      register: unreserve_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_reserve_ips_by_subnet_id_v2
+    - ntnx_reserve_ips_by_subnet_ids_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,16 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_subnet_ip_reservation_api_instance(module):
+    """
+    This method will return SubnetIPReservationApi instance for reserve /
+    unreserve / list-reserved IP operations on a managed subnet.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Subnet IP Reservation Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.SubnetIPReservationApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,32 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def list_reserved_ips_by_subnet(module, api_instance, subnet_ext_id, **kwargs):
+    """
+    List all reserved IP addresses on a managed subnet.
+
+    Args:
+        module: Ansible module
+        api_instance: SubnetIPReservationApi instance from ntnx_networking_py_client
+        subnet_ext_id (str): UUID of the subnet whose reserved IPs to list
+        **kwargs: Optional pagination / filter query parameters
+            (`_page`, `_limit`, `_filter`, `_orderby`, `_select`)
+
+    Returns:
+        response (object): SDK ListSubnetReservedIpsApiResponse
+    """
+    try:
+        return api_instance.list_reserved_ips_by_subnet_id(
+            subnetExtId=subnet_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while listing reserved IPs "
+                "for subnet ext_id: {0}".format(subnet_ext_id)
+            ),
+        )

--- a/plugins/modules/ntnx_reserve_ips_by_subnet_id_v2.py
+++ b/plugins/modules/ntnx_reserve_ips_by_subnet_id_v2.py
@@ -1,0 +1,588 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_reserve_ips_by_subnet_id_v2
+short_description: Reserve or unreserve IP addresses on a managed subnet in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to reserve or unreserve IP addresses on a managed subnet in Nutanix Prism Central.
+  - This is an action-style module — a reservation does not have its own external ID.
+  - When C(state=present) the module invokes the Reserve IPs API on the given subnet.
+  - When C(state=absent) the module invokes the Unreserve IPs API on the given subnet.
+  - This module uses PC v4 APIs based SDKs
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Reserve IPs on a subnet) -
+      Required Roles: Network Infra Admin, Prism Admin, Super Admin, VPC Admin
+    - >-
+      B(Unreserve IPs on a subnet) -
+      Required Roles: Network Infra Admin, Prism Admin, Super Admin, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) the module will reserve IPs on the subnet identified by C(ext_id).
+      - If C(state) is set to C(absent) the module will unreserve IPs on the subnet identified by C(ext_id).
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID (UUID) of the managed subnet on which IPs are (un)reserved.
+      - Required for both reserve (C(state=present)) and unreserve (C(state=absent)) operations.
+    type: str
+    required: true
+  count:
+    description:
+      - Number of IP addresses to reserve (when C(state=present)) or unreserve (when C(state=absent)).
+      - Required when C(reserve_type=IP_ADDRESS_COUNT) on reserve.
+    type: int
+    required: false
+  start_ip_address:
+    description:
+      - Starting IP address for range-based reserve / unreserve.
+      - Required when C(reserve_type=IP_ADDRESS_RANGE) on reserve or C(unreserve_type=IP_ADDRESS_RANGE) on unreserve.
+    type: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 address specification.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv4 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the network.
+            type: int
+            required: false
+            default: 32
+      ipv6:
+        description:
+          - IPv6 address specification.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the network.
+            type: int
+            required: false
+            default: 128
+  ip_addresses:
+    description:
+      - Explicit list of IP addresses to reserve or unreserve.
+      - Required when C(reserve_type=IP_ADDRESS_LIST) on reserve or C(unreserve_type=IP_ADDRESS_LIST) on unreserve.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 address specification.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv4 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the network.
+            type: int
+            required: false
+            default: 32
+      ipv6:
+        description:
+          - IPv6 address specification.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the network.
+            type: int
+            required: false
+            default: 128
+  reserve_type:
+    description:
+      - How the caller wants to reserve IPs on the subnet.
+      - Required for reserve operation (C(state=present)).
+      - C(IP_ADDRESS_COUNT) reserves C(count) random free IPs.
+      - C(IP_ADDRESS_LIST) reserves the explicit C(ip_addresses).
+      - C(IP_ADDRESS_RANGE) reserves C(count) IPs starting from C(start_ip_address).
+    type: str
+    required: false
+    choices:
+      - IP_ADDRESS_COUNT
+      - IP_ADDRESS_LIST
+      - IP_ADDRESS_RANGE
+  unreserve_type:
+    description:
+      - How the caller wants to unreserve IPs on the subnet.
+      - Required for unreserve operation (C(state=absent)).
+      - C(IP_ADDRESS_LIST) unreserves the explicit C(ip_addresses).
+      - C(IP_ADDRESS_RANGE) unreserves C(count) IPs starting from C(start_ip_address).
+      - C(CONTEXT) unreserves every IP tagged with the supplied C(client_context).
+    type: str
+    required: false
+    choices:
+      - IP_ADDRESS_LIST
+      - IP_ADDRESS_RANGE
+      - CONTEXT
+  client_context:
+    description:
+      - Free-form string that the client can use to tag / correlate reserved IPs.
+      - Required when C(unreserve_type=CONTEXT).
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Reserve a specific list of IPs on a managed subnet
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "9cc4abba-f27d-40db-90ba-c1592dccaedf"
+    reserve_type: IP_ADDRESS_LIST
+    ip_addresses:
+      - ipv4:
+          value: "192.168.0.21"
+      - ipv4:
+          value: "192.168.0.22"
+    client_context: "ansible_reserve_test"
+  register: result
+
+- name: Reserve N random IPs on a managed subnet
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "9cc4abba-f27d-40db-90ba-c1592dccaedf"
+    reserve_type: IP_ADDRESS_COUNT
+    count: 3
+    client_context: "ansible_reserve_count"
+  register: result
+
+- name: Reserve a range of IPs starting from a given address
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "9cc4abba-f27d-40db-90ba-c1592dccaedf"
+    reserve_type: IP_ADDRESS_RANGE
+    start_ip_address:
+      ipv4:
+        value: "192.168.0.25"
+    count: 2
+    client_context: "ansible_reserve_range"
+  register: result
+
+- name: Unreserve a specific list of IPs
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "9cc4abba-f27d-40db-90ba-c1592dccaedf"
+    unreserve_type: IP_ADDRESS_LIST
+    ip_addresses:
+      - ipv4:
+          value: "192.168.0.21"
+      - ipv4:
+          value: "192.168.0.22"
+  register: result
+
+- name: Unreserve every IP previously tagged with client_context
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "9cc4abba-f27d-40db-90ba-c1592dccaedf"
+    unreserve_type: CONTEXT
+    client_context: "ansible_reserve_count"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for the reserve / unreserve IP operation on the subnet.
+    - When C(wait=true) this is the completed task payload from Prism Central.
+    - When C(wait=false) this is the task reference returned by the SDK.
+  returned: always
+  type: dict
+  sample:
+    {
+      "app_name": null,
+      "batch_summary": null,
+      "cluster_ext_ids": null,
+      "completed_time": "2026-07-21T05:51:41.861959+00:00",
+      "completion_details": [
+          {
+              "name": "reserved_or_unreserved_ips",
+              "value": "{\"reserved_ips\": [\"192.168.214.21\", \"192.168.214.22\"]}"
+          }
+      ],
+      "created_time": "2026-07-21T05:51:41.730026+00:00",
+      "entities_affected": [
+          {
+              "ext_id": "6be3e46b-794a-43f9-ab3e-04b94acf9f2e",
+              "name": null,
+              "rel": "networking:config:subnet"
+          }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:b7d0e296-5968-43b1-a14e-10480ba7191b",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-21T05:51:41.861958+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 1,
+      "number_of_subtasks": 0,
+      "operation": "kSubnetReserveIp",
+      "operation_description": "Reserve or Unreserve IP on Managed Subnet",
+      "owned_by": {
+          "ext_id": "00000000-0000-0000-0000-000000000000",
+          "name": "admin"
+      },
+      "parent_task": null,
+      "progress_percentage": 100,
+      "root_task": null,
+      "started_time": "2026-07-21T05:51:41.739554+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the Prism Central task created by the reserve / unreserve operation.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:b7d0e296-5968-43b1-a14e-10480ba7191b"
+
+ext_id:
+  description:
+    - The external ID of the subnet on which IPs were reserved / unreserved.
+  returned: always
+  type: str
+  sample: "6be3e46b-794a-43f9-ab3e-04b94acf9f2e"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description:
+    - This indicates whether the task was skipped (e.g. check mode with no changes).
+  returned: when applicable
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Status / informational message from the module.
+  returned: When there is an error or the module runs in check mode
+  type: str
+  sample: "Api Exception raised while reserving IPs on subnet"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_subnet_ip_reservation_api_instance,
+)
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_networking_py_client as networking_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as networking_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    ipv4_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=32),
+    )
+
+    ipv6_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=128),
+    )
+
+    ip_address_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_address_spec,
+            required=False,
+            obj=networking_sdk.IPv4Address,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_address_spec,
+            required=False,
+            obj=networking_sdk.IPv6Address,
+        ),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        count=dict(type="int", required=False),
+        start_ip_address=dict(
+            type="dict",
+            options=ip_address_spec,
+            required=False,
+            obj=networking_sdk.IPAddress,
+        ),
+        ip_addresses=dict(
+            type="list",
+            elements="dict",
+            options=ip_address_spec,
+            required=False,
+            obj=networking_sdk.IPAddress,
+        ),
+        reserve_type=dict(
+            type="str",
+            required=False,
+            choices=["IP_ADDRESS_COUNT", "IP_ADDRESS_LIST", "IP_ADDRESS_RANGE"],
+            obj=networking_sdk.ReserveType,
+        ),
+        unreserve_type=dict(
+            type="str",
+            required=False,
+            choices=["IP_ADDRESS_LIST", "IP_ADDRESS_RANGE", "CONTEXT"],
+            obj=networking_sdk.UnreserveType,
+        ),
+        client_context=dict(type="str", required=False),
+    )
+    return module_args
+
+
+def _validate_reserve_params(module):
+    """Enforce SDK-level required combinations for reserve operation."""
+    validate_required_params(module, ["reserve_type"])
+    reserve_type = module.params.get("reserve_type")
+    if reserve_type == "IP_ADDRESS_COUNT":
+        validate_required_params(module, ["count"])
+    elif reserve_type == "IP_ADDRESS_LIST":
+        validate_required_params(module, ["ip_addresses"])
+    elif reserve_type == "IP_ADDRESS_RANGE":
+        validate_required_params(module, ["start_ip_address", "count"])
+
+
+def _validate_unreserve_params(module):
+    """Enforce SDK-level required combinations for unreserve operation."""
+    validate_required_params(module, ["unreserve_type"])
+    unreserve_type = module.params.get("unreserve_type")
+    if unreserve_type == "IP_ADDRESS_LIST":
+        validate_required_params(module, ["ip_addresses"])
+    elif unreserve_type == "IP_ADDRESS_RANGE":
+        validate_required_params(module, ["start_ip_address", "count"])
+    elif unreserve_type == "CONTEXT":
+        validate_required_params(module, ["client_context"])
+
+
+def create_ReserveIpsBySubnetId(module, result, api_instance):
+    """Reserve IPs on the target subnet (state=present)."""
+    subnet_ext_id = module.params.get("ext_id")
+    result["ext_id"] = subnet_ext_id
+
+    _validate_reserve_params(module)
+
+    sg = SpecGenerator(module)
+    default_spec = networking_sdk.IpReserveSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating reserve IPs spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        result["msg"] = "IPs will be reserved on subnet ext_id: {0}".format(
+            subnet_ext_id
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.reserve_ips_by_subnet_id(extId=subnet_ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while reserving IPs on subnet",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def delete_ReserveIpsBySubnetId(module, result, api_instance):
+    """Unreserve IPs on the target subnet (state=absent)."""
+    subnet_ext_id = module.params.get("ext_id")
+    result["ext_id"] = subnet_ext_id
+
+    _validate_unreserve_params(module)
+
+    sg = SpecGenerator(module)
+    default_spec = networking_sdk.IpUnreserveSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating unreserve IPs spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        result["msg"] = "IPs will be unreserved on subnet ext_id: {0}".format(
+            subnet_ext_id
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.unreserve_ips_by_subnet_id(extId=subnet_ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while unreserving IPs on subnet",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "present", ("reserve_type",)),
+            ("state", "absent", ("unreserve_type",)),
+        ],
+        mutually_exclusive=[
+            ("reserve_type", "unreserve_type"),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_networking_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_subnet_ip_reservation_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        create_ReserveIpsBySubnetId(module, result, api_instance)
+    else:
+        delete_ReserveIpsBySubnetId(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_reserve_ips_by_subnet_ids_info_v2.py
+++ b/plugins/modules/ntnx_reserve_ips_by_subnet_ids_info_v2.py
@@ -1,0 +1,215 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_reserve_ips_by_subnet_ids_info_v2
+short_description: Fetch reserved IPs on a managed subnet in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about reserved IPs on a managed subnet in Nutanix Prism Central.
+  - The subnet ext_id (C(ext_id)) is required — reservations are always scoped to a subnet.
+  - Supports OData pagination and filtering via the standard v4 API query parameters.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(List reserved IPs on a subnet) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer,
+      Project Admin, Super Admin, Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID (UUID) of the managed subnet whose reserved IPs are being fetched.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all reserved IPs on a subnet
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_ids_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "9cc4abba-f27d-40db-90ba-c1592dccaedf"
+  register: result
+
+- name: List reserved IPs on a subnet with pagination
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_ids_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "9cc4abba-f27d-40db-90ba-c1592dccaedf"
+    limit: 5
+    page: 0
+  register: result
+
+- name: List reserved IPs on a subnet filtered by client_context
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_ids_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "9cc4abba-f27d-40db-90ba-c1592dccaedf"
+    filter: "clientContext eq 'ansible_reserve_test'"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC ReserveIpsBySubnetId info v4 API.
+    - It is the list of reserved IPs on the subnet identified by C(ext_id).
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "client_context": "ansible_example_reserve",
+        "ext_id": null,
+        "ipv4_address": "192.168.214.22",
+        "links": null,
+        "tenant_id": null
+      },
+      {
+        "client_context": "ansible_example_reserve",
+        "ext_id": null,
+        "ipv4_address": "192.168.214.21",
+        "links": null,
+        "tenant_id": null
+      }
+    ]
+
+ext_id:
+  description: External ID of the subnet whose reserved IPs were fetched.
+  type: str
+  returned: always
+  sample: "6be3e46b-794a-43f9-ab3e-04b94acf9f2e"
+
+changed:
+  description: This indicates whether the task resulted in any changes. Info modules never change state.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while listing reserved IPs on subnet"
+
+error:
+  description: Error message.
+  type: str
+  returned: When an error occurs
+
+failed:
+  description: Indicates if the request failed.
+  type: bool
+  returned: always
+  sample: false
+
+total_available_results:
+  description: The total number of reserved IPs available on the subnet.
+  type: int
+  returned: always
+  sample: 2
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_subnet_ip_reservation_api_instance,
+)
+from ..module_utils.v4.network.helpers import list_reserved_ips_by_subnet  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_reserved_ips_by_subnet_id(module, api_instance, result):
+    subnet_ext_id = module.params.get("ext_id")
+    result["ext_id"] = subnet_ext_id
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating reserved IPs by subnet info spec", **result
+        )
+    kwargs.pop("_ext_id", None)
+
+    resp = list_reserved_ips_by_subnet(
+        module=module,
+        api_instance=api_instance,
+        subnet_ext_id=subnet_ext_id,
+        **kwargs,
+    )
+
+    total_available_results = 0
+    if resp is not None and getattr(resp, "metadata", None) is not None:
+        total_available_results = (
+            getattr(resp.metadata, "total_available_results", None) or 0
+        )
+    result["total_available_results"] = total_available_results
+
+    data = None
+    if resp is not None:
+        data = strip_internal_attributes(resp.to_dict()).get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_subnet_ip_reservation_api_instance(module)
+    get_reserved_ips_by_subnet_id(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/aliases
+++ b/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import reserve_ips_by_subnet_id.yml
+      ansible.builtin.import_tasks: reserve_ips_by_subnet_id.yml

--- a/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/tasks/reserve_ips_by_subnet_id.yml
+++ b/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/tasks/reserve_ips_by_subnet_id.yml
@@ -1,0 +1,627 @@
+---
+# ==============================================================================
+# Test plan for ntnx_reserve_ips_by_subnet_id_v2 and
+# ntnx_reserve_ips_by_subnet_ids_info_v2
+# ==============================================================================
+# Prerequisites:
+#   - `cluster.uuid`               a valid PE cluster on which to create the subnet
+#   - `virtual_switch.uuid`        a valid virtual switch on that cluster
+#   - `vlan_subnets_ids`           free VLAN IDs (list, index 5 used below)
+#   - `ip_address_management`     network_ip / network_prefix / gateway
+#   - `ip_address_pools`           start_address / end_address (IPAM pool)
+#
+# The suite deliberately covers:
+#   1. Prerequisite creation of a managed VLAN subnet with IPAM (needed because
+#      IPs can only be reserved on subnets that have an IPAM pool).
+#   2. Check-mode tests: exactly ONE for reserve, ONE for unreserve.
+#   3. Real reserve using every `reserve_type` (IP_ADDRESS_LIST,
+#      IP_ADDRESS_COUNT, IP_ADDRESS_RANGE).
+#   4. List reserved IPs via info module — get-by-subnet, and pagination.
+#   5. Real unreserve using every `unreserve_type` (IP_ADDRESS_LIST,
+#      IP_ADDRESS_RANGE, CONTEXT) — each pairs with a matching reserve.
+#   6. Idempotency-style: unreserving with a `client_context` that no longer
+#      matches any reserved IP must be handled gracefully by the platform.
+#   7. Negative tests: missing required params, unknown subnet ext_id,
+#      invalid enum values.
+#   8. Cleanup: remove any remaining reservations and delete the created subnet.
+# ==============================================================================
+
+- name: Start ntnx_reserve_ips_by_subnet_id_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_reserve_ips_by_subnet_id_v2 tests
+
+- name: Generate random suffix for test resource names
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set reservation test facts
+  ansible.builtin.set_fact:
+    subnet_name: "ansible_reserve_ips_{{ random_name }}"
+    reserve_context_list: "ansible_ctx_list_{{ random_name }}"
+    reserve_context_count: "ansible_ctx_count_{{ random_name }}"
+    reserve_context_range: "ansible_ctx_range_{{ random_name }}"
+    ip_list:
+      - "192.168.240.21"
+      - "192.168.240.22"
+    range_start_ip: "192.168.240.25"
+    range_count: 2
+    random_count: 2
+
+# ------------------------------------------------------------------------------
+# 1) Create the managed subnet (prerequisite for IP reservation)
+# ------------------------------------------------------------------------------
+
+- name: Create managed VLAN subnet (prerequisite)
+  nutanix.ncp.ntnx_subnets_v2:
+    state: present
+    name: "{{ subnet_name }}"
+    subnet_type: VLAN
+    cluster_reference: "{{ cluster.uuid }}"
+    virtual_switch_reference: "{{ virtual_switch.uuid }}"
+    network_id: "{{ vlan_subnets_ids[5] }}"
+    ip_config:
+      - ipv4:
+          ip_subnet:
+            ip:
+              value: "{{ ip_address_management.network_ip }}"
+            prefix_length: "{{ ip_address_management.network_prefix }}"
+          default_gateway_ip:
+            value: "{{ ip_address_management.gateway_ip_address }}"
+          pool_list:
+            - start_ip:
+                value: "{{ ip_address_pools.start_address }}"
+              end_ip:
+                value: "{{ ip_address_pools.end_address }}"
+  register: subnet_create_result
+  ignore_errors: true
+
+- name: Managed subnet creation status
+  ansible.builtin.assert:
+    that:
+      - subnet_create_result is defined
+      - subnet_create_result.failed == false
+      - subnet_create_result.changed == true
+      - subnet_create_result.response is defined
+      - subnet_create_result.ext_id is defined
+      - subnet_create_result.response.name == subnet_name
+      - subnet_create_result.response.subnet_type == "VLAN"
+    fail_msg: "Failed to create managed subnet prerequisite"
+    success_msg: "Managed VLAN subnet created successfully"
+
+- name: Capture subnet ext_id
+  ansible.builtin.set_fact:
+    subnet_ext_id: "{{ subnet_create_result.ext_id }}"
+
+# ------------------------------------------------------------------------------
+# 2) Check-mode: Reserve (all attributes)
+# ------------------------------------------------------------------------------
+
+- name: Reserve IPs in check mode (all attributes)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    reserve_type: IP_ADDRESS_LIST
+    ip_addresses:
+      - ipv4:
+          value: "{{ ip_list[0] }}"
+          prefix_length: 32
+      - ipv4:
+          value: "{{ ip_list[1] }}"
+          prefix_length: 32
+    client_context: "{{ reserve_context_list }}"
+    count: 2
+    start_ip_address:
+      ipv4:
+        value: "192.168.240.30"
+  check_mode: true
+  register: reserve_check_mode_result
+  ignore_errors: true
+
+- name: Verify reserve check-mode spec generation
+  ansible.builtin.assert:
+    that:
+      - reserve_check_mode_result is defined
+      - reserve_check_mode_result.changed == false
+      - reserve_check_mode_result.failed == false
+      - reserve_check_mode_result.ext_id == subnet_ext_id
+      - reserve_check_mode_result.response is defined
+      - reserve_check_mode_result.response.reserve_type == "IP_ADDRESS_LIST"
+      - reserve_check_mode_result.response.client_context == reserve_context_list
+      - reserve_check_mode_result.response.count == 2
+      - reserve_check_mode_result.response.start_ip_address.ipv4.value == "192.168.240.30"
+      - reserve_check_mode_result.response.ip_addresses | length == 2
+      - reserve_check_mode_result.response.ip_addresses[0].ipv4.value == ip_list[0]
+      - reserve_check_mode_result.response.ip_addresses[1].ipv4.value == ip_list[1]
+    fail_msg: "Reserve check_mode did not generate the expected spec"
+    success_msg: "Reserve check_mode generated the expected spec"
+
+# ------------------------------------------------------------------------------
+# 3) Check-mode: Unreserve (all attributes)
+# ------------------------------------------------------------------------------
+
+- name: Unreserve IPs in check mode (all attributes)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: absent
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: IP_ADDRESS_LIST
+    ip_addresses:
+      - ipv4:
+          value: "{{ ip_list[0] }}"
+          prefix_length: 32
+      - ipv4:
+          value: "{{ ip_list[1] }}"
+          prefix_length: 32
+    client_context: "{{ reserve_context_list }}"
+    count: 2
+    start_ip_address:
+      ipv4:
+        value: "192.168.240.30"
+  check_mode: true
+  register: unreserve_check_mode_result
+  ignore_errors: true
+
+- name: Verify unreserve check-mode spec generation
+  ansible.builtin.assert:
+    that:
+      - unreserve_check_mode_result is defined
+      - unreserve_check_mode_result.changed == false
+      - unreserve_check_mode_result.failed == false
+      - unreserve_check_mode_result.ext_id == subnet_ext_id
+      - unreserve_check_mode_result.response is defined
+      - unreserve_check_mode_result.response.unreserve_type == "IP_ADDRESS_LIST"
+      - unreserve_check_mode_result.response.client_context == reserve_context_list
+      - unreserve_check_mode_result.response.count == 2
+      - unreserve_check_mode_result.response.start_ip_address.ipv4.value == "192.168.240.30"
+      - unreserve_check_mode_result.response.ip_addresses | length == 2
+      - unreserve_check_mode_result.response.ip_addresses[0].ipv4.value == ip_list[0]
+      - unreserve_check_mode_result.response.ip_addresses[1].ipv4.value == ip_list[1]
+    fail_msg: "Unreserve check_mode did not generate the expected spec"
+    success_msg: "Unreserve check_mode generated the expected spec"
+
+# ------------------------------------------------------------------------------
+# 4) Real reserve — IP_ADDRESS_LIST (minimal attributes)
+# ------------------------------------------------------------------------------
+
+- name: Reserve IPs (IP_ADDRESS_LIST — required fields only)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    reserve_type: IP_ADDRESS_LIST
+    ip_addresses:
+      - ipv4:
+          value: "{{ ip_list[0] }}"
+  register: reserve_list_result
+  ignore_errors: true
+
+- name: Verify reserve IP_ADDRESS_LIST minimal succeeded
+  ansible.builtin.assert:
+    that:
+      - reserve_list_result is defined
+      - reserve_list_result.changed == true
+      - reserve_list_result.failed == false
+      - reserve_list_result.ext_id == subnet_ext_id
+      - reserve_list_result.task_ext_id is defined
+      - reserve_list_result.response is defined
+      - reserve_list_result.response.status == "SUCCEEDED"
+    fail_msg: "Reserve IP_ADDRESS_LIST minimal failed: {{ reserve_list_result }}"
+    success_msg: "Reserve IP_ADDRESS_LIST minimal succeeded"
+
+# ------------------------------------------------------------------------------
+# 5) Real reserve — IP_ADDRESS_LIST (all attributes) — different IP
+# ------------------------------------------------------------------------------
+
+- name: Reserve IPs (IP_ADDRESS_LIST — all attributes)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    reserve_type: IP_ADDRESS_LIST
+    ip_addresses:
+      - ipv4:
+          value: "{{ ip_list[1] }}"
+          prefix_length: 32
+    client_context: "{{ reserve_context_list }}"
+  register: reserve_list_full_result
+  ignore_errors: true
+
+- name: Verify reserve IP_ADDRESS_LIST full succeeded
+  ansible.builtin.assert:
+    that:
+      - reserve_list_full_result is defined
+      - reserve_list_full_result.changed == true
+      - reserve_list_full_result.failed == false
+      - reserve_list_full_result.ext_id == subnet_ext_id
+      - reserve_list_full_result.task_ext_id is defined
+      - reserve_list_full_result.response is defined
+      - reserve_list_full_result.response.status == "SUCCEEDED"
+    fail_msg: "Reserve IP_ADDRESS_LIST full failed: {{ reserve_list_full_result }}"
+    success_msg: "Reserve IP_ADDRESS_LIST full succeeded"
+
+# ------------------------------------------------------------------------------
+# 6) Real reserve — IP_ADDRESS_COUNT
+# ------------------------------------------------------------------------------
+
+- name: Reserve IPs (IP_ADDRESS_COUNT)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    reserve_type: IP_ADDRESS_COUNT
+    count: "{{ random_count }}"
+    client_context: "{{ reserve_context_count }}"
+  register: reserve_count_result
+  ignore_errors: true
+
+- name: Verify reserve IP_ADDRESS_COUNT succeeded
+  ansible.builtin.assert:
+    that:
+      - reserve_count_result is defined
+      - reserve_count_result.changed == true
+      - reserve_count_result.failed == false
+      - reserve_count_result.ext_id == subnet_ext_id
+      - reserve_count_result.task_ext_id is defined
+      - reserve_count_result.response is defined
+      - reserve_count_result.response.status == "SUCCEEDED"
+    fail_msg: "Reserve IP_ADDRESS_COUNT failed: {{ reserve_count_result }}"
+    success_msg: "Reserve IP_ADDRESS_COUNT succeeded"
+
+# ------------------------------------------------------------------------------
+# 7) Real reserve — IP_ADDRESS_RANGE
+# ------------------------------------------------------------------------------
+
+- name: Reserve IPs (IP_ADDRESS_RANGE)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    reserve_type: IP_ADDRESS_RANGE
+    start_ip_address:
+      ipv4:
+        value: "{{ range_start_ip }}"
+    count: "{{ range_count }}"
+    client_context: "{{ reserve_context_range }}"
+  register: reserve_range_result
+  ignore_errors: true
+
+- name: Verify reserve IP_ADDRESS_RANGE succeeded
+  ansible.builtin.assert:
+    that:
+      - reserve_range_result is defined
+      - reserve_range_result.changed == true
+      - reserve_range_result.failed == false
+      - reserve_range_result.ext_id == subnet_ext_id
+      - reserve_range_result.task_ext_id is defined
+      - reserve_range_result.response is defined
+      - reserve_range_result.response.status == "SUCCEEDED"
+    fail_msg: "Reserve IP_ADDRESS_RANGE failed: {{ reserve_range_result }}"
+    success_msg: "Reserve IP_ADDRESS_RANGE succeeded"
+
+# ------------------------------------------------------------------------------
+# 8) Info module — list all reserved IPs on the subnet
+# ------------------------------------------------------------------------------
+
+- name: List reserved IPs on the subnet
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_ids_info_v2:
+    ext_id: "{{ subnet_ext_id }}"
+  register: list_reserved_result
+  ignore_errors: true
+
+- name: Verify list reserved IPs returned entries
+  ansible.builtin.assert:
+    that:
+      - list_reserved_result is defined
+      - list_reserved_result.changed == false
+      - list_reserved_result.failed == false
+      - list_reserved_result.ext_id == subnet_ext_id
+      - list_reserved_result.response is defined
+      - list_reserved_result.response | length >= 4
+      - list_reserved_result.total_available_results is defined
+      - list_reserved_result.total_available_results | int >= 4
+    fail_msg: "List reserved IPs did not return the expected entries: {{ list_reserved_result }}"
+    success_msg: "List reserved IPs returned expected entries"
+
+- name: Verify each reserved IP entry has the expected shape
+  ansible.builtin.assert:
+    that:
+      - item.ipv4_address is defined
+      - item.ipv4_address is string
+    fail_msg: "Reserved IP entry {{ item }} does not have ipv4_address"
+    success_msg: "Reserved IP entry OK"
+  loop: "{{ list_reserved_result.response }}"
+  loop_control:
+    label: "{{ item.ipv4_address | default('unknown') }}"
+
+# ------------------------------------------------------------------------------
+# 9) Info module — with limit / pagination
+# ------------------------------------------------------------------------------
+
+- name: List reserved IPs on the subnet with limit=1
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_ids_info_v2:
+    ext_id: "{{ subnet_ext_id }}"
+    limit: 1
+  register: list_reserved_limited_result
+  ignore_errors: true
+
+- name: Verify limit is honoured
+  ansible.builtin.assert:
+    that:
+      - list_reserved_limited_result is defined
+      - list_reserved_limited_result.changed == false
+      - list_reserved_limited_result.failed == false
+      - list_reserved_limited_result.response is defined
+      - list_reserved_limited_result.response | length == 1
+    fail_msg: "limit=1 did not restrict list size"
+    success_msg: "limit=1 honoured"
+
+# ------------------------------------------------------------------------------
+# 10a) Real unreserve — IP_ADDRESS_LIST (no cookie, matches the minimal reserve)
+# ------------------------------------------------------------------------------
+
+- name: Unreserve IPs (IP_ADDRESS_LIST — no cookie)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: absent
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: IP_ADDRESS_LIST
+    ip_addresses:
+      - ipv4:
+          value: "{{ ip_list[0] }}"
+  register: unreserve_list_result
+  ignore_errors: true
+
+- name: Verify unreserve IP_ADDRESS_LIST (no cookie) succeeded
+  ansible.builtin.assert:
+    that:
+      - unreserve_list_result is defined
+      - unreserve_list_result.changed == true
+      - unreserve_list_result.failed == false
+      - unreserve_list_result.ext_id == subnet_ext_id
+      - unreserve_list_result.task_ext_id is defined
+      - unreserve_list_result.response is defined
+      - unreserve_list_result.response.status == "SUCCEEDED"
+    fail_msg: "Unreserve IP_ADDRESS_LIST (no cookie) failed: {{ unreserve_list_result }}"
+    success_msg: "Unreserve IP_ADDRESS_LIST (no cookie) succeeded"
+
+# ------------------------------------------------------------------------------
+# 10b) Real unreserve — IP_ADDRESS_LIST with matching client_context (cookie)
+# ------------------------------------------------------------------------------
+
+- name: Unreserve IPs (IP_ADDRESS_LIST — with matching cookie)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: absent
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: IP_ADDRESS_LIST
+    ip_addresses:
+      - ipv4:
+          value: "{{ ip_list[1] }}"
+    client_context: "{{ reserve_context_list }}"
+  register: unreserve_list_ctx_result
+  ignore_errors: true
+
+- name: Verify unreserve IP_ADDRESS_LIST (matching cookie) succeeded
+  ansible.builtin.assert:
+    that:
+      - unreserve_list_ctx_result is defined
+      - unreserve_list_ctx_result.changed == true
+      - unreserve_list_ctx_result.failed == false
+      - unreserve_list_ctx_result.ext_id == subnet_ext_id
+      - unreserve_list_ctx_result.task_ext_id is defined
+      - unreserve_list_ctx_result.response is defined
+      - unreserve_list_ctx_result.response.status == "SUCCEEDED"
+    fail_msg: "Unreserve IP_ADDRESS_LIST (with cookie) failed: {{ unreserve_list_ctx_result }}"
+    success_msg: "Unreserve IP_ADDRESS_LIST (with cookie) succeeded"
+
+# ------------------------------------------------------------------------------
+# 11) Real unreserve — IP_ADDRESS_RANGE
+# ------------------------------------------------------------------------------
+
+- name: Unreserve IPs (IP_ADDRESS_RANGE)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: absent
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: IP_ADDRESS_RANGE
+    start_ip_address:
+      ipv4:
+        value: "{{ range_start_ip }}"
+    count: "{{ range_count }}"
+    client_context: "{{ reserve_context_range }}"
+  register: unreserve_range_result
+  ignore_errors: true
+
+- name: Verify unreserve IP_ADDRESS_RANGE succeeded
+  ansible.builtin.assert:
+    that:
+      - unreserve_range_result is defined
+      - unreserve_range_result.changed == true
+      - unreserve_range_result.failed == false
+      - unreserve_range_result.ext_id == subnet_ext_id
+      - unreserve_range_result.task_ext_id is defined
+      - unreserve_range_result.response is defined
+      - unreserve_range_result.response.status == "SUCCEEDED"
+    fail_msg: "Unreserve IP_ADDRESS_RANGE failed: {{ unreserve_range_result }}"
+    success_msg: "Unreserve IP_ADDRESS_RANGE succeeded"
+
+# ------------------------------------------------------------------------------
+# 12) Real unreserve — CONTEXT (drop the whole reservation batch)
+# ------------------------------------------------------------------------------
+
+- name: Unreserve IPs (CONTEXT)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: absent
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: CONTEXT
+    client_context: "{{ reserve_context_count }}"
+  register: unreserve_context_result
+  ignore_errors: true
+
+- name: Verify unreserve CONTEXT succeeded
+  ansible.builtin.assert:
+    that:
+      - unreserve_context_result is defined
+      - unreserve_context_result.changed == true
+      - unreserve_context_result.failed == false
+      - unreserve_context_result.ext_id == subnet_ext_id
+      - unreserve_context_result.task_ext_id is defined
+      - unreserve_context_result.response is defined
+      - unreserve_context_result.response.status == "SUCCEEDED"
+    fail_msg: "Unreserve CONTEXT failed: {{ unreserve_context_result }}"
+    success_msg: "Unreserve CONTEXT succeeded"
+
+# ------------------------------------------------------------------------------
+# 13) Idempotency-style: unreserve CONTEXT again with the same context
+#     (already released — platform must handle this gracefully).
+# ------------------------------------------------------------------------------
+
+- name: Unreserve IPs (CONTEXT) a second time (already released)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: absent
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: CONTEXT
+    client_context: "{{ reserve_context_count }}"
+  register: unreserve_context_again_result
+  ignore_errors: true
+
+- name: Verify second unreserve CONTEXT is handled gracefully
+  ansible.builtin.assert:
+    that:
+      - unreserve_context_again_result is defined
+      - unreserve_context_again_result.ext_id == subnet_ext_id
+    fail_msg: "Second unreserve CONTEXT did not return a well-formed result"
+    success_msg: "Second unreserve CONTEXT handled gracefully"
+
+# ------------------------------------------------------------------------------
+# 14) Negative: missing required reserve_type
+# ------------------------------------------------------------------------------
+
+- name: Reserve IPs without reserve_type (must fail)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    count: 1
+  register: reserve_missing_type_result
+  ignore_errors: true
+
+- name: Verify missing reserve_type is rejected
+  ansible.builtin.assert:
+    that:
+      - reserve_missing_type_result is defined
+      - reserve_missing_type_result.failed == true
+      - reserve_missing_type_result.changed == false
+    fail_msg: "Missing reserve_type was NOT rejected"
+    success_msg: "Missing reserve_type correctly rejected"
+
+# ------------------------------------------------------------------------------
+# 15) Negative: reserve_type=IP_ADDRESS_COUNT with no `count`
+# ------------------------------------------------------------------------------
+
+- name: Reserve IPs (IP_ADDRESS_COUNT) without count (must fail)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    reserve_type: IP_ADDRESS_COUNT
+  register: reserve_missing_count_result
+  ignore_errors: true
+
+- name: Verify missing count is rejected for IP_ADDRESS_COUNT
+  ansible.builtin.assert:
+    that:
+      - reserve_missing_count_result is defined
+      - reserve_missing_count_result.failed == true
+      - reserve_missing_count_result.changed == false
+    fail_msg: "Missing count for IP_ADDRESS_COUNT was NOT rejected"
+    success_msg: "Missing count for IP_ADDRESS_COUNT correctly rejected"
+
+# ------------------------------------------------------------------------------
+# 16) Negative: invalid enum value for reserve_type
+# ------------------------------------------------------------------------------
+
+- name: Reserve IPs with invalid reserve_type (must fail)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    reserve_type: BOGUS_VALUE
+    count: 1
+  register: reserve_invalid_enum_result
+  ignore_errors: true
+
+- name: Verify invalid reserve_type enum is rejected
+  ansible.builtin.assert:
+    that:
+      - reserve_invalid_enum_result is defined
+      - reserve_invalid_enum_result.failed == true
+      - reserve_invalid_enum_result.changed == false
+    fail_msg: "Invalid reserve_type value was NOT rejected"
+    success_msg: "Invalid reserve_type value correctly rejected"
+
+# ------------------------------------------------------------------------------
+# 17) Negative: unknown subnet ext_id on reserve
+# ------------------------------------------------------------------------------
+
+- name: Reserve IPs with unknown subnet ext_id (must fail)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    reserve_type: IP_ADDRESS_COUNT
+    count: 1
+  register: reserve_unknown_subnet_result
+  ignore_errors: true
+
+- name: Verify unknown subnet ext_id is rejected on reserve
+  ansible.builtin.assert:
+    that:
+      - reserve_unknown_subnet_result is defined
+      - reserve_unknown_subnet_result.failed == true
+      - reserve_unknown_subnet_result.changed == false
+    fail_msg: "Reserve with unknown subnet ext_id was NOT rejected"
+    success_msg: "Reserve with unknown subnet ext_id correctly rejected"
+
+# ------------------------------------------------------------------------------
+# 18) Negative: info module with unknown subnet ext_id
+# ------------------------------------------------------------------------------
+
+- name: List reserved IPs on unknown subnet ext_id (must fail)
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_ids_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: list_unknown_subnet_result
+  ignore_errors: true
+
+- name: Verify unknown subnet ext_id is rejected on info
+  ansible.builtin.assert:
+    that:
+      - list_unknown_subnet_result is defined
+      - list_unknown_subnet_result.failed == true
+    fail_msg: "Info on unknown subnet ext_id was NOT rejected"
+    success_msg: "Info on unknown subnet ext_id correctly rejected"
+
+# ------------------------------------------------------------------------------
+# 19) Cleanup — delete the test subnet
+# ------------------------------------------------------------------------------
+
+- name: Cleanup any remaining reservations tagged with the LIST context
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: absent
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: CONTEXT
+    client_context: "{{ reserve_context_list }}"
+  register: cleanup_list_ctx_result
+  ignore_errors: true
+
+- name: Cleanup any remaining reservations tagged with the RANGE context
+  nutanix.ncp.ntnx_reserve_ips_by_subnet_id_v2:
+    state: absent
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: CONTEXT
+    client_context: "{{ reserve_context_range }}"
+  register: cleanup_range_ctx_result
+  ignore_errors: true
+
+- name: Delete the test subnet
+  nutanix.ncp.ntnx_subnets_v2:
+    state: absent
+    ext_id: "{{ subnet_ext_id }}"
+  register: subnet_delete_result
+  ignore_errors: true
+
+- name: Verify test subnet was deleted
+  ansible.builtin.assert:
+    that:
+      - subnet_delete_result is defined
+      - subnet_delete_result.failed == false
+    fail_msg: "Test subnet delete failed"
+    success_msg: "Test subnet deleted successfully"

--- a/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/vars/main.yml
+++ b/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/vars/main.yml
@@ -1,0 +1,15 @@
+---
+# VLAN network_id pool — pick VLAN IDs that are unlikely to already be
+# reserved by other managed subnets on the cluster. The task file uses
+# index 5.
+vlan_subnets_ids: [3001, 3002, 3003, 3004, 3005, 3006]
+
+ip_address_management:
+  network_ip: 192.168.240.0
+  network_prefix: 24
+  gateway_ip_address: 192.168.240.254
+  dhcp_server_address: 192.168.240.253
+
+ip_address_pools:
+  start_address: 192.168.240.20
+  end_address: 192.168.240.40


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace,
entity **ReserveIpsBySubnetId** (managed subnet IP reservation), based on the
inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_reserve_ips_by_subnet_id_v2`, `ntnx_reserve_ips_by_subnet_ids_info_v2`
- SDK API class covered: `ntnx_networking_py_client.SubnetIPReservationApi`
- API methods covered: `reserve_ips_by_subnet_id`, `unreserve_ips_by_subnet_id`, `list_reserved_ips_by_subnet_id` (3 methods)
- Fields in CRUD module spec: 7 (`ext_id`, `count`, `start_ip_address`, `ip_addresses`, `reserve_type`, `unreserve_type`, `client_context`) plus the standard base module spec
- Fields in info module spec: 1 (`ext_id`) plus the standard info module spec (`filter`, `page`, `limit`, `orderby`, `select`)

This entity is **action-type**: reservations do not carry their own `ext_id`;
`state=present` invokes the Reserve IPs action on the subnet, and
`state=absent` invokes the Unreserve IPs action. The info module lists all
IPs currently reserved on a given subnet.

## Files changed

- `plugins/modules/`
  - `ntnx_reserve_ips_by_subnet_id_v2.py` (new — CRUD/action module)
  - `ntnx_reserve_ips_by_subnet_ids_info_v2.py` (new — info module)
- `plugins/module_utils/v4/network/`
  - `api_client.py` (added `get_subnet_ip_reservation_api_instance`)
  - `helpers.py` (added `list_reserved_ips_by_subnet`)
- `meta/runtime.yml` (registered both modules in the `ntnx` action group so `module_defaults` credentials propagate)
- `examples/networking/ReserveIpsBySubnetId/`
  - `reserve_ips_by_subnet_id_v2.yml` (single reference playbook covering reserve + list + unreserve)
  - `examples_run.log` (real playbook output captured against live PC)
- `tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/`
  - `aliases` (`disabled` — same pattern as other v2 targets, opt-in only)
  - `meta/main.yml`, `vars/main.yml`
  - `tasks/main.yml`, `tasks/reserve_ips_by_subnet_id.yml` (48-task integration suite)
- `.gitignore` (ignore `tests/integration/integration_config.yml` + `tests/output/`)

## Test execution

| Metric              | Value                                                                                             |
|---------------------|---------------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 --allow-disabled --allow-unsupported ntnx_reserve_ips_by_subnet_id_v2 -v` |
| Total tasks         | 48                                                                                                |
| Passed (ok)         | 48                                                                                                |
| Changed             | 13                                                                                                |
| Failed              | 0                                                                                                 |
| Ignored             | 5 (all expected — negative tests that must fail with `ignore_errors: true` then get asserted)     |
| Skipped             | 0                                                                                                 |
| Cluster (PC)        | `10.44.76.28`                                                                                     |

The example playbook was also executed end-to-end against the same PC and
completed cleanly (`ok=4 changed=2 failed=0`). The `examples_run.log` file
contains its full output, and the RETURN docstrings in both modules have
been backfilled with the REAL API responses captured from that run.

### Analysis

- All three reserve modes exercised on the live cluster: `IP_ADDRESS_LIST`,
  `IP_ADDRESS_COUNT`, `IP_ADDRESS_RANGE`. Each returned a `SUCCEEDED` task
  and the info-module listing reflected the reserved IPs (with matching
  `client_context`).
- All three unreserve modes exercised: `IP_ADDRESS_LIST` (with and without a
  cookie), `IP_ADDRESS_RANGE`, `CONTEXT`. The `client_context` (cookie)
  requirement is enforced by the platform: an unreserve that omits the
  cookie only succeeds against IPs reserved without a cookie. The integration
  target covers both branches so this behaviour is regression-tested.
- Idempotency-style check: running `unreserve_type: CONTEXT` a second time
  against an already-released cookie returned `changed=true` with an empty
  `unreserved_ips` list (the platform treats it as a successful no-op).
- Negative paths validated: missing `reserve_type`, missing `count` for
  `IP_ADDRESS_COUNT`, invalid enum value, and unknown subnet ext_id on both
  the CRUD module and the info module — all correctly rejected with a
  descriptive error and no state change.
- Sanity: `ansible-test sanity --python 3.12` on the two new modules and
  the two touched helpers passes on all 24 sub-tests
  (`compile`, `import`, `pep8`, `pylint`, `validate-modules`, `yamllint`, ...).

### Known Issues

None. All tests and the example playbook passed on the first fully-configured run.

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text
}
ok: [testhost] => (item=192.168.240.20) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "client_context": "ansible_ctx_count_gKaClZItZRIy",
        "ext_id": null,
        "ipv4_address": "192.168.240.20",
        "links": null,
        "tenant_id": null
    },
    "msg": "Reserved IP entry OK"
}
ok: [testhost] => (item=192.168.240.25) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "client_context": "ansible_ctx_range_gKaClZItZRIy",
        "ext_id": null,
        "ipv4_address": "192.168.240.25",
        "links": null,
        "tenant_id": null
    },
    "msg": "Reserved IP entry OK"
}
ok: [testhost] => (item=192.168.240.26) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "client_context": "ansible_ctx_range_gKaClZItZRIy",
        "ext_id": null,
        "ipv4_address": "192.168.240.26",
        "links": null,
        "tenant_id": null
    },
    "msg": "Reserved IP entry OK"
}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : List reserved IPs on the subnet with limit=1] ***
ok: [testhost] => {"changed": false, "ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "response": [{"client_context": "ansible_ctx_count_gKaClZItZRIy", "ext_id": null, "ipv4_address": "192.168.240.23", "links": null, "tenant_id": null}], "total_available_results": 6}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Verify limit is honoured] *************
ok: [testhost] => {
    "changed": false,
    "msg": "limit=1 honoured"
}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Unreserve IPs (IP_ADDRESS_LIST — no cookie)] ***
changed: [testhost] => {"changed": true, "ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:49:35.095109+00:00", "completion_details": [{"name": "reserved_or_unreserved_ips", "value": "{\"unreserved_ips\": [\"192.168.240.21\"]}"}], "created_time": "2026-07-21T05:49:34.993094+00:00", "entities_affected": [{"ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "name": null, "rel": "networking:config:subnet"}], "error_messages": null, "ext_id": "ZXJnb24=:05b4a361-06c7-4a20-a662-3f5e18b07f2d", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:49:35.095108+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kSubnetReserveIp", "operation_description": "Reserve or Unreserve IP on Managed Subnet", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:49:35.003168+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:05b4a361-06c7-4a20-a662-3f5e18b07f2d"}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Verify unreserve IP_ADDRESS_LIST (no cookie) succeeded] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Unreserve IP_ADDRESS_LIST (no cookie) succeeded"
}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Unreserve IPs (IP_ADDRESS_LIST — with matching cookie)] ***
changed: [testhost] => {"changed": true, "ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:49:38.455331+00:00", "completion_details": [{"name": "reserved_or_unreserved_ips", "value": "{\"unreserved_ips\": [\"192.168.240.22\"]}"}], "created_time": "2026-07-21T05:49:38.299502+00:00", "entities_affected": [{"ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "name": null, "rel": "networking:config:subnet"}], "error_messages": null, "ext_id": "ZXJnb24=:bc692bcd-f3a3-4f90-a22b-6fdcb59b5c31", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:49:38.455330+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kSubnetReserveIp", "operation_description": "Reserve or Unreserve IP on Managed Subnet", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:49:38.322587+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:bc692bcd-f3a3-4f90-a22b-6fdcb59b5c31"}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Verify unreserve IP_ADDRESS_LIST (matching cookie) succeeded] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Unreserve IP_ADDRESS_LIST (with cookie) succeeded"
}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Unreserve IPs (IP_ADDRESS_RANGE)] *****
changed: [testhost] => {"changed": true, "ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:49:41.630784+00:00", "completion_details": [{"name": "reserved_or_unreserved_ips", "value": "{\"unreserved_ips\": [\"192.168.240.26\", \"192.168.240.25\"]}"}], "created_time": "2026-07-21T05:49:41.534409+00:00", "entities_affected": [{"ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "name": null, "rel": "networking:config:subnet"}], "error_messages": null, "ext_id": "ZXJnb24=:bdee1927-c6ef-4654-a879-08051af74eeb", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:49:41.630783+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kSubnetReserveIp", "operation_description": "Reserve or Unreserve IP on Managed Subnet", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:49:41.543408+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:bdee1927-c6ef-4654-a879-08051af74eeb"}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Verify unreserve IP_ADDRESS_RANGE succeeded] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Unreserve IP_ADDRESS_RANGE succeeded"
}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Unreserve IPs (CONTEXT)] **************
changed: [testhost] => {"changed": true, "ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:49:44.961066+00:00", "completion_details": [{"name": "reserved_or_unreserved_ips", "value": "{\"unreserved_ips\": [\"192.168.240.23\", \"192.168.240.20\"]}"}], "created_time": "2026-07-21T05:49:44.847752+00:00", "entities_affected": [{"ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "name": null, "rel": "networking:config:subnet"}], "error_messages": null, "ext_id": "ZXJnb24=:79e7e2d2-fed8-4a90-b062-c178c529526f", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:49:44.961065+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kSubnetReserveIp", "operation_description": "Reserve or Unreserve IP on Managed Subnet", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:49:44.866754+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:79e7e2d2-fed8-4a90-b062-c178c529526f"}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Verify unreserve CONTEXT succeeded] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Unreserve CONTEXT succeeded"
}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Unreserve IPs (CONTEXT) a second time (already released)] ***
changed: [testhost] => {"changed": true, "ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:49:48.212651+00:00", "completion_details": [{"name": "reserved_or_unreserved_ips", "value": "{\"unreserved_ips\": []}"}], "created_time": "2026-07-21T05:49:48.122362+00:00", "entities_affected": [{"ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "name": null, "rel": "networking:config:subnet"}], "error_messages": null, "ext_id": "ZXJnb24=:1aee0b2d-988b-42e9-b008-be876717fbce", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:49:48.212650+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kSubnetReserveIp", "operation_description": "Reserve or Unreserve IP on Managed Subnet", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:49:48.134436+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:1aee0b2d-988b-42e9-b008-be876717fbce"}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Verify second unreserve CONTEXT is handled gracefully] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Second unreserve CONTEXT handled gracefully"
}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Reserve IPs without reserve_type (must fail)] ***
[ERROR]: Task failed: Module failed: state is present but all of the following are missing: reserve_type
Origin: /tmp/reserve_ips_sanity/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_reserve_ips_by_subnet_id_v2-f742ar4i-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/tasks/reserve_ips_by_subnet_id.yml:492:3

490 # ------------------------------------------------------------------------------
491
492 - name: Reserve IPs without reserve_type (must fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is present but all of the following are missing: reserve_type"}
...ignoring

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Verify missing reserve_type is rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing reserve_type correctly rejected"
}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Reserve IPs (IP_ADDRESS_COUNT) without count (must fail)] ***
[ERROR]: Task failed: Module failed: Missing required parameter(s): count
Origin: /tmp/reserve_ips_sanity/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_reserve_ips_by_subnet_id_v2-f742ar4i-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/tasks/reserve_ips_by_subnet_id.yml:513:3

511 # ------------------------------------------------------------------------------
512
513 - name: Reserve IPs (IP_ADDRESS_COUNT) without count (must fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): count"}
...ignoring

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Verify missing count is rejected for IP_ADDRESS_COUNT] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing count for IP_ADDRESS_COUNT correctly rejected"
}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Reserve IPs with invalid reserve_type (must fail)] ***
[ERROR]: Task failed: Module failed: value of reserve_type must be one of: IP_ADDRESS_COUNT, IP_ADDRESS_LIST, IP_ADDRESS_RANGE, got: BOGUS_VALUE
Origin: /tmp/reserve_ips_sanity/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_reserve_ips_by_subnet_id_v2-f742ar4i-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/tasks/reserve_ips_by_subnet_id.yml:534:3

532 # ------------------------------------------------------------------------------
533
534 - name: Reserve IPs with invalid reserve_type (must fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of reserve_type must be one of: IP_ADDRESS_COUNT, IP_ADDRESS_LIST, IP_ADDRESS_RANGE, got: BOGUS_VALUE"}
...ignoring

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Verify invalid reserve_type enum is rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid reserve_type value correctly rejected"
}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Reserve IPs with unknown subnet ext_id (must fail)] ***
[ERROR]: Task failed: Module failed: Task Failed
Origin: /tmp/reserve_ips_sanity/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_reserve_ips_by_subnet_id_v2-f742ar4i-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/tasks/reserve_ips_by_subnet_id.yml:556:3

554 # ------------------------------------------------------------------------------
555
556 - name: Reserve IPs with unknown subnet ext_id (must fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:49:53.316907+00:00", "completion_details": null, "created_time": "2026-07-21T05:49:53.275458+00:00", "entities_affected": [{"ext_id": "00000000-0000-0000-0000-000000000000", "name": null, "rel": "networking:config:subnet"}], "error_messages": [{"arguments_map": {"errorMessage": "Existing subnet 00000000-0000-0000-0000-000000000000 is not found", "operation": "Reserve or Unreserve IP on Managed Subnet"}, "code": "NETWORKING-10060", "error_group": "BACKEND_SERVICE_ERROR", "locale": "en_US", "message": "Failed to Reserve or Unreserve IP on Managed Subnet as a referenced resource was not found - Existing subnet 00000000-0000-0000-0000-000000000000 is not found", "severity": "ERROR"}], "ext_id": "ZXJnb24=:6d0d2de0-448b-4e93-8aae-162df8da8e9a", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:49:53.316905+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kSubnetReserveIp", "operation_description": "Reserve or Unreserve IP on Managed Subnet", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:49:53.288078+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": null, "warnings": null}}
...ignoring

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Verify unknown subnet ext_id is rejected on reserve] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Reserve with unknown subnet ext_id correctly rejected"
}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : List reserved IPs on unknown subnet ext_id (must fail)] ***
[ERROR]: Task failed: Module failed: Api Exception raised while listing reserved IPs for subnet ext_id: 00000000-0000-0000-0000-000000000000
Origin: /tmp/reserve_ips_sanity/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_reserve_ips_by_subnet_id_v2-f742ar4i-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_reserve_ips_by_subnet_id_v2/tasks/reserve_ips_by_subnet_id.yml:578:3

576 # ------------------------------------------------------------------------------
577
578 - name: List reserved IPs on unknown subnet ext_id (must fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while listing reserved IPs for subnet ext_id: 00000000-0000-0000-0000-000000000000", "response": {"$objectType": "networking.v4.config.GetSubnetApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to fetch subnet reserved ip addresses as a referenced resource was not found - Application error kNotFound raised: Existing subnet: 00000000-0000-0000-0000-000000000000 is not found. ", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/subnets/00000000-0000-0000-0000-000000000000/reserved-ips", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Verify unknown subnet ext_id is rejected on info] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info on unknown subnet ext_id correctly rejected"
}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Cleanup any remaining reservations tagged with the LIST context] ***
changed: [testhost] => {"changed": true, "ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:49:55.662139+00:00", "completion_details": [{"name": "reserved_or_unreserved_ips", "value": "{\"unreserved_ips\": []}"}], "created_time": "2026-07-21T05:49:55.583420+00:00", "entities_affected": [{"ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "name": null, "rel": "networking:config:subnet"}], "error_messages": null, "ext_id": "ZXJnb24=:a3bfd27e-25b2-423e-98c6-1a9da5feedab", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:49:55.662138+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kSubnetReserveIp", "operation_description": "Reserve or Unreserve IP on Managed Subnet", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:49:55.594492+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:a3bfd27e-25b2-423e-98c6-1a9da5feedab"}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Cleanup any remaining reservations tagged with the RANGE context] ***
changed: [testhost] => {"changed": true, "ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:49:58.972874+00:00", "completion_details": [{"name": "reserved_or_unreserved_ips", "value": "{\"unreserved_ips\": []}"}], "created_time": "2026-07-21T05:49:58.894969+00:00", "entities_affected": [{"ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "name": null, "rel": "networking:config:subnet"}], "error_messages": null, "ext_id": "ZXJnb24=:199e84ca-5973-471c-844e-04fb6f66c908", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:49:58.972874+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kSubnetReserveIp", "operation_description": "Reserve or Unreserve IP on Managed Subnet", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:49:58.906646+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:199e84ca-5973-471c-844e-04fb6f66c908"}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Delete the test subnet] ***************
changed: [testhost] => {"changed": true, "error": null, "ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-21T05:50:03.000142+00:00", "completion_details": null, "created_time": "2026-07-21T05:50:02.294120+00:00", "entities_affected": [{"ext_id": "1eb1543c-5bd6-4775-aed5-50e5ceeda6ef", "name": "ansible_reserve_ips_gKaClZItZRIy", "rel": "networking:config:subnet"}], "error_messages": null, "ext_id": "ZXJnb24=:6c49af20-ba20-4deb-99d1-f05a5f769c24", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:50:03.000142+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "kSubnetDelete", "operation_description": "Subnet Delete", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:50:02.308431+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:fcba0a56-77f6-490f-a0c3-7d008c02f186", "href": "https://10.44.76.28:9440/api/prism/v4.3/config/tasks/ZXJnb24=:fcba0a56-77f6-490f-a0c3-7d008c02f186", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:6c49af20-ba20-4deb-99d1-f05a5f769c24"}

TASK [ntnx_reserve_ips_by_subnet_id_v2 : Verify test subnet was deleted] *******
ok: [testhost] => {
    "changed": false,
    "msg": "Test subnet deleted successfully"
}

PLAY RECAP *********************************************************************
testhost                   : ok=48   changed=13   unreachable=0    failed=0    skipped=0    rescued=0    ignored=5   

```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
