### PR TITLE
AdDnsFailover Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/files/AdDnsFailover/examples_run.log
+++ b/examples/files/AdDnsFailover/examples_run.log
@@ -1,0 +1,25 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Nutanix Files AD-DNS failover playbook] **********************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"primary_file_server_ext_id": "c66fcb19-01f0-49de-9d35-4b90ebbca2d9", "secondary_file_server_ext_id": "483ca0d4-855e-4f92-a5a0-fc56907d919b"}, "changed": false}
+
+TASK [Perform a planned AD-DNS failover with all attributes] *******************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while performing AD-DNS failover", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Perform an unplanned AD-DNS failover] ************************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while performing AD-DNS failover", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Perform an AD-DNS failback to the original primary file server] **********
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while performing AD-DNS failover", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   
+

--- a/examples/files/AdDnsFailover/ntnx_files_ad_dns_failover_v2.yml
+++ b/examples/files/AdDnsFailover/ntnx_files_ad_dns_failover_v2.yml
@@ -1,0 +1,69 @@
+---
+# Summary:
+# This playbook demonstrates the Nutanix Files AD-DNS failover action module.
+# It covers the three failover types supported by the API:
+# 1. Perform a planned AD-DNS failover (with all attributes)
+# 2. Perform an unplanned AD-DNS failover
+# 3. Perform an AD-DNS failback to the original primary file server
+#
+# Prerequisites:
+# - Two Nutanix Files file servers configured with a replication policy between them.
+# - Valid Active Directory and DNS credentials with permissions to move the file
+#   server computer account and update the DNS records.
+
+- name: Nutanix Files AD-DNS failover playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "10.44.76.28"
+      nutanix_username: "admin"
+      nutanix_password: "Nutanix.123"
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        primary_file_server_ext_id: "c66fcb19-01f0-49de-9d35-4b90ebbca2d9"
+        secondary_file_server_ext_id: "483ca0d4-855e-4f92-a5a0-fc56907d919b"
+
+    - name: Perform a planned AD-DNS failover with all attributes
+      nutanix.ncp.ntnx_files_ad_dns_failover_v2:
+        primary_file_server_ext_id: "{{ primary_file_server_ext_id }}"
+        secondary_file_server_ext_id: "{{ secondary_file_server_ext_id }}"
+        type: "PLANNED"
+        active_directory:
+          credential:
+            username: "ad-admin"
+            password: "ad-password"
+          preferred_domain_controller: "dc1.ansible.local"
+        dns:
+          preferred_name_server: "10.44.76.10"
+          action: "ADD"
+          credential:
+            username: "dns-admin"
+            password: "dns-password"
+      register: result
+      ignore_errors: true
+
+    - name: Perform an unplanned AD-DNS failover
+      nutanix.ncp.ntnx_files_ad_dns_failover_v2:
+        primary_file_server_ext_id: "{{ primary_file_server_ext_id }}"
+        secondary_file_server_ext_id: "{{ secondary_file_server_ext_id }}"
+        type: "UNPLANNED"
+        active_directory:
+          credential:
+            username: "ad-admin"
+            password: "ad-password"
+      register: result
+      ignore_errors: true
+
+    - name: Perform an AD-DNS failback to the original primary file server
+      nutanix.ncp.ntnx_files_ad_dns_failover_v2:
+        primary_file_server_ext_id: "{{ secondary_file_server_ext_id }}"
+        secondary_file_server_ext_id: "{{ primary_file_server_ext_id }}"
+        type: "FAILBACK"
+        dns:
+          preferred_name_server: "10.44.76.10"
+          action: "REMOVE"
+      register: result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_files_ad_dns_failover_v2

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,103 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details.
+    Args:
+        module (object): Ansible module object
+    return:
+        client (object): api client object
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    # Not every Files SDK release accepts allow_version_negotiation, so fall
+    # back to the configuration-only constructor when the keyword is unknown.
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    # Setup API logging if debug is enabled
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    return:
+        etag (str): etag value
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_replication_policies_api_instance(module):
+    """
+    This method will return ReplicationPoliciesApi instance.
+
+    The Files replication policies API also hosts the file server operations
+    such as AD-DNS failover, data replication failover and resume replication.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Replication Policies Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.ReplicationPoliciesApi(api_client=api_client)

--- a/plugins/modules/ntnx_files_ad_dns_failover_v2.py
+++ b/plugins/modules/ntnx_files_ad_dns_failover_v2.py
@@ -1,0 +1,409 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_ad_dns_failover_v2
+short_description: Perform an AD-DNS failover between Nutanix Files file servers
+version_added: 2.7.0
+description:
+  - This module performs an Active Directory (AD) and DNS failover between a primary and a secondary file server in Nutanix Prism Central.
+  - The failover switches the AD computer account and DNS records so that clients continue to resolve and authenticate against the surviving file server.
+  - This is an action module, it triggers the AD-DNS failover operation and does not create, update or delete a persistent resource.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the appropriate Nutanix IAM roles for Files replication and disaster recovery operations to be
+    assigned to the user performing the operation.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  state:
+    description:
+      - State of the module.
+      - If C(state) is C(present), the module performs the AD-DNS failover.
+    type: str
+    choices:
+      - present
+    default: present
+  primary_file_server_ext_id:
+    description:
+      - The external identifier of the primary file server for the replication.
+      - This is the file server that is failing over.
+    type: str
+    required: false
+  secondary_file_server_ext_id:
+    description:
+      - The external identifier of the secondary file server for the replication.
+      - This is the file server that takes over the AD computer account and DNS records.
+    type: str
+    required: false
+  active_directory:
+    description:
+      - Configuration used to access the file server Active Directory server during the failover.
+    type: dict
+    required: false
+    suboptions:
+      credential:
+        description:
+          - Active Directory user credential used to perform the AD failover.
+        type: dict
+        required: false
+        suboptions:
+          username:
+            description:
+              - Name of the Active Directory user.
+            type: str
+            required: false
+          password:
+            description:
+              - Password of the Active Directory user.
+            type: str
+            required: false
+      preferred_domain_controller:
+        description:
+          - Preferred domain controller to use for the AD failover.
+        type: str
+        required: false
+  dns:
+    description:
+      - DNS record configuration used during the failover.
+    type: dict
+    required: false
+    suboptions:
+      preferred_name_server:
+        description:
+          - Preferred name server for the file server.
+        type: str
+        required: false
+      action:
+        description:
+          - The DNS action to perform for the file server records during the failover.
+        type: str
+        choices:
+          - ADD
+          - REMOVE
+        required: false
+      credential:
+        description:
+          - DNS user credential used to update the DNS records.
+        type: dict
+        required: false
+        suboptions:
+          username:
+            description:
+              - Name of the DNS user.
+            type: str
+            required: false
+          password:
+            description:
+              - Password of the DNS user.
+            type: str
+            required: false
+  type:
+    description:
+      - The type of failover to perform.
+      - C(PLANNED) performs a graceful, coordinated failover to the secondary file server.
+      - C(UNPLANNED) performs a failover when the primary file server is unavailable.
+      - C(FAILBACK) reverts a previous failover back to the original primary file server.
+    type: str
+    choices:
+      - PLANNED
+      - UNPLANNED
+      - FAILBACK
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Perform a planned AD-DNS failover with all attributes
+  nutanix.ncp.ntnx_files_ad_dns_failover_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    primary_file_server_ext_id: "c66fcb19-01f0-49de-9d35-4b90ebbca2d9"
+    secondary_file_server_ext_id: "483ca0d4-855e-4f92-a5a0-fc56907d919b"
+    type: "PLANNED"
+    active_directory:
+      credential:
+        username: "ad-admin"
+        password: "ad-password"
+      preferred_domain_controller: "dc1.ansible.local"
+    dns:
+      preferred_name_server: "10.44.76.10"
+      action: "ADD"
+      credential:
+        username: "dns-admin"
+        password: "dns-password"
+  register: result
+  ignore_errors: true
+
+- name: Perform an unplanned AD-DNS failover
+  nutanix.ncp.ntnx_files_ad_dns_failover_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    primary_file_server_ext_id: "c66fcb19-01f0-49de-9d35-4b90ebbca2d9"
+    secondary_file_server_ext_id: "483ca0d4-855e-4f92-a5a0-fc56907d919b"
+    type: "UNPLANNED"
+    active_directory:
+      credential:
+        username: "ad-admin"
+        password: "ad-password"
+  register: result
+  ignore_errors: true
+
+- name: Perform an AD-DNS failback to the original primary file server
+  nutanix.ncp.ntnx_files_ad_dns_failover_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    primary_file_server_ext_id: "483ca0d4-855e-4f92-a5a0-fc56907d919b"
+    secondary_file_server_ext_id: "c66fcb19-01f0-49de-9d35-4b90ebbca2d9"
+    type: "FAILBACK"
+    dns:
+      preferred_name_server: "10.44.76.10"
+      action: "REMOVE"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for the AD-DNS failover operation.
+    - Task details if C(wait) is true.
+    - Task reference details if C(wait) is false.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_ids": [
+        "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2"
+      ],
+      "completed_time": "2026-07-21T06:26:51.524581+00:00",
+      "created_time": "2026-07-21T06:26:47.167906+00:00",
+      "entities_affected": [
+        {
+          "ext_id": "c66fcb19-01f0-49de-9d35-4b90ebbca2d9",
+          "rel": "files:config:file-server"
+        }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1",
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-21T06:26:51.524581+00:00",
+      "legacy_error_message": null,
+      "operation": "AdDnsFailover",
+      "operation_description": "Perform an AD-DNS failover",
+      "owned_by": {
+        "ext_id": "00000000-0000-0000-0000-000000000000",
+        "name": "admin"
+      },
+      "parent_task": null,
+      "progress_percentage": 100,
+      "started_time": "2026-07-21T06:26:47.185754+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while performing AD-DNS failover"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  returned: when an error occurs
+  type: str
+  sample: "Failed generating spec for AD-DNS failover"
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+task_ext_id:
+  description: The external ID of the task
+  returned: always
+  type: str
+  sample: "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1"
+
+ext_id:
+  description: The external ID of the primary file server on which the AD-DNS failover is performed
+  returned: always
+  type: str
+  sample: "c66fcb19-01f0-49de-9d35-4b90ebbca2d9"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_replication_policies_api_instance,
+)
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client as files_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as files_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    credential_spec = dict(
+        username=dict(type="str"),
+        password=dict(type="str", no_log=True),
+    )
+
+    ad_server_spec = dict(
+        credential=dict(
+            type="dict",
+            options=credential_spec,
+            obj=files_sdk.Credential,
+            no_log=False,
+        ),
+        preferred_domain_controller=dict(type="str"),
+    )
+
+    dns_record_spec = dict(
+        preferred_name_server=dict(type="str"),
+        action=dict(type="str", choices=["ADD", "REMOVE"], obj=files_sdk.DnsActionType),
+        credential=dict(
+            type="dict",
+            options=credential_spec,
+            obj=files_sdk.Credential,
+            no_log=False,
+        ),
+    )
+
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        primary_file_server_ext_id=dict(type="str"),
+        secondary_file_server_ext_id=dict(type="str"),
+        active_directory=dict(
+            type="dict",
+            options=ad_server_spec,
+            obj=files_sdk.ADServerSpec,
+        ),
+        dns=dict(
+            type="dict",
+            options=dns_record_spec,
+            obj=files_sdk.DnsRecordSpec,
+        ),
+        type=dict(
+            type="str",
+            choices=["PLANNED", "UNPLANNED", "FAILBACK"],
+            obj=files_sdk.FailoverType,
+        ),
+    )
+
+    return module_args
+
+
+def perform_ad_dns_failover(module, result, replication_policies_api):
+    result["ext_id"] = module.params.get("primary_file_server_ext_id")
+
+    sg = SpecGenerator(module)
+    default_spec = files_sdk.AdDnsFailoverSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating spec for AD-DNS failover", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = replication_policies_api.ad_dns_failover(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while performing AD-DNS failover",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    replication_policies_api = get_replication_policies_api_instance(module)
+    perform_ad_dns_failover(module, result, replication_policies_api)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_files_ad_dns_failover_v2/aliases
+++ b/tests/integration/targets/ntnx_files_ad_dns_failover_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_files_ad_dns_failover_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_files_ad_dns_failover_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_files_ad_dns_failover_v2/tasks/ad_dns_failover.yml
+++ b/tests/integration/targets/ntnx_files_ad_dns_failover_v2/tasks/ad_dns_failover.yml
@@ -1,0 +1,194 @@
+---
+# Test plan for ntnx_files_ad_dns_failover_v2 (action module)
+#
+# The AD-DNS failover is an ACTION performed between two already existing Files
+# file servers that are paired by a replication policy. There is no create /
+# read / update / delete life-cycle and no queryable "AdDnsFailover" entity,
+# therefore the tests below focus on:
+#
+#   1. check_mode spec generation for every FailoverType (PLANNED, UNPLANNED,
+#      FAILBACK) and for the minimal / full attribute sets. check_mode never
+#      touches the cluster, so these assertions are deterministic and validate
+#      that every argument-spec attribute is wired to the SDK spec correctly.
+#   2. Argument-spec validation (negative): invalid enum values for `type` and
+#      `dns.action` must be rejected by Ansible before any API call.
+#   3. A real API invocation against the live cluster using well-formed but
+#      non-existent file server external IDs. Because the referenced file
+#      servers / replication policy do not exist, the API is expected to fail
+#      gracefully and the module must surface the error (failed == true) with a
+#      descriptive message instead of raising an unhandled traceback.
+#
+# A fully successful failover requires two paired file servers with a
+# configured replication policy plus valid AD/DNS credentials; that
+# prerequisite cannot be provisioned by this collection, so the happy-path is
+# validated via check_mode.
+
+- name: Start ntnx_files_ad_dns_failover_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_files_ad_dns_failover_v2 tests
+
+- name: Set file server external IDs for the test run
+  ansible.builtin.set_fact:
+    primary_fs_ext_id: "c66fcb19-01f0-49de-9d35-4b90ebbca2d9"
+    secondary_fs_ext_id: "483ca0d4-855e-4f92-a5a0-fc56907d919b"
+
+########################################################################################
+# check_mode - Create/Perform spec generation (happy path)
+########################################################################################
+
+- name: Generate spec for a planned AD-DNS failover using check mode with all attributes
+  nutanix.ncp.ntnx_files_ad_dns_failover_v2:
+    primary_file_server_ext_id: "{{ primary_fs_ext_id }}"
+    secondary_file_server_ext_id: "{{ secondary_fs_ext_id }}"
+    type: "PLANNED"
+    active_directory:
+      credential:
+        username: "ad-admin"
+        password: "ad-password"
+      preferred_domain_controller: "dc1.ansible.local"
+    dns:
+      preferred_name_server: "10.44.76.10"
+      action: "ADD"
+      credential:
+        username: "dns-admin"
+        password: "dns-password"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for a planned AD-DNS failover using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == primary_fs_ext_id
+      - result.response.primary_file_server_ext_id == primary_fs_ext_id
+      - result.response.secondary_file_server_ext_id == secondary_fs_ext_id
+      - result.response.type == "PLANNED"
+      - result.response.active_directory.credential.username == "ad-admin"
+      - result.response.active_directory.preferred_domain_controller == "dc1.ansible.local"
+      - result.response.dns.preferred_name_server == "10.44.76.10"
+      - result.response.dns.action == "ADD"
+      - result.response.dns.credential.username == "dns-admin"
+    success_msg: "Spec for a planned AD-DNS failover with all attributes is generated successfully"
+    fail_msg: "Spec for a planned AD-DNS failover with all attributes is not generated successfully"
+
+- name: Generate spec for an unplanned AD-DNS failover using check mode with minimum attributes
+  nutanix.ncp.ntnx_files_ad_dns_failover_v2:
+    primary_file_server_ext_id: "{{ primary_fs_ext_id }}"
+    secondary_file_server_ext_id: "{{ secondary_fs_ext_id }}"
+    type: "UNPLANNED"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for an unplanned AD-DNS failover using check mode with minimum attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.primary_file_server_ext_id == primary_fs_ext_id
+      - result.response.secondary_file_server_ext_id == secondary_fs_ext_id
+      - result.response.type == "UNPLANNED"
+      - result.response.active_directory is not defined or result.response.active_directory == None
+    success_msg: "Spec for an unplanned AD-DNS failover with minimum attributes is generated successfully"
+    fail_msg: "Spec for an unplanned AD-DNS failover with minimum attributes is not generated successfully"
+
+- name: Generate spec for an AD-DNS failback using check mode
+  nutanix.ncp.ntnx_files_ad_dns_failover_v2:
+    primary_file_server_ext_id: "{{ secondary_fs_ext_id }}"
+    secondary_file_server_ext_id: "{{ primary_fs_ext_id }}"
+    type: "FAILBACK"
+    dns:
+      preferred_name_server: "10.44.76.10"
+      action: "REMOVE"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for an AD-DNS failback using check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.primary_file_server_ext_id == secondary_fs_ext_id
+      - result.response.secondary_file_server_ext_id == primary_fs_ext_id
+      - result.response.type == "FAILBACK"
+      - result.response.dns.preferred_name_server == "10.44.76.10"
+      - result.response.dns.action == "REMOVE"
+    success_msg: "Spec for an AD-DNS failback is generated successfully"
+    fail_msg: "Spec for an AD-DNS failback is not generated successfully"
+
+########################################################################################
+# Negative - argument spec validation
+########################################################################################
+
+- name: Perform AD-DNS failover with an invalid failover type
+  nutanix.ncp.ntnx_files_ad_dns_failover_v2:
+    primary_file_server_ext_id: "{{ primary_fs_ext_id }}"
+    secondary_file_server_ext_id: "{{ secondary_fs_ext_id }}"
+    type: "INVALID_TYPE"
+  register: result
+  ignore_errors: true
+
+- name: Perform AD-DNS failover with an invalid failover type status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'must be one of' in result.msg"
+    success_msg: "AD-DNS failover with an invalid failover type failed as expected"
+    fail_msg: "AD-DNS failover with an invalid failover type did not fail as expected"
+
+- name: Perform AD-DNS failover with an invalid dns action
+  nutanix.ncp.ntnx_files_ad_dns_failover_v2:
+    primary_file_server_ext_id: "{{ primary_fs_ext_id }}"
+    secondary_file_server_ext_id: "{{ secondary_fs_ext_id }}"
+    type: "PLANNED"
+    dns:
+      preferred_name_server: "10.44.76.10"
+      action: "INVALID_ACTION"
+  register: result
+  ignore_errors: true
+
+- name: Perform AD-DNS failover with an invalid dns action status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'must be one of' in result.msg"
+    success_msg: "AD-DNS failover with an invalid dns action failed as expected"
+    fail_msg: "AD-DNS failover with an invalid dns action did not fail as expected"
+
+########################################################################################
+# Real API call - non-existent file servers (expected graceful failure)
+########################################################################################
+
+- name: Perform a planned AD-DNS failover for non-existent file servers
+  nutanix.ncp.ntnx_files_ad_dns_failover_v2:
+    primary_file_server_ext_id: "{{ primary_fs_ext_id }}"
+    secondary_file_server_ext_id: "{{ secondary_fs_ext_id }}"
+    type: "PLANNED"
+    active_directory:
+      credential:
+        username: "ad-admin"
+        password: "ad-password"
+  register: result
+  ignore_errors: true
+
+- name: Perform a planned AD-DNS failover for non-existent file servers status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "AD-DNS failover for non-existent file servers failed gracefully as expected"
+    fail_msg: "AD-DNS failover for non-existent file servers did not fail gracefully as expected"

--- a/tests/integration/targets/ntnx_files_ad_dns_failover_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_files_ad_dns_failover_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import ad_dns_failover.yml
+      ansible.builtin.import_tasks: ad_dns_failover.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection module for the **files** namespace, entity
**AdDnsFailover**, based on the inline `sdk_info.json`. One PR per code-gen run.

`AdDnsFailover` is an **action-type** operation (a single `POST` to
`/api/files/v4.0/operations/$actions/ad-dns-failover`), so it is implemented as
an action module following the `ntnx_vm_revert_v2` pattern. As per the code-gen
rules, the companion `*_info` module is **skipped** for action-type entities
(there is no queryable AdDnsFailover resource — the SDK exposes no
Create/Get/Update/Delete for it).

- Modules generated: `ntnx_files_ad_dns_failover_v2` (action module)
- Info module: intentionally skipped (action-type entity)
- API methods covered: 1 (`AdDnsFailover` on `ReplicationPoliciesApi`)
- Top-level fields in module spec: 6 (`state`, `primary_file_server_ext_id`, `secondary_file_server_ext_id`, `active_directory`, `dns`, `type`)
- New helper package: `plugins/module_utils/v4/files/` (`api_client.py`)

## Domain knowledge (from Glean)

The Glean MCP tools were **unavailable** during this run — the `glean__chat`
query timed out on three separate attempts, so no Glean answer or references
could be retrieved. Per the code-gen rules, no internal ticket/Confluence/design
links are included in this PR regardless.

Feature summary derived from the SDK contract: An AD-DNS failover moves a Nutanix
Files file server's Active Directory computer account and DNS records from a
primary file server to a paired secondary file server (and back, via failback).
It supports three failover types — `PLANNED` (graceful, coordinated),
`UNPLANNED` (primary unavailable) and `FAILBACK` (revert to the original
primary). The action accepts optional Active Directory credentials
(`active_directory.credential` + `preferred_domain_controller`) and DNS update
details (`dns.preferred_name_server`, `dns.action` = ADD/REMOVE, `dns.credential`).
Prerequisite: two file servers paired by a replication policy plus valid AD/DNS
credentials.

## Files changed

- `plugins/modules/`
  - `ntnx_files_ad_dns_failover_v2.py` (new action module)
- `plugins/module_utils/v4/files/`
  - `__init__.py` (new)
  - `api_client.py` (new — Files API client + `get_replication_policies_api_instance`)
- `examples/files/AdDnsFailover/`
  - `ntnx_files_ad_dns_failover_v2.yml` (new example playbook)
  - `examples_run.log` (real output from running the playbook against the live PC)
- `tests/integration/targets/ntnx_files_ad_dns_failover_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/ad_dns_failover.yml` (new)
- `meta/runtime.yml` (registered `ntnx_files_ad_dns_failover_v2` in the `ntnx` action group)

## Test execution

| Metric              | Value                                                                             |
|---------------------|-----------------------------------------------------------------------------------|
| Command             | `ansible-test integration --local --python 3.11 --allow-disabled ntnx_files_ad_dns_failover_v2` |
| Total tasks (ok)    | 15                                                                                |
| Passed assertions   | 6 (3 check_mode + 2 negative + 1 live-failure)                                    |
| Failed              | 0                                                                                 |
| Ignored             | 3 (expected graceful failures with `ignore_errors`)                             |
| Duration            | ~0:01:37                                                                          |
| Cluster (PC)        | 10.44.76.28                                                                        |

Additional gates (all green):
- `black --check` / `isort --check` / `flake8`: pass
- `ansible-test sanity --local --python 3.11` (32 tests) on the module + api_client: pass
- `ansible-lint` (production profile): 0 failures, 5/5 stars (2 warnings are the
  intentional invalid-enum negative tests)

### Analysis

All check_mode and negative tests pass deterministically. The single live API
call (planned failover for non-existent file servers) returns HTTP 503
`SERVICE UNAVAILABLE` from the Files replication microservice on the target PC —
the module surfaces this gracefully (`failed: true`, populated `error`, `msg`,
and `response`) rather than raising an unhandled traceback, which is exactly what
the negative assertion verifies.

The happy-path (a fully successful failover producing a `SUCCEEDED` task) could
**not** be executed end-to-end because it requires two file servers paired by a
replication policy plus valid AD/DNS credentials, and the target PC has no Files
deployment configured (hence the 503). The success path is therefore validated
via check_mode spec generation, and the `RETURN` `response` sample uses a
representative task structure.

### Test logs (tail)

<details>
<summary>tail of test_logs.log</summary>

```text
PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_files_ad_dns_failover_v2 : Start ntnx_files_ad_dns_failover_v2 tests] ***
ok: [testhost] => {
    "msg": "Start ntnx_files_ad_dns_failover_v2 tests"
}

TASK [ntnx_files_ad_dns_failover_v2 : Set file server external IDs for the test run] ***
ok: [testhost]

TASK [ntnx_files_ad_dns_failover_v2 : Generate spec for a planned AD-DNS failover using check mode with all attributes] ***
ok: [testhost]

TASK [ntnx_files_ad_dns_failover_v2 : Generate spec for a planned AD-DNS failover using check mode with all attributes status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Spec for a planned AD-DNS failover with all attributes is generated successfully"
}

TASK [ntnx_files_ad_dns_failover_v2 : Generate spec for an unplanned AD-DNS failover using check mode with minimum attributes] ***
ok: [testhost]

TASK [ntnx_files_ad_dns_failover_v2 : Generate spec for an unplanned AD-DNS failover using check mode with minimum attributes status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Spec for an unplanned AD-DNS failover with minimum attributes is generated successfully"
}

TASK [ntnx_files_ad_dns_failover_v2 : Generate spec for an AD-DNS failback using check mode] ***
ok: [testhost]

TASK [ntnx_files_ad_dns_failover_v2 : Generate spec for an AD-DNS failback using check mode status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Spec for an AD-DNS failback is generated successfully"
}

TASK [ntnx_files_ad_dns_failover_v2 : Perform AD-DNS failover with an invalid failover type] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of type must be one of: PLANNED, UNPLANNED, FAILBACK, got: INVALID_TYPE"}
...ignoring

TASK [ntnx_files_ad_dns_failover_v2 : Perform AD-DNS failover with an invalid failover type status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "AD-DNS failover with an invalid failover type failed as expected"
}

TASK [ntnx_files_ad_dns_failover_v2 : Perform AD-DNS failover with an invalid dns action] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of action must be one of: ADD, REMOVE, got: INVALID_ACTION found in dns"}
...ignoring

TASK [ntnx_files_ad_dns_failover_v2 : Perform AD-DNS failover with an invalid dns action status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "AD-DNS failover with an invalid dns action failed as expected"
}

TASK [ntnx_files_ad_dns_failover_v2 : Perform a planned AD-DNS failover for non-existent file servers] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while performing AD-DNS failover", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_files_ad_dns_failover_v2 : Perform a planned AD-DNS failover for non-existent file servers status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "AD-DNS failover for non-existent file servers failed gracefully as expected"
}

PLAY RECAP *********************************************************************
testhost                   : ok=15   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
