### PR TITLE
code-gen(volumes/VmAttachmentsByVolumeGroupId): ansible collection modules

### DIFF
--- a/examples/volumes/VmAttachmentsByVolumeGroupId/vm_attachments_by_volume_group_id_v2.yml
+++ b/examples/volumes/VmAttachmentsByVolumeGroupId/vm_attachments_by_volume_group_id_v2.yml
@@ -1,0 +1,111 @@
+---
+# Summary:
+# This playbook exercises the ntnx_vm_attachments_by_volume_group_id_v2 module and
+# the companion ntnx_volume_group_vm_attachment_info_v2 module. It:
+# 1. Prepares a fresh Volume Group and an AHV VM to attach.
+# 2. Attaches the VM to the Volume Group at a specific SCSI index.
+# 3. Fetches the newly created VmAttachment via the info module (get-by-ext_id).
+# 4. Lists all VM attachments for the Volume Group (unfiltered).
+# 5. Lists VM attachments with a limit (paginated).
+# 6. Detaches the VM from the Volume Group.
+# 7. Cleans up the VM and the Volume Group.
+
+- name: VmAttachmentsByVolumeGroupId playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting variables
+      ansible.builtin.set_fact:
+        cluster_uuid: "<cluster_ext_id>"
+        subnet_uuid: "<subnet_ext_id>"
+        vg_name: "ansible-vg-vm-attach-example"
+        vm_name: "ansible-vm-vm-attach-example"
+
+    - name: Create Volume Group for VM attachment example
+      nutanix.ncp.ntnx_volume_groups_v2:
+        state: present
+        name: "{{ vg_name }}"
+        description: "Volume group used by the VmAttachmentsByVolumeGroupId example"
+        should_load_balance_vm_attachments: true
+        sharing_status: "SHARED"
+        target_prefix: "vgvmex"
+        cluster_reference: "{{ cluster_uuid }}"
+        usage_type: "USER"
+      register: vg_result
+
+    - name: Store Volume Group ext_id
+      ansible.builtin.set_fact:
+        volume_group_ext_id: "{{ vg_result.ext_id }}"
+
+    - name: Create AHV VM used for the attachment
+      nutanix.ncp.ntnx_vms_v2:
+        state: present
+        name: "{{ vm_name }}"
+        num_sockets: 1
+        num_cores_per_socket: 1
+        memory_size_bytes: 1073741824
+        cluster:
+          ext_id: "{{ cluster_uuid }}"
+        nics:
+          - network_info:
+              nic_type: "NORMAL_NIC"
+              vlan_mode: "ACCESS"
+              subnet:
+                ext_id: "{{ subnet_uuid }}"
+              ipv4_config:
+                should_assign_ip: true
+      register: vm_result
+
+    - name: Store VM ext_id
+      ansible.builtin.set_fact:
+        vm_ext_id: "{{ vm_result.ext_id }}"
+
+    - name: Attach VM to Volume Group at SCSI index 1
+      nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+        state: present
+        volume_group_ext_id: "{{ volume_group_ext_id }}"
+        ext_id: "{{ vm_ext_id }}"
+        index: 1
+      register: attach_result
+
+    - name: Fetch specific VM attachment on the Volume Group by ext_id
+      nutanix.ncp.ntnx_volume_group_vm_attachment_info_v2:
+        volume_group_ext_id: "{{ volume_group_ext_id }}"
+        ext_id: "{{ vm_ext_id }}"
+      register: get_result
+
+    - name: List all VM attachments for the Volume Group
+      nutanix.ncp.ntnx_volume_group_vm_attachment_info_v2:
+        volume_group_ext_id: "{{ volume_group_ext_id }}"
+      register: list_result
+
+    - name: List VM attachments with a limit
+      nutanix.ncp.ntnx_volume_group_vm_attachment_info_v2:
+        volume_group_ext_id: "{{ volume_group_ext_id }}"
+        limit: 5
+      register: list_limit_result
+
+    - name: Detach VM from Volume Group
+      nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+        state: absent
+        volume_group_ext_id: "{{ volume_group_ext_id }}"
+        ext_id: "{{ vm_ext_id }}"
+      register: detach_result
+
+    - name: Delete VM used for the example
+      nutanix.ncp.ntnx_vms_v2:
+        state: absent
+        ext_id: "{{ vm_ext_id }}"
+      register: vm_delete_result
+
+    - name: Delete Volume Group used for the example
+      nutanix.ncp.ntnx_volume_groups_v2:
+        state: absent
+        ext_id: "{{ volume_group_ext_id }}"
+      register: vg_delete_result

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -151,6 +151,8 @@ action_groups:
     - ntnx_volume_groups_vms_v2
     - ntnx_volume_groups_iscsi_clients_v2
     - ntnx_volume_groups_iscsi_clients_info_v2
+    - ntnx_vm_attachments_by_volume_group_id_v2
+    - ntnx_volume_group_vm_attachment_info_v2
     - ntnx_roles_v2
     - ntnx_roles_info_v2
     - ntnx_directory_services_v2

