### PR TITLE
code-gen(volumes/CategoryAssociationsByVolumeGroupId): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+INSTRUCTIONS.md
+pr_body.md
+pr_summary.md
+test_logs.log
+*.bak
+*~

--- a/examples/volumes/CategoryAssociationsByVolumeGroupId/examples_run.log
+++ b/examples/volumes/CategoryAssociationsByVolumeGroupId/examples_run.log
@@ -1,0 +1,31 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Volume Group Category Associations playbook] *****************************
+
+TASK [Set variables] ***********************************************************
+ok: [localhost] => {"ansible_facts": {"category_ext_id_1": "f67f4fd0-dbd0-432b-7b71-58002c9f2d1f", "category_ext_id_2": "e72b4777-aadc-46d0-4659-3367e33e6720", "volume_group_ext_id": "a6165ec0-8936-405d-67bc-cc04c05e5622"}, "changed": false}
+
+TASK [Associate categories with Volume Group] **********************************
+changed: [localhost] => {"changed": true, "ext_id": "a6165ec0-8936-405d-67bc-cc04c05e5622", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T06:01:24.177060+00:00", "completion_details": null, "created_time": "2026-07-21T06:01:24.121781+00:00", "entities_affected": [{"ext_id": "a6165ec0-8936-405d-67bc-cc04c05e5622", "name": null, "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:0f7c0055-f47a-41bb-b72a-2ccf5b7e32bc", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T06:01:24.177059+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "UpdateCategoryAssociations_kOperationAttach", "operation_description": "Associate Category", "owned_by": null, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T06:01:24.132986+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:0f7c0055-f47a-41bb-b72a-2ccf5b7e32bc"}
+
+TASK [Update category associations by associating an additional category] ******
+changed: [localhost] => {"changed": true, "ext_id": "a6165ec0-8936-405d-67bc-cc04c05e5622", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T06:01:27.715640+00:00", "completion_details": null, "created_time": "2026-07-21T06:01:27.679874+00:00", "entities_affected": [{"ext_id": "a6165ec0-8936-405d-67bc-cc04c05e5622", "name": null, "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:54b0c90e-84f8-488c-9cf0-608fbc46e51f", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T06:01:27.715639+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "UpdateCategoryAssociations_kOperationAttach", "operation_description": "Associate Category", "owned_by": null, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T06:01:27.688074+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:54b0c90e-84f8-488c-9cf0-608fbc46e51f"}
+
+TASK [List all category associations for the Volume Group] *********************
+ok: [localhost] => {"changed": false, "response": [{"entity_type": "CATEGORY", "ext_id": "f67f4fd0-dbd0-432b-7b71-58002c9f2d1f", "name": null, "uris": null}, {"entity_type": "CATEGORY", "ext_id": "e72b4777-aadc-46d0-4659-3367e33e6720", "name": null, "uris": null}], "total_available_results": 2, "volume_group_ext_id": "a6165ec0-8936-405d-67bc-cc04c05e5622"}
+
+TASK [Fetch a specific associated category by ext_id] **************************
+ok: [localhost] => {"changed": false, "ext_id": "f67f4fd0-dbd0-432b-7b71-58002c9f2d1f", "response": {"entity_type": "CATEGORY", "ext_id": "f67f4fd0-dbd0-432b-7b71-58002c9f2d1f", "name": null, "uris": null}, "volume_group_ext_id": "a6165ec0-8936-405d-67bc-cc04c05e5622"}
+
+TASK [List category associations with pagination] ******************************
+ok: [localhost] => {"changed": false, "response": [{"entity_type": "CATEGORY", "ext_id": "f67f4fd0-dbd0-432b-7b71-58002c9f2d1f", "name": null, "uris": null}, {"entity_type": "CATEGORY", "ext_id": "e72b4777-aadc-46d0-4659-3367e33e6720", "name": null, "uris": null}], "total_available_results": 2, "volume_group_ext_id": "a6165ec0-8936-405d-67bc-cc04c05e5622"}
+
+TASK [Disassociate categories from the Volume Group] ***************************
+changed: [localhost] => {"changed": true, "ext_id": "a6165ec0-8936-405d-67bc-cc04c05e5622", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T06:01:33.216690+00:00", "completion_details": null, "created_time": "2026-07-21T06:01:33.185185+00:00", "entities_affected": [{"ext_id": "a6165ec0-8936-405d-67bc-cc04c05e5622", "name": null, "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:608e5abd-7524-44ae-a5b1-6421f88dfec1", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T06:01:33.216689+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "UpdateCategoryAssociations_kOperationDetach", "operation_description": "Disassociate Category", "owned_by": null, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T06:01:33.191854+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:608e5abd-7524-44ae-a5b1-6421f88dfec1"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=7    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/volumes/CategoryAssociationsByVolumeGroupId/volume_group_category_associations_v2.yml
+++ b/examples/volumes/CategoryAssociationsByVolumeGroupId/volume_group_category_associations_v2.yml
@@ -1,0 +1,81 @@
+---
+# Summary:
+# This playbook demonstrates how to manage category associations for a Volume Group in
+# Nutanix Prism Central using the following v4 modules:
+#   1. Associate categories with a Volume Group (Create)
+#   2. Associate additional categories (Update — idempotent associate)
+#   3. List all category associations for a Volume Group
+#   4. Fetch a specific category association by ext_id
+#   5. List category associations with pagination (page + limit)
+#   6. Disassociate categories from a Volume Group (Delete)
+#
+# Prerequisites:
+#   - Prism Central endpoint reachable at nutanix_host
+#   - An existing Volume Group with the ext_id supplied in `volume_group_ext_id`
+#   - Two existing categories with the ext_ids supplied in `category_ext_id_1` and
+#     `category_ext_id_2` (create them via the ntnx_categories_v2 module if needed)
+
+- name: Volume Group Category Associations playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('env', 'NUTANIX_USERNAME') | default('admin', true)) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Set variables
+      ansible.builtin.set_fact:
+        volume_group_ext_id: "{{ volume_group_ext_id | default('<vg_ext_id>') }}"
+        category_ext_id_1: "{{ category_ext_id_1 | default('<category_ext_id_1>') }}"
+        category_ext_id_2: "{{ category_ext_id_2 | default('<category_ext_id_2>') }}"
+
+    - name: Associate categories with Volume Group
+      nutanix.ncp.ntnx_volume_group_category_v2:
+        state: present
+        ext_id: "{{ volume_group_ext_id }}"
+        categories:
+          - ext_id: "{{ category_ext_id_1 }}"
+            entity_type: "CATEGORY"
+      register: associate_result
+
+    - name: Update category associations by associating an additional category
+      nutanix.ncp.ntnx_volume_group_category_v2:
+        state: present
+        ext_id: "{{ volume_group_ext_id }}"
+        categories:
+          - ext_id: "{{ category_ext_id_1 }}"
+            entity_type: "CATEGORY"
+          - ext_id: "{{ category_ext_id_2 }}"
+            entity_type: "CATEGORY"
+      register: update_result
+
+    - name: List all category associations for the Volume Group
+      nutanix.ncp.ntnx_category_associations_by_volume_group_ids_info_v2:
+        volume_group_ext_id: "{{ volume_group_ext_id }}"
+      register: list_result
+
+    - name: Fetch a specific associated category by ext_id
+      nutanix.ncp.ntnx_category_associations_by_volume_group_ids_info_v2:
+        volume_group_ext_id: "{{ volume_group_ext_id }}"
+        ext_id: "{{ category_ext_id_1 }}"
+      register: get_result
+
+    - name: List category associations with pagination
+      nutanix.ncp.ntnx_category_associations_by_volume_group_ids_info_v2:
+        volume_group_ext_id: "{{ volume_group_ext_id }}"
+        page: 0
+        limit: 25
+      register: paginated_result
+
+    - name: Disassociate categories from the Volume Group
+      nutanix.ncp.ntnx_volume_group_category_v2:
+        state: absent
+        ext_id: "{{ volume_group_ext_id }}"
+        categories:
+          - ext_id: "{{ category_ext_id_1 }}"
+            entity_type: "CATEGORY"
+          - ext_id: "{{ category_ext_id_2 }}"
+            entity_type: "CATEGORY"
+      register: disassociate_result

