### PR TITLE
code-gen(networking/RouteForBgpSession): ansible collection modules

### DIFF
--- a/examples/networking/RouteForBgpSession/examples_run.log
+++ b/examples/networking/RouteForBgpSession/examples_run.log
@@ -1,0 +1,31 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [RouteForBgpSession playbook] *********************************************
+
+TASK [Set BGP session ext_id] **************************************************
+ok: [localhost] => {"ansible_facts": {"bgp_session_ext_id": "0005c73f-8fdb-4c86-83a3-a97e7a5e8ff2"}, "changed": false}
+
+TASK [List all BGP routes for the specified BGP session] ***********************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching BGP routes info", "response": {"$objectType": "networking.v4.config.GetBgpRouteApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to list BGP routes as a referenced resource was not found - Application error kNotFound raised: BGP session not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.4/config/bgp-sessions/0005c73f-8fdb-4c86-83a3-a97e7a5e8ff2/bgp-routes", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [Set BGP route ext_id from list result (if any)] **************************
+ok: [localhost] => {"ansible_facts": {"bgp_route_ext_id": ""}, "changed": false}
+
+TASK [Fetch a specific BGP route by external ID] *******************************
+skipping: [localhost] => {"changed": false, "false_condition": "bgp_route_ext_id | length > 0", "skip_reason": "Conditional result was False"}
+
+TASK [List BGP routes filtered by bgpRouteType == ADVERTISED] ******************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching BGP routes info", "response": {"$objectType": "networking.v4.config.GetBgpRouteApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to list BGP routes as a referenced resource was not found - Application error kNotFound raised: BGP session not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.4/config/bgp-sessions/0005c73f-8fdb-4c86-83a3-a97e7a5e8ff2/bgp-routes", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [List first BGP route for the specified BGP session (limit)] **************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching BGP routes info", "response": {"$objectType": "networking.v4.config.GetBgpRouteApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to list BGP routes as a referenced resource was not found - Application error kNotFound raised: BGP session not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.4/config/bgp-sessions/0005c73f-8fdb-4c86-83a3-a97e7a5e8ff2/bgp-routes", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=5    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=3   
+

--- a/examples/networking/RouteForBgpSession/route_for_bgp_sessions_v2.yml
+++ b/examples/networking/RouteForBgpSession/route_for_bgp_sessions_v2.yml
@@ -1,0 +1,72 @@
+---
+# Summary:
+# This playbook will do:
+# 1. List all BGP routes for the specified BGP session.
+# 2. Fetch a specific BGP route by external ID.
+# 3. List BGP routes filtered by bgpRouteType.
+# 4. List BGP routes with pagination (limit).
+#
+# Notes:
+#   - RouteForBgpSession is a read-only entity in the Nutanix Networking v4 API:
+#     the SDK exposes only GetRouteForBgpSessionById and ListRoutesByBgpSessionId.
+#     BGP routes are learned/advertised dynamically by the BGP session — they
+#     are NOT created, updated, or deleted through the API.
+#   - Prerequisites on the cluster:
+#       * A Transit VPC / Flow Gateway is deployed.
+#       * At least one BGP session is configured and established.
+#     Supply the ext_id of the BGP session via the `bgp_session_ext_id`
+#     variable (either through --extra-vars, an inventory var, or by editing
+#     the set_fact task below).
+
+- name: RouteForBgpSession playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip | default('10.44.76.28') }}"
+      nutanix_username: "{{ username | default('admin') }}"
+      nutanix_password: "{{ password | default('Nutanix.123') }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+  tasks:
+    - name: Set BGP session ext_id
+      ansible.builtin.set_fact:
+        bgp_session_ext_id: "{{ bgp_session_ext_id | default('0005c73f-8fdb-4c86-83a3-a97e7a5e8ff2') }}"
+
+    - name: List all BGP routes for the specified BGP session
+      nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+        bgp_session_ext_id: "{{ bgp_session_ext_id }}"
+      register: bgp_routes_list_result
+      ignore_errors: true
+
+    - name: Set BGP route ext_id from list result (if any)
+      ansible.builtin.set_fact:
+        bgp_route_ext_id: "{{ (bgp_routes_list_result.response[0].ext_id) | default('') }}"
+      when:
+        - bgp_routes_list_result is defined
+        - bgp_routes_list_result.response is defined
+        - bgp_routes_list_result.response is not none
+        - (bgp_routes_list_result.response | length) > 0
+
+    - name: Fetch a specific BGP route by external ID
+      nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+        bgp_session_ext_id: "{{ bgp_session_ext_id }}"
+        ext_id: "{{ bgp_route_ext_id }}"
+      register: bgp_route_by_ext_id_result
+      ignore_errors: true
+      when:
+        - bgp_route_ext_id is defined
+        - bgp_route_ext_id | length > 0
+
+    - name: List BGP routes filtered by bgpRouteType == ADVERTISED
+      nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+        bgp_session_ext_id: "{{ bgp_session_ext_id }}"
+        filter: "bgpRouteType eq Networking.Config.BgpRouteType'ADVERTISED'"
+      register: bgp_routes_filtered_result
+      ignore_errors: true
+
+    - name: List first BGP route for the specified BGP session (limit)
+      nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+        bgp_session_ext_id: "{{ bgp_session_ext_id }}"
+        limit: 1
+      register: bgp_routes_limited_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -142,6 +142,7 @@ action_groups:
     - ntnx_routes_v2
     - ntnx_routes_info_v2
     - ntnx_route_tables_info_v2
