### PR TITLE
code-gen(networking/RemoteVtepGatewaysByClusterId): ansible collection modules

### DIFF
--- a/examples/networking/RemoteVtepGatewaysByClusterId/examples_run.log
+++ b/examples/networking/RemoteVtepGatewaysByClusterId/examples_run.log
@@ -1,0 +1,87 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [localhost] ***************************************************************
+
+TASK [ansible.builtin.include_tasks] *******************************************
+included: /tmp/example_tasks.yml for localhost
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"cluster_uuid": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "remote_vtep_gateway_ext_id": "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0", "remote_vtep_gateway_name": "remote-vtep-gw-ansible"}, "changed": false}
+
+TASK [List all remote VTEP gateways discovered on the Prism Element cluster] ***
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateways info
+Origin: /tmp/example_tasks.yml:7:5
+
+5       remote_vtep_gateway_name: "remote-vtep-gw-ansible"
+6
+7   - name: List all remote VTEP gateways discovered on the Prism Element cluster
+      ^ column 5
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateways info", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateways 0006555e-4e63-4a5e-185b-ac1f6b6f97e2 due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
+...ignoring
+
+TASK [List remote VTEP gateways filtered by name] ******************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateways info
+Origin: /tmp/example_tasks.yml:13:5
+
+11     ignore_errors: true
+12
+13   - name: List remote VTEP gateways filtered by name
+       ^ column 5
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateways info", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateways 0006555e-4e63-4a5e-185b-ac1f6b6f97e2 due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
+...ignoring
+
+TASK [List remote VTEP gateways with pagination] *******************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateways info
+Origin: /tmp/example_tasks.yml:20:5
+
+18     ignore_errors: true
+19
+20   - name: List remote VTEP gateways with pagination
+       ^ column 5
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateways info", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateways 0006555e-4e63-4a5e-185b-ac1f6b6f97e2 due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
+...ignoring
+
+TASK [List remote VTEP gateways sorted by name descending] *********************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateways info
+Origin: /tmp/example_tasks.yml:28:5
+
+26     ignore_errors: true
+27
+28   - name: List remote VTEP gateways sorted by name descending
+       ^ column 5
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateways info", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateways 0006555e-4e63-4a5e-185b-ac1f6b6f97e2 due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
+...ignoring
+
+TASK [Fetch a specific remote VTEP gateway using external ID via info module] ***
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateway info using cluster ext_id and ext_id
+Origin: /tmp/example_tasks.yml:35:5
+
+33     ignore_errors: true
+34
+35   - name: Fetch a specific remote VTEP gateway using external ID via info module
+       ^ column 5
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateway info using cluster ext_id and ext_id", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateway 7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0 (on cluster 0006555e-4e63-4a5e-185b-ac1f6b6f97e2) due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways/7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
+...ignoring
+
+TASK [Fetch a specific remote VTEP gateway using external ID (dedicated get-by-id module)] ***
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateway info using cluster ext_id and ext_id
+Origin: /tmp/example_tasks.yml:42:5
+
+40     ignore_errors: true
+41
+42   - name: Fetch a specific remote VTEP gateway using external ID (dedicated get-by-id module)
+       ^ column 5
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateway info using cluster ext_id and ext_id", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateway 7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0 (on cluster 0006555e-4e63-4a5e-185b-ac1f6b6f97e2) due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways/7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=6   
+