--- a/plugins/modules/ntnx_vm_attachments_by_volume_group_id_v2.py
+++ b/plugins/modules/ntnx_vm_attachments_by_volume_group_id_v2.py
@@ -1,0 +1,381 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_attachments_by_volume_group_id_v2
+short_description: Attach or detach an AHV VM as a VmAttachment on a Nutanix Volume Group.
+version_added: 2.7.0
+description:
+  - This module manages VmAttachmentsByVolumeGroupId on a Nutanix Volume Group in Prism Central.
+  - A VmAttachment binds an AHV VM directly to a Volume Group so the VG is hot-plugged
+    onto the VM SCSI bus (hypervisor-attached storage), bypassing the guest iSCSI path.
+  - If C(state) is C(present) then an AHV VM is attached to the given Volume Group using
+    the C(AttachVm) API on C(VolumeGroupsApi).
+  - If C(state) is C(absent) then the referenced VM is detached from the Volume Group using
+    the C(DetachVm) API on C(VolumeGroupsApi).
+  - The list-side (C(ListVmAttachmentsByVolumeGroupId)) is exposed by the companion info
+    module C(ntnx_volume_group_vm_attachment_info_v2).
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    The required roles depend on the operation being performed.
+  - >-
+    B(Attach an AHV VM to the given Volume Group) -
+    Required Roles: Backup Admin, Prism Admin, Project Manager, Storage Admin, Super Admin,
+    Virtual Machine Admin, Self-Service Admin (deprecated)
+  - >-
+    B(Detach an AHV VM from the given Volume Group) -
+    Required Roles: Backup Admin, Prism Admin, Project Manager, Storage Admin, Super Admin,
+    Virtual Machine Admin, Self-Service Admin (deprecated)
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=volumes)"
+options:
+  state:
+    description:
+      - Specify the desired state of the VM attachment.
+      - If C(state) is set to C(present) the module attaches the VM to the given Volume Group.
+      - If C(state) is set to C(absent) the module detaches the VM from the given Volume Group.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  volume_group_ext_id:
+    description:
+      - The external identifier of the Volume Group that the VM will be attached to or detached from.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external identifier of the AHV VM to attach to or detach from the Volume Group.
+    type: str
+    required: true
+  index:
+    description:
+      - The index on the SCSI bus at which the Volume Group should be attached to the VM.
+      - This is optional. When omitted, the hypervisor picks the next available index.
+      - Ignored when C(state) is C(absent).
+    type: int
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Attach VM to Volume Group at a specific SCSI index
+  nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b35"
+    ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4a5d"
+    index: 1
+  register: result
+
+- name: Detach VM from Volume Group
+  nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b35"
+    ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4a5d"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response of the attach/detach operation.
+    - When C(wait) is C(true) the module returns the final task details.
+    - When C(wait) is C(false) the module returns the queued task response.
+    - In C(check_mode) the module returns the VmAttachment spec that would be sent.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_ids": [
+        "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+      ],
+      "completed_time": "2026-07-21T06:09:26.134731+00:00",
+      "completion_details": null,
+      "created_time": "2026-07-21T06:09:25.848056+00:00",
+      "entities_affected": [
+        {
+          "ext_id": "2b18feee-4502-4f73-4fa7-1216446cf8e5",
+          "rel": "volumes:config:volume-group"
+        },
+        {
+          "ext_id": "16f04294-2b2b-4b2b-7b34-9cb81195f92c",
+          "rel": "vmm:ahv:config:vm"
+        }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:8c8c692a-e0c6-4fa2-bbf1-10af383fab63",
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-21T06:09:26.134730+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 2,
+      "number_of_subtasks": 1,
+      "operation": "VolumeGroupAttachVm",
+      "operation_description": "Volume group attach to VM",
+      "owned_by": {
+        "ext_id": "00000000-0000-0000-0000-000000000000",
+        "name": "admin"
+      },
+      "parent_task": null,
+      "progress_percentage": 100,
+      "started_time": "2026-07-21T06:09:25.848056+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": [
+        {
+          "ext_id": "ZXJnb24=:6463bfb0-9a70-4055-903a-b941e5ae7101",
+          "href": "https://pc.example.com:9440/api/prism/v4.3/config/tasks/ZXJnb24=:6463bfb0-9a70-4055-903a-b941e5ae7101",
+          "rel": "subtask"
+        }
+      ],
+      "warnings": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the attach/detach task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:8c8c692a-e0c6-4fa2-bbf1-10af383fab63"
+
+ext_id:
+  description:
+    - The external ID of the AHV VM that was attached/detached.
+  returned: always
+  type: str
+  sample: "16f04294-2b2b-4b2b-7b34-9cb81195f92c"
+
+volume_group_ext_id:
+  description:
+    - The external ID of the Volume Group the operation was performed on.
+  returned: always
+  type: str
+  sample: "2b18feee-4502-4f73-4fa7-1216446cf8e5"
+
+changed:
+  description: Indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped.
+  returned: when applicable
+  type: bool
+  sample: false
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, module is idempotent, or check mode
+  type: str
+  sample: "Api Exception raised while attaching VM to volume group"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+from ..module_utils.v4.volumes.api_client import (  # noqa: E402
+    get_etag,
+    get_vg_api_instance,
+)
+from ..module_utils.v4.volumes.helpers import get_volume_group  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_volumes_py_client as volumes_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as volumes_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        volume_group_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+        index=dict(type="int", required=False),
+    )
+    return module_args
+
+
+def _build_vm_attachment_spec(module, result, operation):
+    """Build a ``VmAttachment`` request body for the attach/detach action."""
+    sg = SpecGenerator(module)
+    default_spec = volumes_sdk.VmAttachment()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating {0} VM to volume group spec".format(operation),
+            **result,
+        )
+    return spec
+
+
+def _finalize_task_response(module, result, resp):
+    """Populate result with task info; wait for completion when requested."""
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def create_VmAttachmentsByVolumeGroupId(module, result, api_instance):
+    """Attach the requested AHV VM to the Volume Group (state=present)."""
+    validate_required_params(module, ["volume_group_ext_id", "ext_id"])
+
+    volume_group_ext_id = module.params.get("volume_group_ext_id")
+    result["volume_group_ext_id"] = volume_group_ext_id
+    result["ext_id"] = module.params.get("ext_id")
+
+    spec = _build_vm_attachment_spec(module, result, operation="attach")
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    vg = get_volume_group(module, api_instance, volume_group_ext_id)
+    etag = get_etag(vg)
+    kwargs = {"if_match": etag}
+
+    try:
+        resp = api_instance.attach_vm(body=spec, extId=volume_group_ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while attaching VM to volume group",
+        )
+
+    _finalize_task_response(module, result, resp)
+
+
+def delete_VmAttachmentsByVolumeGroupId(module, result, api_instance):
+    """Detach the requested AHV VM from the Volume Group (state=absent)."""
+    validate_required_params(module, ["volume_group_ext_id", "ext_id"])
+
+    volume_group_ext_id = module.params.get("volume_group_ext_id")
+    result["volume_group_ext_id"] = volume_group_ext_id
+    result["ext_id"] = module.params.get("ext_id")
+
+    spec = _build_vm_attachment_spec(module, result, operation="detach")
+
+    if module.check_mode:
+        result["msg"] = (
+            "VM with ext_id: {0} will be detached from Volume Group with ext_id: {1}.".format(
+                module.params.get("ext_id"), volume_group_ext_id
+            )
+        )
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    vg = get_volume_group(module, api_instance, volume_group_ext_id)
+    etag = get_etag(vg)
+    kwargs = {"if_match": etag}
+
+    try:
+        resp = api_instance.detach_vm(body=spec, extId=volume_group_ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while detaching VM from volume group",
+        )
+
+    _finalize_task_response(module, result, resp)
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "present", ("volume_group_ext_id", "ext_id")),
+            ("state", "absent", ("volume_group_ext_id", "ext_id")),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_volumes_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "volume_group_ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_vg_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        create_VmAttachmentsByVolumeGroupId(module, result, api_instance)
+    else:
+        delete_VmAttachmentsByVolumeGroupId(module, result, api_instance)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_volume_group_vm_attachment_info_v2.py
+++ b/plugins/modules/ntnx_volume_group_vm_attachment_info_v2.py
@@ -1,0 +1,254 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_volume_group_vm_attachment_info_v2
+short_description: Fetch VmAttachmentsByVolumeGroupId info in Nutanix Prism Central.
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about VmAttachmentsByVolumeGroupId in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific VmAttachmentsByVolumeGroupId.
+  - If C(ext_id) is not provided, list multiple VmAttachmentsByVolumeGroupId optionally filtered / paginated.
+  - Uses the V4 C(ListVmAttachmentsByVolumeGroupId) API on C(VolumeGroupsApi).
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    The required roles depend on the operation being performed.
+  - >-
+    B(List VM attachments by Volume Group) -
+    Required Roles: Backup Admin, Prism Admin, Prism Viewer, Project Manager, Storage Admin, Storage Viewer,
+    Super Admin, Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer,
+    Self-Service Admin (deprecated)
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=volumes)"
+options:
+  volume_group_ext_id:
+    description:
+      - The external identifier of the Volume Group whose VM attachments should be listed.
+      - Required for both single and list operations because the API is scoped to a parent Volume Group.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external identifier (VM ext_id) of a specific VmAttachment on the Volume Group.
+      - When provided the module filters the underlying list response and returns only the
+        matching VmAttachment; when omitted the full list is returned.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all VM attachments for a Volume Group
+  nutanix.ncp.ntnx_volume_group_vm_attachment_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b35"
+  register: result
+
+- name: List VM attachments with a limit
+  nutanix.ncp.ntnx_volume_group_vm_attachment_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b35"
+    limit: 5
+  register: result
+
+- name: Fetch a specific VM attachment on a Volume Group
+  nutanix.ncp.ntnx_volume_group_vm_attachment_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b35"
+    ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4a5d"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VmAttachmentsByVolumeGroupId info v4 API.
+    - It can be a single VmAttachmentsByVolumeGroupId if external ID is provided.
+    - List of multiple VmAttachmentsByVolumeGroupId if external ID is not provided
+      with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "ext_id": "16f04294-2b2b-4b2b-7b34-9cb81195f92c",
+        "index": null
+      }
+    ]
+
+ext_id:
+  description: External ID of the specific VmAttachment on the Volume Group.
+  type: str
+  returned: when C(ext_id) is provided
+  sample: "16f04294-2b2b-4b2b-7b34-9cb81195f92c"
+
+volume_group_ext_id:
+  description: External ID of the parent Volume Group.
+  type: str
+  returned: always
+  sample: "2b18feee-4502-4f73-4fa7-1216446cf8e5"
+
+total_available_results:
+  description: The total number of VmAttachment records available for the Volume Group.
+  type: int
+  returned: when listing all VM attachments
+  sample: 1
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching VM attachments for volume group"
+
+error:
+  description: The error message if any error occurred.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.volumes.api_client import get_vg_api_instance  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        volume_group_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=False),
+    )
+    return module_args
+
+
+def _list_vm_attachments(module, api_instance, kwargs):
+    volume_group_ext_id = module.params.get("volume_group_ext_id")
+    try:
+        return api_instance.list_vm_attachments_by_volume_group_id(
+            volumeGroupExtId=volume_group_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VM attachments for volume group",
+        )
+
+
+def get_vm_attachment_by_ext_id(module, api_instance, result):
+    """Return the single VmAttachment matching module.params['ext_id']."""
+    volume_group_ext_id = module.params.get("volume_group_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["volume_group_ext_id"] = volume_group_ext_id
+    result["ext_id"] = ext_id
+
+    resp = _list_vm_attachments(module, api_instance, kwargs={})
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+
+    attachments = strip_internal_attributes(resp.to_dict()).get("data") or []
+    matched = next((item for item in attachments if item.get("ext_id") == ext_id), None)
+    if matched is None:
+        module.fail_json(
+            msg=(
+                "VmAttachment with ext_id: {0} was not found on Volume Group "
+                "ext_id: {1}."
+            ).format(ext_id, volume_group_ext_id),
+            **result,
+        )
+    result["response"] = matched
+
+
+def list_vm_attachments(module, api_instance, result):
+    """List every VmAttachment for the given Volume Group, honouring filters."""
+    volume_group_ext_id = module.params.get("volume_group_ext_id")
+    result["volume_group_ext_id"] = volume_group_ext_id
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating VM attachments info spec", **result)
+    kwargs.pop("volumeGroupExtId", None)
+
+    resp = _list_vm_attachments(module, api_instance, kwargs=kwargs)
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+
+    data = strip_internal_attributes(resp.to_dict()).get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_vg_api_instance(module)
+
+    if module.params.get("ext_id"):
+        get_vm_attachment_by_ext_id(module, api_instance, result)
+    else:
+        list_vm_attachments(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
-ntnx-volumes-py-client==4.2.2
+ntnx-volumes-py-client==latest
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2
 ntnx-lifecycle-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_attachments_by_volume_group_id_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_attachments_by_volume_group_id_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_attachments_by_volume_group_id_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_attachments_by_volume_group_id_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_vm_attachments_by_volume_group_id_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_attachments_by_volume_group_id_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import vm_attachments_by_volume_group_id.yml
+      ansible.builtin.import_tasks: "vm_attachments_by_volume_group_id.yml"

--- a/tests/integration/targets/ntnx_vm_attachments_by_volume_group_id_v2/tasks/vm_attachments_by_volume_group_id.yml
+++ b/tests/integration/targets/ntnx_vm_attachments_by_volume_group_id_v2/tasks/vm_attachments_by_volume_group_id.yml
@@ -1,0 +1,504 @@
+---
+# Integration tests for:
+#   - ntnx_vm_attachments_by_volume_group_id_v2 (attach/detach VmAttachment on a VG)
+#   - ntnx_volume_group_vm_attachment_info_v2   (list / get-by-ext_id)
+#
+# Test plan (why each block exists):
+#   1. Discover cluster + subnet — every test needs real cluster/network refs.
+#   2. Test setup — create a fresh Volume Group and two AHV VMs.
+#   3. check_mode: create (attach), update (attach with different index), delete (detach).
+#      Each has exactly one check_mode task (per reviewer feedback).
+#   4. Real attach with only required fields (no index) — validates minimum spec.
+#   5. Real attach with all fields (index set) — validates full spec.
+#   6. Info: list all VM attachments — assert list contains both VMs, index values.
+#   7. Info: list with limit — assert pagination truncates.
+#   8. Info: get single by ext_id — assert single entity returned.
+#   9. Info: get by non-existent ext_id — assert descriptive error.
+#   10. Negative: attach with non-existent VG ext_id — assert API exception.
+#   11. Negative: attach with missing volume_group_ext_id — assert Ansible argument error.
+#   12. Detach both VMs — assert both detaches succeed.
+#   13. Idempotency: detach a VM that is already detached — API returns failure/error,
+#       we tolerate it via ignore_errors and assert we did not silently mark changed.
+#   14. Cleanup — delete VMs and Volume Group.
+
+- name: Start VmAttachmentsByVolumeGroupId tests
+  ansible.builtin.debug:
+    msg: "Start VmAttachmentsByVolumeGroupId tests"
+
+- name: Generate random suffix
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set entity names
+  ansible.builtin.set_fact:
+    vg_name: "ansible-vg-vmattach-{{ random_name }}"
+    vm1_name: "ansible-vm-vmattach-{{ random_name }}-1"
+    vm2_name: "ansible-vm-vmattach-{{ random_name }}-2"
+
+############################################ Discover cluster ############################################
+- name: List clusters and pick the first AOS cluster
+  nutanix.ncp.ntnx_clusters_info_v2:
+  register: clusters_result
+
+- name: Verify clusters listing succeeded
+  ansible.builtin.assert:
+    that:
+      - clusters_result.changed == false
+      - clusters_result.failed == false
+    fail_msg: "Unable to list clusters — cannot proceed with VmAttachmentsByVolumeGroupId tests"
+    success_msg: "Clusters listed successfully"
+
+- name: Filter to AOS clusters only
+  ansible.builtin.set_fact:
+    aos_clusters: "{{ clusters_result.response | selectattr('config.cluster_function', 'defined')
+                     | selectattr('config.cluster_function', 'contains', 'AOS') | list }}"
+
+- name: Store target cluster ext_id
+  ansible.builtin.set_fact:
+    target_cluster_uuid: "{{ aos_clusters[0].ext_id }}"
+
+############################################ Discover a usable subnet ############################################
+- name: List subnets available on this PC
+  nutanix.ncp.ntnx_subnets_info_v2:
+  register: subnets_result
+
+- name: Verify subnets listing succeeded
+  ansible.builtin.assert:
+    that:
+      - subnets_result.changed == false
+      - subnets_result.failed == false
+    fail_msg: "Unable to list subnets — cannot create VMs for tests"
+    success_msg: "Subnets listed successfully"
+
+- name: Filter VLAN subnets on target cluster
+  ansible.builtin.set_fact:
+    usable_subnets: "{{ subnets_result.response | selectattr('subnet_type', 'equalto', 'VLAN')
+                       | selectattr('cluster_reference', 'equalto', target_cluster_uuid) | list }}"
+
+- name: Store target subnet ext_id
+  ansible.builtin.set_fact:
+    target_subnet_uuid: "{{ usable_subnets[0].ext_id }}"
+
+############################################ Setup: create Volume Group ############################################
+- name: Create Volume Group for VM attachment tests
+  nutanix.ncp.ntnx_volume_groups_v2:
+    state: present
+    name: "{{ vg_name }}"
+    description: "Volume Group for VmAttachmentsByVolumeGroupId tests"
+    should_load_balance_vm_attachments: true
+    sharing_status: "SHARED"
+    target_prefix: "vmattach"
+    cluster_reference: "{{ target_cluster_uuid }}"
+    usage_type: "USER"
+  register: vg_result
+
+- name: Verify VG creation
+  ansible.builtin.assert:
+    that:
+      - vg_result.changed == true
+      - vg_result.failed == false
+      - vg_result.ext_id is defined
+    fail_msg: "Unable to create Volume Group for tests"
+    success_msg: "Volume Group created successfully"
+
+- name: Store Volume Group ext_id
+  ansible.builtin.set_fact:
+    vg_uuid: "{{ vg_result.ext_id }}"
+
+############################################ Setup: create two AHV VMs ############################################
+- name: Create VM1 for attachment
+  nutanix.ncp.ntnx_vms_v2:
+    state: present
+    name: "{{ vm1_name }}"
+    num_sockets: 1
+    num_cores_per_socket: 1
+    memory_size_bytes: 1073741824
+    cluster:
+      ext_id: "{{ target_cluster_uuid }}"
+    nics:
+      - network_info:
+          nic_type: "NORMAL_NIC"
+          vlan_mode: "ACCESS"
+          subnet:
+            ext_id: "{{ target_subnet_uuid }}"
+  register: vm1_result
+
+- name: Verify VM1 creation
+  ansible.builtin.assert:
+    that:
+      - vm1_result.changed == true
+      - vm1_result.failed == false
+      - vm1_result.ext_id is defined
+    fail_msg: "Unable to create VM1 for tests"
+    success_msg: "VM1 created successfully"
+
+- name: Store VM1 ext_id
+  ansible.builtin.set_fact:
+    vm1_uuid: "{{ vm1_result.ext_id }}"
+
+- name: Create VM2 for attachment
+  nutanix.ncp.ntnx_vms_v2:
+    state: present
+    name: "{{ vm2_name }}"
+    num_sockets: 1
+    num_cores_per_socket: 1
+    memory_size_bytes: 1073741824
+    cluster:
+      ext_id: "{{ target_cluster_uuid }}"
+    nics:
+      - network_info:
+          nic_type: "NORMAL_NIC"
+          vlan_mode: "ACCESS"
+          subnet:
+            ext_id: "{{ target_subnet_uuid }}"
+  register: vm2_result
+
+- name: Verify VM2 creation
+  ansible.builtin.assert:
+    that:
+      - vm2_result.changed == true
+      - vm2_result.failed == false
+      - vm2_result.ext_id is defined
+    fail_msg: "Unable to create VM2 for tests"
+    success_msg: "VM2 created successfully"
+
+- name: Store VM2 ext_id
+  ansible.builtin.set_fact:
+    vm2_uuid: "{{ vm2_result.ext_id }}"
+
+############################################ check_mode tests ############################################
+- name: Check_mode — attach VM1 to VG with ALL attributes
+  nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+    state: present
+    volume_group_ext_id: "{{ vg_uuid }}"
+    ext_id: "{{ vm1_uuid }}"
+    index: 1
+  register: check_attach_result
+  check_mode: true
+
+- name: Verify check_mode attach (present) did not mutate the API
+  ansible.builtin.assert:
+    that:
+      - check_attach_result.changed == false
+      - check_attach_result.failed == false
+      - check_attach_result.ext_id == vm1_uuid
+      - check_attach_result.volume_group_ext_id == vg_uuid
+      - check_attach_result.response.index == 1
+      - check_attach_result.response.ext_id == vm1_uuid
+    fail_msg: "check_mode attach did not produce the expected spec"
+    success_msg: "check_mode attach produced the expected VmAttachment spec"
+
+- name: Check_mode — attach VM1 to VG with a DIFFERENT index (update transition)
+  nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+    state: present
+    volume_group_ext_id: "{{ vg_uuid }}"
+    ext_id: "{{ vm1_uuid }}"
+    index: 3
+  register: check_attach_update_result
+  check_mode: true
+
+- name: Verify check_mode update-style spec (different index)
+  ansible.builtin.assert:
+    that:
+      - check_attach_update_result.changed == false
+      - check_attach_update_result.failed == false
+      - check_attach_update_result.response.index == 3
+      - check_attach_update_result.response.ext_id == vm1_uuid
+    fail_msg: "check_mode update-style spec did not reflect the new index"
+    success_msg: "check_mode update-style spec correctly reflected the new index"
+
+- name: Check_mode — detach VM1 from VG
+  nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+    state: absent
+    volume_group_ext_id: "{{ vg_uuid }}"
+    ext_id: "{{ vm1_uuid }}"
+  register: check_detach_result
+  check_mode: true
+
+- name: Verify check_mode detach did not mutate the API
+  ansible.builtin.assert:
+    that:
+      - check_detach_result.changed == false
+      - check_detach_result.failed == false
+      - check_detach_result.ext_id == vm1_uuid
+      - check_detach_result.volume_group_ext_id == vg_uuid
+      - check_detach_result.msg is defined
+      - check_detach_result.msg is search("will be detached")
+    fail_msg: "check_mode detach did not return the expected preview message"
+    success_msg: "check_mode detach preview message returned as expected"
+
+############################################ Real attach ############################################
+- name: Attach VM1 to VG using ONLY required fields (no index)
+  nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+    state: present
+    volume_group_ext_id: "{{ vg_uuid }}"
+    ext_id: "{{ vm1_uuid }}"
+  register: attach_vm1_result
+
+- name: Verify VM1 attach succeeded
+  ansible.builtin.assert:
+    that:
+      - attach_vm1_result.changed == true
+      - attach_vm1_result.failed == false
+      - attach_vm1_result.ext_id == vm1_uuid
+      - attach_vm1_result.volume_group_ext_id == vg_uuid
+      - attach_vm1_result.task_ext_id is defined
+      - attach_vm1_result.response.status == "SUCCEEDED"
+    fail_msg: "Unable to attach VM1 to VG"
+    success_msg: "VM1 attached to VG successfully"
+
+- name: Attach VM2 to VG with ALL fields (explicit SCSI index)
+  nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+    state: present
+    volume_group_ext_id: "{{ vg_uuid }}"
+    ext_id: "{{ vm2_uuid }}"
+    index: 4
+  register: attach_vm2_result
+
+- name: Verify VM2 attach succeeded with explicit index
+  ansible.builtin.assert:
+    that:
+      - attach_vm2_result.changed == true
+      - attach_vm2_result.failed == false
+      - attach_vm2_result.ext_id == vm2_uuid
+      - attach_vm2_result.volume_group_ext_id == vg_uuid
+      - attach_vm2_result.task_ext_id is defined
+      - attach_vm2_result.response.status == "SUCCEEDED"
+    fail_msg: "Unable to attach VM2 to VG"
+    success_msg: "VM2 attached to VG successfully"
+
+############################################ Info: list ############################################
+- name: List all VM attachments on the Volume Group
+  nutanix.ncp.ntnx_volume_group_vm_attachment_info_v2:
+    volume_group_ext_id: "{{ vg_uuid }}"
+  register: list_vmattach_result
+
+- name: Verify list contains both VM attachments
+  ansible.builtin.assert:
+    that:
+      - list_vmattach_result.changed == false
+      - list_vmattach_result.failed == false
+      - list_vmattach_result.volume_group_ext_id == vg_uuid
+      - list_vmattach_result.response is iterable
+      - list_vmattach_result.response | length >= 2
+      - (list_vmattach_result.response | map(attribute='ext_id') | list) is superset([vm1_uuid, vm2_uuid])
+      - list_vmattach_result.total_available_results is defined
+      - list_vmattach_result.total_available_results >= 2
+    fail_msg: "list_vm_attachments did not return both attached VMs"
+    success_msg: "list_vm_attachments returned both attached VMs"
+
+- name: Verify VM2 attachment record surfaces in the list
+  ansible.builtin.assert:
+    that:
+      - (list_vmattach_result.response
+           | selectattr('ext_id', 'equalto', vm2_uuid) | list | length) == 1
+      # NOTE: the deprecated ListVmAttachmentsByVolumeGroupId API returns
+      # `index: null` for entries; the SCSI index requested at attach time is
+      # not echoed back on the list response. We assert the record exists but
+      # tolerate a null index. The full disk-address (with index) can be seen
+      # via the VM info module (ntnx_vms_info_v2 -> disks[*].disk_address).
+      - ((list_vmattach_result.response
+             | selectattr('ext_id', 'equalto', vm2_uuid)
+             | map(attribute='index') | list | first) in [4, None])
+    fail_msg: "list_vm_attachments did not include VM2 as expected"
+    success_msg: "list_vm_attachments included VM2 as expected"
+
+- name: List VM attachments with a limit of 1
+  nutanix.ncp.ntnx_volume_group_vm_attachment_info_v2:
+    volume_group_ext_id: "{{ vg_uuid }}"
+    limit: 1
+  register: list_vmattach_limit_result
+
+- name: Verify limit truncates the response
+  ansible.builtin.assert:
+    that:
+      - list_vmattach_limit_result.changed == false
+      - list_vmattach_limit_result.failed == false
+      - list_vmattach_limit_result.response | length == 1
+      - list_vmattach_limit_result.total_available_results >= 2
+    fail_msg: "limit parameter did not truncate the VM attachment list"
+    success_msg: "limit parameter correctly truncated the VM attachment list"
+
+############################################ Info: get by ext_id ############################################
+- name: Fetch VM1 attachment by ext_id
+  nutanix.ncp.ntnx_volume_group_vm_attachment_info_v2:
+    volume_group_ext_id: "{{ vg_uuid }}"
+    ext_id: "{{ vm1_uuid }}"
+  register: get_vm1_result
+
+- name: Verify single VM attachment fetched
+  ansible.builtin.assert:
+    that:
+      - get_vm1_result.changed == false
+      - get_vm1_result.failed == false
+      - get_vm1_result.ext_id == vm1_uuid
+      - get_vm1_result.volume_group_ext_id == vg_uuid
+      - get_vm1_result.response.ext_id == vm1_uuid
+    fail_msg: "Unable to fetch VM1 attachment by ext_id"
+    success_msg: "VM1 attachment fetched by ext_id successfully"
+
+- name: Fetch a non-existent VM attachment on this VG
+  nutanix.ncp.ntnx_volume_group_vm_attachment_info_v2:
+    volume_group_ext_id: "{{ vg_uuid }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: get_missing_result
+  ignore_errors: true
+
+- name: Verify not-found error is descriptive
+  ansible.builtin.assert:
+    that:
+      - get_missing_result.failed == true
+      - get_missing_result.msg is defined
+      - get_missing_result.msg is search("not found")
+    fail_msg: "Fetching a non-existent VmAttachment did not fail with a descriptive error"
+    success_msg: "Fetching a non-existent VmAttachment failed with a descriptive error"
+
+############################################ Negative: attach on non-existent VG ############################################
+- name: Attempt to attach VM1 to a non-existent Volume Group
+  nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+    state: present
+    volume_group_ext_id: "00000000-0000-0000-0000-000000000000"
+    ext_id: "{{ vm1_uuid }}"
+  register: attach_bad_vg_result
+  ignore_errors: true
+
+- name: Verify attach against invalid VG failed
+  ansible.builtin.assert:
+    that:
+      - attach_bad_vg_result.failed == true
+    fail_msg: "Attach to a non-existent VG unexpectedly succeeded"
+    success_msg: "Attach to a non-existent VG failed as expected"
+
+############################################ Negative: missing required param ############################################
+- name: Attempt to attach without volume_group_ext_id (should fail spec validation)
+  nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+    state: present
+    ext_id: "{{ vm1_uuid }}"
+  register: attach_missing_vg_result
+  ignore_errors: true
+
+- name: Verify Ansible argument-spec rejected the missing required param
+  ansible.builtin.assert:
+    that:
+      - attach_missing_vg_result.failed == true
+      - attach_missing_vg_result.msg is defined
+      - attach_missing_vg_result.msg is search("volume_group_ext_id")
+    fail_msg: "Ansible spec did not reject a missing required parameter"
+    success_msg: "Ansible spec correctly rejected the missing required parameter"
+
+############################################ Detach ############################################
+- name: Detach VM1 from VG
+  nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+    state: absent
+    volume_group_ext_id: "{{ vg_uuid }}"
+    ext_id: "{{ vm1_uuid }}"
+  register: detach_vm1_result
+
+- name: Verify VM1 detach succeeded
+  ansible.builtin.assert:
+    that:
+      - detach_vm1_result.changed == true
+      - detach_vm1_result.failed == false
+      - detach_vm1_result.ext_id == vm1_uuid
+      - detach_vm1_result.volume_group_ext_id == vg_uuid
+      - detach_vm1_result.task_ext_id is defined
+      - detach_vm1_result.response.status == "SUCCEEDED"
+    fail_msg: "Unable to detach VM1 from VG"
+    success_msg: "VM1 detached from VG successfully"
+
+- name: Detach VM2 from VG
+  nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+    state: absent
+    volume_group_ext_id: "{{ vg_uuid }}"
+    ext_id: "{{ vm2_uuid }}"
+  register: detach_vm2_result
+
+- name: Verify VM2 detach succeeded
+  ansible.builtin.assert:
+    that:
+      - detach_vm2_result.changed == true
+      - detach_vm2_result.failed == false
+      - detach_vm2_result.ext_id == vm2_uuid
+      - detach_vm2_result.volume_group_ext_id == vg_uuid
+      - detach_vm2_result.task_ext_id is defined
+      - detach_vm2_result.response.status == "SUCCEEDED"
+    fail_msg: "Unable to detach VM2 from VG"
+    success_msg: "VM2 detached from VG successfully"
+
+############################################ Idempotency: detach twice ############################################
+- name: Detach VM1 a second time (already detached — expect API error, tolerated)
+  nutanix.ncp.ntnx_vm_attachments_by_volume_group_id_v2:
+    state: absent
+    volume_group_ext_id: "{{ vg_uuid }}"
+    ext_id: "{{ vm1_uuid }}"
+  register: detach_vm1_again_result
+  ignore_errors: true
+
+- name: Verify repeat detach did not silently succeed
+  ansible.builtin.assert:
+    that:
+      - detach_vm1_again_result.changed == false or detach_vm1_again_result.failed == true
+    fail_msg: "Detaching an already-detached VM silently reported changed=true, which is unsafe"
+    success_msg: "Detaching an already-detached VM correctly reported no-change / failure"
+
+- name: List VM attachments after detach — expect empty
+  nutanix.ncp.ntnx_volume_group_vm_attachment_info_v2:
+    volume_group_ext_id: "{{ vg_uuid }}"
+  register: list_after_detach_result
+
+- name: Verify listing shows no VM attachments after detach
+  ansible.builtin.assert:
+    that:
+      - list_after_detach_result.changed == false
+      - list_after_detach_result.failed == false
+      - (list_after_detach_result.response | length) == 0
+      - list_after_detach_result.total_available_results == 0
+    fail_msg: "VG still shows VM attachments after detaching both VMs"
+    success_msg: "VG shows no VM attachments after detaching both VMs"
+
+############################################ Cleanup ############################################
+- name: Delete VM1
+  nutanix.ncp.ntnx_vms_v2:
+    state: absent
+    ext_id: "{{ vm1_uuid }}"
+  register: delete_vm1_result
+  ignore_errors: true
+
+- name: Verify VM1 deletion
+  ansible.builtin.assert:
+    that:
+      - delete_vm1_result.failed == false
+      - delete_vm1_result.changed == true
+    fail_msg: "Failed to delete VM1 during cleanup"
+    success_msg: "VM1 deleted successfully during cleanup"
+
+- name: Delete VM2
+  nutanix.ncp.ntnx_vms_v2:
+    state: absent
+    ext_id: "{{ vm2_uuid }}"
+  register: delete_vm2_result
+  ignore_errors: true
+
+- name: Verify VM2 deletion
+  ansible.builtin.assert:
+    that:
+      - delete_vm2_result.failed == false
+      - delete_vm2_result.changed == true
+    fail_msg: "Failed to delete VM2 during cleanup"
+    success_msg: "VM2 deleted successfully during cleanup"
+
+- name: Delete Volume Group
+  nutanix.ncp.ntnx_volume_groups_v2:
+    state: absent
+    ext_id: "{{ vg_uuid }}"
+  register: delete_vg_result
+  ignore_errors: true
+
+- name: Verify Volume Group deletion
+  ansible.builtin.assert:
+    that:
+      - delete_vg_result.failed == false
+      - delete_vg_result.changed == true
+      - delete_vg_result.ext_id == vg_uuid
+    fail_msg: "Failed to delete Volume Group during cleanup"
+    success_msg: "Volume Group deleted successfully during cleanup"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **volumes** namespace, entity
**VmAttachmentsByVolumeGroupId**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_vm_attachments_by_volume_group_id_v2`, `ntnx_volume_group_vm_attachment_info_v2`
- API methods covered: `3` — `ListVmAttachmentsByVolumeGroupId`, `AttachVm`, `DetachVm` (on `VolumeGroupsApi`)
- Fields in CRUD module spec: `5` — `state`, `wait`, `volume_group_ext_id`, `ext_id`, `index`
- Fields in info module spec: `7` — `volume_group_ext_id`, `ext_id`, `filter`, `limit`, `page`, `orderby`, `select`

The entity `VmAttachmentsByVolumeGroupId` does not have direct create/update/delete
endpoints on itself: it is manipulated indirectly through the parent Volume Group's
`AttachVm`/`DetachVm` actions. The CRUD module therefore exposes `state: present`
(attach) and `state: absent` (detach). There is no update operation.

## Domain knowledge (from Glean)

### Glean answer (retained verbatim)

The Nutanix Volumes v4 API introduces streamlined endpoints on the `VolumeGroupsApi` to manage direct, hypervisor-level attachments of Volume Groups (VGs) to Virtual Machines (VMs).

#### API Endpoints Overview

The following endpoints manage `VmAttachment` entities for a Volume Group:

- **ListVmAttachmentsByVolumeGroupId**
    - **Endpoint**: `GET /api/volumes/v4.x/config/volume-groups/{volumeGroupExtId}/vm-attachments`
    - **Function**: Retrieves a list of all VMs currently attached to the specified VG. It supports standard OData filters, sorting, and pagination (e.g., `$page`, `$limit`, `$filter`).
- **AttachVm**
    - **Endpoint**: `POST /api/volumes/v4.x/config/volume-groups/{extId}/$actions/attach-vm`
    - **Function**: Attaches an AHV VM to the given Volume Group. The request body requires a `VmAttachment` model specifying the target VM.
- **DetachVm**
    - **Endpoint**: `POST /api/volumes/v4.x/config/volume-groups/{extId}/$actions/detach-vm`
    - **Function**: Detaches a specific AHV VM from the Volume Group.

#### The `VmAttachment` Entity & Features

Instead of mounting a volume over the guest network using traditional iSCSI, the `VmAttachment` entity represents a **Hypervisor-Attached Storage** (Direct Attach) configuration.

**Key Features:**
- **Direct SCSI Hot-Plug**: The API executes a `vm disk add` operation, instructing the Acropolis Hypervisor (AHV) to hot-plug the VG directly onto the VM's virtual SCSI bus.
- **Bypasses Guest Networking**: The Guest OS sees the disk as a local, physical SCSI drive. I/O is intercepted by AHV and routed over the internal private vSwitch directly to the local Controller VM (CVM/Stargate), which is significantly more secure and efficient than iSCSI.
- **No IQN Required**: Unlike external iSCSI attachments, the metadata for a `VmAttachment` does not require or generate an iSCSI Qualified Name (IQN). The attachment is tracked purely by the `vm_uuid` and the internal attachment type is marked as `kDirectAttach`.

#### Prerequisites

- **Same-Cluster Constraint**: The compute (worker node/VM) and the storage (the Volume Group) **must reside on the same Prism Element (PE) cluster**. Kubernetes Topology features and CSI drivers strictly enforce this for pod migrations.
- **Hypervisor Requirement**: This workflow is explicitly designed for **AHV**. ESXi environments still require standard iSCSI attachments.
- **RBAC Permissions**: The caller must have adequate privileges (e.g., `View_Volume_Group_VM_Attachments` or `Update_Volume_Group`). Legacy roles mapped to this include Prism Admin, Super Admin, and Volumes Admin.

#### Workflow (Example via Nutanix CSI)

1. **Provisioning**: A Volume Group is created on the backend Distributed Storage Fabric (DSF) via the VG Create API.
2. **Attachment**: The orchestrator (e.g., the CSI driver) issues an `AttachVm` API call, passing the VG's `extId` and a `VmAttachment` payload containing the target VM's UUID.
3. **Hypervisor Execution**: AHV hot-plugs the VG as a virtual SCSI device on the target VM.
4. **Guest OS Mounting**: The Guest OS detects the new block device natively, allowing it to be formatted and mounted (e.g., by the Kubelet for a container pod).
5. **Detachment/Migration**: If the VM is deleted or a pod migrates, a `DetachVm` call is issued to cleanly remove the disk from the VM's SCSI bus before it can be re-attached elsewhere.

#### Related Resources & Documentation

**Design & Documentation**
- [Understanding Hypervisor-Attached Storage with Nutanix CSI](https://confluence.eng.nutanix.com:8443/spaces/INFRA/pages/560097921/Understanding+Hypervisor-Attached+Storage+with+Nutanix+CSI) (CSI Driver direct-attach mechanics)
- [Volume Group v4 API Performance & Benchmarking](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/243785476/Volume+Group+v4+API)
- [VG V2-V4 API Mapping](https://confluence.eng.nutanix.com:8443/spaces/CDPE/pages/223338915/VG+V2-V4+Mapping)
- [V4 APIs for Volume Groups](https://confluence.eng.nutanix.com:8443/spaces/CLP/pages/500171673/V4+APIs+for+Volume+Groups)
- [BackUp and Restore V4 API](https://confluence.eng.nutanix.com:8443/spaces/~srinivasa.arjilla/pages/289720526/BackUp+and+Restore+V4+API)
- [Prism V4 APIs](https://confluence.eng.nutanix.com:8443/spaces/SIZER/pages/528533216/Prism+V4+API+S)
- [Volume Group Recovery Points API: v4 API PM Checklist (Kronos)](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/528542280/Volume+Group+Recovery+Points+API+v4+API+PM+Checklist+Kronos)
- [Volumes VG Recovery Point v4 APIs - GA Performance](https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/528543565/Volumes+VG+Recovery+Point+v4+APIs+-+GA+Performance)
- [CSI support for role based access to V4 Prism Central APIs](https://confluence.eng.nutanix.com:8443/spaces/STK/pages/344995589/CSI+support+for+role+based+access+to+V4+Prism+Central+APIs)
- [FEAT-11104 Storage Management in PC](https://confluence.eng.nutanix.com:8443/spaces/STK/pages/137587597/FEAT-11104+Storage+Management+in+PC)
- [VG SyncRep Drop 2](https://nutanixinc-my.sharepoint.com/personal/joshua_eddy_nutanix_com/_layouts/15/Doc.aspx?sourcedoc=%7BCD29A5A4-E478-4086-8AD0-54321DDCF9A1%7D&file=VG%20SyncRep%20Drop%202.docx&action=default&mobileredirect=true)

**Relevant ENG / JIRA Tickets**
- **[ENG-688689](https://jira.nutanix.com/browse/ENG-688689)**: `TypeError: list_vm_attachments_by_volume_group_id() missing 1 required positional argument: 'volumeGroupExtId'`.
- **[ENG-906246](https://jira.nutanix.com/browse/ENG-906246)**: `[Volume Group] API api/volumes/v4.3/config/volume-groups/{id}/vm-attachments failed with 403` — RBAC 403 authorization errors for `list_vm_attachments_by_volume_group_id` when scoped to a specific cluster.
- **[ENG-924632](https://jira.nutanix.com/browse/ENG-924632)**: Acropolis `VolumeGroupAttachVmTask` doesn't return the VM logical timestamp in the task ret entity list.
- **[ENG-954537](https://jira.nutanix.com/browse/ENG-954537)**: `[Setup FIO VG Scale]`: Attach vg to vm operations is failing (`VOLUME_UNKNOWN_ENTITY_ERROR`).
- **[ENG-886646](https://jira.nutanix.com/browse/ENG-886646)**: `Infra Domain VG: Enable volume v4 APIs for Backup/Restore`.
- **[ENG-916924](https://jira.nutanix.com/browse/ENG-916924)**: `VolumeGroupDetachVm failed`.
- **[ENG-940698](https://jira.nutanix.com/browse/ENG-940698)**: `[VG Batch API] Batch API schema missing nvmf_client_attachment_entity field - NVMf detach operations fail with discriminator validation error`.
- **[ENG-942042](https://jira.nutanix.com/browse/ENG-942042)**: Declare NTNX-Request-Id as a required header in the spec for associate-category and disassociate-category Volume Group APIs.
- **[ENG-795267](https://jira.nutanix.com/browse/ENG-795267)**: `[multilang/volumes/VolumeGroupsApi] 'NoneType' object is not subscriptable during listIscsiClients API call in Volumes SDK`.
- **[ENG-823913](https://jira.nutanix.com/browse/ENG-823913)**: `[multilang/volumes] To triage the sdk failure`.

**Source code / SDK references**
- [ntnx-api-python-sdk-external `volume_groups_api.py`](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/volumes/ntnx_volumes_py_client/api/volume_groups_api.py)
- [ntnx-api-golang-sdk-external `list_vm_attachments_by_volume_group_id_request.go`](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/volumes-go-client/models/volumes/v4/request/volumegroups/list_vm_attachments_by_volume_group_id_request.go)
- [ntnx-api-volumes `VolumeConstants.java`](https://github.com/nutanix-core/ntnx-api-volumes/blob/main/volumes-api-utils/src/main/java/com/nutanix/volumes/utils/util/VolumeConstants.java)
- [ntnx-api-volumes `StorageRbacUtil.java`](https://github.com/nutanix-core/ntnx-api-volumes/blob/main/volumes-api-codegen/volumes-springmvc-interfaces/src/main/java/com/nutanix/prism/volumes/rbac/StorageRbacUtil.java)
- [ntnx-api-volumes `VolumeApiControllerImpl.java`](https://github.com/nutanix-core/ntnx-api-volumes/blob/main/volumes-api-controller/src/main/java/com/nutanix/volumes/controllers/VolumeApiControllerImpl.java)
- [ntnx-api-volumes `volumeConfigEndpoints.yaml`](https://github.com/nutanix-core/ntnx-api-volumes/blob/main/volumes-api-definitions/defs/namespaces/volumes/versioned/v4/modules/config/released/api/volumeConfigEndpoints.yaml)
- [k8s-csi-utils `volume_group.go`](https://github.com/nutanix-core/k8s-csi-utils/blob/master/pkg/v4/utils/volume_group.go)
- [swagger volumes v4.2 all](https://github.com/nutanix-core/qa-initiatives-cz/blob/main/open_api_spec/swagger_volumes_v4_2_all.yaml)
- [swagger-volumes-v4.r0.b2-all-documentation.yaml](https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/api_artifacts/volumes/v4.r0.b2/volumes-api-definitions-<PHONE_1>-RELEASE/swagger-volumes-v4.r0.b2-all-documentation.yaml)
- [envoy-hackathon `volumes_v4_r0_b1_proto.proto`](https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/generated_protos/volumes/v4/r0/b1/volumes_v4_r0_b1_proto.proto)
- [VolumeGroupsApi test workflow JSON](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/v4/tests/volumes/VolumeGroupsApi.json)
- [v4_volume_group_vm_attachment_crud.json](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/api_benchmark/config/storage/volume_group/v4_volume_group_vm_attachment_crud.json)
- [test_vg_vm_attachment_list_with_odata_support.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/cdp/stargate/volume_group/odata/test_vg_vm_attachment_list_with_odata_support.py)
- [vg_attach_vm_verification.py](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/verification/vg/vg_attach_vm_verification.py)
- [volume_group_utils.py (magneto)](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/dp/dp_server/magneto/py/magneto/utils/volume_group_utils.py)
- [VolumeGroups_service_grpc.pb.go (go-cache)](https://github.com/nutanix-core/go-cache/blob/master/cdp/client/ntnx_api_volumes/proto2/volumes/v4/config/VolumeGroups_service_grpc.pb.go)
- [volumeGroupsApi.js (prism-ui)](https://github.com/nutanix-engineering/hack2025-d1949/blob/main/prism/aphrodite/web/app/react/16/src/storage/api/volumeGroupsApi.js)
- [volumeGroupsApi.test.js (prism-ui)](https://github.com/nutanix-engineering/hack2025-d1949/blob/main/prism/aphrodite/web/app/react/16/src/storage/api/volumeGroupsApi.test.js)
- [VG - vm attachment workflow: filter pcvms (PR #1904)](https://github.com/nutanix-core/prism-ui-ntnx-react-ui-app/pull/1904)
- [mock_volume_group_api.go (era)](https://github.com/nutanix-engineering/hack2026-d2871/blob/main/nutanix-era-airavata/services/cloud_task_executor/providers/nutanix/mocks/mock_volume_group_api.go)
- [endpoints_index.json](https://github.com/nutanix-engineering/hack2026-d2855/blob/main/api_reference/volumes/endpoints_index.json)

#### Required Domain Skills

To work on this feature end-to-end (module, tests, examples) you need working knowledge of:
1. Nutanix Volume Groups (VG) concept — DSF-backed block storage, external iSCSI vs Direct-Attach paths.
2. AHV hypervisor SCSI hot-plug semantics — how the disk appears to guest OS, controller assignment, index.
3. Nutanix Volumes v4.x REST API surface (`VolumeGroupsApi`) — action-style POSTs, ETag/If-Match concurrency, task-driven async responses.
4. Nutanix Prism Central authentication, RBAC model, and IAM roles required for volume-group and VM admin actions.
5. Python SDK usage (`ntnx_volumes_py_client`) — request/response models (`VmAttachment`, `ListVmAttachmentsApiResponse`), API instance construction.
6. Nutanix v4 task orchestration (`ntnx_prism_py_client` tasks) — `wait_for_completion`, `entities_affected` extraction.
7. Ansible Collection patterns — argument spec, DOCUMENTATION/EXAMPLES/RETURN docstrings, integration test targets, module_defaults fragment.
8. Kubernetes CSI provider integration with VG (only for context on where this feature is consumed).
9. OData v4 query syntax (`$filter`, `$orderby`, `$page`, `$limit`) as accepted by the list endpoint.

## Files changed

- `plugins/modules/`
  - `ntnx_vm_attachments_by_volume_group_id_v2.py` — CRUD (attach/detach)
  - `ntnx_volume_group_vm_attachment_info_v2.py` — info (get / list)
- `examples/volumes/VmAttachmentsByVolumeGroupId/`
  - `vm_attachments_by_volume_group_id_v2.yml` — end-to-end example playbook
- `tests/integration/targets/ntnx_vm_attachments_by_volume_group_id_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/vm_attachments_by_volume_group_id.yml`
- `meta/runtime.yml` — registered both new modules in the `nutanix.ncp.ntnx` action group

## Test execution

| Metric              | Value                                                                 |
|---------------------|-----------------------------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 --allow-disabled --allow-unsupported ntnx_vm_attachments_by_volume_group_id_v2 -v` |
| Total tests         | 62 tasks (`ok=58 changed=10 ignored=4`)                             |
| Passed              | 58                                                                    |
| Failed              | 0                                                                     |
| Skipped             | 0                                                                     |
| Ignored             | 4 (negative & idempotency probes guarded by `ignore_errors: true`)  |
| Duration            | ~0:00:58                                                              |
| Cluster (PC)        | 10.44.76.28:9440 (PC `PC_10.44.76.29`, PE `auto_cluster_prod_36acf9b012ca`, AOS 7.6)   |