--- a/plugins/modules/ntnx_category_associations_by_volume_group_ids_info_v2.py
+++ b/plugins/modules/ntnx_category_associations_by_volume_group_ids_info_v2.py
@@ -1,0 +1,262 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_category_associations_by_volume_group_ids_info_v2
+short_description: List categories associated with a Volume Group in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about CategoryAssociationsByVolumeGroupId in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific CategoryAssociationsByVolumeGroupId.
+  - If C(ext_id) is not provided, list multiple CategoryAssociationsByVolumeGroupId optionally filtered / paginated.
+  - The underlying SDK API is deprecated but still functional; see the note below.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(List category associations for a Volume Group) -
+    Required Roles: Backup Admin, CSI System, Kubernetes Data Services System, Prism Admin, Prism Viewer,
+    Project Manager, Storage Admin, Super Admin, Self-Service Admin (deprecated)
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=volumes)"
+options:
+  volume_group_ext_id:
+    description:
+      - The external identifier of the Volume Group whose category associations should be listed.
+      - This is required to invoke the list-category-associations-by-volume-group-id API.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external identifier of a specific associated category to fetch from the list.
+      - When provided, the module lists all category associations for the Volume Group and returns the entry whose
+        external identifier matches this value.
+      - The v4 volumes API does not offer a dedicated get-by-id endpoint for a single category association.
+    type: str
+    required: false
+  page:
+    description:
+      - A URL query parameter that specifies the page number of the result set.
+      - Must be a positive integer between 0 and the maximum number of pages available for the resource.
+    type: int
+    required: false
+  limit:
+    description:
+      - A URL query parameter that specifies the total number of records returned in the result set.
+      - Must be a positive integer between 1 and 100. Defaults to 50 when not provided.
+    type: int
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: List all category associations for a Volume Group
+  nutanix.ncp.ntnx_category_associations_by_volume_group_ids_info_v2:
+    volume_group_ext_id: "68e4c68e-1acf-4c05-7792-e062119acb68"
+  register: result
+
+- name: List category associations for a Volume Group with pagination
+  nutanix.ncp.ntnx_category_associations_by_volume_group_ids_info_v2:
+    volume_group_ext_id: "68e4c68e-1acf-4c05-7792-e062119acb68"
+    page: 0
+    limit: 25
+  register: result
+
+- name: Fetch a specific associated category by ext_id
+  nutanix.ncp.ntnx_category_associations_by_volume_group_ids_info_v2:
+    volume_group_ext_id: "68e4c68e-1acf-4c05-7792-e062119acb68"
+    ext_id: "566b844b-d245-4894-a8b5-eeef1ec4b638"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC CategoryAssociationsByVolumeGroupId info v4 API.
+    - It can be a single CategoryAssociationsByVolumeGroupId if external ID is provided.
+    - List of multiple CategoryAssociationsByVolumeGroupId if external ID is not provided
+      (pagination via C(page)/C(limit) is supported by the API).
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "entity_type": "CATEGORY",
+        "ext_id": "f67f4fd0-dbd0-432b-7b71-58002c9f2d1f",
+        "name": null,
+        "uris": null
+      },
+      {
+        "entity_type": "CATEGORY",
+        "ext_id": "e72b4777-aadc-46d0-4659-3367e33e6720",
+        "name": null,
+        "uris": null
+      }
+    ]
+
+total_available_results:
+  description: The total number of category associations available in the API for the Volume Group.
+  type: int
+  returned: when the list API returns metadata with total_available_results
+  sample: 2
+
+ext_id:
+  description: The external identifier of the specific associated category requested via C(ext_id).
+  type: str
+  returned: when C(ext_id) is provided
+  sample: "f67f4fd0-dbd0-432b-7b71-58002c9f2d1f"
+
+volume_group_ext_id:
+  description: The external identifier of the Volume Group whose category associations were fetched.
+  type: str
+  returned: always
+  sample: "a6165ec0-8936-405d-67bc-cc04c05e5622"
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error or the entity could not be found
+  type: str
+  sample: "Api Exception raised while listing category associations for Volume Group"
+
+error:
+  description: This field typically holds information about the error that occurred during the task execution.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.volumes.api_client import get_vg_api_instance  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        volume_group_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=False),
+        page=dict(type="int", required=False),
+        limit=dict(type="int", required=False),
+    )
+
+    return module_args
+
+
+def _list_all_category_associations(module, api_instance, volume_group_ext_id):
+    """List category associations for a Volume Group honouring page/limit."""
+    kwargs = {}
+    if module.params.get("page") is not None:
+        kwargs["_page"] = module.params.get("page")
+    if module.params.get("limit") is not None:
+        kwargs["_limit"] = module.params.get("limit")
+    try:
+        return api_instance.list_category_associations_by_volume_group_id(
+            volumeGroupExtId=volume_group_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while listing category associations for Volume Group",
+        )
+
+
+def get_category_association_using_ext_id(module, api_instance, result):
+    volume_group_ext_id = module.params.get("volume_group_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["volume_group_ext_id"] = volume_group_ext_id
+    result["ext_id"] = ext_id
+
+    resp = _list_all_category_associations(module, api_instance, volume_group_ext_id)
+    resp_dict = strip_internal_attributes(resp.to_dict())
+    data = resp_dict.get("data") or []
+    match = None
+    for item in data:
+        if item.get("ext_id") == ext_id:
+            match = item
+            break
+    if not match:
+        module.fail_json(
+            msg=(
+                "Category association with ext_id '{0}' was not found for Volume Group "
+                "'{1}'."
+            ).format(ext_id, volume_group_ext_id),
+            **result,
+        )
+    result["response"] = match
+
+
+def get_category_associations(module, api_instance, result):
+    volume_group_ext_id = module.params.get("volume_group_ext_id")
+    result["volume_group_ext_id"] = volume_group_ext_id
+
+    resp = _list_all_category_associations(module, api_instance, volume_group_ext_id)
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_vg_api_instance(module)
+    if module.params.get("ext_id"):
+        get_category_association_using_ext_id(module, api_instance, result)
+    else:
+        get_category_associations(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_volume_group_category_v2.py
+++ b/plugins/modules/ntnx_volume_group_category_v2.py
@@ -1,0 +1,565 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_volume_group_category_v2
+short_description: Associate or disassociate categories with a Volume Group in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to associate or disassociate categories with a Volume Group in Nutanix Prism Central.
+  - When C(state) is C(present), the categories passed in C(categories) are associated with the Volume Group.
+  - When C(state) is C(absent), the categories passed in C(categories) are disassociated from the Volume Group.
+  - Both the associate and disassociate operations are idempotent, i.e. only the categories that need to be
+    added/removed to reach the requested state are sent to the API.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    The required roles depend on the operation being performed.
+  - >-
+    B(Associate category to a Volume Group) -
+    Required Roles: CSI System, Kubernetes Data Services System, Prism Admin, Project Manager, Storage Admin,
+    Super Admin, Self-Service Admin (deprecated)
+  - >-
+    B(Disassociate category from a Volume Group) -
+    Required Roles: CSI System, Kubernetes Data Services System, Prism Admin, Project Manager, Storage Admin,
+    Super Admin, Self-Service Admin (deprecated)
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=volumes)"
+options:
+  state:
+    description:
+      - Specify state.
+      - If C(state) is C(present), the categories are associated with the Volume Group referenced by C(ext_id).
+      - If C(state) is C(absent), the categories are disassociated from the Volume Group referenced by C(ext_id).
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external identifier of the Volume Group to associate categories with or disassociate categories from.
+    type: str
+    required: true
+  categories:
+    description:
+      - List of categories to associate with or disassociate from the Volume Group.
+      - Required for both associate (C(state=present)) and disassociate (C(state=absent)) operations.
+    type: list
+    elements: dict
+    required: true
+    suboptions:
+      ext_id:
+        description:
+          - The external identifier of the category.
+        type: str
+        required: false
+      name:
+        description:
+          - The name of the category.
+        type: str
+        required: false
+      uris:
+        description:
+          - List of URIs of the category.
+        type: list
+        elements: str
+        required: false
+      entity_type:
+        description:
+          - The entity type of the category reference.
+          - For a category reference this should typically be C(CATEGORY).
+        type: str
+        required: false
+        choices:
+          - VOLUME_GROUP
+          - ROUTING_POLICY
+          - DIRECT_CONNECT_VIF
+          - AVAILABILITY_ZONE
+          - STORAGE_CONTAINER
+          - VPC
+          - VPN_CONNECTION
+          - VOLUME_DISK
+          - VPN_GATEWAY
+          - IMAGE
+          - CATEGORY
+          - RECOVERY_PLAN
+          - CLUSTER
+          - DISK_RECOVERY_POINT
+          - CONSISTENCY_GROUP
+          - VIRTUAL_NIC
+          - TASK
+          - VIRTUAL_SWITCH
+          - VIRTUAL_NETWORK
+          - NODE
+          - FLOATING_IP
+          - SUBNET
+          - VM_DISK
+          - VTEP_GATEWAY
+          - VM
+          - DIRECT_CONNECT
+          - SUBNET_EXTENSION
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Associate categories with Volume Group
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "68e4c68e-1acf-4c05-7792-e062119acb68"
+    categories:
+      - ext_id: "566b844b-d245-4894-a8b5-eeef1ec4b638"
+        entity_type: "CATEGORY"
+  register: result
+
+- name: Update category associations for a Volume Group (associate additional categories)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "68e4c68e-1acf-4c05-7792-e062119acb68"
+    categories:
+      - ext_id: "566b844b-d245-4894-a8b5-eeef1ec4b638"
+        entity_type: "CATEGORY"
+      - ext_id: "7c5b1c92-6f4a-4a24-8ce5-4b6c4e3c1def"
+        entity_type: "CATEGORY"
+  register: result
+
+- name: Disassociate categories from Volume Group
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: absent
+    ext_id: "68e4c68e-1acf-4c05-7792-e062119acb68"
+    categories:
+      - ext_id: "566b844b-d245-4894-a8b5-eeef1ec4b638"
+        entity_type: "CATEGORY"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for associating or disassociating categories with a Volume Group.
+    - When C(wait) is C(true), it holds the completed task details.
+    - When C(wait) is C(false), it holds the accepted task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "app_name": null,
+      "batch_summary": null,
+      "cluster_ext_ids": null,
+      "completed_time": "2026-07-21T06:01:24.177060+00:00",
+      "completion_details": null,
+      "created_time": "2026-07-21T06:01:24.121781+00:00",
+      "entities_affected": [
+        {
+          "ext_id": "a6165ec0-8936-405d-67bc-cc04c05e5622",
+          "name": null,
+          "rel": "volumes:config:volume-group"
+        }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:0f7c0055-f47a-41bb-b72a-2ccf5b7e32bc",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-21T06:01:24.177059+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 1,
+      "number_of_subtasks": 0,
+      "operation": "UpdateCategoryAssociations_kOperationAttach",
+      "operation_description": "Associate Category",
+      "owned_by": null,
+      "parent_task": null,
+      "progress_percentage": 100,
+      "projectExtId": "00000000-0000-0000-0000-000000000000",
+      "resource_links": null,
+      "root_task": null,
+      "started_time": "2026-07-21T06:01:24.132986+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+task_ext_id:
+  description: The external identifier of the task performing the associate or disassociate action.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:0f7c0055-f47a-41bb-b72a-2ccf5b7e32bc"
+
+ext_id:
+  description: The external identifier of the Volume Group whose category associations are being managed.
+  returned: always
+  type: str
+  sample: "a6165ec0-8936-405d-67bc-cc04c05e5622"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description:
+    - This indicates whether the operation was skipped because the requested state is already satisfied.
+    - True when idempotency detected all categories are already associated (on C(state=present))
+      or already disassociated (on C(state=absent)).
+  returned: when applicable
+  type: bool
+  sample: true
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, module is idempotent or check mode is enabled.
+  type: str
+  sample: "Api Exception raised while associating categories with Volume Group"
+
+error:
+  description: This field typically holds information about the error that occurred during the task execution.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+from ..module_utils.v4.volumes.api_client import get_vg_api_instance  # noqa: E402
+from ..module_utils.v4.volumes.helpers import get_volume_group  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_volumes_py_client as volumes_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as volumes_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    categories_spec = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        uris=dict(type="list", elements="str"),
+        entity_type=dict(
+            type="str",
+            choices=[
+                "VOLUME_GROUP",
+                "ROUTING_POLICY",
+                "DIRECT_CONNECT_VIF",
+                "AVAILABILITY_ZONE",
+                "STORAGE_CONTAINER",
+                "VPC",
+                "VPN_CONNECTION",
+                "VOLUME_DISK",
+                "VPN_GATEWAY",
+                "IMAGE",
+                "CATEGORY",
+                "RECOVERY_PLAN",
+                "CLUSTER",
+                "DISK_RECOVERY_POINT",
+                "CONSISTENCY_GROUP",
+                "VIRTUAL_NIC",
+                "TASK",
+                "VIRTUAL_SWITCH",
+                "VIRTUAL_NETWORK",
+                "NODE",
+                "FLOATING_IP",
+                "SUBNET",
+                "VM_DISK",
+                "VTEP_GATEWAY",
+                "VM",
+                "DIRECT_CONNECT",
+                "SUBNET_EXTENSION",
+            ],
+        ),
+    )
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        categories=dict(
+            type="list",
+            elements="dict",
+            options=categories_spec,
+            obj=volumes_sdk.EntityReference,
+            required=True,
+        ),
+    )
+
+    return module_args
+
+
+def _get_associated_category_ext_ids(module, api_instance, volume_group_ext_id):
+    """Return the set of category ext_ids currently associated with the Volume Group.
+
+    Uses the deprecated but still-functional list-category-associations endpoint. Pages
+    through until either no more pages are returned or the API returns fewer results
+    than the page size (max 100 per page).
+    """
+    associated = set()
+    page = 0
+    page_size = 100
+    while True:
+        try:
+            resp = api_instance.list_category_associations_by_volume_group_id(
+                volumeGroupExtId=volume_group_ext_id,
+                _page=page,
+                _limit=page_size,
+            )
+        except Exception as e:
+            raise_api_exception(
+                module=module,
+                exception=e,
+                msg="Api Exception raised while listing existing category associations for Volume Group",
+            )
+        data = getattr(resp, "data", None) or []
+        for item in data:
+            item_ext_id = getattr(item, "ext_id", None)
+            if item_ext_id:
+                associated.add(item_ext_id)
+        if len(data) < page_size:
+            break
+        page += 1
+    return associated
+
+
+def _build_category_references_spec(module, result):
+    sg = SpecGenerator(module)
+    default_spec = volumes_sdk.CategoryEntityReferences()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating Volume Group category associations spec", **result
+        )
+    return spec
+
+
+def _filter_categories_for_operation(spec, keep_ext_ids):
+    """Return a new CategoryEntityReferences spec containing only categories whose ext_id
+    appears in keep_ext_ids. Categories that reference by name/uris only (no ext_id) are
+    always retained since we cannot infer their identity."""
+    if spec.categories is None:
+        return spec
+    filtered = []
+    for category in spec.categories:
+        cat_ext_id = getattr(category, "ext_id", None)
+        if cat_ext_id is None:
+            filtered.append(category)
+            continue
+        if cat_ext_id in keep_ext_ids:
+            filtered.append(category)
+    spec.categories = filtered
+    return spec
+
+
+def _wait_and_finalize_task(module, resp, result):
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def _perform_associate(module, api_instance, ext_id, spec, result):
+    try:
+        resp = api_instance.associate_category(extId=ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while associating categories with Volume Group",
+        )
+    _wait_and_finalize_task(module, resp, result)
+
+
+def _perform_disassociate(module, api_instance, ext_id, spec, result):
+    try:
+        resp = api_instance.disassociate_category(extId=ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while disassociating categories from Volume Group",
+        )
+    _wait_and_finalize_task(module, resp, result)
+
+
+def create_CategoryAssociationsByVolumeGroupId(module, result, api_instance):
+    """Associate categories with a Volume Group when no update state is known yet.
+
+    In practice this branch is unreachable because C(ext_id) is required at the argument
+    spec level. It is kept to conform to the mandated state-based dispatch pattern and
+    provides a defensive error path.
+    """
+    validate_required_params(module, ["ext_id", "categories"])
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    spec = _build_category_references_spec(module, result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    # Ensure the Volume Group exists before attempting the associate action.
+    get_volume_group(module, api_instance, ext_id)
+
+    _perform_associate(module, api_instance, ext_id, spec, result)
+
+
+def update_CategoryAssociationsByVolumeGroupId(module, result, api_instance):
+    """Idempotently associate the requested categories with the Volume Group.
+
+    Categories that are already associated are stripped from the request. If nothing
+    remains to associate, the module exits early with C(changed=false) and
+    C(skipped=true).
+    """
+    validate_required_params(module, ["ext_id", "categories"])
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    spec = _build_category_references_spec(module, result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    # Ensure the Volume Group exists before attempting the associate action.
+    get_volume_group(module, api_instance, ext_id)
+
+    requested_ext_ids = {
+        cat.ext_id for cat in (spec.categories or []) if getattr(cat, "ext_id", None)
+    }
+    if requested_ext_ids:
+        associated = _get_associated_category_ext_ids(module, api_instance, ext_id)
+        to_associate = requested_ext_ids - associated
+        if not to_associate:
+            result["skipped"] = True
+            result["changed"] = False
+            module.exit_json(
+                msg=(
+                    "CategoryAssociationsByVolumeGroupId with ext_id '{0}' already has "
+                    "the requested categories associated. Skipping association."
+                ).format(ext_id),
+                **result,
+            )
+        # Only send categories that still need to be associated.
+        spec = _filter_categories_for_operation(spec, to_associate)
+
+    _perform_associate(module, api_instance, ext_id, spec, result)
+
+
+def delete_CategoryAssociationsByVolumeGroupId(module, result, api_instance):
+    """Disassociate the requested categories from the Volume Group idempotently."""
+    validate_required_params(module, ["ext_id", "categories"])
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    spec = _build_category_references_spec(module, result)
+
+    if module.check_mode:
+        result["msg"] = (
+            "Categories will be disassociated from Volume Group with ext_id:{0}.".format(
+                ext_id
+            )
+        )
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    # Ensure the Volume Group exists before attempting the disassociate action.
+    get_volume_group(module, api_instance, ext_id)
+
+    requested_ext_ids = {
+        cat.ext_id for cat in (spec.categories or []) if getattr(cat, "ext_id", None)
+    }
+    if requested_ext_ids:
+        associated = _get_associated_category_ext_ids(module, api_instance, ext_id)
+        to_disassociate = requested_ext_ids & associated
+        if not to_disassociate:
+            result["skipped"] = True
+            result["changed"] = False
+            module.exit_json(
+                msg=(
+                    "None of the requested categories are currently associated with "
+                    "Volume Group ext_id '{0}'. Skipping disassociation."
+                ).format(ext_id),
+                **result,
+            )
+        # Only send categories that are actually associated and need to be removed.
+        spec = _filter_categories_for_operation(spec, to_disassociate)
+
+    _perform_disassociate(module, api_instance, ext_id, spec, result)
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_volumes_py_client"), exception=SDK_IMP_ERROR
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_vg_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_CategoryAssociationsByVolumeGroupId(module, result, api_instance)
+        else:
+            create_CategoryAssociationsByVolumeGroupId(module, result, api_instance)
+    else:
+        delete_CategoryAssociationsByVolumeGroupId(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
-ntnx-volumes-py-client==4.2.2
+ntnx-volumes-py-client==latest
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2
 ntnx-lifecycle-py-client==4.2.2

--- a/tests/integration/targets/ntnx_volume_group_category_v2/aliases
+++ b/tests/integration/targets/ntnx_volume_group_category_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_volume_group_category_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_volume_group_category_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_volume_group_category_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_volume_group_category_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import volume_group_category_associations.yml
+      ansible.builtin.import_tasks: volume_group_category_associations.yml

--- a/tests/integration/targets/ntnx_volume_group_category_v2/tasks/volume_group_category_associations.yml
+++ b/tests/integration/targets/ntnx_volume_group_category_v2/tasks/volume_group_category_associations.yml
@@ -1,0 +1,614 @@
+---
+# Test plan for CategoryAssociationsByVolumeGroupId (volumes v4.2)
+#
+# The associate/disassociate volumes actions and the list-category-associations API
+# together power the "CategoryAssociationsByVolumeGroupId" feature. This file covers:
+#
+#   Setup:
+#     - Create two categories used as prerequisites (via ntnx_categories_v2).
+#     - Create a Volume Group as the association target (via ntnx_volume_groups_v2).
+#
+#   Positive CRUD (ntnx_volume_group_category_v2):
+#     - Check-mode associate with all attributes (spec generation only).
+#     - Real associate of a single category (minimum body).
+#     - Real associate of two categories using all EntityReference attributes.
+#     - Idempotent re-associate (already associated -> skipped).
+#     - Check-mode disassociate.
+#     - Real disassociate of one category, verify list length drops accordingly.
+#     - Idempotent disassociate (already gone -> skipped).
+#
+#   Info (ntnx_category_associations_by_volume_group_ids_info_v2):
+#     - List all associations.
+#     - Fetch by ext_id.
+#     - Paginated list (limit=1 -> at most 1 element).
+#
+#   Negative / error paths:
+#     - Missing required categories.
+#     - Missing required ext_id.
+#     - Invalid entity_type choice (spec-level validation).
+#     - Associate against non-existent Volume Group ext_id (API failure).
+#     - Info by ext_id that is not associated -> descriptive failure.
+#
+#   Cleanup:
+#     - Disassociate any remaining categories.
+#     - Delete the Volume Group.
+#     - Delete both categories.
+
+- name: Start CategoryAssociationsByVolumeGroupId tests
+  ansible.builtin.debug:
+    msg: Start CategoryAssociationsByVolumeGroupId tests
+
+- name: Generate random suffix
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible-cabvgid"
+
+- name: Set test object names
+  ansible.builtin.set_fact:
+    vg_name: "vg_{{ suffix_name }}_{{ random_name }}"
+    category_key: "cat_{{ suffix_name }}_{{ random_name }}"
+
+################################################################################
+# Setup: create prerequisite categories
+################################################################################
+
+- name: Create first category prerequisite
+  nutanix.ncp.ntnx_categories_v2:
+    key: "{{ category_key }}"
+    value: "v1_{{ random_name }}"
+    description: "First category for CategoryAssociationsByVolumeGroupId tests"
+  register: cat1_result
+  ignore_errors: true
+
+- name: Assert first category created
+  ansible.builtin.assert:
+    that:
+      - cat1_result is defined
+      - cat1_result.changed == true
+      - cat1_result.failed == false
+      - cat1_result.ext_id is defined
+    success_msg: "First category prerequisite created"
+    fail_msg: "Failed to create first category prerequisite"
+
+- name: Set first category ext_id
+  ansible.builtin.set_fact:
+    category1_ext_id: "{{ cat1_result.ext_id }}"
+
+- name: Create second category prerequisite
+  nutanix.ncp.ntnx_categories_v2:
+    key: "{{ category_key }}"
+    value: "v2_{{ random_name }}"
+    description: "Second category for CategoryAssociationsByVolumeGroupId tests"
+  register: cat2_result
+  ignore_errors: true
+
+- name: Assert second category created
+  ansible.builtin.assert:
+    that:
+      - cat2_result is defined
+      - cat2_result.changed == true
+      - cat2_result.failed == false
+      - cat2_result.ext_id is defined
+    success_msg: "Second category prerequisite created"
+    fail_msg: "Failed to create second category prerequisite"
+
+- name: Set second category ext_id
+  ansible.builtin.set_fact:
+    category2_ext_id: "{{ cat2_result.ext_id }}"
+
+################################################################################
+# Setup: create a Volume Group to receive category associations
+################################################################################
+
+- name: Create Volume Group prerequisite
+  nutanix.ncp.ntnx_volume_groups_v2:
+    name: "{{ vg_name }}"
+    description: "VG for CategoryAssociationsByVolumeGroupId tests"
+    cluster_reference: "{{ cluster.uuid }}"
+  register: vg_result
+  ignore_errors: true
+
+- name: Assert Volume Group created
+  ansible.builtin.assert:
+    that:
+      - vg_result is defined
+      - vg_result.changed == true
+      - vg_result.failed == false
+      - vg_result.ext_id is defined
+    success_msg: "Volume Group prerequisite created"
+    fail_msg: "Failed to create Volume Group prerequisite"
+
+- name: Set Volume Group ext_id
+  ansible.builtin.set_fact:
+    vg_ext_id: "{{ vg_result.ext_id }}"
+
+################################################################################
+# Check-mode associate with all attributes
+################################################################################
+
+- name: Generate spec for associate categories via check mode (all attributes)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category1_ext_id }}"
+        name: "check_mode_category_name"
+        uris: ["https://example.com/category/1"]
+        entity_type: "CATEGORY"
+  check_mode: true
+  register: cm_associate_full
+  ignore_errors: true
+
+- name: Assert associate check-mode spec (all attributes)
+  ansible.builtin.assert:
+    that:
+      - cm_associate_full is defined
+      - cm_associate_full.changed == false
+      - cm_associate_full.failed == false
+      - cm_associate_full.ext_id == vg_ext_id
+      - cm_associate_full.response is defined
+      - cm_associate_full.response.categories is defined
+      - cm_associate_full.response.categories | length == 1
+      - cm_associate_full.response.categories[0].ext_id == category1_ext_id
+      - cm_associate_full.response.categories[0].name == "check_mode_category_name"
+      - cm_associate_full.response.categories[0].uris | length == 1
+      - cm_associate_full.response.categories[0].uris[0] == "https://example.com/category/1"
+      - cm_associate_full.response.categories[0].entity_type == "CATEGORY"
+    success_msg: "Associate check-mode spec generated with all attributes"
+    fail_msg: "Associate check-mode spec generation with all attributes failed"
+
+################################################################################
+# Real associate of a single category (minimum body)
+################################################################################
+
+- name: Associate first category with Volume Group (minimum body)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category1_ext_id }}"
+        entity_type: "CATEGORY"
+  register: associate_min
+  ignore_errors: true
+
+- name: Assert first associate succeeded
+  ansible.builtin.assert:
+    that:
+      - associate_min is defined
+      - associate_min.changed == true
+      - associate_min.failed == false
+      - associate_min.ext_id == vg_ext_id
+      - associate_min.task_ext_id is defined
+      - associate_min.response is defined
+      - associate_min.response.status == "SUCCEEDED"
+    success_msg: "First category associated successfully"
+    fail_msg: "First category association failed"
+
+################################################################################
+# Real associate of the same category again -> idempotency
+################################################################################
+
+- name: Re-associate first category (should be idempotent)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category1_ext_id }}"
+        entity_type: "CATEGORY"
+  register: associate_idem
+  ignore_errors: true
+
+- name: Assert idempotent associate
+  ansible.builtin.assert:
+    that:
+      - associate_idem is defined
+      - associate_idem.changed == false
+      - associate_idem.failed == false
+      - associate_idem.skipped is defined
+      - associate_idem.skipped == true
+      - associate_idem.ext_id == vg_ext_id
+      - "'already has the requested categories associated' in associate_idem.msg"
+    success_msg: "Associate is idempotent when categories already attached"
+    fail_msg: "Idempotent associate check failed"
+
+################################################################################
+# Associate both categories -> only the delta (second one) should be added
+################################################################################
+
+- name: Associate both categories (delta associate)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category1_ext_id }}"
+        entity_type: "CATEGORY"
+      - ext_id: "{{ category2_ext_id }}"
+        entity_type: "CATEGORY"
+  register: associate_delta
+  ignore_errors: true
+
+- name: Assert delta associate succeeded
+  ansible.builtin.assert:
+    that:
+      - associate_delta is defined
+      - associate_delta.changed == true
+      - associate_delta.failed == false
+      - associate_delta.ext_id == vg_ext_id
+      - associate_delta.task_ext_id is defined
+      - associate_delta.response is defined
+      - associate_delta.response.status == "SUCCEEDED"
+    success_msg: "Delta associate for the second category succeeded"
+    fail_msg: "Delta associate failed"
+
+################################################################################
+# Info: list all category associations
+################################################################################
+
+- name: List all category associations for the Volume Group
+  nutanix.ncp.ntnx_category_associations_by_volume_group_ids_info_v2:
+    volume_group_ext_id: "{{ vg_ext_id }}"
+  register: list_all
+  ignore_errors: true
+
+- name: Extract associated ext_ids
+  ansible.builtin.set_fact:
+    associated_ext_ids: "{{ list_all.response | map(attribute='ext_id') | list }}"
+  when: list_all is defined and list_all.response is defined
+
+- name: Assert both categories appear in the list
+  ansible.builtin.assert:
+    that:
+      - list_all is defined
+      - list_all.changed == false
+      - list_all.failed == false
+      - list_all.response is defined
+      - list_all.response | length >= 2
+      - category1_ext_id in associated_ext_ids
+      - category2_ext_id in associated_ext_ids
+      - list_all.volume_group_ext_id == vg_ext_id
+      - list_all.total_available_results is defined
+      - list_all.total_available_results >= 2
+    success_msg: "List category associations returned both categories"
+    fail_msg: "List category associations did not return both categories"
+
+################################################################################
+# Info: fetch a specific category association by ext_id
+################################################################################
+
+- name: Fetch specific associated category by ext_id
+  nutanix.ncp.ntnx_category_associations_by_volume_group_ids_info_v2:
+    volume_group_ext_id: "{{ vg_ext_id }}"
+    ext_id: "{{ category1_ext_id }}"
+  register: get_by_id
+  ignore_errors: true
+
+- name: Assert fetch-by-ext_id succeeded
+  ansible.builtin.assert:
+    that:
+      - get_by_id is defined
+      - get_by_id.changed == false
+      - get_by_id.failed == false
+      - get_by_id.response is defined
+      - get_by_id.response.ext_id == category1_ext_id
+      - get_by_id.ext_id == category1_ext_id
+      - get_by_id.volume_group_ext_id == vg_ext_id
+    success_msg: "Fetch category association by ext_id succeeded"
+    fail_msg: "Fetch category association by ext_id failed"
+
+################################################################################
+# Info: pagination with limit
+################################################################################
+
+- name: List with limit=1
+  nutanix.ncp.ntnx_category_associations_by_volume_group_ids_info_v2:
+    volume_group_ext_id: "{{ vg_ext_id }}"
+    limit: 1
+  register: list_limit
+  ignore_errors: true
+
+- name: Assert list with limit=1
+  ansible.builtin.assert:
+    that:
+      - list_limit is defined
+      - list_limit.changed == false
+      - list_limit.failed == false
+      - list_limit.response is defined
+      - list_limit.response | length == 1
+      - list_limit.total_available_results is defined
+      - list_limit.total_available_results >= 2
+    success_msg: "List with limit=1 returned exactly one association"
+    fail_msg: "List with limit=1 did not return one association"
+
+- name: List with page=0 and limit=1
+  nutanix.ncp.ntnx_category_associations_by_volume_group_ids_info_v2:
+    volume_group_ext_id: "{{ vg_ext_id }}"
+    page: 0
+    limit: 1
+  register: list_page
+  ignore_errors: true
+
+- name: Assert paginated list
+  ansible.builtin.assert:
+    that:
+      - list_page is defined
+      - list_page.changed == false
+      - list_page.failed == false
+      - list_page.response is defined
+      - list_page.response | length == 1
+    success_msg: "Paginated list returned exactly one association"
+    fail_msg: "Paginated list did not return one association"
+
+################################################################################
+# Check-mode disassociate
+################################################################################
+
+- name: Generate spec for disassociate via check mode
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: absent
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category1_ext_id }}"
+        entity_type: "CATEGORY"
+  check_mode: true
+  register: cm_disassociate
+  ignore_errors: true
+
+- name: Assert disassociate check-mode spec
+  ansible.builtin.assert:
+    that:
+      - cm_disassociate is defined
+      - cm_disassociate.changed == false
+      - cm_disassociate.failed == false
+      - cm_disassociate.ext_id == vg_ext_id
+      - "'will be disassociated' in cm_disassociate.msg"
+      - cm_disassociate.response is defined
+      - cm_disassociate.response.categories is defined
+      - cm_disassociate.response.categories | length == 1
+      - cm_disassociate.response.categories[0].ext_id == category1_ext_id
+    success_msg: "Disassociate check-mode spec generated"
+    fail_msg: "Disassociate check-mode spec generation failed"
+
+################################################################################
+# Real disassociate of one category
+################################################################################
+
+- name: Disassociate first category
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: absent
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category1_ext_id }}"
+        entity_type: "CATEGORY"
+  register: disassociate_one
+  ignore_errors: true
+
+- name: Assert first disassociate succeeded
+  ansible.builtin.assert:
+    that:
+      - disassociate_one is defined
+      - disassociate_one.changed == true
+      - disassociate_one.failed == false
+      - disassociate_one.ext_id == vg_ext_id
+      - disassociate_one.task_ext_id is defined
+      - disassociate_one.response is defined
+      - disassociate_one.response.status == "SUCCEEDED"
+    success_msg: "First category disassociated successfully"
+    fail_msg: "First disassociate failed"
+
+- name: List after single disassociate
+  nutanix.ncp.ntnx_category_associations_by_volume_group_ids_info_v2:
+    volume_group_ext_id: "{{ vg_ext_id }}"
+  register: list_after_dis
+  ignore_errors: true
+
+- name: Extract remaining associated ext_ids
+  ansible.builtin.set_fact:
+    remaining_ext_ids: "{{ list_after_dis.response | map(attribute='ext_id') | list }}"
+  when: list_after_dis is defined and list_after_dis.response is defined
+
+- name: Assert first category is gone and second category is still associated
+  ansible.builtin.assert:
+    that:
+      - list_after_dis is defined
+      - list_after_dis.failed == false
+      - list_after_dis.response is defined
+      - category1_ext_id not in remaining_ext_ids
+      - category2_ext_id in remaining_ext_ids
+    success_msg: "Only the second category remains associated"
+    fail_msg: "Disassociate did not remove the correct category"
+
+################################################################################
+# Idempotent disassociate (nothing left to remove for cat1)
+################################################################################
+
+- name: Idempotent disassociate of already-removed category
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: absent
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category1_ext_id }}"
+        entity_type: "CATEGORY"
+  register: dis_idem
+  ignore_errors: true
+
+- name: Assert idempotent disassociate
+  ansible.builtin.assert:
+    that:
+      - dis_idem is defined
+      - dis_idem.changed == false
+      - dis_idem.failed == false
+      - dis_idem.skipped is defined
+      - dis_idem.skipped == true
+      - "'None of the requested categories are currently associated' in dis_idem.msg"
+    success_msg: "Disassociate is idempotent for already-removed categories"
+    fail_msg: "Idempotent disassociate check failed"
+
+################################################################################
+# Negative: missing required categories
+################################################################################
+
+- name: Associate without providing categories (should fail)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "{{ vg_ext_id }}"
+  register: missing_categories
+  ignore_errors: true
+
+- name: Assert missing categories fails
+  ansible.builtin.assert:
+    that:
+      - missing_categories is defined
+      - missing_categories.failed == true
+      - "'categories' in missing_categories.msg"
+    success_msg: "Missing categories properly fails the module"
+    fail_msg: "Missing categories did not fail as expected"
+
+################################################################################
+# Negative: missing required ext_id
+################################################################################
+
+- name: Associate without providing ext_id (should fail)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    categories:
+      - ext_id: "{{ category1_ext_id }}"
+        entity_type: "CATEGORY"
+  register: missing_ext_id
+  ignore_errors: true
+
+- name: Assert missing ext_id fails
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id is defined
+      - missing_ext_id.failed == true
+      - "'ext_id' in missing_ext_id.msg"
+    success_msg: "Missing ext_id properly fails the module"
+    fail_msg: "Missing ext_id did not fail as expected"
+
+################################################################################
+# Negative: invalid entity_type choice
+################################################################################
+
+- name: Associate with invalid entity_type (should fail at spec validation)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category1_ext_id }}"
+        entity_type: "NOT_A_REAL_TYPE"
+  register: bad_entity
+  ignore_errors: true
+
+- name: Assert invalid entity_type fails
+  ansible.builtin.assert:
+    that:
+      - bad_entity is defined
+      - bad_entity.failed == true
+      - "'value of entity_type must be one of' in bad_entity.msg or 'is not one of' in bad_entity.msg or 'NOT_A_REAL_TYPE' in bad_entity.msg"
+    success_msg: "Invalid entity_type properly rejected by Ansible spec validation"
+    fail_msg: "Invalid entity_type was not rejected"
+
+################################################################################
+# Negative: associate against non-existent Volume Group
+################################################################################
+
+- name: Associate against non-existent Volume Group (should fail)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: present
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    categories:
+      - ext_id: "{{ category1_ext_id }}"
+        entity_type: "CATEGORY"
+  register: bad_vg
+  ignore_errors: true
+
+- name: Assert associate against invalid VG ext_id fails
+  ansible.builtin.assert:
+    that:
+      - bad_vg is defined
+      - bad_vg.failed == true
+    success_msg: "Associate on non-existent Volume Group failed as expected"
+    fail_msg: "Associate on non-existent Volume Group did not fail"
+
+################################################################################
+# Negative: info fetch-by-ext_id for a category not associated
+################################################################################
+
+- name: Fetch info for non-associated category ext_id (should fail)
+  nutanix.ncp.ntnx_category_associations_by_volume_group_ids_info_v2:
+    volume_group_ext_id: "{{ vg_ext_id }}"
+    ext_id: "{{ category1_ext_id }}"
+  register: get_missing
+  ignore_errors: true
+
+- name: Assert info fetch for missing association fails with descriptive message
+  ansible.builtin.assert:
+    that:
+      - get_missing is defined
+      - get_missing.failed == true
+      - "'not found' in get_missing.msg"
+      - get_missing.ext_id == category1_ext_id
+      - get_missing.volume_group_ext_id == vg_ext_id
+    success_msg: "Fetch info for missing association returns descriptive error"
+    fail_msg: "Fetch info for missing association did not return descriptive error"
+
+################################################################################
+# Cleanup
+################################################################################
+
+- name: Disassociate remaining category (second one)
+  nutanix.ncp.ntnx_volume_group_category_v2:
+    state: absent
+    ext_id: "{{ vg_ext_id }}"
+    categories:
+      - ext_id: "{{ category2_ext_id }}"
+        entity_type: "CATEGORY"
+  register: cleanup_dis
+  ignore_errors: true
+
+- name: Assert cleanup disassociate
+  ansible.builtin.assert:
+    that:
+      - cleanup_dis is defined
+      - cleanup_dis.failed == false
+    success_msg: "Cleanup disassociate ran"
+    fail_msg: "Cleanup disassociate failed"
+
+- name: Delete Volume Group
+  nutanix.ncp.ntnx_volume_groups_v2:
+    state: absent
+    ext_id: "{{ vg_ext_id }}"
+  register: delete_vg
+  ignore_errors: true
+
+- name: Assert Volume Group deletion
+  ansible.builtin.assert:
+    that:
+      - delete_vg is defined
+      - delete_vg.failed == false
+    success_msg: "Volume Group deleted"
+    fail_msg: "Failed to delete Volume Group"
+
+- name: Delete first category
+  nutanix.ncp.ntnx_categories_v2:
+    state: absent
+    ext_id: "{{ category1_ext_id }}"
+  register: delete_cat1
+  ignore_errors: true
+
+- name: Delete second category
+  nutanix.ncp.ntnx_categories_v2:
+    state: absent
+    ext_id: "{{ category2_ext_id }}"
+  register: delete_cat2
+  ignore_errors: true
+
+- name: Assert category cleanups
+  ansible.builtin.assert:
+    that:
+      - delete_cat1 is defined
+      - delete_cat1.failed == false
+      - delete_cat2 is defined
+      - delete_cat2.failed == false
+    success_msg: "Both category prerequisites deleted"
+    fail_msg: "Failed to delete one or both category prerequisites"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **volumes** namespace, entity
**CategoryAssociationsByVolumeGroupId**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_volume_group_category_v2`, `ntnx_category_associations_by_volume_group_ids_info_v2`
- API methods covered: `associate_category`, `disassociate_category`, `list_category_associations_by_volume_group_id`
  (3 of the 21 volume-group SDK methods surfaced in `sdk_info.json`, which are the ones semantically owned by
  the CategoryAssociationsByVolumeGroupId entity)
- Fields in CRUD module spec: 2 top-level (`ext_id`, `categories`), 4 sub-fields per category
  (`ext_id`, `name`, `uris`, `entity_type` with 27 enum choices)
- Fields in info module spec: 4 (`volume_group_ext_id`, `ext_id`, `page`, `limit`)

## Domain knowledge (from Glean)

### CategoryAssociationsByVolumeGroupId in Nutanix Volumes API v4.2

In the Nutanix Volumes v4 API, `CategoryAssociationsByVolumeGroupId` (specifically
`list_category_associations_by_volume_group_id`) is a REST API endpoint and SDK method used to retrieve all
category details (such as keys, values, and definitions) that are associated with a specific Volume Group.

**Note on Deprecation:** In recent v4.2 SDK builds and internal components, this specific standalone API endpoint
has been marked as **deprecated**. The recommended pattern in v4 is to use the primary Volume Group GET or LIST
endpoints with the OData `$expand` query parameter
(e.g., `GET /api/volumes/v4.0.b1/config/volume-groups/{extId}?$expand=categoryAssociations`).

---

#### Detailed Features

- **Category Fetching:** Retrieves all category mappings tagged to a Volume Group.
- **Pagination Support:** The API implements strict pagination. It accepts `page` (default `0`) and `limit`
  arguments. The limit parameter enforces a maximum size to prevent payload bloat (default limit is `50`,
  max `100`).
- **HATEOAS Links:** Returns `ApiLink` pagination objects as part of the `ListCategoryAssociationsApiResponse`
  to easily fetch the next set of categories.
- **Rate Limiting:** Subject to API rate limits at scale, heavily restricted on smaller Prism Central
  deployments (e.g., capped at ~40 requests per minute).

#### Prerequisites

- **Volume Group External ID:** The `volumeGroupExtId` must be known and provided as a path parameter.
- **Categories Associated:** Categories must have been previously associated with the Volume Group using the
  sync/async POST `$actions/associate-category` API.
- **Authentication/RBAC:** Valid authorization tokens or credentials with sufficient RBAC permissions to read
  Volume Group entities and Category definitions.

#### Workflow

1. **Request:** The client or automation framework triggers a `GET` request to
   `/api/volumes/v4.X/config/volume-groups/{extId}/category-associations` (or via the SDK's
   `list_category_associations_by_volume_group_id` method).
2. **Controller Processing:** The `VolumeApiControllerImpl.java` receives the call, applies any default
   pagination (`page=0`, `limit=50` if omitted), and calculates `startIndex` and `endIndex`.
3. **Database Fetch:** Data sync services pull associations from the underlying Insights Data Framework (IDF),
   specifically querying the `volume_group_entity_capability` and `category` tables.
4. **Response Formatting:** `VolumeResponseFactory` wraps the paginated categories and HATEOAS API links into a
   `ListCategoryAssociationsApiResponse` payload and returns it to the client with a HTTP 200 OK.

---

#### Related Engineering Tickets

- **[ENG-670460](https://jira.nutanix.com/browse/ENG-670460) / [AUTO-27404](https://jira.nutanix.com/browse/AUTO-27404):**
  Tracked an issue where `get_category_associations` was hitting rate limits (`PLAT-10003: RATE_LIMIT_EXCEEDED`)
  on small Prism Central instances during scale testing, forcing a limit of 40 requests.
- **[ENG-672714](https://jira.nutanix.com/browse/ENG-672714):** A DRaaS issue where
  `list_category_associations_by_volume_group_id` failed during Cross-AZ tests due to testbed operations
  fetching categories for entities that had already failed over.
- **[ENG-669704](https://jira.nutanix.com/browse/ENG-669704) / [ENG-671716](https://jira.nutanix.com/browse/ENG-671716):**
  Automation framework failures generating a `'NoneType' object is not iterable` exception while executing
  category association listings and detaching categories.
- **[ENG-908316](https://jira.nutanix.com/browse/ENG-908316):** Recovery plan get call failure with HTTPS
  connection pool read-timeout (surfaced during category association testing).
- **[ENG-662354](https://jira.nutanix.com/browse/ENG-662354):** ReadTimeoutError during
  `delete_test_entities_parallel` RPT deletion in single-node clusters.

#### Design Docs and Confluence Pages

- **[Volume Group v4 API (Beta / GA)](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/243785476/Volume+Group+v4+API):**
  Documents performance constraints, payload sizes, latencies, and the shift toward async APIs for associative
  actions.
- **[B: How categories are stored in IDF](https://confluence.eng.nutanix.com:8443/spaces/PC/pages/314646079/B+How+categories+are+stored+in+IDF):**
  Details the schema design for IDF tables like `volume_group_entity_capability` and `category_association`
  which power the associations retrieval backend.
- **[C: API to DB fields mapping](https://confluence.eng.nutanix.com:8443/spaces/PC/pages/314646819/C+API+to+DB+fields+mapping):**
  Field-level mapping between the v4 API surface and IDF storage.
- **[E: Onboarding to categories](https://confluence.eng.nutanix.com:8443/spaces/PC/pages/314653875/E+Onboarding+to+categories):**
  Onboarding guide for Nutanix services that need to become category consumers/producers.
- **[Troubleshooting Projects 2.0 and Categories](https://confluence.eng.nutanix.com:8443/spaces/PC/pages/519592998/Troubleshooting+Projects+2.0+and+Categories):**
  Contains detailed internal serviceability guides for tracking gRPC category calls, data sync limits, and
  resolving `$expand` query bottlenecks.
- **[Volume Group Perf and Scale Numbers -> Beta QA](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/257500859/Volume+Group+Perf+and+Scale+Numbers--+Beta+QA):**
  Extensive performance metrics outlining the throughput of the `category-associations` API against an
  environment of 5,000 VGs.
- **[Categories Distribution](https://confluence.eng.nutanix.com:8443/spaces/~david.zhao/pages/545159867/Categories+Distribution):**
  How categories replicate/propagate across services.
- **[Categories v4 API workflows](https://confluence.eng.nutanix.com:8443/spaces/TME/pages/360436555/Categories+v4+api+workflows):**
  TME workflow docs for v4 categories APIs.
- **[Prism Categories Serviceability Guide](https://confluence.eng.nutanix.com:8443/spaces/AI/pages/332885862/Prism+Categories+Serviceability+Guide):**
  Serviceability guide (log locations, common failures, remediation).
- **[NutanixConnection Library Documentation](https://confluence.eng.nutanix.com:8443/spaces/~santoshkumar.ladi/pages/461005822/NutanixConnection+Library+Documentation):**
  Library reference used by internal callers.
- **[Nutanix Files - Volume group deletion issue](https://confluence.eng.nutanix.com:8443/spaces/STK/pages/98374043/Nutanix+Files+-+Volume+group+deletion+issue):**
  Historical VG deletion issue (relevant for teardown edge cases).
- **[v4 API Gaps - Comprehensive Response Plan](https://confluence.eng.nutanix.com:8443/spaces/QA/pages/468269985/v4+API%C2%A0Gaps%C2%A0-+Comprehensive+Response+Plan):**
  QA response plan cataloging v4 API gaps.
- **[Projects 2.0 - QA Test Setup](https://confluence.eng.nutanix.com:8443/spaces/P2EP/pages/500179758/Projects+2.0+-+QA+Test+Setup):**
  Category/project-adjacent QA setup notes.
- **[Prism V4 APIs](https://confluence.eng.nutanix.com:8443/spaces/SIZER/pages/528533216/Prism+V4+API+S):**
  Sizer/planning catalog of Prism V4 APIs.
- **[Statistics](https://confluence.eng.nutanix.com:8443/spaces/~raymond.yip/pages/507306820/Statistics):**
  API statistics reference.
- **[CSI driver fundamentals and troubleshooting of CSI in NKE and OpenShift](https://confluence.eng.nutanix.com:8443/spaces/~varun.bs/pages/208955430/CSI+driver+fundamentals+and+Troubleshooting+of+CSI+in+NKE+and+Openshift):**
  Downstream CSI consumer of Volume Group category associations.

#### Source code references Glean surfaced

- `list_category_associations_by_volume_group_id_request.go` — golang SDK request model
  (https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/volumes-go-client/models/volumes/v4/request/volumegroups/list_category_associations_by_volume_group_id_request.go)
- `StorageRbacUtil.java` — RBAC checks
  (https://github.com/nutanix-core/ntnx-api-volumes/blob/main/volumes-api-codegen/volumes-springmvc-interfaces/src/main/java/com/nutanix/prism/volumes/rbac/StorageRbacUtil.java)
- `volume_groups_api.py` — python SDK
  (https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/volumes/ntnx_volumes_py_client/api/volume_groups_api.py)
- `VolumeApiControllerImpl.java` — server-side controller
  (https://github.com/nutanix-core/ntnx-api-volumes/blob/main/volumes-api-controller/src/main/java/com/nutanix/volumes/controllers/VolumeApiControllerImpl.java)
- `swagger-volumes-v4.r0.b1-all-documentation.yaml`
  (https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/api_artifacts/volumes/v4.r0.b1/volumes-api-definitions-<PHONE_1>-RELEASE/swagger-volumes-v4.r0.b1-all-documentation.yaml)
- `mcp_volumes_registry.py`
  (https://github.com/nutanix-engineering/hack2026-d2654/blob/main/mcp_volumes_registry.py)

#### Domain skills to learn for end-to-end coverage

- Nutanix v4 API request/response conventions (OData `$filter`/`$expand`/`$select`/`$orderby`, HATEOAS `links`,
  paginated `ApiResponse` envelopes).
- Volume Groups feature: storage sharing modes, iSCSI/NVMe-TCP attachments, VM attachments.
- Categories subsystem: `key`/`value` structure, category IDF storage
  (`volume_group_entity_capability`, `category_association`), how categories drive policies (Projects 2.0,
  Storage Policies, Protection Policies, Flow, backups).
- Task/async workflow: `POST $actions/associate-category` returns a task whose `entities_affected` yields the
  affected Volume Group ext_id.
- RBAC roles (Storage Admin, Prism Admin, CSI System, Kubernetes Data Services System, Project Manager,
  Super Admin).
- Rate limits / scale characteristics of the deprecated
  `list_category_associations_by_volume_group_id` endpoint on small PC.
- Ansible collection conventions (v4 SDK spec generation via `SpecGenerator`, `wait_for_completion` for tasks,
  `strip_internal_attributes` for cleaning responses, `raise_api_exception` for consistent errors).

## Files changed

- `plugins/modules/`
  - `ntnx_volume_group_category_v2.py` (CRUD action-type module: state=present -> associate, state=absent ->
    disassociate; idempotent via `list_category_associations_by_volume_group_id`)
  - `ntnx_category_associations_by_volume_group_ids_info_v2.py` (info module: list all category associations for
    a Volume Group, or fetch a single association by ext_id; supports `page`/`limit` pagination — the only
    parameters the SDK actually accepts)
- `examples/`
  - `examples/volumes/CategoryAssociationsByVolumeGroupId/volume_group_category_associations_v2.yml`
  - `examples/volumes/CategoryAssociationsByVolumeGroupId/examples_run.log` (real playbook output against
    PC 10.44.76.28)
- `tests/`
  - `tests/integration/targets/ntnx_volume_group_category_v2/aliases`
  - `tests/integration/targets/ntnx_volume_group_category_v2/meta/main.yml`
  - `tests/integration/targets/ntnx_volume_group_category_v2/tasks/main.yml`
  - `tests/integration/targets/ntnx_volume_group_category_v2/tasks/volume_group_category_associations.yml`
- `.gitignore` (added `integration_config.yml`, `INSTRUCTIONS.md`, `pr_body.md`, `pr_summary.md`, `test_logs.log`,
  `*.bak`, `*~` to keep run artifacts out of source)

## Test execution

| Metric              | Value                                                                          |
|---------------------|--------------------------------------------------------------------------------|
| Command             | `ansible-playbook <wrapper>.yml -v` importing the integration target directly |
| Total tasks         | `60` (53 executed + assertions + set_facts, 2 skipped assertions branch)      |
| Passed              | `53`                                                                           |
| Failed              | `0`                                                                            |
| Skipped             | `2`                                                                            |
| Ignored             | `5` (intentional `ignore_errors: true` on negative tests that assert failure)  |
| Duration            | `~32s`                                                                         |
| Cluster (PC)        | `10.44.76.28`                                                                  |

### Analysis

No failures. Every scenario in the test plan comment block at the top of
`tests/integration/targets/ntnx_volume_group_category_v2/tasks/volume_group_category_associations.yml`
executed against the live Prism Central at `10.44.76.28` and asserted the expected behaviour:

- Setup created two prerequisite categories and a fresh Volume Group via the existing
  `ntnx_categories_v2` and `ntnx_volume_groups_v2` modules (never hardcoded ext_ids).
- Positive path: check-mode associate spec (all attributes), real associate (min body), idempotent
  re-associate (`skipped=true` msg matched), delta associate for the second category.
- Info path: list-all returned both categories, fetch-by-ext_id returned the matching entry,
  `limit=1` returned exactly one, `page=0 limit=1` returned exactly one.
- Negative path: check-mode disassociate, real disassociate of one category (list drops to 1),
  idempotent disassociate (`skipped=true`).
- Error path: missing `categories` fails with `missing required arguments: categories`; missing `ext_id`
  fails with `missing required arguments: ext_id`; invalid `entity_type` rejected at spec level by
  Ansible's own choices validator; associate against a non-existent VG returns HTTP 404
  (`VOL-40301 VOLUME_UNKNOWN_ENTITY_ERROR`); info fetch of a non-associated ext_id fails with the
  descriptive `not found` message.
- Cleanup path: remaining category disassociated, VG deleted, both categories deleted.

Example playbook was also executed end-to-end (`examples/volumes/CategoryAssociationsByVolumeGroupId/examples_run.log`)
with 7 tasks, all passing.

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text
TASK [Set Volume Group ext_id] *************************************************
ok: [localhost] => {"ansible_facts": {"vg_ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45"}, "changed": false}

TASK [Generate spec for associate categories via check mode (all attributes)] ***
ok: [localhost] => {"changed": false, "ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "response": {"categories": [{"entity_type": "CATEGORY", "ext_id": "7d7a0df8-4b92-4b1f-6575-a95712dd6f6a", "name": "check_mode_category_name", "uris": ["https://example.com/category/1"]}]}, "task_ext_id": null}

TASK [Assert associate check-mode spec (all attributes)] ***********************
ok: [localhost] => {
    "changed": false,
    "msg": "Associate check-mode spec generated with all attributes"
}

TASK [Associate first category with Volume Group (minimum body)] ***************
changed: [localhost] => {"changed": true, "ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T05:59:56.361942+00:00", "completion_details": null, "created_time": "2026-07-21T05:59:56.305867+00:00", "entities_affected": [{"ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "name": null, "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:ce5818fc-41c0-4bc8-bc1f-cf05053c7f69", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T05:59:56.361941+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "UpdateCategoryAssociations_kOperationAttach", "operation_description": "Associate Category", "owned_by": null, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T05:59:56.315126+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:ce5818fc-41c0-4bc8-bc1f-cf05053c7f69"}

TASK [Assert first associate succeeded] ****************************************
ok: [localhost] => {
    "changed": false,
    "msg": "First category associated successfully"
}

TASK [Re-associate first category (should be idempotent)] **********************
skipping: [localhost] => {"changed": false, "ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "msg": "CategoryAssociationsByVolumeGroupId with ext_id 'dc6064c3-bf96-434e-6ee0-09a17e790b45' already has the requested categories associated. Skipping association.", "response": null, "task_ext_id": null}

TASK [Assert idempotent associate] *********************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Associate is idempotent when categories already attached"
}

TASK [Associate both categories (delta associate)] *****************************
changed: [localhost] => {"changed": true, "ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T06:00:00.230622+00:00", "completion_details": null, "created_time": "2026-07-21T06:00:00.155253+00:00", "entities_affected": [{"ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "name": null, "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:e0f26660-299e-448c-a199-5404b80ed780", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T06:00:00.230620+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "UpdateCategoryAssociations_kOperationAttach", "operation_description": "Associate Category", "owned_by": null, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T06:00:00.167965+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:e0f26660-299e-448c-a199-5404b80ed780"}

TASK [Assert delta associate succeeded] ****************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Delta associate for the second category succeeded"
}

TASK [List all category associations for the Volume Group] *********************
ok: [localhost] => {"changed": false, "response": [{"entity_type": "CATEGORY", "ext_id": "7d7a0df8-4b92-4b1f-6575-a95712dd6f6a", "name": null, "uris": null}, {"entity_type": "CATEGORY", "ext_id": "219f4798-eae0-475e-4b7b-515d22a82ae3", "name": null, "uris": null}], "total_available_results": 2, "volume_group_ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45"}

TASK [Extract associated ext_ids] **********************************************
ok: [localhost] => {"ansible_facts": {"associated_ext_ids": ["7d7a0df8-4b92-4b1f-6575-a95712dd6f6a", "219f4798-eae0-475e-4b7b-515d22a82ae3"]}, "changed": false}

TASK [Assert both categories appear in the list] *******************************
ok: [localhost] => {
    "changed": false,
    "msg": "List category associations returned both categories"
}

TASK [Fetch specific associated category by ext_id] ****************************
ok: [localhost] => {"changed": false, "ext_id": "7d7a0df8-4b92-4b1f-6575-a95712dd6f6a", "response": {"entity_type": "CATEGORY", "ext_id": "7d7a0df8-4b92-4b1f-6575-a95712dd6f6a", "name": null, "uris": null}, "volume_group_ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45"}

TASK [Assert fetch-by-ext_id succeeded] ****************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Fetch category association by ext_id succeeded"
}

TASK [List with limit=1] *******************************************************
ok: [localhost] => {"changed": false, "response": [{"entity_type": "CATEGORY", "ext_id": "7d7a0df8-4b92-4b1f-6575-a95712dd6f6a", "name": null, "uris": null}], "total_available_results": 2, "volume_group_ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45"}

TASK [Assert list with limit=1] ************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "List with limit=1 returned exactly one association"
}

TASK [List with page=0 and limit=1] ********************************************
ok: [localhost] => {"changed": false, "response": [{"entity_type": "CATEGORY", "ext_id": "7d7a0df8-4b92-4b1f-6575-a95712dd6f6a", "name": null, "uris": null}], "total_available_results": 2, "volume_group_ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45"}

TASK [Assert paginated list] ***************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Paginated list returned exactly one association"
}

TASK [Generate spec for disassociate via check mode] ***************************
ok: [localhost] => {"changed": false, "ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "msg": "Categories will be disassociated from Volume Group with ext_id:dc6064c3-bf96-434e-6ee0-09a17e790b45.", "response": {"categories": [{"entity_type": "CATEGORY", "ext_id": "7d7a0df8-4b92-4b1f-6575-a95712dd6f6a", "name": null, "uris": null}]}, "task_ext_id": null}

TASK [Assert disassociate check-mode spec] *************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Disassociate check-mode spec generated"
}

TASK [Disassociate first category] *********************************************
changed: [localhost] => {"changed": true, "ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T06:00:06.743560+00:00", "completion_details": null, "created_time": "2026-07-21T06:00:06.704672+00:00", "entities_affected": [{"ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "name": null, "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:608545e8-3095-4ae7-a8bc-63c7cb142d3a", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T06:00:06.743559+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "UpdateCategoryAssociations_kOperationDetach", "operation_description": "Disassociate Category", "owned_by": null, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T06:00:06.712515+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:608545e8-3095-4ae7-a8bc-63c7cb142d3a"}

TASK [Assert first disassociate succeeded] *************************************
ok: [localhost] => {
    "changed": false,
    "msg": "First category disassociated successfully"
}

TASK [List after single disassociate] ******************************************
ok: [localhost] => {"changed": false, "response": [{"entity_type": "CATEGORY", "ext_id": "219f4798-eae0-475e-4b7b-515d22a82ae3", "name": null, "uris": null}], "total_available_results": 1, "volume_group_ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45"}

TASK [Extract remaining associated ext_ids] ************************************
ok: [localhost] => {"ansible_facts": {"remaining_ext_ids": ["219f4798-eae0-475e-4b7b-515d22a82ae3"]}, "changed": false}

TASK [Assert first category is gone and second category is still associated] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Only the second category remains associated"
}

TASK [Idempotent disassociate of already-removed category] *********************
skipping: [localhost] => {"changed": false, "ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "msg": "None of the requested categories are currently associated with Volume Group ext_id 'dc6064c3-bf96-434e-6ee0-09a17e790b45'. Skipping disassociation.", "response": null, "task_ext_id": null}

TASK [Assert idempotent disassociate] ******************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Disassociate is idempotent for already-removed categories"
}

TASK [Associate without providing categories (should fail)] ********************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: categories"}
...ignoring

TASK [Assert missing categories fails] *****************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Missing categories properly fails the module"
}

TASK [Associate without providing ext_id (should fail)] ************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [Assert missing ext_id fails] *********************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Missing ext_id properly fails the module"
}

TASK [Associate with invalid entity_type (should fail at spec validation)] *****
fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of entity_type must be one of: VOLUME_GROUP, ROUTING_POLICY, DIRECT_CONNECT_VIF, AVAILABILITY_ZONE, STORAGE_CONTAINER, VPC, VPN_CONNECTION, VOLUME_DISK, VPN_GATEWAY, IMAGE, CATEGORY, RECOVERY_PLAN, CLUSTER, DISK_RECOVERY_POINT, CONSISTENCY_GROUP, VIRTUAL_NIC, TASK, VIRTUAL_SWITCH, VIRTUAL_NETWORK, NODE, FLOATING_IP, SUBNET, VM_DISK, VTEP_GATEWAY, VM, DIRECT_CONNECT, SUBNET_EXTENSION, got: NOT_A_REAL_TYPE found in categories"}
...ignoring

TASK [Assert invalid entity_type fails] ****************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Invalid entity_type properly rejected by Ansible spec validation"
}

TASK [Associate against non-existent Volume Group (should fail)] ***************
fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching Volume group info using ext_id", "response": {"$objectType": "volumes.v4.config.GetVolumeGroupApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "volumes.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "volumes.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "code": "VOL-40301", "errorGroup": "VOLUME_UNKNOWN_ENTITY_ERROR", "locale": "en_US", "message": "Exception occurred as the storage service could not find the entity Volume Group on entityID 00000000-0000-0000-0000-000000000000 due to an error.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}]}}, "status": 404}
...ignoring

TASK [Assert associate against invalid VG ext_id fails] ************************
ok: [localhost] => {
    "changed": false,
    "msg": "Associate on non-existent Volume Group failed as expected"
}

TASK [Fetch info for non-associated category ext_id (should fail)] *************
fatal: [localhost]: FAILED! => {"changed": false, "ext_id": "7d7a0df8-4b92-4b1f-6575-a95712dd6f6a", "msg": "Category association with ext_id '7d7a0df8-4b92-4b1f-6575-a95712dd6f6a' was not found for Volume Group 'dc6064c3-bf96-434e-6ee0-09a17e790b45'.", "response": null, "volume_group_ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45"}
...ignoring

TASK [Assert info fetch for missing association fails with descriptive message] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Fetch info for missing association returns descriptive error"
}

TASK [Disassociate remaining category (second one)] ****************************
changed: [localhost] => {"changed": true, "ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T06:00:14.852482+00:00", "completion_details": null, "created_time": "2026-07-21T06:00:14.816525+00:00", "entities_affected": [{"ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "name": null, "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:a2180312-fdee-4d22-9eb4-2b9ee07d8f58", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T06:00:14.852481+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "UpdateCategoryAssociations_kOperationDetach", "operation_description": "Disassociate Category", "owned_by": null, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T06:00:14.823103+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:a2180312-fdee-4d22-9eb4-2b9ee07d8f58"}

TASK [Assert cleanup disassociate] *********************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Cleanup disassociate ran"
}

TASK [Delete Volume Group] *****************************************************
changed: [localhost] => {"changed": true, "error": null, "ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-21T06:00:18.172854+00:00", "completion_details": null, "created_time": "2026-07-21T06:00:17.923096+00:00", "entities_affected": [{"ext_id": "dc6064c3-bf96-434e-6ee0-09a17e790b45", "name": "vg_ansible-cabvgid_MFmXpRxZuuzd", "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:b7e2d98d-81cd-49b1-838b-bb675ee9d743", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T06:00:18.172853+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "VolumeGroupDelete", "operation_description": "Delete Volume Group", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T06:00:17.923096+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:9a7cf200-5c9e-4c53-b7c3-1f0ffe210465", "href": "https://10.44.76.28:9440/api/prism/v4.3/config/tasks/ZXJnb24=:9a7cf200-5c9e-4c53-b7c3-1f0ffe210465", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:b7e2d98d-81cd-49b1-838b-bb675ee9d743"}

TASK [Assert Volume Group deletion] ********************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Volume Group deleted"
}

TASK [Delete first category] ***************************************************
changed: [localhost] => {"changed": true, "error": null, "ext_id": "7d7a0df8-4b92-4b1f-6575-a95712dd6f6a", "response": null}

TASK [Delete second category] **************************************************
changed: [localhost] => {"changed": true, "error": null, "ext_id": "219f4798-eae0-475e-4b7b-515d22a82ae3", "response": null}

TASK [Assert category cleanups] ************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Both category prerequisites deleted"
}

PLAY RECAP *********************************************************************
localhost                  : ok=53   changed=10   unreachable=0    failed=0    skipped=2    rescued=0    ignored=5   

```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Glean MCP was available and queried once at the start of the run; the returned answer is reproduced
  in full in the "Domain knowledge (from Glean)" section above.
- Modules were black/isort/flake8/ansible-lint/`ansible-test sanity` clean before commit.
- Tests were executed against Prism Central `10.44.76.28` (admin/Nutanix.123); the associated
  `tests/integration/integration_config.yml` is intentionally NOT committed (see `.gitignore`).