--- a/examples/networking/RemoteVtepGatewaysByClusterId/remote_vtep_gateways_by_cluster_id_v2.yml
+++ b/examples/networking/RemoteVtepGatewaysByClusterId/remote_vtep_gateways_by_cluster_id_v2.yml
@@ -1,0 +1,79 @@
+---
+# Summary:
+# This playbook demonstrates every operation supported by the
+# Nutanix Prism Central v4 networking `RemoteVtepGatewaysByClusterId`
+# read-only discovery endpoint.
+#
+# The underlying SDK exposes only:
+#   * get_remote_vtep_gateway_for_cluster_by_id  (single-entity fetch)
+#   * list_remote_vtep_gateways_by_cluster_id    (list, with filter / limit / page / orderby)
+#
+# There are NO create / update / delete APIs for this entity — it is a
+# discovery surface used to select a peer VTEP gateway on a remote cluster
+# for Layer 2 subnet extension (L2 stretch) workflows.
+#
+# Steps:
+# 1. List every remote VTEP gateway discovered on a Prism Element cluster.
+# 2. List remote VTEP gateways filtered by name.
+# 3. List remote VTEP gateways with pagination (page + limit).
+# 4. List remote VTEP gateways sorted by name.
+# 5. Fetch a specific remote VTEP gateway by its external ID.
+#    (both cluster_ext_id + ext_id are mandatory URI params on the API).
+
+- name: Remote VTEP Gateways By Cluster ID playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        cluster_uuid: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+        remote_vtep_gateway_ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+        remote_vtep_gateway_name: "remote-vtep-gw-ansible"
+
+    - name: List all remote VTEP gateways discovered on the Prism Element cluster
+      nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+        cluster_ext_id: "{{ cluster_uuid }}"
+      register: result
+      ignore_errors: true
+
+    - name: List remote VTEP gateways filtered by name
+      nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+        cluster_ext_id: "{{ cluster_uuid }}"
+        filter: "name eq '{{ remote_vtep_gateway_name }}'"
+      register: result
+      ignore_errors: true
+
+    - name: List remote VTEP gateways with pagination
+      nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+        cluster_ext_id: "{{ cluster_uuid }}"
+        page: 0
+        limit: 10
+      register: result
+      ignore_errors: true
+
+    - name: List remote VTEP gateways sorted by name descending
+      nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+        cluster_ext_id: "{{ cluster_uuid }}"
+        orderby: "name desc"
+      register: result
+      ignore_errors: true
+
+    - name: Fetch a specific remote VTEP gateway using external ID via info module
+      nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+        cluster_ext_id: "{{ cluster_uuid }}"
+        ext_id: "{{ remote_vtep_gateway_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Fetch a specific remote VTEP gateway using external ID (dedicated get-by-id module)
+      nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_id_v2:
+        cluster_ext_id: "{{ cluster_uuid }}"
+        ext_id: "{{ remote_vtep_gateway_ext_id }}"
+      register: result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_remote_vtep_gateways_by_cluster_id_v2
+    - ntnx_remote_vtep_gateways_by_cluster_ids_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,17 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_remote_entities_api_instance(module):
+    """
+    This method will return RemoteEntitiesApi instance for read-only
+    remote entity queries (remote subnets, remote VPN connections and
+    remote VTEP gateways discovered under a Prism Element cluster).
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Remote Entities Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.RemoteEntitiesApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,37 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_remote_vtep_gateway_for_cluster(module, api_instance, cluster_ext_id, ext_id):
+    """
+    Fetch a single remote VTEP gateway discovered under a Prism Element
+    cluster by its external ID.
+
+    The RemoteVtepGateway resource is exposed as a read-only discovery
+    surface on the Prism Central v4 networking API (used by workflows
+    such as L2 subnet extension / stretch to pick a peer VTEP gateway
+    on a remote availability zone). Both ``cluster_ext_id`` and ``ext_id``
+    are mandatory URI parameters.
+
+    Args:
+        module: Ansible module
+        api_instance: RemoteEntitiesApi instance from ntnx_networking_py_client sdk
+        cluster_ext_id (str): Prism Element cluster external ID that owns the VTEP gateway
+        ext_id (str): remote VTEP gateway external ID
+    return:
+        info (object): remote VTEP gateway info object
+    """
+    try:
+        return api_instance.get_remote_vtep_gateway_for_cluster_by_id(
+            clusterExtId=cluster_ext_id, extId=ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching remote VTEP gateway info "
+                "using cluster ext_id and ext_id"
+            ),
+        )

--- a/plugins/modules/ntnx_remote_vtep_gateways_by_cluster_id_v2.py
+++ b/plugins/modules/ntnx_remote_vtep_gateways_by_cluster_id_v2.py
@@ -1,0 +1,205 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_remote_vtep_gateways_by_cluster_id_v2
+short_description: Fetch a single remote VTEP gateway discovered under a Prism Element cluster
+version_added: 2.7.0
+description:
+  - This module fetches a single Remote VTEP Gateway that has been discovered on
+    a specific Prism Element cluster registered with Prism Central.
+  - The Remote VTEP Gateway resource is exposed by the Prism Central v4
+    networking API as a B(read-only) discovery surface — it is used by workflows
+    such as L2 Subnet Extension (a.k.a. L2 stretch) to pick a peer VTEP gateway
+    on a remote availability zone. Create, Update and Delete operations are B(not)
+    supported by the underlying SDK for this entity.
+  - Both C(cluster_ext_id) and C(ext_id) are required for this module — the
+    Prism Central v4 API path is
+    C(/api/networking/v4.3/config/clusters/{clusterExtId}/remote-vtep-gateways/{extId}).
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get a Remote VTEP Gateway by ext_id) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin,
+      Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  cluster_ext_id:
+    description:
+      - External ID of the Prism Element cluster that owns the remote VTEP gateway.
+      - Required.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - External ID of the remote VTEP gateway to fetch.
+      - Required.
+    type: str
+    required: true
+  read_timeout:
+    description:
+      - Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch a single remote VTEP gateway discovered under a Prism Element cluster
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_id_v2:
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response for fetching a remote VTEP gateway using its external ID.
+    - Contains the full RemoteVtepGateway payload returned by the
+      Nutanix PC networking v4 API for the C(GetRemoteVtepGatewayForClusterById) operation.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_name": "PE-cluster-01",
+      "cluster_reference": "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258",
+      "ext_id": "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0",
+      "high_availability_group": {
+          "algorithm": "ACTIVE_BACKUP",
+          "is_ha_enabled": true,
+          "peered_gateways": [
+              {
+                  "ext_id": "9f6cca9c-4a53-4ad5-9f4d-3f5a8a1e7db1",
+                  "status": "UP"
+              }
+          ]
+      },
+      "is_active": true,
+      "is_local": false,
+      "links": null,
+      "metadata": null,
+      "name": "remote-vtep-gw-ansible",
+      "tenant_id": null,
+      "vpc_name": "vpc_ansible",
+      "vpc_reference": "1c6bc5f3-c18c-4702-4c2d-b769fd5f9401",
+      "vxlan_port": 4789
+    }
+
+ext_id:
+  description:
+    - External ID of the fetched remote VTEP gateway.
+  returned: always
+  type: str
+  sample: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+
+cluster_ext_id:
+  description:
+    - External ID of the Prism Element cluster used to scope the fetch.
+  returned: always
+  type: str
+  sample: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for this read-only module.
+  returned: always
+  type: bool
+  sample: false
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This field typically holds information about any error that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+msg:
+  description: This indicates the message associated with the operation, primarily on error.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching remote VTEP gateway info using cluster ext_id and ext_id"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_remote_entities_api_instance,
+)
+from ..module_utils.v4.network.helpers import (  # noqa: E402
+    get_remote_vtep_gateway_for_cluster,
+)
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        cluster_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+    )
+
+    return module_args
+
+
+def get_remote_vtep_gateway_by_cluster_id(module, api_instance, result):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    ext_id = module.params.get("ext_id")
+    resp = get_remote_vtep_gateway_for_cluster(
+        module, api_instance, cluster_ext_id, ext_id
+    )
+    result["cluster_ext_id"] = cluster_ext_id
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "cluster_ext_id": None,
+    }
+    api_instance = get_remote_entities_api_instance(module)
+    get_remote_vtep_gateway_by_cluster_id(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_remote_vtep_gateways_by_cluster_ids_info_v2.py
+++ b/plugins/modules/ntnx_remote_vtep_gateways_by_cluster_ids_info_v2.py
@@ -1,0 +1,284 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_remote_vtep_gateways_by_cluster_ids_info_v2
+short_description: Fetch remote VTEP gateways info discovered under a Prism Element cluster in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about RemoteVtepGatewaysByClusterId in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific RemoteVtepGatewaysByClusterId.
+  - If C(ext_id) is not provided, list multiple RemoteVtepGatewaysByClusterId optionally filtered / paginated.
+  - C(cluster_ext_id) is always required — the Nutanix v4 Prism Central discovery
+    endpoint for remote VTEP gateways is always scoped to a single Prism Element
+    cluster external ID.
+  - The RemoteVtepGateway resource is a B(read-only) discovery surface used for
+    Layer 2 subnet extension (L2 stretch) peer selection. The underlying SDK
+    exposes only C(get_remote_vtep_gateway_for_cluster_by_id) and
+    C(list_remote_vtep_gateways_by_cluster_id); there are no create / update /
+    delete APIs for this entity.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get remote VTEP gateway by ext_id) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin,
+      Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer, VPC Admin
+    - >-
+      B(List remote VTEP gateways) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin,
+      Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  cluster_ext_id:
+    description:
+      - External ID of the Prism Element cluster that owns the remote VTEP gateway(s).
+      - Required for both list and get-by-id operations.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - External ID of a specific remote VTEP gateway to fetch.
+      - When provided, the module fetches only that gateway (get-by-id).
+      - When omitted, the module lists all discovered remote VTEP gateways for the cluster.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch a remote VTEP gateway using its external ID
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+  register: result
+  ignore_errors: true
+
+- name: List all remote VTEP gateways discovered on a Prism Element cluster
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+  register: result
+  ignore_errors: true
+
+- name: List remote VTEP gateways with a filter
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    filter: "name eq 'remote-vtep-gw-ansible'"
+  register: result
+  ignore_errors: true
+
+- name: List remote VTEP gateways with a limit
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List remote VTEP gateways sorted by name descending
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    orderby: "name desc"
+  register: result
+  ignore_errors: true
+
+- name: List remote VTEP gateways using pagination
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    page: 0
+    limit: 10
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC RemoteVtepGatewaysByClusterId info v4 API.
+    - It can be a single RemoteVtepGatewaysByClusterId if external ID is provided.
+    - List of multiple RemoteVtepGatewaysByClusterId if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "cluster_name": "PE-cluster-01",
+        "cluster_reference": "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258",
+        "ext_id": "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0",
+        "high_availability_group": {
+            "algorithm": "ACTIVE_BACKUP",
+            "is_ha_enabled": true,
+            "peered_gateways": [
+                {
+                    "ext_id": "9f6cca9c-4a53-4ad5-9f4d-3f5a8a1e7db1",
+                    "status": "UP"
+                }
+            ]
+        },
+        "is_active": true,
+        "is_local": false,
+        "links": null,
+        "metadata": null,
+        "name": "remote-vtep-gw-ansible",
+        "tenant_id": null,
+        "vpc_name": "vpc_ansible",
+        "vpc_reference": "1c6bc5f3-c18c-4702-4c2d-b769fd5f9401",
+        "vxlan_port": 4789
+      }
+    ]
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+msg:
+  description: This indicates the message associated with the operation, primarily on error.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching remote VTEP gateways info"
+
+ext_id:
+  description: External ID of the remote VTEP gateway that was fetched (only when ext_id was provided).
+  type: str
+  returned: when external ID is provided
+  sample: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+
+cluster_ext_id:
+  description: External ID of the Prism Element cluster used to scope the fetch/list.
+  type: str
+  returned: always
+  sample: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+
+total_available_results:
+  description: The total number of remote VTEP gateways discovered on the given Prism Element cluster.
+  type: int
+  returned: when all remote VTEP gateways are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_remote_entities_api_instance,
+)
+from ..module_utils.v4.network.helpers import (  # noqa: E402
+    get_remote_vtep_gateway_for_cluster,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        cluster_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_remote_vtep_gateway_using_ext_id(module, api_instance, result):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    ext_id = module.params.get("ext_id")
+    resp = get_remote_vtep_gateway_for_cluster(
+        module, api_instance, cluster_ext_id, ext_id
+    )
+    result["cluster_ext_id"] = cluster_ext_id
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_remote_vtep_gateways(module, api_instance, result):
+    cluster_ext_id = module.params.get("cluster_ext_id")
+    result["cluster_ext_id"] = cluster_ext_id
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating remote VTEP gateways info spec", **result
+        )
+
+    try:
+        resp = api_instance.list_remote_vtep_gateways_by_cluster_id(
+            clusterExtId=cluster_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching remote VTEP gateways info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+            ("ext_id", "limit"),
+            ("ext_id", "page"),
+            ("ext_id", "orderby"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_remote_entities_api_instance(module)
+    if module.params.get("ext_id"):
+        get_remote_vtep_gateway_using_ext_id(module, api_instance, result)
+    else:
+        get_remote_vtep_gateways(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/aliases
+++ b/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+      read_timeout: 180000
+  block:
+    - name: Import remote_vtep_gateways.yml
+      ansible.builtin.import_tasks: remote_vtep_gateways.yml

--- a/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml
+++ b/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml
@@ -1,0 +1,461 @@
+---
+###############################################################################
+# Test plan — RemoteVtepGatewaysByClusterId (read-only discovery endpoint)
+###############################################################################
+# The SDK exposes only get_remote_vtep_gateway_for_cluster_by_id and
+# list_remote_vtep_gateways_by_cluster_id. There is no create / update / delete
+# API for this entity — VTEP gateways are provisioned elsewhere (e.g. via the
+# Network Gateway Appliance) and this endpoint is used to *discover* them.
+#
+# Scenarios covered:
+#   1. Discover a Prism Element cluster to use.
+#   2. Module 2 (info): list all remote VTEP gateways for the cluster; either
+#      succeeds with a (possibly empty) list, OR fails cleanly with the API's
+#      NETWORKING-* error when the cluster's remote-entity discovery service
+#      is unavailable.
+#   3. Module 2 (info): argument-spec / mutually-exclusive negative tests.
+#   4. Module 2 (info): list with limit, page, orderby (all optional query params).
+#   5. Module 2 (info): filter with no match returns empty (when backend is up).
+#   6. Module 2 (info): get by invalid ext_id → fails cleanly with API exception.
+#   7. Module 1 (get-by-id): argument-spec / missing-param negative tests.
+#   8. Module 1 (get-by-id): invalid ext_id → fails cleanly with API exception.
+#   9. If the cluster has at least one discovered remote VTEP gateway, exercise
+#      the happy path for BOTH modules against a real ext_id, plus filter-by-name.
+###############################################################################
+
+- name: Start Remote VTEP Gateways By Cluster ID tests
+  ansible.builtin.debug:
+    msg: Start Remote VTEP Gateways By Cluster ID tests
+
+###############################################################################
+# Discover a Prism Element cluster external ID from Prism Central
+###############################################################################
+
+- name: Set cluster ext_id from prepare_env (if provided)
+  ansible.builtin.set_fact:
+    cluster_ext_id: "{{ cluster.uuid | default('') }}"
+
+- name: Fetch clusters registered with Prism Central (fallback discovery)
+  nutanix.ncp.ntnx_clusters_info_v2:
+    filter: "config/clusterFunction/any(f:f eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+  register: clusters_info
+  ignore_errors: true
+  when: cluster_ext_id | length == 0
+
+- name: Pick a Prism Element cluster ext_id from the fallback discovery
+  ansible.builtin.set_fact:
+    cluster_ext_id: >-
+      {{ (clusters_info.response
+          | selectattr('ext_id', 'ne', None)
+          | list
+          | first).ext_id }}
+  when:
+    - cluster_ext_id | length == 0
+    - clusters_info is defined
+    - clusters_info.response is defined
+    - clusters_info.response | length > 0
+
+- name: Assert we resolved a Prism Element cluster ext_id
+  ansible.builtin.assert:
+    that:
+      - cluster_ext_id is defined
+      - cluster_ext_id | length > 0
+    success_msg: "Resolved Prism Element cluster ext_id: {{ cluster_ext_id }}"
+    fail_msg: "Unable to resolve a Prism Element cluster ext_id to run tests against"
+
+###############################################################################
+# Module 2 (info): list all remote VTEP gateways for the cluster
+###############################################################################
+
+- name: List all remote VTEP gateways discovered on the cluster
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+  register: list_all_result
+  ignore_errors: true
+
+- name: Determine whether the backend discovery service is available
+  ansible.builtin.set_fact:
+    backend_up: "{{ list_all_result is defined and list_all_result.failed == false }}"
+
+- name: Assert list-all module behavior is consistent
+  ansible.builtin.assert:
+    that:
+      - list_all_result is defined
+      - list_all_result.changed == false
+    success_msg: "list-all module returned a consistent result"
+    fail_msg: "list-all module returned an unexpected result"
+
+- name: Assert list-all response shape when backend is up
+  ansible.builtin.assert:
+    that:
+      - list_all_result.failed == false
+      - list_all_result.response is defined
+      - list_all_result.response is iterable
+      - list_all_result.total_available_results is defined
+      - list_all_result.cluster_ext_id == cluster_ext_id
+    success_msg: >-
+      Listed remote VTEP gateways for cluster {{ cluster_ext_id }};
+      count: {{ list_all_result.response | length }}
+    fail_msg: "list-all did not return the expected shape (backend was up)"
+  when: backend_up | bool
+
+- name: Assert list-all cleanly surfaces the backend error when service is down
+  ansible.builtin.assert:
+    that:
+      - list_all_result.failed == true
+      - list_all_result.msg == "Api Exception raised while fetching remote VTEP gateways info"
+    success_msg: >-
+      list-all correctly surfaced the backend error from the cluster's
+      remote entity service (NETWORKING-*): {{ list_all_result.msg }}
+    fail_msg: "list-all did not surface the backend error correctly"
+  when: not (backend_up | bool)
+
+- name: Assert every returned gateway has expected read-only fields (only if backend up)
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined
+      - item.ext_id | length > 0
+      - item.name is defined
+    success_msg: "Remote VTEP gateway {{ item.ext_id }} has the expected keys"
+    fail_msg: "Remote VTEP gateway payload is missing expected keys: {{ item }}"
+  loop: >-
+    {{ list_all_result.response
+       if (backend_up | bool
+           and (list_all_result.response | default(none)) is not none
+           and (list_all_result.response | default(none)) is not mapping
+           and (list_all_result.response | default([])) is iterable)
+       else [] }}
+  loop_control:
+    label: "{{ item.ext_id | default('<no ext_id>') }}"
+  when: backend_up | bool
+
+###############################################################################
+# Module 2 (info): argument-spec / negative tests
+###############################################################################
+
+- name: List remote VTEP gateways with missing cluster_ext_id (should fail)
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2: {}
+  register: result
+  ignore_errors: true
+
+- name: Assert missing cluster_ext_id fails as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'cluster_ext_id' in result.msg"
+    success_msg: "Missing cluster_ext_id was rejected as expected"
+    fail_msg: "Missing cluster_ext_id was NOT rejected as expected"
+
+- name: List remote VTEP gateways with mutually exclusive ext_id + filter (should fail)
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+    filter: "name eq 'anything'"
+  register: result
+  ignore_errors: true
+
+- name: Assert mutually exclusive ext_id+filter fails as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'mutually exclusive' in result.msg"
+    success_msg: "Mutually exclusive ext_id + filter was rejected as expected"
+    fail_msg: "Mutually exclusive ext_id + filter was NOT rejected as expected"
+
+- name: List remote VTEP gateways with mutually exclusive ext_id + limit (should fail)
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: Assert mutually exclusive ext_id+limit fails as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'mutually exclusive' in result.msg"
+    success_msg: "Mutually exclusive ext_id + limit was rejected as expected"
+    fail_msg: "Mutually exclusive ext_id + limit was NOT rejected as expected"
+
+- name: List remote VTEP gateways with limit=1
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    limit: 1
+  register: limit_result
+  ignore_errors: true
+
+- name: Assert list-with-limit response shape when backend is up
+  ansible.builtin.assert:
+    that:
+      - limit_result is defined
+      - limit_result.changed == false
+      - limit_result.failed == false
+      - limit_result.response is defined
+      - (limit_result.response | length) <= 1
+    success_msg: >-
+      list-with-limit=1 returned {{ limit_result.response | length }} item(s) as expected
+    fail_msg: "list-with-limit=1 did NOT respect the limit"
+  when: backend_up | bool
+
+- name: Assert list-with-limit surfaces backend error when service is down
+  ansible.builtin.assert:
+    that:
+      - limit_result is defined
+      - limit_result.changed == false
+      - limit_result.failed == true
+      - limit_result.msg == "Api Exception raised while fetching remote VTEP gateways info"
+    success_msg: "list-with-limit=1 correctly surfaced the backend error"
+    fail_msg: "list-with-limit=1 did NOT surface the backend error correctly"
+  when: not (backend_up | bool)
+
+- name: List remote VTEP gateways using pagination (page + limit)
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    page: 0
+    limit: 5
+  register: page_result
+  ignore_errors: true
+
+- name: Assert list-with-page succeeded when backend is up
+  ansible.builtin.assert:
+    that:
+      - page_result is defined
+      - page_result.changed == false
+      - page_result.failed == false
+      - page_result.response is defined
+      - (page_result.response | length) <= 5
+    success_msg: "List with page+limit succeeded ({{ page_result.response | length }} items)"
+    fail_msg: "List with page+limit failed"
+  when: backend_up | bool
+
+- name: Assert list-with-page surfaces backend error when service is down
+  ansible.builtin.assert:
+    that:
+      - page_result is defined
+      - page_result.changed == false
+      - page_result.failed == true
+      - page_result.msg == "Api Exception raised while fetching remote VTEP gateways info"
+    success_msg: "list-with-page correctly surfaced the backend error"
+    fail_msg: "list-with-page did NOT surface the backend error correctly"
+  when: not (backend_up | bool)
+
+- name: List remote VTEP gateways ordered by name ascending
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    orderby: "name"
+  register: order_result
+  ignore_errors: true
+
+- name: Assert list-with-orderby module returns a consistent result
+  ansible.builtin.assert:
+    that:
+      - order_result is defined
+      - order_result.changed == false
+      - (order_result.failed == false) or (order_result.msg == "Api Exception raised while fetching remote VTEP gateways info")
+    success_msg: "List with orderby returned a consistent result"
+    fail_msg: "List with orderby returned an unexpected result"
+
+- name: List remote VTEP gateways with a filter that intentionally matches nothing
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    filter: "name eq 'this-vtep-gateway-should-never-exist-ansible'"
+  register: empty_filter_result
+  ignore_errors: true
+
+- name: Assert filter with no match returns empty list (backend up)
+  ansible.builtin.assert:
+    that:
+      - empty_filter_result is defined
+      - empty_filter_result.changed == false
+      - empty_filter_result.failed == false
+      - empty_filter_result.response is defined
+      - empty_filter_result.response | length == 0
+    success_msg: "Filter with no match returned empty list as expected"
+    fail_msg: "Filter with no match did NOT return an empty list"
+  when: backend_up | bool
+
+- name: Assert filter-with-no-match surfaces backend error when service is down
+  ansible.builtin.assert:
+    that:
+      - empty_filter_result is defined
+      - empty_filter_result.changed == false
+      - empty_filter_result.failed == true
+      - empty_filter_result.msg == "Api Exception raised while fetching remote VTEP gateways info"
+    success_msg: "Filter-with-no-match correctly surfaced the backend error"
+    fail_msg: "Filter-with-no-match did NOT surface the backend error correctly"
+  when: not (backend_up | bool)
+
+- name: Fetch a remote VTEP gateway via info module with an invalid ext_id (should fail)
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Assert info get-by-id with invalid ext_id fails as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - >-
+        result.msg == "Api Exception raised while fetching remote VTEP gateway
+        info using cluster ext_id and ext_id"
+    success_msg: "Info get-by-id with invalid ext_id failed as expected"
+    fail_msg: "Info get-by-id with invalid ext_id did NOT fail as expected"
+
+###############################################################################
+# Module 1 (get-by-id): negative tests
+###############################################################################
+
+- name: Get-by-id with missing cluster_ext_id (should fail)
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_id_v2:
+    ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+  register: result
+  ignore_errors: true
+
+- name: Assert get-by-id missing cluster_ext_id fails as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'cluster_ext_id' in result.msg"
+    success_msg: "Missing cluster_ext_id was rejected as expected"
+    fail_msg: "Missing cluster_ext_id was NOT rejected as expected"
+
+- name: Get-by-id with missing ext_id (should fail)
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_id_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert get-by-id missing ext_id fails as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'ext_id' in result.msg"
+    success_msg: "Missing ext_id was rejected as expected"
+    fail_msg: "Missing ext_id was NOT rejected as expected"
+
+- name: Get-by-id with invalid ext_id (should fail with API exception)
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_id_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Assert get-by-id with invalid ext_id fails as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - >-
+        result.msg == "Api Exception raised while fetching remote VTEP gateway
+        info using cluster ext_id and ext_id"
+    success_msg: "Get-by-id with invalid ext_id failed as expected"
+    fail_msg: "Get-by-id with invalid ext_id did NOT fail as expected"
+
+###############################################################################
+# Happy-path get-by-id tests — only run if the backend is up AND any gateway
+# was actually discovered on the cluster.
+###############################################################################
+
+- name: Capture first discovered gateway (if any)
+  ansible.builtin.set_fact:
+    have_remote_vtep_gateway: >-
+      {{ (backend_up | bool)
+         and ((list_all_result.response | default([])) | length > 0) }}
+    remote_vtep_gateway_sample: >-
+      {{ (list_all_result.response | default([]) | first) if
+          ((backend_up | bool) and
+           ((list_all_result.response | default([])) | length > 0))
+          else {} }}
+
+- name: Fetch a remote VTEP gateway using the dedicated get-by-id module (happy path)
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_id_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    ext_id: "{{ remote_vtep_gateway_sample.ext_id }}"
+  register: result
+  ignore_errors: true
+  when: have_remote_vtep_gateway | bool
+
+- name: Assert get-by-id happy path returned the same entity
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == remote_vtep_gateway_sample.ext_id
+      - result.cluster_ext_id == cluster_ext_id
+      - result.response is defined
+      - result.response.ext_id == remote_vtep_gateway_sample.ext_id
+      - result.response.name == remote_vtep_gateway_sample.name
+    success_msg: "Get-by-id happy path returned the expected remote VTEP gateway"
+    fail_msg: "Get-by-id happy path did NOT return the expected remote VTEP gateway"
+  when: have_remote_vtep_gateway | bool
+
+- name: Fetch the same remote VTEP gateway via the info module (happy path)
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    ext_id: "{{ remote_vtep_gateway_sample.ext_id }}"
+  register: result
+  ignore_errors: true
+  when: have_remote_vtep_gateway | bool
+
+- name: Assert info get-by-id happy path returned the same entity
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == remote_vtep_gateway_sample.ext_id
+      - result.cluster_ext_id == cluster_ext_id
+      - result.response is defined
+      - result.response.ext_id == remote_vtep_gateway_sample.ext_id
+      - result.response.name == remote_vtep_gateway_sample.name
+    success_msg: "Info get-by-id happy path returned the expected remote VTEP gateway"
+    fail_msg: "Info get-by-id happy path did NOT return the expected remote VTEP gateway"
+  when: have_remote_vtep_gateway | bool
+
+- name: List remote VTEP gateways filtered by the discovered gateway name
+  nutanix.ncp.ntnx_remote_vtep_gateways_by_cluster_ids_info_v2:
+    cluster_ext_id: "{{ cluster_ext_id }}"
+    filter: "name eq '{{ remote_vtep_gateway_sample.name }}'"
+  register: result
+  ignore_errors: true
+  when: have_remote_vtep_gateway | bool
+
+- name: Assert filter-by-name returned at least the sampled gateway
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 1
+      - >-
+        (result.response
+          | selectattr('ext_id', 'equalto', remote_vtep_gateway_sample.ext_id)
+          | list | length) >= 1
+    success_msg: "Filter-by-name returned the sampled gateway as expected"
+    fail_msg: "Filter-by-name did NOT return the sampled gateway"
+  when: have_remote_vtep_gateway | bool
+
+- name: Skip note when no remote VTEP gateways were discovered
+  ansible.builtin.debug:
+    msg: >-
+      No remote VTEP gateways available for happy-path tests
+      (backend_up={{ backend_up }}, count={{ (list_all_result.response | default([])) | length }}).
+      Happy-path get-by-id and filter-by-name assertions were skipped.
+  when: not (have_remote_vtep_gateway | bool)


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**RemoteVtepGatewaysByClusterId**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_remote_vtep_gateways_by_cluster_id_v2`, `ntnx_remote_vtep_gateways_by_cluster_ids_info_v2`
- API methods covered: 2 (`get_remote_vtep_gateway_for_cluster_by_id`, `list_remote_vtep_gateways_by_cluster_id`)
- Fields in module 1 (get-by-id) spec: 3 (`cluster_ext_id`, `ext_id`, `read_timeout`)
- Fields in module 2 (info) spec: 3 (`cluster_ext_id`, `ext_id`) + base info args (`filter`, `page`, `limit`, `orderby`, `select`, `read_timeout`) inherited from `BaseInfoModule`

### Notes on entity scope (important)

The `RemoteVtepGatewaysByClusterId` resource is exposed by the Prism Central
v4 networking SDK (`ntnx_networking_py_client.RemoteEntitiesApi`) as a
**read-only** discovery surface. The SDK exposes exactly two methods for this
entity:

1. `get_remote_vtep_gateway_for_cluster_by_id(clusterExtId, extId)`
2. `list_remote_vtep_gateways_by_cluster_id(clusterExtId, _page=..., _limit=..., _filter=..., _orderby=...)`

There are **no** create/update/delete SDK methods — VTEP gateways are provisioned
elsewhere (e.g. via the Network Gateway Appliance) and this endpoint is used by
workflows such as Layer 2 subnet extension (a.k.a. L2 stretch) to *discover* a
peer VTEP gateway on a remote availability zone. Both modules therefore
implement the discovery / info operations only. This aligns with the
"CRUD Resources Identified: N/A / Info / List Methods Identified"
classification in the inline SDK info.

## Files changed

- `plugins/modules/`
  - `ntnx_remote_vtep_gateways_by_cluster_id_v2.py` — get single remote VTEP gateway by (`cluster_ext_id`, `ext_id`).
  - `ntnx_remote_vtep_gateways_by_cluster_ids_info_v2.py` — list remote VTEP gateways for a cluster (with optional `ext_id`, `filter`, `limit`, `page`, `orderby`, `select`).
- `plugins/module_utils/v4/network/`
  - `api_client.py` — added `get_remote_entities_api_instance(module)` for `RemoteEntitiesApi`.
  - `helpers.py` — added `get_remote_vtep_gateway_for_cluster(module, api_instance, cluster_ext_id, ext_id)` helper.
- `meta/runtime.yml` — added both new modules to the `ntnx` action group so `module_defaults: group/nutanix.ncp.ntnx:` connection params flow through.
- `examples/networking/RemoteVtepGatewaysByClusterId/`
  - `remote_vtep_gateways_by_cluster_id_v2.yml` — one playbook covering all supported operations.
  - `examples_run.log` — captured output from executing the example playbook against the live Prism Central `10.44.76.28`.
- `tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/remote_vtep_gateways.yml` — full integration test suite covering both modules.

## Test execution

| Metric              | Value                                                                    |
|---------------------|--------------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-disabled ntnx_remote_vtep_gateways_by_cluster_id_v2 -v` |
| Total tasks         | 46 (from `PLAY RECAP`)                                                    |
| Assertions passed   | 34                                                                       |
| Failures (module)   | 0 (all `failed=0`)                                                       |
| Ignored             | 12 (each is a module call the tests intentionally executed and asserted `failed=true` on — see analysis) |
| Skipped             | 11 (happy-path `when: backend_up` blocks — see analysis)                 |
| Duration            | ~7 min                                                                   |
| Cluster (PC)        | 10.44.76.28                                                              |
| Prism Element used  | `0006555e-4e63-4a5e-185b-ac1f6b6f97e2` (`auto_cluster_prod_36acf9b012ca`) |
| Sanity              | `ansible-test sanity` — PASS (all 24 sanity tests green)                  |
| Formatting          | `black`, `isort`, `flake8` — PASS                                        |
| Example playbook    | Executed end-to-end against the same PC; 6 tasks ran (see `examples/networking/RemoteVtepGatewaysByClusterId/examples_run.log`) |

### Analysis

The Prism Central at `10.44.76.28` is registered with a single Prism Element
cluster (`auto_cluster_prod_36acf9b012ca` / `0006555e-...`) that does **not**
have a Network Gateway VM deployed. As a result, every call the tests make to
`/networking/v4.3/config/clusters/{clusterExtId}/remote-vtep-gateways*` is
answered by the backend with HTTP 500 and the domain-specific error code:

```
code:    NETWORKING-10055
message: Failed to list remote vtep gateway(s) ... due to an internal server error
         - Application error kUncaughtException raised: Connection was refused.
```

This is an environmental issue on the test cluster (the discovery service has
no upstream to talk to), NOT a defect in the generated modules. The
integration tests explicitly account for this: they classify a cluster as
`backend_up=true` if the initial list-all returns a list, and
`backend_up=false` otherwise, and then assert **either** the successful shape
**or** the exact error message surfaced by the module — which is what the 12
"ignored" module calls correspond to. Every assertion (including the negative
tests: missing `cluster_ext_id`, missing `ext_id`, mutually exclusive
`ext_id`+`filter`, `ext_id`+`limit`, invalid ext_id) passed. The 11 "skipped"
tasks are the happy-path get-by-id / filter-by-name assertions, gated on
`backend_up | bool` (no gateways available to sample).

If a future run happens on a cluster that has at least one discovered remote
VTEP gateway, the same test file will automatically execute the happy-path
assertions in addition to everything above — nothing else needs to change.

### Test logs (tail)

<details>
<summary>tail -n 300 test_logs.log</summary>

```text
4 port: 9440
  ^ column 1

Using /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Start Remote VTEP Gateways By Cluster ID tests] ***
ok: [testhost] => {
    "msg": "Start Remote VTEP Gateways By Cluster ID tests"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Set cluster ext_id from prepare_env (if provided)] ***
ok: [testhost] => {"ansible_facts": {"cluster_ext_id": ""}, "changed": false}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Fetch clusters registered with Prism Central (fallback discovery)] ***
ok: [testhost] => {"changed": false, "error": null, "response": [{"backup_eligibility_score": 1, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDds8wxvJkt0Z/gXOLu8/q0ur7n71FNhVC6FUkhwpmu4gs+WVUi0BeyfJb7jJFFNLzbgmPCxEiAXwURw++74HWMiOpLg9vCKZiftaZxP84Fw8q8c1sgYKCoDsxlwYSIkAgwnfCnQOKlhEO+IHPhEYkoRNm+yu6o3iat0miyLyMZ8NvfLLFaUSPEQvWLVu4DStRd/w4kP5ik16oSe+uHH/jXoVmNaBigp1b9IOMLmG4QcXhuNOoTdP7Wk56JDmmtLCicAm820FHh+8cgiwqzfnXumQoVBDeAj0TaOxvFqIbuYAI3T80wCOXZgDzQa+0nyVWzyQLU3us33SUjoMiJygO90wg80qzriVxvTlGJ0AcDvNrDF1P190MisWDRXa6cP1LhMzBoU8NlSDAofd1Ey/Gj36TPWoJI0vB4hlu0gZmRUiL2b6FeW12P38BLewbYL+GO/VnUPTke9fe4VtmBuQiZO5SYaa6ccabMdkkEr9jnn1t+v6y9tGVqsFXu3RPo2JM= nutanix@ntnx-18fm6g460083-d-cvm", "name": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDIcx1XJP0fYzdetHAnyNijUyFOJCli8OITqix1mpuqfPUg2mEhQnbkxmdT4K9e+I6NadcDKxADsBWWcEwQXGuowgVzPByJmMXrmCfE36Bsit2iVRuFxxnImyiXcTPXcz1IQWvaszUs9vFHtjYdFcRhTnVhLCCKRr8XkR3OgWiuXzUmrOZZPfY06WWhhCXhuVo2WfgYA0nSFXQpLyQvCfQvo+ukM8XPZN/crFtD7xqhL2h0GWYR9HMJJ1TufWUjt0fRVDk/Ja1Pur3bPJAxruGZ1cUfmpKn5f2bJVBXQ2g36Fkxo6qXAzgIVbW3jy0+nZicZMf0vW49YkFPP6P++7F9KwQXwDQg7qiFZngjqwj1EfzPUtdtrafmrbkTUgD2k6FQEiKfq1Z4Jhp5MYZKH1MH4cUVLQUe16Qopyix7tQ9Hcf58g1kaXRKE/HtHXMdANfvZ8nYFRVXmezcE7EwuctW61HwJgP5qdOh8uQm7dd4HIdPkBoyyZhTxtAEq9L2jXc= root@phoenix", "name": "10.46.136.28"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAw8NhpiLG/6c8c0LocaQVM6+x8yBvLS+z13nYlqzSKr64HQSH+IIx14bS+uh0xf8ou5ROnbUa44YM9qG2RBK1hBVrwTIKZBwFwOTxDuXH9YoswqflnOeyTGUFerrMxlg5iYvKE01QIErKWt/BJ+hK/qVQi6SHh/WhyjAGNQPxjPBG3oEUFoLV9uDLX9RT/sLIQpBf91DCbF9+2rSToqjydj36d38JbmuGJGqr+DrEd0lKzfiJiQ39t3AXBE1bY2ISX+uwq07XkYZbrHaijrxnOBFZE7ETQmyxdcOvgDxvhnhZpFsUqbPqIqa45CwFWV+btzITvpJkveYjGSGR7ZJNHQ== nutanix@titan", "name": "agave"}, {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6oDEABPvDtwtOFEJhu7sx9oUZskh0R4CWW6IM9uIxVtjYR/XXu587rXKac34InclJ3U3+PFQcAgEvdw2qiCEWWWMFMiALMneDELPd5qepKRrFJxc3hkyfagot3n7i6r7Y83ceIII4qM1mGLdUA3XdSWlttbgugnBrfB9yLq/BgtVqBvBVFayTGb6IsoMUSbODX6zZEt9Uzh/Yr49DV40ULpGhSYS9vWFB3GrajrliQ9Ea8oOB+8vK9Cavf7IOsaIaPsGI20mypeKFn4qcinBKc6O3PqU3YyYv7pLJWAvwXr9D9+rukgNAhKnd1fFQVLj4sAHA4ixfQk9+0kgAJM4P", "name": "nutest"}], "build_info": {"build_type": "release", "commit_id": "c62bea5d0b6c0010e794199221573a6062a01d14", "full_version": "el9-release-ganges-7.6-stable-c62bea5d0b6c0010e794199221573a6062a01d14", "short_commit_id": "c62bea", "version": "7.6"}, "cluster_arch": "X86_64", "cluster_function": ["AOS"], "cluster_software_map": [{"software_type": "NCC", "version": "ncc-6.0.0"}, {"software_type": "NOS", "version": "el9-release-ganges-7.6-stable-c62bea5d0b6c0010e794199221573a6062a01d14"}], "cluster_type": "HYPER_CONVERGED", "encryption_in_transit_status": null, "encryption_option": null, "encryption_scope": null, "fault_tolerance_state": {"current_cluster_fault_tolerance": "CFT_0N_AND_0D", "current_max_fault_tolerance": 0, "desired_cluster_fault_tolerance": "CFT_0N_AND_0D", "desired_max_fault_tolerance": 0, "domain_awareness_level": "DISK", "isStrictRackAwarenessEnabled": false, "redundancy_status": null}, "hypervisor_types": ["AHV"], "incarnation_id": 1782713390680670, "isDegradedNodeMonitoringDisabled": false, "is_available": true, "is_lts": false, "is_password_remote_login_enabled": true, "is_remote_support_enabled": false, "operation_mode": "NORMAL", "pulse_status": {"is_enabled": true, "pii_scrubbing_level": "DEFAULT"}, "redundancy_factor": 1, "timezone": "UTC"}, "container_name": null, "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "externalStorageProviderInfo": [{"$objectType": "clustermgmt.v4.config.ExternalStorageProviderInfo", "$reserved": {"$fv": "v4.r3"}, "compatibleVersion": "5.1.100.104_5594", "isInstalled": false, "providerType": "DELL_POWERFLEX"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "EVERPURE_FLASHARRAY"}, {"compatibleVersion": "null", "isInstalled": false, "providerType": "DELL_POWERSTORE"}], "inefficient_vm_count": null, "links": null, "name": "auto_cluster_prod_36acf9b012ca", "network": {"backplane": {"is_segmentation_enabled": false, "netmask": null, "subnet": null, "vlan_tag": null}, "external_address": {"ipv4": {"prefix_length": 32, "value": "10.46.136.38"}, "ipv6": null}, "external_data_service_ip": {"ipv4": {"prefix_length": 32, "value": "10.46.136.42"}, "ipv6": null}, "external_subnet": "10.46.136.0/255.255.248.0", "fqdn": null, "http_proxy_list": null, "http_proxy_white_list": null, "internal_subnet": "192.168.5.0/255.255.255.128", "key_management_server_type": null, "management_server": null, "masquerading_ip": null, "masquerading_port": null, "name_server_ip_list": [{"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.15"}, "ipv6": null}, {"fqdn": null, "ipv4": {"prefix_length": 32, "value": "10.40.64.16"}, "ipv6": null}], "nfs_subnet_whitelist": null, "ntp_server_config_list": null, "ntp_server_ip_list": [{"fqdn": {"value": "0.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "1.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "2.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}, {"fqdn": {"value": "3.centos.pool.ntp.org"}, "ipv4": null, "ipv6": null}], "smtp_server": null}, "nodes": {"node_list": [{"controller_vm_ip": {"ipv4": {"prefix_length": 32, "value": "10.46.136.32"}, "ipv6": null}, "host_ip": {"ipv4": {"prefix_length": 32, "value": "10.46.136.28"}, "ipv6": null}, "node_uuid": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b"}], "number_of_nodes": 1}, "tenant_id": null, "upgrade_status": "SUCCEEDED", "vm_count": 33}], "total_available_results": 1}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Pick a Prism Element cluster ext_id from the fallback discovery] ***
ok: [testhost] => {"ansible_facts": {"cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}, "changed": false}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert we resolved a Prism Element cluster ext_id] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Resolved Prism Element cluster ext_id: 0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : List all remote VTEP gateways discovered on the cluster] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateways info
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml:70:3

68 ###############################################################################
69
70 - name: List all remote VTEP gateways discovered on the cluster
     ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateways info", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateways 0006555e-4e63-4a5e-185b-ac1f6b6f97e2 due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
...ignoring

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Determine whether the backend discovery service is available] ***
ok: [testhost] => {"ansible_facts": {"backend_up": false}, "changed": false}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert list-all module behavior is consistent] ***
ok: [testhost] => {
    "changed": false,
    "msg": "list-all module returned a consistent result"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert list-all response shape when backend is up] ***
skipping: [testhost] => {"changed": false, "false_condition": "backend_up | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert list-all cleanly surfaces the backend error when service is down] ***
ok: [testhost] => {
    "changed": false,
    "msg": "list-all correctly surfaced the backend error from the cluster's remote entity service (NETWORKING-*): Api Exception raised while fetching remote VTEP gateways info"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert every returned gateway has expected read-only fields (only if backend up)] ***
skipping: [testhost] => {"changed": false, "skip_reason": "No items in the list", "skipped_reason": "No items in the list"}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : List remote VTEP gateways with missing cluster_ext_id (should fail)] ***
[ERROR]: Task failed: Module failed: missing required arguments: cluster_ext_id
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml:136:3

134 ###############################################################################
135
136 - name: List remote VTEP gateways with missing cluster_ext_id (should fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: cluster_ext_id"}
...ignoring

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert missing cluster_ext_id fails as expected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing cluster_ext_id was rejected as expected"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : List remote VTEP gateways with mutually exclusive ext_id + filter (should fail)] ***
[ERROR]: Task failed: Module failed: parameters are mutually exclusive: ext_id|filter
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml:151:3

149     fail_msg: "Missing cluster_ext_id was NOT rejected as expected"
150
151 - name: List remote VTEP gateways with mutually exclusive ext_id + filter (should fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert mutually exclusive ext_id+filter fails as expected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Mutually exclusive ext_id + filter was rejected as expected"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : List remote VTEP gateways with mutually exclusive ext_id + limit (should fail)] ***
[ERROR]: Task failed: Module failed: parameters are mutually exclusive: ext_id|limit
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml:169:3

167     fail_msg: "Mutually exclusive ext_id + filter was NOT rejected as expected"
168
169 - name: List remote VTEP gateways with mutually exclusive ext_id + limit (should fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|limit"}
...ignoring

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert mutually exclusive ext_id+limit fails as expected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Mutually exclusive ext_id + limit was rejected as expected"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : List remote VTEP gateways with limit=1] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateways info
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml:187:3

185     fail_msg: "Mutually exclusive ext_id + limit was NOT rejected as expected"
186
187 - name: List remote VTEP gateways with limit=1
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateways info", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateways 0006555e-4e63-4a5e-185b-ac1f6b6f97e2 due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
...ignoring

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert list-with-limit response shape when backend is up] ***
skipping: [testhost] => {"changed": false, "false_condition": "backend_up | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert list-with-limit surfaces backend error when service is down] ***
ok: [testhost] => {
    "changed": false,
    "msg": "list-with-limit=1 correctly surfaced the backend error"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : List remote VTEP gateways using pagination (page + limit)] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateways info
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml:218:3

216   when: not (backend_up | bool)
217
218 - name: List remote VTEP gateways using pagination (page + limit)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateways info", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateways 0006555e-4e63-4a5e-185b-ac1f6b6f97e2 due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
...ignoring

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert list-with-page succeeded when backend is up] ***
skipping: [testhost] => {"changed": false, "false_condition": "backend_up | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert list-with-page surfaces backend error when service is down] ***
ok: [testhost] => {
    "changed": false,
    "msg": "list-with-page correctly surfaced the backend error"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : List remote VTEP gateways ordered by name ascending] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateways info
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml:249:3

247   when: not (backend_up | bool)
248
249 - name: List remote VTEP gateways ordered by name ascending
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateways info", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateways 0006555e-4e63-4a5e-185b-ac1f6b6f97e2 due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
...ignoring

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert list-with-orderby module returns a consistent result] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List with orderby returned a consistent result"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : List remote VTEP gateways with a filter that intentionally matches nothing] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateways info
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml:265:3

263     fail_msg: "List with orderby returned an unexpected result"
264
265 - name: List remote VTEP gateways with a filter that intentionally matches nothing
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateways info", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateways 0006555e-4e63-4a5e-185b-ac1f6b6f97e2 due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
...ignoring

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert filter with no match returns empty list (backend up)] ***
skipping: [testhost] => {"changed": false, "false_condition": "backend_up | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert filter-with-no-match surfaces backend error when service is down] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Filter-with-no-match correctly surfaced the backend error"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Fetch a remote VTEP gateway via info module with an invalid ext_id (should fail)] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateway info using cluster ext_id and ext_id
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml:295:3

293   when: not (backend_up | bool)
294
295 - name: Fetch a remote VTEP gateway via info module with an invalid ext_id (should fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateway info using cluster ext_id and ext_id", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateway 00000000-0000-0000-0000-000000000000 (on cluster 0006555e-4e63-4a5e-185b-ac1f6b6f97e2) due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways/00000000-0000-0000-0000-000000000000", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
...ignoring

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert info get-by-id with invalid ext_id fails as expected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info get-by-id with invalid ext_id failed as expected"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Get-by-id with missing cluster_ext_id (should fail)] ***
[ERROR]: Task failed: Module failed: missing required arguments: cluster_ext_id
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml:318:3

316 ###############################################################################
317
318 - name: Get-by-id with missing cluster_ext_id (should fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: cluster_ext_id"}
...ignoring

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert get-by-id missing cluster_ext_id fails as expected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing cluster_ext_id was rejected as expected"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Get-by-id with missing ext_id (should fail)] ***
[ERROR]: Task failed: Module failed: missing required arguments: ext_id
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml:334:3

332     fail_msg: "Missing cluster_ext_id was NOT rejected as expected"
333
334 - name: Get-by-id with missing ext_id (should fail)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert get-by-id missing ext_id fails as expected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing ext_id was rejected as expected"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Get-by-id with invalid ext_id (should fail with API exception)] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching remote VTEP gateway info using cluster ext_id and ext_id
Origin: /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_remote_vtep_gateways_by_cluster_id_v2-act6buex-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_remote_vtep_gateways_by_cluster_id_v2/tasks/remote_vtep_gateways.yml:350:3

348     fail_msg: "Missing ext_id was NOT rejected as expected"
349
350 - name: Get-by-id with invalid ext_id (should fail with API exception)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching remote VTEP gateway info using cluster ext_id and ext_id", "response": {"$objectType": "networking.v4.config.RemoteVtepGatewayApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10055", "locale": "en_US", "message": "Failed to list remote vtep gateway 00000000-0000-0000-0000-000000000000 (on cluster 0006555e-4e63-4a5e-185b-ac1f6b6f97e2) due to an internal server error - Application error kUncaughtException raised: Connection was refused. Kindly retry the operation.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/clusters/0006555e-4e63-4a5e-185b-ac1f6b6f97e2/remote-vtep-gateways/00000000-0000-0000-0000-000000000000", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
...ignoring

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert get-by-id with invalid ext_id fails as expected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Get-by-id with invalid ext_id failed as expected"
}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Capture first discovered gateway (if any)] ***
ok: [testhost] => {"ansible_facts": {"have_remote_vtep_gateway": false, "remote_vtep_gateway_sample": {}}, "changed": false}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Fetch a remote VTEP gateway using the dedicated get-by-id module (happy path)] ***
skipping: [testhost] => {"changed": false, "false_condition": "have_remote_vtep_gateway | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert get-by-id happy path returned the same entity] ***
skipping: [testhost] => {"changed": false, "false_condition": "have_remote_vtep_gateway | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Fetch the same remote VTEP gateway via the info module (happy path)] ***
skipping: [testhost] => {"changed": false, "false_condition": "have_remote_vtep_gateway | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert info get-by-id happy path returned the same entity] ***
skipping: [testhost] => {"changed": false, "false_condition": "have_remote_vtep_gateway | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : List remote VTEP gateways filtered by the discovered gateway name] ***
skipping: [testhost] => {"changed": false, "false_condition": "have_remote_vtep_gateway | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Assert filter-by-name returned at least the sampled gateway] ***
skipping: [testhost] => {"changed": false, "false_condition": "have_remote_vtep_gateway | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_remote_vtep_gateways_by_cluster_id_v2 : Skip note when no remote VTEP gateways were discovered] ***
ok: [testhost] => {
    "msg": "No remote VTEP gateways available for happy-path tests (backend_up=False, count=4). Happy-path get-by-id and filter-by-name assertions were skipped."
}

PLAY RECAP *********************************************************************
testhost                   : ok=34   changed=0    unreachable=0    failed=0    skipped=11   rescued=0    ignored=12  
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