Recap:

```text
PLAY RECAP *********************************************************************
testhost                   : ok=58   changed=10   unreachable=0    failed=0    skipped=0    rescued=0    ignored=4   
```

### Analysis

- All four `fatal:` entries in the log come from negative / idempotency probes
  (nonexistent VG lookup, missing required parameter, and a repeat-detach that
  the API correctly rejects with `legacy_error_message: "VG does not have VM
  attachment with UUID: …"`). These are guarded by `ignore_errors: true` and
  are counted in `ignored=4`, not `failed=`. The play recap therefore reports
  `failed=0`.
- The example playbook was executed end-to-end against the same live PC and
  used to backfill `sample:` blocks in each module's `RETURN` docstring, so
  the samples match real API output.
- Known API behavior: `ListVmAttachmentsByVolumeGroupId` (deprecated v4.2
  endpoint) always returns `index: null` — the SCSI index requested at attach
  time is not echoed back on the list response. The full disk address (which
  contains the SCSI index) can be observed via `ntnx_vms_info_v2`
  (`disks[*].disk_address`). The integration test asserts presence of the
  attachment record and tolerates a null index.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log (compact — long JSON payloads truncated)</summary>

```text
PLAY [testhost] ****************************************************************
TASK [Gathering Facts] *********************************************************
ok: [testhost]
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Start VmAttachmentsByVolumeGroupId tests] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Generate random suffix] ******
ok: [testhost] => {"ansible_facts": {"random_name": "QJSoNTzCAeJG"}, "changed": false}
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Set entity names] ************
ok: [testhost] => {"ansible_facts": {"vg_name": "ansible-vg-vmattach-QJSoNTzCAeJG", "vm1_name": "ansible-vm-vmattach-QJSoNTzCAeJG-1", "vm2_name": "ansible-vm-vmattach-QJSoNTzCAeJG-2"}, "changed": false}
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : List clusters and pick the first AOS cluster] ***
ok: [testhost] => {"changed": false, "error": null, "response": [{"backup_eligibility_score": 1, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDd…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify clusters listing succeeded] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Filter to AOS clusters only] ***
ok: [testhost] => {"ansible_facts": {"aos_clusters": [{"backup_eligibility_score": 1, "categories": null, "cluster_profile_ext_id": null, "config": {"authorized_public_key_list": [{"key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDds8wxvJkt0Z/…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Store target cluster ext_id] ***
ok: [testhost] => {"ansible_facts": {"target_cluster_uuid": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}, "changed": false}
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : List subnets available on this PC] ***
ok: [testhost] => {"changed": false, "error": null, "response": [{"bridge_name": null, "cluster_name": null, "cluster_name_list": null, "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "cluster_reference_list": ["0006555e-4e63-4…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify subnets listing succeeded] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Filter VLAN subnets on target cluster] ***
ok: [testhost] => {"ansible_facts": {"usable_subnets": [{"bridge_name": null, "cluster_name": null, "cluster_name_list": null, "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "cluster_reference_list": ["0006555e-4e63-4a5e-185b-…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Store target subnet ext_id] ***
ok: [testhost] => {"ansible_facts": {"target_subnet_uuid": "c9b8886d-3929-4e03-90ef-49c6d6f7e349"}, "changed": false}
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Create Volume Group for VM attachment tests] ***
changed: [testhost] => {"changed": true, "error": null, "ext_id": "a5464471-afa6-406f-4fe6-25070b063cd5", "response": {"attachment_type": "NONE", "attachments": null, "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "created_by"…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify VG creation] **********
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Store Volume Group ext_id] ***
ok: [testhost] => {"ansible_facts": {"vg_uuid": "a5464471-afa6-406f-4fe6-25070b063cd5"}, "changed": false}
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Create VM1 for attachment] ***
changed: [testhost] => {"changed": true, "error": null, "ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "response": {"apc_config": {"cpu_model": null, "is_apc_enabled": false}, "availability_zone": null, "bios_uuid": "6b50d7c2-9225-472e-7…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify VM1 creation] *********
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Store VM1 ext_id] ************
ok: [testhost] => {"ansible_facts": {"vm1_uuid": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f"}, "changed": false}
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Create VM2 for attachment] ***
changed: [testhost] => {"changed": true, "error": null, "ext_id": "d01b09ca-65cc-40d4-551d-30c11ffa2d24", "response": {"apc_config": {"cpu_model": null, "is_apc_enabled": false}, "availability_zone": null, "bios_uuid": "d01b09ca-65cc-40d4-5…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify VM2 creation] *********
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Store VM2 ext_id] ************
ok: [testhost] => {"ansible_facts": {"vm2_uuid": "d01b09ca-65cc-40d4-551d-30c11ffa2d24"}, "changed": false}
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Check_mode — attach VM1 to VG with ALL attributes] ***
ok: [testhost] => {"changed": false, "ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "response": {"ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "index": 1}, "task_ext_id": null, "volume_group_ext_id": "a5464471-afa6-406f-4fe6-25070b06…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify check_mode attach (present) did not mutate the API] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Check_mode — attach VM1 to VG with a DIFFERENT index (update transition)] ***
ok: [testhost] => {"changed": false, "ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "response": {"ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "index": 3}, "task_ext_id": null, "volume_group_ext_id": "a5464471-afa6-406f-4fe6-25070b06…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify check_mode update-style spec (different index)] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Check_mode — detach VM1 from VG] ***
ok: [testhost] => {"changed": false, "ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "msg": "VM with ext_id: 6b50d7c2-9225-472e-7db5-f88c5d8aa54f will be detached from Volume Group with ext_id: a5464471-afa6-406f-4fe6-25070b063cd5.", "res…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify check_mode detach did not mutate the API] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Attach VM1 to VG using ONLY required fields (no index)] ***
changed: [testhost] => {"changed": true, "ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-21T06:0…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify VM1 attach succeeded] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Attach VM2 to VG with ALL fields (explicit SCSI index)] ***
changed: [testhost] => {"changed": true, "ext_id": "d01b09ca-65cc-40d4-551d-30c11ffa2d24", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-21T06:0…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify VM2 attach succeeded with explicit index] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : List all VM attachments on the Volume Group] ***
ok: [testhost] => {"changed": false, "response": [{"ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "index": null}, {"ext_id": "d01b09ca-65cc-40d4-551d-30c11ffa2d24", "index": null}], "total_available_results": 2, "volume_group_ext_id": "a…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify list contains both VM attachments] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify VM2 attachment record surfaces in the list] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : List VM attachments with a limit of 1] ***
ok: [testhost] => {"changed": false, "response": [{"ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "index": null}], "total_available_results": 2, "volume_group_ext_id": "a5464471-afa6-406f-4fe6-25070b063cd5"}
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify limit truncates the response] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Fetch VM1 attachment by ext_id] ***
ok: [testhost] => {"changed": false, "ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "response": {"ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "index": null}, "total_available_results": 2, "volume_group_ext_id": "a5464471-afa6-406f-4…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify single VM attachment fetched] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Fetch a non-existent VM attachment on this VG] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": "00000000-0000-0000-0000-000000000000", "msg": "VmAttachment with ext_id: 00000000-0000-0000-0000-000000000000 was not found on Volume Group ext_id: a5464471-afa6-406f-4fe6-25070b06…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify not-found error is descriptive] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Attempt to attach VM1 to a non-existent Volume Group] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching Volume group info using ext_id", "response": {"$objectType": "volumes.v4.config.GetVolumeGroupApiResponse", "$reserved": {"$f…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify attach against invalid VG failed] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Attempt to attach without volume_group_ext_id (should fail spec validation)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: volume_group_ext_id"}
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify Ansible argument-spec rejected the missing required param] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Detach VM1 from VG] **********
changed: [testhost] => {"changed": true, "ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-21T06:0…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify VM1 detach succeeded] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Detach VM2 from VG] **********
changed: [testhost] => {"changed": true, "ext_id": "d01b09ca-65cc-40d4-551d-30c11ffa2d24", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-21T06:0…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify VM2 detach succeeded] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Detach VM1 a second time (already detached — expect API error, tolerated)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-21T06:06:55.396558+00:00", …(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify repeat detach did not silently succeed] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : List VM attachments after detach — expect empty] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0, "volume_group_ext_id": "a5464471-afa6-406f-4fe6-25070b063cd5"}
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify listing shows no VM attachments after detach] ***
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Delete VM1] ******************
changed: [testhost] => {"changed": true, "error": null, "ext_id": "6b50d7c2-9225-472e-7db5-f88c5d8aa54f", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify VM1 deletion] *********
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Delete VM2] ******************
changed: [testhost] => {"changed": true, "error": null, "ext_id": "d01b09ca-65cc-40d4-551d-30c11ffa2d24", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify VM2 deletion] *********
ok: [testhost] => {
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Delete Volume Group] *********
changed: [testhost] => {"changed": true, "error": null, "ext_id": "a5464471-afa6-406f-4fe6-25070b063cd5", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "…(truncated)
TASK [ntnx_vm_attachments_by_volume_group_id_v2 : Verify Volume Group deletion] ***
ok: [testhost] => {
PLAY RECAP *********************************************************************
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Reference modules used as templates: `ntnx_virtual_switch_v2`,
  `ntnx_virtual_switches_info_v2`.
- Formatting/linting: `black`, `isort`, `flake8`, `ansible-lint`,
  `ansible-test sanity` (all green).
- Integration + example runs executed against a live Prism Central instance;
  `RETURN` samples backfilled from live task/list payloads.