+    - ntnx_route_for_bgp_sessions_info_v2
     - ntnx_categories_v2
     - ntnx_categories_info_v2
     - ntnx_volume_groups_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_bgp_routes_api_instance(module):
+    """
+    This method will return BgpRoutesApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): BGP Routes Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.BgpRoutesApi(api_client=api_client)

--- a/plugins/modules/ntnx_route_for_bgp_sessions_info_v2.py
+++ b/plugins/modules/ntnx_route_for_bgp_sessions_info_v2.py
@@ -1,0 +1,262 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_route_for_bgp_sessions_info_v2
+short_description: Fetch BGP routes for a BGP session in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about RouteForBgpSession in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific RouteForBgpSession for the given BGP session.
+  - If C(ext_id) is not provided, list multiple RouteForBgpSession optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Get the specified route of the specified BGP session) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin, VPC Admin
+    - >-
+      B(List routes of the specified BGP session) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID of the BGP route.
+      - When provided together with C(bgp_session_ext_id), fetch a single route by ID.
+    type: str
+  bgp_session_ext_id:
+    description:
+      - The external ID of the BGP session that owns the BGP routes.
+      - Required to list routes for a BGP session or to fetch a single BGP route by ID.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: List all BGP routes for the specified BGP session
+  nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+    bgp_session_ext_id: "0005c73f-8fdb-4c86-83a3-a97e7a5e8ff2"
+  register: result
+  ignore_errors: true
+
+- name: Fetch a specific BGP route by ext_id
+  nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+    bgp_session_ext_id: "0005c73f-8fdb-4c86-83a3-a97e7a5e8ff2"
+    ext_id: "8b2bf3d0-6c5f-42d2-8b0a-9f2fbc7a2b17"
+  register: result
+  ignore_errors: true
+
+- name: List BGP routes advertised by the specified BGP session
+  nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+    bgp_session_ext_id: "0005c73f-8fdb-4c86-83a3-a97e7a5e8ff2"
+    filter: "bgpRouteType eq Networking.Config.BgpRouteType'ADVERTISED'"
+  register: result
+  ignore_errors: true
+
+- name: List first BGP route for the specified BGP session
+  nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+    bgp_session_ext_id: "0005c73f-8fdb-4c86-83a3-a97e7a5e8ff2"
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC RouteForBgpSession info v4 API.
+    - It can be a single RouteForBgpSession if external ID is provided.
+    - List of multiple RouteForBgpSession if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "bgp_communities": null,
+      "bgp_route_type": "ADVERTISED",
+      "bgp_session_reference": "0005c73f-8fdb-4c86-83a3-a97e7a5e8ff2",
+      "description": null,
+      "destination": {
+        "ipv4": {
+          "prefix_length": 24,
+          "value": "10.0.0.0"
+        },
+        "ipv6": null
+      },
+      "ext_id": "8b2bf3d0-6c5f-42d2-8b0a-9f2fbc7a2b17",
+      "links": null,
+      "metadata": null,
+      "name": null,
+      "nexthop": {
+        "nexthop_ip_address": {
+          "ipv4": {
+            "prefix_length": 32,
+            "value": "10.44.0.1"
+          },
+          "ipv6": null
+        },
+        "nexthop_name": null,
+        "nexthop_reference": null,
+        "nexthop_type": null
+      },
+      "nexthops": null,
+      "project_ext_id": null,
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the BGP route (only returned when a single BGP route is fetched by ext_id).
+  type: str
+  returned: when external ID is provided
+  sample: "8b2bf3d0-6c5f-42d2-8b0a-9f2fbc7a2b17"
+
+bgp_session_ext_id:
+  description: External ID of the BGP session used to scope the request.
+  type: str
+  returned: always
+  sample: "0005c73f-8fdb-4c86-83a3-a97e7a5e8ff2"
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching BGP route info"
+
+error:
+  description: This field typically holds information about the error that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+total_available_results:
+  description: The total number of available BGP routes in the BGP session.
+  type: int
+  returned: when all BGP routes are fetched
+  sample: 8
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_bgp_routes_api_instance,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        bgp_session_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_bgp_route_by_ext_id(module, bgp_routes_api, result):
+    ext_id = module.params.get("ext_id")
+    bgp_session_ext_id = module.params.get("bgp_session_ext_id")
+    result["ext_id"] = ext_id
+    result["bgp_session_ext_id"] = bgp_session_ext_id
+    try:
+        resp = bgp_routes_api.get_route_for_bgp_session_by_id(
+            extId=ext_id, bgpSessionExtId=bgp_session_ext_id
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching BGP route info",
+        )
+
+    result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+
+
+def list_bgp_routes(module, bgp_routes_api, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    bgp_session_ext_id = module.params.get("bgp_session_ext_id")
+    result["bgp_session_ext_id"] = bgp_session_ext_id
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating BGP routes info spec", **result)
+
+    try:
+        resp = bgp_routes_api.list_routes_by_bgp_session_id(
+            bgpSessionExtId=bgp_session_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching BGP routes info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    bgp_routes_api = get_bgp_routes_api_instance(module)
+    if module.params.get("ext_id"):
+        get_bgp_route_by_ext_id(module, bgp_routes_api, result)
+    else:
+        list_bgp_routes(module, bgp_routes_api, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_route_for_bgp_sessions_v2/aliases
+++ b/tests/integration/targets/ntnx_route_for_bgp_sessions_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_route_for_bgp_sessions_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_route_for_bgp_sessions_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_route_for_bgp_sessions_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_route_for_bgp_sessions_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import route_for_bgp_sessions.yml
+      ansible.builtin.import_tasks: "route_for_bgp_sessions.yml"

--- a/tests/integration/targets/ntnx_route_for_bgp_sessions_v2/tasks/route_for_bgp_sessions.yml
+++ b/tests/integration/targets/ntnx_route_for_bgp_sessions_v2/tasks/route_for_bgp_sessions.yml
@@ -1,0 +1,215 @@
+---
+############################################################################
+# RouteForBgpSession integration tests
+#
+# Test plan:
+#   The RouteForBgpSession API is READ-ONLY (GetRouteForBgpSessionById and
+#   ListRoutesByBgpSessionId only). BGP routes are learned/advertised
+#   dynamically by the BGP session — they cannot be created, updated, or
+#   deleted through the API. So the tests focus on:
+#
+#     1. Missing required parameter (bgp_session_ext_id) is rejected.
+#     2. Fetching by ext_id without bgp_session_ext_id is rejected.
+#     3. Listing with an invalid / non-existent bgp_session_ext_id returns
+#        a proper API error.
+#     4. Fetching a single route with an invalid ext_id returns a proper
+#        API error.
+#     5. If a real BGP session exists on the cluster:
+#         a. List all BGP routes for that session.
+#         b. Fetch the first route by ext_id and assert equality with the
+#            corresponding entry from the list.
+#         c. List routes filtered by bgpRouteType == ADVERTISED and assert
+#            every returned route has that type.
+#         d. List with limit=1 and assert only 1 route is returned.
+#         e. Mutually-exclusive check: passing both ext_id and filter must
+#            fail.
+############################################################################
+
+- name: Start RouteForBgpSession tests
+  ansible.builtin.debug:
+    msg: Start RouteForBgpSession tests
+
+############################################################################
+# Negative tests — argument spec validation and API errors
+############################################################################
+
+- name: List BGP routes without required bgp_session_ext_id
+  nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2: {}
+  register: result
+  ignore_errors: true
+
+- name: List BGP routes without required bgp_session_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'bgp_session_ext_id' in result.msg"
+    success_msg: "List BGP routes without required bgp_session_ext_id failed as expected"
+    fail_msg: "List BGP routes without required bgp_session_ext_id did not fail as expected"
+
+- name: List BGP routes with a non-existent bgp_session_ext_id
+  nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+    bgp_session_ext_id: "00000000-0000-0000-0000-000000000001"
+  register: result
+  ignore_errors: true
+
+- name: List BGP routes with a non-existent bgp_session_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg is defined
+      - "'Api Exception raised while fetching BGP routes info' in result.msg"
+    success_msg: "List BGP routes with a non-existent bgp_session_ext_id failed as expected"
+    fail_msg: "List BGP routes with a non-existent bgp_session_ext_id did not fail as expected"
+
+- name: Get BGP route with non-existent ext_id
+  nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+    bgp_session_ext_id: "00000000-0000-0000-0000-000000000001"
+    ext_id: "00000000-0000-0000-0000-000000000002"
+  register: result
+  ignore_errors: true
+
+- name: Get BGP route with non-existent ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg is defined
+      - "'Api Exception raised while fetching BGP route info' in result.msg"
+    success_msg: "Get BGP route with non-existent ext_id failed as expected"
+    fail_msg: "Get BGP route with non-existent ext_id did not fail as expected"
+
+- name: Get BGP route with both ext_id and filter (mutually exclusive)
+  nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+    bgp_session_ext_id: "00000000-0000-0000-0000-000000000001"
+    ext_id: "00000000-0000-0000-0000-000000000002"
+    filter: "bgpRouteType eq Networking.Config.BgpRouteType'ADVERTISED'"
+  register: result
+  ignore_errors: true
+
+- name: Get BGP route with both ext_id and filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'mutually exclusive' in result.msg"
+    success_msg: "ext_id + filter mutually exclusive validation works as expected"
+    fail_msg: "ext_id + filter mutually exclusive validation did not fail as expected"
+
+############################################################################
+# Live-cluster tests — only run when a real BGP session exists
+############################################################################
+
+- name: Set discovery variables
+  ansible.builtin.set_fact:
+    live_bgp_session_ext_id: "{{ bgp_session_ext_id | default('') }}"
+
+- name: Live-cluster BGP route tests (only when a real BGP session ext_id is supplied)
+  when: live_bgp_session_ext_id | length > 0
+  block:
+    - name: List all BGP routes for the specified BGP session
+      nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+        bgp_session_ext_id: "{{ live_bgp_session_ext_id }}"
+      register: list_result
+      ignore_errors: true
+
+    - name: List all BGP routes for the specified BGP session status
+      ansible.builtin.assert:
+        that:
+          - list_result is defined
+          - list_result.changed == false
+          - list_result.failed == false
+          - list_result.response is defined
+          - list_result.bgp_session_ext_id == live_bgp_session_ext_id
+        success_msg: "List all BGP routes for the specified BGP session passed"
+        fail_msg: "List all BGP routes for the specified BGP session failed"
+
+    - name: Assert that every listed route has expected shape
+      ansible.builtin.assert:
+        that:
+          - item.ext_id is defined
+          - item.bgp_session_reference == live_bgp_session_ext_id
+        success_msg: "Route {{ item.ext_id }} has expected shape"
+        fail_msg: "Route {{ item.ext_id | default('<no ext_id>') }} missing bgp_session_reference or ext_id"
+      loop: "{{ list_result.response }}"
+      when: list_result.response | length > 0
+
+    - name: Fetch first BGP route by ext_id (only when the list is non-empty)
+      when: list_result.response | length > 0
+      block:
+        - name: Fetch first BGP route by ext_id
+          nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+            bgp_session_ext_id: "{{ live_bgp_session_ext_id }}"
+            ext_id: "{{ list_result.response[0].ext_id }}"
+          register: get_by_id_result
+          ignore_errors: true
+
+        - name: Fetch first BGP route by ext_id status
+          ansible.builtin.assert:
+            that:
+              - get_by_id_result is defined
+              - get_by_id_result.changed == false
+              - get_by_id_result.failed == false
+              - get_by_id_result.response is defined
+              - get_by_id_result.response.ext_id == list_result.response[0].ext_id
+              - get_by_id_result.response.bgp_session_reference == live_bgp_session_ext_id
+              - get_by_id_result.ext_id == list_result.response[0].ext_id
+              - get_by_id_result.bgp_session_ext_id == live_bgp_session_ext_id
+            success_msg: "Fetch first BGP route by ext_id passed"
+            fail_msg: "Fetch first BGP route by ext_id failed"
+
+    - name: List BGP routes with limit
+      nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+        bgp_session_ext_id: "{{ live_bgp_session_ext_id }}"
+        limit: 1
+      register: limited_result
+      ignore_errors: true
+
+    - name: List BGP routes with limit status
+      ansible.builtin.assert:
+        that:
+          - limited_result is defined
+          - limited_result.changed == false
+          - limited_result.failed == false
+          - (limited_result.response | default([])) | length <= 1
+        success_msg: "List BGP routes with limit passed"
+        fail_msg: "List BGP routes with limit failed"
+
+    - name: List BGP routes filtered by bgpRouteType == ADVERTISED
+      nutanix.ncp.ntnx_route_for_bgp_sessions_info_v2:
+        bgp_session_ext_id: "{{ live_bgp_session_ext_id }}"
+        filter: "bgpRouteType eq Networking.Config.BgpRouteType'ADVERTISED'"
+      register: filtered_result
+      ignore_errors: true
+
+    - name: List BGP routes filtered by bgpRouteType == ADVERTISED status
+      ansible.builtin.assert:
+        that:
+          - filtered_result is defined
+          - filtered_result.changed == false
+          - filtered_result.failed == false
+          - filtered_result.response is defined
+        success_msg: "List BGP routes filtered by bgpRouteType == ADVERTISED passed"
+        fail_msg: "List BGP routes filtered by bgpRouteType == ADVERTISED failed"
+
+    - name: Assert every filtered route has bgp_route_type == ADVERTISED
+      ansible.builtin.assert:
+        that:
+          - item.bgp_route_type == 'ADVERTISED'
+        success_msg: "Route {{ item.ext_id }} filtered correctly"
+        fail_msg: "Route {{ item.ext_id }} was returned by the ADVERTISED filter but bgp_route_type={{ item.bgp_route_type }}"
+      loop: "{{ filtered_result.response }}"
+      when: (filtered_result.response | default([])) | length > 0
+
+- name: Live-cluster BGP route tests skipped (no bgp_session_ext_id supplied)
+  ansible.builtin.debug:
+    msg: >-
+      Live-cluster BGP route tests were skipped because no bgp_session_ext_id
+      was supplied via extra-vars or inventory. Only negative / spec-validation
+      tests were executed.
+  when: live_bgp_session_ext_id | length == 0


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**RouteForBgpSession**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_route_for_bgp_sessions_info_v2`
- API methods covered: `2` (`GetRouteForBgpSessionById`, `ListRoutesByBgpSessionId`)
- Fields in CRUD module spec: `n/a` — see note below
- Fields in info module spec: `2` (`ext_id`, `bgp_session_ext_id`) + shared info args
  (`filter`, `page`, `limit`, `orderby`, `select`)

### Note on the missing CRUD (Module 1) generation

The RouteForBgpSession entity is **read-only** in the Nutanix Networking v4 API.
The SDK (`ntnx_networking_py_client.BgpRoutesApi`) exposes ONLY two methods:

| Method | HTTP | URI |
|---|---|---|
| `get_route_for_bgp_session_by_id` | `GET` | `/api/networking/v4.3/config/bgp-sessions/{bgpSessionExtId}/bgp-routes/{extId}` |
| `list_routes_by_bgp_session_id`   | `GET` | `/api/networking/v4.3/config/bgp-sessions/{bgpSessionExtId}/bgp-routes` |

There are **no** `Create*`, `Update*`, or `Delete*` APIs for BGP routes: routes are
learned or advertised dynamically by an established BGP session (types
`ADVERTISED`, `RECEIVED`, `RECEIVED_AND_IGNORED`) and are not user-manageable
resources. Generating an `ntnx_route_for_bgp_session_v2` CRUD module would
therefore have no corresponding SDK calls to invoke. The instructions in
Step 1.2 ("First check if the operation is action or CRUD type. If it is CRUD
type then follow the CRUD type module patterns. If it is action type then
follow the action type module patterns.") explicitly gate the generation of
Module 1 on the entity's operation type; since this entity is neither CRUD nor
action, only the info module (Step 2) is produced. This mirrors the pattern
already established in the collection for other read-only network entities
(e.g. `ntnx_route_tables_info_v2` exists but there is no
`ntnx_route_tables_v2` CRUD counterpart).

## Domain knowledge (from Glean)

**Question asked (verbatim):**

> What is RouteForBgpSession in Nutanix networking v4 API? Explain BGP routes for a BGP session, their types (advertised, received), prerequisites, and how they are used.

**Answer (verbatim, with references):**

In the Nutanix Networking v4 API, **`RouteForBgpSession`** refers to the API endpoints and data models used to query and manage BGP routes associated with a specific BGP session. It provides read-only visibility into the routing information that is being exchanged between a Nutanix Flow Gateway and an external BGP peer.

Here is a detailed explanation of BGP routes for a BGP session, their types, prerequisites, and use cases:

### BGP Routes for a BGP Session
A **`BgpRoute`** represents a single routing prefix (and its attributes) that is either sent to or learned from an external BGP router over an established BGP session.
These routes govern how north-south traffic flows between your Nutanix VPCs and the external datacenter or cloud network. A BGP route entity typically contains:
* **Destination**: The IP subnet/prefix being routed.
* **Nexthop**: The next-hop IP address or connection name to reach the destination.
* **BGP Communities**: Tags attached to the route for traffic engineering and filtering.
* **BGP Session Reference**: The UUID of the BGP session facilitating this route.

### Route Types
The `BgpRouteType` specifies the direction and status of the route relative to the Nutanix environment. There are three primary types:
* **`ADVERTISED`**: A route that the Nutanix local BGP gateway is actively advertising to the remote external BGP peer. These are typically the Externally Routable Prefixes (ERPs) of your tenant VPCs.
* **`RECEIVED`**: A route that was learned from the remote BGP peer and has been successfully accepted and programmed into the local route table.
* **`RECEIVED_AND_IGNORED`**: A route that was received from the external peer but was discarded or not programmed into the route table. This usually happens when the route fails to pass internal BGP filters, or if the next-hop IP does not match the expected constraints (e.g., in no-NAT direct routing topologies).

### Prerequisites
To retrieve or view BGP routes via the v4 API, the following prerequisites must be met:
1. **API Requirement**: You must know the `bgpSessionExtId` (the UUID of the BGP session) to query its routes using the `/api/networking/v4.x/config/bgp-sessions/{bgpSessionExtId}/bgp-routes` endpoints.
2. **Infrastructure Requirements**:
   * A **Transit VPC** must be configured to act as the central routing hub.
   * **Flow Gateways (BGP Gateways)** must be deployed and healthy.
   * A **BGP Session** must be successfully established and peered with an external router.

### How They Are Used
* **Troubleshooting and Verification**: Network administrators query these routes to confirm that the expected tenant subnets are actually being advertised (`ADVERTISED`) to the upstream datacenter router. If a subnet is unreachable, checking the BGP routes helps determine if the prefix was never advertised or if the return route was `RECEIVED_AND_IGNORED`.
* **Programmatic Monitoring**: Using the `list_routes_by_bgp_session_id` API, automation scripts can filter and monitor routes. For example, filtering by `$filter=bgpRouteType eq 'RECEIVED'` helps audit what external networks the Nutanix environment currently knows how to reach.
* **Scale-Out Routing**: In scale-out gateway deployments, checking BGP routes allows admins to verify Equal-Cost Multi-Path (ECMP) routing and ensure that traffic is correctly distributed across multiple gateways via the External Routing Domain (ERD).

**Required domain skills to work end-to-end on this feature:**

- Nutanix Flow Virtual Networking (FVN) architecture: Transit VPC, tenant VPCs, ANC (Advanced Networking Controller), Flow Gateway / BGP Gateway topology.
- BGP protocol fundamentals: peering, AS numbers, communities, advertised vs. learned routes, ECMP, route filtering.
- OData query semantics for the v4 REST API (`$filter`, `$page`, `$limit`, `$orderby`), enum-typed filter values (e.g. `bgpRouteType eq Networking.Config.BgpRouteType'ADVERTISED'`).
- Nutanix SDK (`ntnx_networking_py_client`) usage: `BgpSessionsApi`, `BgpRoutesApi`, `Configuration`, and Basic-auth wiring.
- Ansible module conventions in this collection (`plugins/module_utils/v4/`, `BaseInfoModule`, `SpecGenerator`, `strip_internal_attributes`, `raise_api_exception`).

## Files changed

- `plugins/modules/`
  - `ntnx_route_for_bgp_sessions_info_v2.py` (new — the info module)
- `plugins/module_utils/v4/network/`
  - `api_client.py` (added `get_bgp_routes_api_instance`)
- `meta/`
  - `runtime.yml` (added `ntnx_route_for_bgp_sessions_info_v2` to the
    `ntnx` action group so `module_defaults: group/nutanix.ncp.ntnx:` applies)
- `examples/networking/RouteForBgpSession/`
  - `route_for_bgp_sessions_v2.yml` (new — example playbook)
  - `examples_run.log` (new — captured live run output)
- `tests/integration/targets/ntnx_route_for_bgp_sessions_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/route_for_bgp_sessions.yml`

## Test execution

| Metric              | Value                                                                                          |
|---------------------|------------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-disabled ntnx_route_for_bgp_sessions_v2 -v`                  |
| Total tests         | `26` playbook tasks (assertions + module invocations)                                          |
| Passed (ok)         | `12`                                                                                           |
| Failed (hard)       | `0`                                                                                            |
| Skipped             | `10` (live-cluster BGP-route tests gated on the presence of a real BGP session — see below)    |
| Ignored             | `4` (deliberate module-level errors captured under `ignore_errors: true` and then asserted on) |
| Duration            | `~10s`                                                                                         |
| Cluster (PC)        | `10.44.76.28` (Prism Central v4.4 / PC 7.6)                                                    |

### Analysis

The cluster at `10.44.76.28` does **not** currently have any BGP sessions
configured — the direct v4 API call to `GET
/api/networking/v4.3/config/bgp-sessions` returns
`metadata.totalAvailableResults == 0`. Because RouteForBgpSession routes only
exist as children of a live BGP session, the live-cluster happy-path
assertions (list all routes, fetch by ext_id, filter by
`bgpRouteType == ADVERTISED`, limit) are conditional on a real
`bgp_session_ext_id` being supplied via `--extra-vars`. In this run they were
correctly skipped with a debug message explaining the reason. All negative /
argument-spec / API-error tests ran and passed on the live cluster:

- `List BGP routes without required bgp_session_ext_id` → module reports
  `missing required arguments: bgp_session_ext_id` (asserted).
- `List BGP routes with a non-existent bgp_session_ext_id` → API returns HTTP
  `404` with `code == "NETWORKING-10060"` ("BGP session not found"), which the
  module wraps in `Api Exception raised while fetching BGP routes info`
  (asserted).
- `Get BGP route with non-existent ext_id` → HTTP `404`; module wraps as
  `Api Exception raised while fetching BGP route info` (asserted).
- `Get BGP route with both ext_id and filter` → module rejects with
  `parameters are mutually exclusive: ext_id|filter` (asserted).

No hard failures. To also cover the happy-path assertions, re-run with
`--extra-vars bgp_session_ext_id=<real-uuid>` on a cluster where a Flow
Gateway BGP session is established.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: C.UTF-8
WARNING: Using locale "C.UTF-8" instead of "en_US.UTF-8". Tests which depend on the locale may behave unexpectedly.
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_route_for_bgp_sessions_v2
Detected architecture x86_64 for Python interpreter: /home/george2/.local/bin/python3
Creating container database.
Run command: /home/george2/.local/bin/python3 /home/george2/.local/lib/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_route_for_bgp_sessions_v2 integration test role
Initializing "/tmp/ansible-test-vqrhe_f7-injector" as the temporary injector directory.
Injecting "/tmp/python-fw30lum2-ansible/python" as a execv wrapper for the "/home/george2/.local/bin/python3" interpreter.
Stream command: ansible-playbook ntnx_route_for_bgp_sessions_v2-q17ng5k2.yml -i inventory -v
Using /tmp/ac/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_route_for_bgp_sessions_v2-nztdctsq-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_route_for_bgp_sessions_v2 : Start RouteForBgpSession tests] *********
ok: [testhost] => {
    "msg": "Start RouteForBgpSession tests"
}

TASK [ntnx_route_for_bgp_sessions_v2 : List BGP routes without required bgp_session_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: bgp_session_ext_id"}
...ignoring

TASK [ntnx_route_for_bgp_sessions_v2 : List BGP routes without required bgp_session_ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List BGP routes without required bgp_session_ext_id failed as expected"
}

TASK [ntnx_route_for_bgp_sessions_v2 : List BGP routes with a non-existent bgp_session_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching BGP routes info", "response": {"$objectType": "networking.v4.config.GetBgpRouteApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to list BGP routes as a referenced resource was not found - Application error kNotFound raised: BGP session not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.4/config/bgp-sessions/00000000-0000-0000-0000-000000000001/bgp-routes", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [ntnx_route_for_bgp_sessions_v2 : List BGP routes with a non-existent bgp_session_ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List BGP routes with a non-existent bgp_session_ext_id failed as expected"
}

TASK [ntnx_route_for_bgp_sessions_v2 : Get BGP route with non-existent ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching BGP route info", "response": {"$objectType": "networking.v4.config.GetBgpRouteApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get BGP route 00000000-0000-0000-0000-000000000002 as a referenced resource was not found - Application error kNotFound raised: BGP session not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.4/config/bgp-sessions/00000000-0000-0000-0000-000000000001/bgp-routes/00000000-0000-0000-0000-000000000002", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [ntnx_route_for_bgp_sessions_v2 : Get BGP route with non-existent ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Get BGP route with non-existent ext_id failed as expected"
}

TASK [ntnx_route_for_bgp_sessions_v2 : Get BGP route with both ext_id and filter (mutually exclusive)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_route_for_bgp_sessions_v2 : Get BGP route with both ext_id and filter status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "ext_id + filter mutually exclusive validation works as expected"
}

TASK [ntnx_route_for_bgp_sessions_v2 : Set discovery variables] ****************
ok: [testhost] => {"ansible_facts": {"live_bgp_session_ext_id": ""}, "changed": false}

TASK [ntnx_route_for_bgp_sessions_v2 : List all BGP routes for the specified BGP session] ***
skipping: [testhost] => {"changed": false, "false_condition": "live_bgp_session_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_route_for_bgp_sessions_v2 : List all BGP routes for the specified BGP session status] ***
skipping: [testhost] => {"changed": false, "false_condition": "live_bgp_session_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_route_for_bgp_sessions_v2 : Assert that every listed route has expected shape] ***
skipping: [testhost] => {"changed": false, "false_condition": "live_bgp_session_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_route_for_bgp_sessions_v2 : Fetch first BGP route by ext_id] ********
skipping: [testhost] => {"changed": false, "false_condition": "live_bgp_session_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_route_for_bgp_sessions_v2 : Fetch first BGP route by ext_id status] ***
skipping: [testhost] => {"changed": false, "false_condition": "live_bgp_session_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_route_for_bgp_sessions_v2 : List BGP routes with limit] *************
skipping: [testhost] => {"changed": false, "false_condition": "live_bgp_session_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_route_for_bgp_sessions_v2 : List BGP routes with limit status] ******
skipping: [testhost] => {"changed": false, "false_condition": "live_bgp_session_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_route_for_bgp_sessions_v2 : List BGP routes filtered by bgpRouteType == ADVERTISED] ***
skipping: [testhost] => {"changed": false, "false_condition": "live_bgp_session_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_route_for_bgp_sessions_v2 : List BGP routes filtered by bgpRouteType == ADVERTISED status] ***
skipping: [testhost] => {"changed": false, "false_condition": "live_bgp_session_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_route_for_bgp_sessions_v2 : Assert every filtered route has bgp_route_type == ADVERTISED] ***
skipping: [testhost] => {"changed": false, "false_condition": "live_bgp_session_ext_id | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_route_for_bgp_sessions_v2 : Live-cluster BGP route tests skipped (no bgp_session_ext_id supplied)] ***
ok: [testhost] => {
    "msg": "Live-cluster BGP route tests were skipped because no bgp_session_ext_id was supplied via extra-vars or inventory. Only negative / spec-validation tests were executed."
}

PLAY RECAP *********************************************************************
testhost                   : ok=12   changed=0    unreachable=0    failed=0    skipped=10   rescued=0    ignored=4   

WARNING: Reviewing previous 2 warning(s):
WARNING: Using locale "C.UTF-8" instead of "en_US.UTF-8". Tests which depend on the locale may behave unexpectedly.
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_route_for_bgp_sessions_v2

```

</details>

## Examples execution

The example playbook (`examples/networking/RouteForBgpSession/route_for_bgp_sessions_v2.yml`)
was executed end-to-end against the same Prism Central. Because the cluster has
no BGP sessions, every task that calls the module surfaced the expected
`404 / BGP session not found` from the live API (rather than a mock). This
proves that the module wiring — credential resolution via `module_defaults`
(now correctly plumbed through the `ntnx` action group in `meta/runtime.yml`),
BgpRoutesApi construction, request-URI templating, and error-response parsing
— all work against the live v4 API. The full run is captured in
`examples/networking/RouteForBgpSession/examples_run.log`.

Because no real route was returned, per-task `sample:` response blocks in
`RETURN:` for the module use a realistic synthetic example (annotated in the
module docstring), consistent with the fields the SDK / API would populate.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
