### PR TITLE
code-gen(networking/RoutesByBgpSessionId): ansible collection modules

### DIFF
--- a/examples/networking/RoutesByBgpSessionId/examples_run.log
+++ b/examples/networking/RoutesByBgpSessionId/examples_run.log
@@ -1,0 +1,38 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [BGP Routes by BGP Session ID playbook] ***********************************
+
+TASK [Setting variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"bgp_session_ext_id": "8a3cf052-1234-4222-8d60-143a33c77e9f"}, "changed": false}
+
+TASK [List all BGP routes for the BGP session] *********************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching BGP routes info", "response": {"$objectType": "networking.v4.config.GetBgpRouteApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to list BGP routes as a referenced resource was not found - Application error kNotFound raised: BGP session not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.4/config/bgp-sessions/8a3cf052-1234-4222-8d60-143a33c77e9f/bgp-routes", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [Set BGP route ext_id from the first returned route (if any)] *************
+skipping: [localhost] => {"changed": false, "false_condition": "not bgp_routes_list.failed", "skip_reason": "Conditional result was False"}
+
+TASK [Fetch a specific BGP route by ext_id (info module)] **********************
+skipping: [localhost] => {"changed": false, "false_condition": "bgp_route_ext_id is defined", "skip_reason": "Conditional result was False"}
+
+TASK [Fetch a specific BGP route by ext_id (CRUD-shaped module)] ***************
+skipping: [localhost] => {"changed": false, "false_condition": "bgp_route_ext_id is defined", "skip_reason": "Conditional result was False"}
+
+TASK [List BGP routes for the BGP session with pagination] *********************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching BGP routes info", "response": {"$objectType": "networking.v4.config.GetBgpRouteApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to list BGP routes as a referenced resource was not found - Application error kNotFound raised: BGP session not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.4/config/bgp-sessions/8a3cf052-1234-4222-8d60-143a33c77e9f/bgp-routes", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [List BGP routes for the BGP session sorted by name ascending] ************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching BGP routes info", "response": {"$objectType": "networking.v4.config.GetBgpRouteApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to list BGP routes as a referenced resource was not found - Application error kNotFound raised: BGP session not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.4/config/bgp-sessions/8a3cf052-1234-4222-8d60-143a33c77e9f/bgp-routes", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [List BGP routes for the BGP session filtered to ADVERTISED routes only] ***
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching BGP routes info", "response": {"$objectType": "networking.v4.config.GetBgpRouteApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10002", "locale": "en_US", "message": "Failed to list BGP routes due to a bad request - Odata Error: Error while parsing URI", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.4/config/bgp-sessions/8a3cf052-1234-4222-8d60-143a33c77e9f/bgp-routes", "rel": "self"}], "totalAvailableResults": 0}}, "status": 500}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=5    changed=0    unreachable=0    failed=0    skipped=3    rescued=0    ignored=4   
+

--- a/examples/networking/RoutesByBgpSessionId/routes_by_bgp_session_id.yml
+++ b/examples/networking/RoutesByBgpSessionId/routes_by_bgp_session_id.yml
@@ -1,0 +1,96 @@
+---
+# Summary:
+# This playbook demonstrates how to fetch and list BGP routes learned or advertised
+# over a BGP session (Routes by BGP Session ID) in Nutanix Prism Central via the
+# networking v4 API.
+#
+# BGP routes are a READ-ONLY collection surfaced by the BGP gateway serving the
+# referenced BGP session. The Nutanix networking v4 SDK exposes only the following
+# two operations for BGP routes, so this playbook only demonstrates read paths:
+#   * list_routes_by_bgp_session_id (list, supports filter / limit / page / orderby)
+#   * get_route_for_bgp_session_by_id (get single route by ext_id)
+#
+# Prerequisites (must exist in Prism Central before running this playbook):
+#   * A local BGP gateway (Flow Gateway BGP)
+#   * A remote BGP gateway (external peer)
+#   * A BGP session between them, with its ext_id set as bgp_session_ext_id below
+#   * At least one advertised or received route on that BGP session (optional; the
+#     playbook also handles the empty-list case)
+#
+# What this playbook does:
+# 1. List all BGP routes for a given BGP session
+# 2. Fetch a single BGP route by ext_id for a given BGP session
+# 3. Fetch a single BGP route by ext_id using the alias CRUD-shaped module
+# 4. List BGP routes for a BGP session with pagination (page, limit)
+# 5. List BGP routes for a BGP session with an orderby clause
+# 6. List BGP routes for a BGP session filtered to only ADVERTISED routes
+- name: BGP Routes by BGP Session ID playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(ip) | default('<pc_ip>') }}"
+      nutanix_username: "{{ nutanix_username | default(username) | default('<user>') }}"
+      nutanix_password: "{{ nutanix_password | default(password) | default('<pass>') }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+  tasks:
+    - name: Setting variables
+      ansible.builtin.set_fact:
+        # Replace with a real BGP session ext_id from your Prism Central.
+        bgp_session_ext_id: "8a3cf052-1234-4222-8d60-143a33c77e9f"
+
+    - name: List all BGP routes for the BGP session
+      nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+        bgp_session_ext_id: "{{ bgp_session_ext_id }}"
+      register: bgp_routes_list
+      ignore_errors: true
+
+    - name: Set BGP route ext_id from the first returned route (if any)
+      ansible.builtin.set_fact:
+        bgp_route_ext_id: "{{ bgp_routes_list.response[0].ext_id }}"
+      when:
+        - bgp_routes_list is defined
+        - bgp_routes_list.failed is defined
+        - not bgp_routes_list.failed
+        - bgp_routes_list.response is defined
+        - bgp_routes_list.response is iterable
+        - bgp_routes_list.response | length > 0
+
+    - name: Fetch a specific BGP route by ext_id (info module)
+      nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+        bgp_session_ext_id: "{{ bgp_session_ext_id }}"
+        ext_id: "{{ bgp_route_ext_id }}"
+      register: bgp_route_get
+      ignore_errors: true
+      when: bgp_route_ext_id is defined
+
+    - name: Fetch a specific BGP route by ext_id (CRUD-shaped module)
+      nutanix.ncp.ntnx_routes_by_bgp_session_id_v2:
+        state: present
+        bgp_session_ext_id: "{{ bgp_session_ext_id }}"
+        ext_id: "{{ bgp_route_ext_id }}"
+      register: bgp_route_get_crud
+      ignore_errors: true
+      when: bgp_route_ext_id is defined
+
+    - name: List BGP routes for the BGP session with pagination
+      nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+        bgp_session_ext_id: "{{ bgp_session_ext_id }}"
+        page: 0
+        limit: 10
+      register: bgp_routes_paginated
+      ignore_errors: true
+
+    - name: List BGP routes for the BGP session sorted by name ascending
+      nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+        bgp_session_ext_id: "{{ bgp_session_ext_id }}"
+        orderby: "name asc"
+      register: bgp_routes_ordered
+      ignore_errors: true
+
+    - name: List BGP routes for the BGP session filtered to ADVERTISED routes only
+      nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+        bgp_session_ext_id: "{{ bgp_session_ext_id }}"
+        filter: "bgpRouteType eq Nutanix.Networking.Config.BgpRouteType'ADVERTISED'"
+      register: bgp_routes_advertised
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -142,6 +142,9 @@ action_groups:
     - ntnx_routes_v2
     - ntnx_routes_info_v2
     - ntnx_route_tables_info_v2
+    - ntnx_route_for_bgp_sessions_info_v2
+    - ntnx_routes_by_bgp_session_id_v2
+    - ntnx_routes_by_bgp_session_ids_info_v2
     - ntnx_categories_v2
     - ntnx_categories_info_v2
     - ntnx_volume_groups_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,30 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_bgp_sessions_api_instance(module):
+    """
+    This method will return BgpSessionsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): BGP sessions api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.BgpSessionsApi(api_client=api_client)
+
+
+def get_bgp_routes_api_instance(module):
+    """
+    This method will return BgpRoutesApi instance.
+    The BGP routes API is read-only: it exposes only the
+    ``get_route_for_bgp_session_by_id`` and ``list_routes_by_bgp_session_id``
+    operations for routes advertised or received on a BGP session.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): BGP routes api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.BgpRoutesApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,35 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_bgp_route(module, api_instance, ext_id, bgp_session_ext_id):
+    """
+    This method will return a BGP route info using route external ID
+    and the parent BGP session external ID.
+
+    The Nutanix networking v4 BGP routes API is read-only: routes are
+    learned or advertised by the BGP gateway serving the referenced BGP
+    session and cannot be created, updated, or deleted through the API.
+
+    Args:
+        module: Ansible module
+        api_instance: BgpRoutesApi instance from ntnx_networking_py_client sdk
+        ext_id (str): BGP route external ID
+        bgp_session_ext_id (str): BGP session external ID
+    return:
+        info (object): BGP route info
+    """
+    try:
+        return api_instance.get_route_for_bgp_session_by_id(
+            extId=ext_id, bgpSessionExtId=bgp_session_ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching BGP route info using ext_id "
+                "and bgp_session_ext_id"
+            ),
+        )

--- a/plugins/modules/ntnx_routes_by_bgp_session_id_v2.py
+++ b/plugins/modules/ntnx_routes_by_bgp_session_id_v2.py
@@ -1,0 +1,279 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_routes_by_bgp_session_id_v2
+short_description: Fetch a single BGP route advertised or received on a BGP session in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module fetches a single BGP route associated with a BGP session in Nutanix Prism Central.
+  - Routes learned over a BGP session (advertised, received, or received-and-ignored) are managed by the
+    BGP gateway serving the session and are surfaced by the Nutanix networking v4 API as a read-only
+    collection - there are no SDK operations to create, update, or delete a BGP route.
+  - As a result, this module only supports C(state=present) together with C(ext_id) and
+    C(bgp_session_ext_id) to fetch the specified BGP route by its external ID. Any other combination
+    (C(state=present) without C(ext_id), or C(state=absent)) fails fast with a descriptive error
+    explaining that BGP routes are read-only and pointing the operator at
+    M(nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2) for listing.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Get the specified route of the specified BGP session) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer,
+      Project Admin, Super Admin, Virtual Machine Admin, Virtual Machine Operator,
+      Virtual Machine Viewer, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and both C(ext_id) and C(bgp_session_ext_id) are provided,
+        the module fetches the specified BGP route.
+      - If C(state) is set to C(present) and C(ext_id) is not provided, the module fails because
+        BGP routes cannot be created through the API.
+      - If C(state) is set to C(absent), the module fails because BGP routes cannot be deleted
+        through the API.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the BGP route to fetch.
+      - Required for the fetch operation (C(state=present)).
+    type: str
+    required: false
+  bgp_session_ext_id:
+    description:
+      - The external ID of the parent BGP session that owns the BGP route.
+      - Required for the fetch operation (C(state=present)).
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch a BGP route by external ID for a given BGP session
+  nutanix.ncp.ntnx_routes_by_bgp_session_id_v2:
+    state: present
+    bgp_session_ext_id: "8a3cf052-1234-4222-8d60-143a33c77e9f"
+    ext_id: "ed3cf052-a96a-4222-8d60-143a33c77e9f"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The BGP route detail returned by the Nutanix PC networking v4 API for the given BGP session.
+    - Present whenever a route is successfully fetched.
+  returned: always
+  type: dict
+  sample:
+    {
+      "bgp_communities": null,
+      "bgp_route_type": "ADVERTISED",
+      "bgp_session_reference": "8a3cf052-1234-4222-8d60-143a33c77e9f",
+      "description": null,
+      "destination": {
+          "ipv4": {"ip": {"prefix_length": 32, "value": "10.0.0.0"}, "prefix_length": 24},
+          "ipv6": null
+      },
+      "ext_id": "ed3cf052-a96a-4222-8d60-143a33c77e9f",
+      "links": null,
+      "metadata": null,
+      "name": "advertised_route",
+      "nexthop": {
+          "nexthop_ip_address": {"ipv4": {"prefix_length": 32, "value": "10.44.3.1"}, "ipv6": null},
+          "nexthop_name": "local-bgp-gateway",
+          "nexthop_reference": "5e98d574-c54c-4775-9f7a-8ebb2bc77d2c",
+          "nexthop_type": "EXTERNAL_SUBNET"
+      },
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+    - BGP routes are read-only, so this value is always C(None) for this module.
+  returned: always
+  type: str
+  sample: null
+
+ext_id:
+  description:
+    - The external ID of the BGP route that was fetched.
+  returned: always
+  type: str
+  sample: "ed3cf052-a96a-4222-8d60-143a33c77e9f"
+
+bgp_session_ext_id:
+  description:
+    - The external ID of the parent BGP session.
+  returned: when C(bgp_session_ext_id) is provided
+  type: str
+  sample: "8a3cf052-1234-4222-8d60-143a33c77e9f"
+
+changed:
+  description:
+    - This indicates whether the task resulted in any changes.
+    - Always C(False) because the BGP routes API only supports read operations.
+  returned: always
+  type: bool
+  sample: false
+
+skipped:
+  description:
+    - This indicates whether the task was skipped.
+    - Always C(False) because the module either fetches the route or fails.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error or when the operation is not supported by the API
+  type: str
+  sample: "BGP routes are read-only. Use ntnx_routes_by_bgp_session_ids_info_v2 to fetch or list them."
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_bgp_routes_api_instance,
+)
+from ..module_utils.v4.network.helpers import get_bgp_route  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+READ_ONLY_MSG = (
+    "BGP routes are read-only. The Nutanix networking v4 SDK does not expose "
+    "create, update, or delete operations for routes advertised or received "
+    "over a BGP session. Use nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2 "
+    "to list or fetch BGP routes."
+)
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        bgp_session_ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def _fetch_route(module, result, api_instance):
+    """Fetch a single BGP route by (bgp_session_ext_id, ext_id).
+
+    Semantics: BGP routes are a read-only collection surfaced by the
+    networking v4 API, so this is the only operation supported by this
+    module. ``changed`` remains ``False`` because no server-side state is
+    modified.
+    """
+    validate_required_params(module, ["ext_id", "bgp_session_ext_id"])
+    ext_id = module.params.get("ext_id")
+    bgp_session_ext_id = module.params.get("bgp_session_ext_id")
+    result["ext_id"] = ext_id
+    result["bgp_session_ext_id"] = bgp_session_ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "BGP route with ext_id:{0} for BGP session ext_id:{1} would be fetched.".format(
+                ext_id, bgp_session_ext_id
+            )
+        )
+        return
+
+    resp = get_bgp_route(module, api_instance, ext_id, bgp_session_ext_id)
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def create_RoutesByBgpSessionId(module, result, api_instance):
+    """BGP routes cannot be created via the API - fail with a descriptive error."""
+    module.fail_json(msg=READ_ONLY_MSG, **result)
+
+
+def update_RoutesByBgpSessionId(module, result, api_instance):
+    """BGP routes cannot be updated via the API - fetch and return the current
+    state instead. ``changed`` stays ``False`` to reflect that no mutation
+    happened server-side.
+    """
+    _fetch_route(module, result, api_instance)
+
+
+def delete_RoutesByBgpSessionId(module, result, api_instance):
+    """BGP routes cannot be deleted via the API - fail with a descriptive error."""
+    module.fail_json(msg=READ_ONLY_MSG, **result)
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+        "failed": False,
+    }
+    api_instance = get_bgp_routes_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_RoutesByBgpSessionId(module, result, api_instance)
+        else:
+            create_RoutesByBgpSessionId(module, result, api_instance)
+    else:
+        delete_RoutesByBgpSessionId(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_routes_by_bgp_session_ids_info_v2.py
+++ b/plugins/modules/ntnx_routes_by_bgp_session_ids_info_v2.py
@@ -1,0 +1,259 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_routes_by_bgp_session_ids_info_v2
+short_description: Fetch BGP routes info for a BGP session in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about RoutesByBgpSessionId in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific RoutesByBgpSessionId.
+  - If C(ext_id) is not provided, list multiple RoutesByBgpSessionId optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Get the specified route of the specified BGP session) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer,
+      Project Admin, Super Admin, Virtual Machine Admin, Virtual Machine Operator,
+      Virtual Machine Viewer, VPC Admin
+    - >-
+      B(Lists routes of the specified BGP session) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer,
+      Project Admin, Super Admin, Virtual Machine Admin, Virtual Machine Operator,
+      Virtual Machine Viewer, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID of the BGP route to fetch.
+      - When provided together with C(bgp_session_ext_id), the module fetches only that route.
+    type: str
+    required: false
+  bgp_session_ext_id:
+    description:
+      - The external ID of the parent BGP session whose routes should be fetched or listed.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all BGP routes for a given BGP session
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "8a3cf052-1234-4222-8d60-143a33c77e9f"
+  register: result
+  ignore_errors: true
+
+- name: Fetch a specific BGP route for a BGP session by external ID
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "8a3cf052-1234-4222-8d60-143a33c77e9f"
+    ext_id: "ed3cf052-a96a-4222-8d60-143a33c77e9f"
+  register: result
+  ignore_errors: true
+
+- name: List BGP routes for a BGP session with a filter (only received routes)
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "8a3cf052-1234-4222-8d60-143a33c77e9f"
+    filter: "bgpRouteType eq Nutanix.Networking.Config.BgpRouteType'RECEIVED'"
+  register: result
+  ignore_errors: true
+
+- name: List BGP routes for a BGP session with pagination (page 0, limit 10)
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "8a3cf052-1234-4222-8d60-143a33c77e9f"
+    page: 0
+    limit: 10
+  register: result
+  ignore_errors: true
+
+- name: List BGP routes for a BGP session sorted by name
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "8a3cf052-1234-4222-8d60-143a33c77e9f"
+    orderby: "name asc"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC RoutesByBgpSessionId info v4 API.
+    - It can be a single RoutesByBgpSessionId if external ID is provided.
+    - List of multiple RoutesByBgpSessionId if external ID is not provided
+      with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "bgp_communities": null,
+        "bgp_route_type": "ADVERTISED",
+        "bgp_session_reference": "8a3cf052-1234-4222-8d60-143a33c77e9f",
+        "description": null,
+        "destination": {
+            "ipv4": {"ip": {"prefix_length": 32, "value": "10.0.0.0"}, "prefix_length": 24},
+            "ipv6": null
+        },
+        "ext_id": "ed3cf052-a96a-4222-8d60-143a33c77e9f",
+        "links": null,
+        "metadata": null,
+        "name": "advertised_route",
+        "nexthop": {
+            "nexthop_ip_address": {"ipv4": {"prefix_length": 32, "value": "10.44.3.1"}, "ipv6": null},
+            "nexthop_name": "local-bgp-gateway",
+            "nexthop_reference": "5e98d574-c54c-4775-9f7a-8ebb2bc77d2c",
+            "nexthop_type": "EXTERNAL_SUBNET"
+        },
+        "tenant_id": null
+      }
+    ]
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always C(False) for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching BGP routes info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the BGP route when a single route is fetched.
+  type: str
+  returned: when external ID is provided
+  sample: "ed3cf052-a96a-4222-8d60-143a33c77e9f"
+
+bgp_session_ext_id:
+  description: External ID of the parent BGP session.
+  type: str
+  returned: always
+  sample: "8a3cf052-1234-4222-8d60-143a33c77e9f"
+
+total_available_results:
+  description: The total number of BGP routes available for the parent BGP session.
+  type: int
+  returned: when all BGP routes are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_bgp_routes_api_instance,
+)
+from ..module_utils.v4.network.helpers import get_bgp_route  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        bgp_session_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_bgp_route_by_ext_id(module, api_instance, result):
+    """Fetch a single BGP route by (bgp_session_ext_id, ext_id)."""
+    ext_id = module.params.get("ext_id")
+    bgp_session_ext_id = module.params.get("bgp_session_ext_id")
+    result["ext_id"] = ext_id
+    result["bgp_session_ext_id"] = bgp_session_ext_id
+    resp = get_bgp_route(module, api_instance, ext_id, bgp_session_ext_id)
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def list_bgp_routes(module, api_instance, result):
+    """List BGP routes for a given BGP session (supports filter/limit/page/orderby)."""
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    bgp_session_ext_id = module.params.get("bgp_session_ext_id")
+    result["bgp_session_ext_id"] = bgp_session_ext_id
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating BGP routes info Spec", **result)
+
+    try:
+        resp = api_instance.list_routes_by_bgp_session_id(
+            bgpSessionExtId=bgp_session_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching BGP routes info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "error": None, "response": None}
+    api_instance = get_bgp_routes_api_instance(module)
+    if module.params.get("ext_id"):
+        get_bgp_route_by_ext_id(module, api_instance, result)
+    else:
+        list_bgp_routes(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_routes_by_bgp_session_id_v2/aliases
+++ b/tests/integration/targets/ntnx_routes_by_bgp_session_id_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_routes_by_bgp_session_id_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_routes_by_bgp_session_id_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_routes_by_bgp_session_id_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_routes_by_bgp_session_id_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import routes_by_bgp_session_id.yml
+      ansible.builtin.import_tasks: "routes_by_bgp_session_id.yml"

--- a/tests/integration/targets/ntnx_routes_by_bgp_session_id_v2/tasks/routes_by_bgp_session_id.yml
+++ b/tests/integration/targets/ntnx_routes_by_bgp_session_id_v2/tasks/routes_by_bgp_session_id.yml
@@ -1,0 +1,265 @@
+---
+# Test plan for ntnx_routes_by_bgp_session_id_v2
+#
+# BGP routes exposed by the Nutanix networking v4 API are a READ-ONLY collection
+# surfaced by the BGP gateway serving the referenced BGP session. The SDK does
+# not provide create/update/delete operations for a BGP route, so this module's
+# ``create`` and ``delete`` code paths are intentional fail-fast paths that
+# guard the user with a descriptive error, and the ``update`` path is a fetch
+# that always reports changed=False.
+#
+# Coverage:
+#   1. Positive fetch by (bgp_session_ext_id, ext_id) when a route exists
+#      (skipped when the cluster has no BGP session/route to reference).
+#   2. Positive fetch in check_mode: no API call, but result carries a
+#      descriptive msg and both ext_ids.
+#   3. Negative: state=present without ext_id -> read-only error.
+#   4. Negative: state=absent + ext_id + bgp_session_ext_id -> read-only error.
+#   5. Negative: state=absent without ext_id -> required_if enforces failure.
+#   6. Negative: state=present + ext_id pointing at a non-existent BGP route
+#      surfaces the underlying API error.
+#   7. Argument-spec validation: state must be one of {present, absent}.
+
+- name: Start ntnx_routes_by_bgp_session_id_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_routes_by_bgp_session_id_v2 tests
+
+- name: Generate random suffix for scoping test facts
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set static test facts (fake ext_ids used by negative paths)
+  ansible.builtin.set_fact:
+    fake_bgp_session_ext_id: "00000000-0000-0000-0000-{{ random_name | lower | truncate(12, True, '') }}"
+    fake_route_ext_id: "11111111-1111-1111-1111-{{ random_name | lower | truncate(12, True, '') }}"
+
+########################################################################################
+# 1. Discovery - is there any BGP session with any BGP route we can exercise the
+#    positive fetch path against? The Nutanix BGP sessions listing is not exposed
+#    as an Ansible module in this collection today, so we hit the v4 REST API
+#    directly through ansible.builtin.uri. When the operator provides a
+#    ``bgp_session_ext_id_for_tests`` extra var, we honor it and skip discovery.
+########################################################################################
+
+- name: Honor operator-supplied BGP session ext_id (if any)
+  ansible.builtin.set_fact:
+    real_bgp_session_ext_id: "{{ bgp_session_ext_id_for_tests }}"
+  when: bgp_session_ext_id_for_tests is defined and bgp_session_ext_id_for_tests | length > 0
+
+- name: Discover a BGP session via v4 REST (list_bgp_sessions)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ nutanix_port | default('9440') }}/api/networking/v4.3/config/bgp-sessions?$limit=5"
+    method: GET
+    force_basic_auth: true
+    user: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    return_content: true
+    status_code: [200, 400, 401, 403, 404]
+  register: bgp_sessions_probe
+  ignore_errors: true
+  no_log: false
+  when: real_bgp_session_ext_id is not defined
+
+- name: Set real BGP session ext_id if discovered
+  ansible.builtin.set_fact:
+    real_bgp_session_ext_id: "{{ (bgp_sessions_probe.json.data | first).extId }}"
+  when:
+    - real_bgp_session_ext_id is not defined
+    - bgp_sessions_probe is defined
+    - bgp_sessions_probe.status is defined
+    - bgp_sessions_probe.status == 200
+    - bgp_sessions_probe.json is defined
+    - bgp_sessions_probe.json.data is defined
+    - bgp_sessions_probe.json.data is iterable
+    - bgp_sessions_probe.json.data | length > 0
+
+- name: Probe first available BGP route on the discovered BGP session
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "{{ real_bgp_session_ext_id }}"
+    limit: 1
+  register: bgp_routes_probe
+  ignore_errors: true
+  failed_when: false
+  when: real_bgp_session_ext_id is defined
+
+- name: Set real BGP route ext_id if discovered
+  ansible.builtin.set_fact:
+    real_bgp_route_ext_id: "{{ bgp_routes_probe.response[0].ext_id }}"
+  when:
+    - bgp_routes_probe is defined
+    - bgp_routes_probe.response is defined
+    - bgp_routes_probe.response is iterable
+    - bgp_routes_probe.response | length > 0
+
+########################################################################################
+# 2. Check_mode fetch (state=present) - never calls the API, so it works
+#    even on a cluster with no BGP session/route.
+########################################################################################
+
+- name: Check-mode fetch of a single BGP route
+  nutanix.ncp.ntnx_routes_by_bgp_session_id_v2:
+    state: present
+    bgp_session_ext_id: "{{ fake_bgp_session_ext_id }}"
+    ext_id: "{{ fake_route_ext_id }}"
+  register: cm_fetch
+  check_mode: true
+  ignore_errors: true
+
+- name: Assert check-mode fetch reports the intended action without touching state
+  ansible.builtin.assert:
+    that:
+      - cm_fetch is defined
+      - not cm_fetch.changed
+      - not cm_fetch.failed
+      - not cm_fetch.skipped
+      - cm_fetch.ext_id == fake_route_ext_id
+      - cm_fetch.bgp_session_ext_id == fake_bgp_session_ext_id
+      - cm_fetch.task_ext_id is none
+      - "'would be fetched' in cm_fetch.msg"
+    fail_msg: "Check-mode fetch did not behave as documented"
+    success_msg: "Check-mode fetch returned the expected preview result"
+
+########################################################################################
+# 3. Positive fetch (real API) - only when the cluster actually has a route.
+########################################################################################
+
+- name: Positive fetch of a real BGP route (when discovered)
+  nutanix.ncp.ntnx_routes_by_bgp_session_id_v2:
+    state: present
+    bgp_session_ext_id: "{{ real_bgp_session_ext_id }}"
+    ext_id: "{{ real_bgp_route_ext_id }}"
+  register: real_fetch
+  ignore_errors: true
+  when:
+    - real_bgp_session_ext_id is defined
+    - real_bgp_route_ext_id is defined
+
+- name: Assert positive fetch returned the requested route
+  ansible.builtin.assert:
+    that:
+      - not real_fetch.changed
+      - not real_fetch.failed
+      - not real_fetch.skipped
+      - real_fetch.ext_id == real_bgp_route_ext_id
+      - real_fetch.bgp_session_ext_id == real_bgp_session_ext_id
+      - real_fetch.response is defined
+      - real_fetch.response.ext_id == real_bgp_route_ext_id
+      - real_fetch.response.bgp_session_reference == real_bgp_session_ext_id
+      - real_fetch.response.bgp_route_type in ["ADVERTISED", "RECEIVED", "RECEIVED_AND_IGNORED"]
+    fail_msg: "Positive fetch of BGP route failed"
+    success_msg: "Positive fetch of BGP route succeeded"
+  when:
+    - real_bgp_session_ext_id is defined
+    - real_bgp_route_ext_id is defined
+    - real_fetch is defined
+    - not real_fetch.failed
+########################################################################################
+# 4. Negative: state=present without ext_id must fail because CRUD is unsupported.
+########################################################################################
+
+- name: Attempt to "create" a BGP route (unsupported by the API)
+  nutanix.ncp.ntnx_routes_by_bgp_session_id_v2:
+    state: present
+    bgp_session_ext_id: "{{ fake_bgp_session_ext_id }}"
+  register: create_attempt
+  ignore_errors: true
+
+- name: Assert create is blocked with a read-only error
+  ansible.builtin.assert:
+    that:
+      - create_attempt is defined
+      - create_attempt.failed
+      - "'BGP routes are read-only' in create_attempt.msg"
+      - "'ntnx_routes_by_bgp_session_ids_info_v2' in create_attempt.msg"
+    fail_msg: "Create attempt did not surface a read-only error"
+    success_msg: "Create attempt correctly surfaced the read-only error"
+
+########################################################################################
+# 5. Negative: state=absent with both ext_ids must fail with a read-only error.
+########################################################################################
+
+- name: Attempt to delete a BGP route (unsupported by the API)
+  nutanix.ncp.ntnx_routes_by_bgp_session_id_v2:
+    state: absent
+    bgp_session_ext_id: "{{ fake_bgp_session_ext_id }}"
+    ext_id: "{{ fake_route_ext_id }}"
+  register: delete_attempt
+  ignore_errors: true
+
+- name: Assert delete is blocked with a read-only error
+  ansible.builtin.assert:
+    that:
+      - delete_attempt is defined
+      - delete_attempt.failed
+      - "'BGP routes are read-only' in delete_attempt.msg"
+      - not delete_attempt.changed
+    fail_msg: "Delete attempt did not surface a read-only error"
+    success_msg: "Delete attempt correctly surfaced the read-only error"
+
+########################################################################################
+# 6. Negative: state=absent without ext_id trips the required_if guard.
+########################################################################################
+
+- name: Attempt to delete without ext_id (required_if)  # noqa: args[module]
+  nutanix.ncp.ntnx_routes_by_bgp_session_id_v2:
+    state: absent
+    bgp_session_ext_id: "{{ fake_bgp_session_ext_id }}"
+  register: delete_missing_ext_id
+  ignore_errors: true
+
+- name: Assert required_if rejects delete without ext_id
+  ansible.builtin.assert:
+    that:
+      - delete_missing_ext_id is defined
+      - delete_missing_ext_id.failed
+      - "'ext_id' in (delete_missing_ext_id.msg | string)"
+    fail_msg: "state=absent without ext_id was not rejected"
+    success_msg: "state=absent without ext_id was correctly rejected"
+
+########################################################################################
+# 7. Negative: state=present + fake ext_id -> API surfaces "not found" (best effort;
+#    if the cluster has no BGP session at all, the API will still return an error).
+########################################################################################
+
+- name: Fetch a non-existent BGP route to trigger an API not-found style error
+  nutanix.ncp.ntnx_routes_by_bgp_session_id_v2:
+    state: present
+    bgp_session_ext_id: "{{ fake_bgp_session_ext_id }}"
+    ext_id: "{{ fake_route_ext_id }}"
+  register: fetch_missing
+  ignore_errors: true
+
+- name: Assert not-found fetch is reported as failed
+  ansible.builtin.assert:
+    that:
+      - fetch_missing is defined
+      - fetch_missing.failed
+      - not fetch_missing.changed
+    fail_msg: "Fetch of a non-existent BGP route did not report failed=true"
+    success_msg: "Fetch of a non-existent BGP route correctly reported failed=true"
+
+########################################################################################
+# 8. Argument-spec: state must be one of {present, absent}.
+########################################################################################
+
+- name: Attempt to use an invalid state value  # noqa: args[module]
+  nutanix.ncp.ntnx_routes_by_bgp_session_id_v2:
+    state: "bogus"
+    bgp_session_ext_id: "{{ fake_bgp_session_ext_id }}"
+    ext_id: "{{ fake_route_ext_id }}"
+  register: invalid_state
+  ignore_errors: true
+
+- name: Assert invalid state is rejected by argument-spec validation
+  ansible.builtin.assert:
+    that:
+      - invalid_state is defined
+      - invalid_state.failed
+      - "'state' in (invalid_state.msg | string)"
+    fail_msg: "Invalid state value was not rejected"
+    success_msg: "Invalid state value was rejected by argument-spec validation"
+
+- name: End ntnx_routes_by_bgp_session_id_v2 tests
+  ansible.builtin.debug:
+    msg: End ntnx_routes_by_bgp_session_id_v2 tests

--- a/tests/integration/targets/ntnx_routes_by_bgp_session_ids_info_v2/aliases
+++ b/tests/integration/targets/ntnx_routes_by_bgp_session_ids_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_routes_by_bgp_session_ids_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_routes_by_bgp_session_ids_info_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_routes_by_bgp_session_ids_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_routes_by_bgp_session_ids_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import routes_by_bgp_session_ids_info.yml
+      ansible.builtin.import_tasks: "routes_by_bgp_session_ids_info.yml"

--- a/tests/integration/targets/ntnx_routes_by_bgp_session_ids_info_v2/tasks/routes_by_bgp_session_ids_info.yml
+++ b/tests/integration/targets/ntnx_routes_by_bgp_session_ids_info_v2/tasks/routes_by_bgp_session_ids_info.yml
@@ -1,0 +1,317 @@
+---
+# Test plan for ntnx_routes_by_bgp_session_ids_info_v2
+#
+# Coverage:
+#   1. Argument-spec: bgp_session_ext_id is required.
+#   2. Argument-spec: ext_id and filter are mutually exclusive.
+#   3. Discovery: attempt to find a real BGP session via v4 REST.
+#   4. Positive list against a real BGP session (when discovered):
+#      - assert response is a list, changed=False, total_available_results is int.
+#      - if any routes present, assert bgp_route_type is a valid enum and
+#        bgp_session_reference matches the parent session ext_id.
+#   5. Positive list with limit=1 (when a real BGP session exists).
+#   6. Positive list with orderby=name asc (when a real BGP session exists).
+#   7. Positive list with a filter for ADVERTISED routes (when a real BGP
+#      session exists).
+#   8. Positive fetch by ext_id (when a real BGP route exists).
+#   9. Negative: fetch a non-existent BGP route.
+#  10. Negative: list against a non-existent BGP session.
+
+- name: Start ntnx_routes_by_bgp_session_ids_info_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_routes_by_bgp_session_ids_info_v2 tests
+
+- name: Generate random suffix for scoping test facts
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set static test facts (fake ext_ids used by negative paths)
+  ansible.builtin.set_fact:
+    fake_bgp_session_ext_id: "00000000-0000-0000-0000-{{ random_name | lower | truncate(12, True, '') }}"
+    fake_route_ext_id: "11111111-1111-1111-1111-{{ random_name | lower | truncate(12, True, '') }}"
+
+########################################################################################
+# 1. Argument-spec: bgp_session_ext_id is required.
+########################################################################################
+
+- name: Call info module without bgp_session_ext_id  # noqa: args[module]
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2: {}
+  register: missing_parent
+  ignore_errors: true
+
+- name: Assert missing bgp_session_ext_id is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_parent is defined
+      - missing_parent.failed
+      - "'bgp_session_ext_id' in (missing_parent.msg | string)"
+    fail_msg: "Missing bgp_session_ext_id was not rejected"
+    success_msg: "Missing bgp_session_ext_id was rejected as expected"
+
+########################################################################################
+# 2. Argument-spec: ext_id and filter are mutually exclusive.
+########################################################################################
+
+- name: Call info module with ext_id + filter (mutually exclusive)
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "{{ fake_bgp_session_ext_id }}"
+    ext_id: "{{ fake_route_ext_id }}"
+    filter: "name eq 'foo'"
+  register: mx_call
+  ignore_errors: true
+
+- name: Assert mutually exclusive rejection
+  ansible.builtin.assert:
+    that:
+      - mx_call is defined
+      - mx_call.failed
+      - "'mutually exclusive' in (mx_call.msg | string)"
+    fail_msg: "ext_id + filter were not rejected as mutually exclusive"
+    success_msg: "ext_id + filter were rejected as mutually exclusive"
+
+########################################################################################
+# 3. Discovery of a real BGP session on the cluster (best effort).
+########################################################################################
+
+- name: Honor operator-supplied BGP session ext_id (if any)
+  ansible.builtin.set_fact:
+    real_bgp_session_ext_id: "{{ bgp_session_ext_id_for_tests }}"
+  when: bgp_session_ext_id_for_tests is defined and bgp_session_ext_id_for_tests | length > 0
+
+- name: Discover a BGP session via v4 REST (list_bgp_sessions)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ nutanix_port | default('9440') }}/api/networking/v4.3/config/bgp-sessions?$limit=5"
+    method: GET
+    force_basic_auth: true
+    user: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: "{{ validate_certs }}"
+    return_content: true
+    status_code: [200, 400, 401, 403, 404]
+  register: bgp_sessions_probe
+  ignore_errors: true
+  when: real_bgp_session_ext_id is not defined
+
+- name: Set real BGP session ext_id if discovered
+  ansible.builtin.set_fact:
+    real_bgp_session_ext_id: "{{ (bgp_sessions_probe.json.data | first).extId }}"
+  when:
+    - real_bgp_session_ext_id is not defined
+    - bgp_sessions_probe is defined
+    - bgp_sessions_probe.status is defined
+    - bgp_sessions_probe.status == 200
+    - bgp_sessions_probe.json is defined
+    - bgp_sessions_probe.json.data is defined
+    - bgp_sessions_probe.json.data is iterable
+    - bgp_sessions_probe.json.data | length > 0
+
+########################################################################################
+# 4. Positive list against a real BGP session (when discovered).
+########################################################################################
+
+- name: List BGP routes for the discovered BGP session
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "{{ real_bgp_session_ext_id }}"
+  register: real_list
+  ignore_errors: true
+  when: real_bgp_session_ext_id is defined
+
+- name: Assert real list contract
+  ansible.builtin.assert:
+    that:
+      - real_list is defined
+      - not real_list.changed
+      - not real_list.failed
+      - real_list.bgp_session_ext_id == real_bgp_session_ext_id
+      - real_list.total_available_results is defined
+      - real_list.total_available_results | int >= 0
+      - real_list.response is defined
+      - real_list.response is iterable
+    fail_msg: "List for the discovered BGP session did not honor the info module contract"
+    success_msg: "List for the discovered BGP session honored the info module contract"
+  when: real_bgp_session_ext_id is defined and real_list is defined and not real_list.failed
+
+- name: Assert per-route invariants when routes are present
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined
+      - item.bgp_session_reference == real_bgp_session_ext_id
+      - item.bgp_route_type in ["ADVERTISED", "RECEIVED", "RECEIVED_AND_IGNORED"]
+    fail_msg: "BGP route entry did not satisfy invariants"
+    success_msg: "BGP route entry satisfied invariants"
+  loop: "{{ real_list.response | default([]) }}"
+  loop_control:
+    label: "{{ item.ext_id | default('<no-ext-id>') }}"
+  when:
+    - real_bgp_session_ext_id is defined
+    - real_list is defined
+    - not real_list.failed
+    - real_list.response is defined
+    - real_list.response | length > 0
+
+- name: Set real BGP route ext_id (if any) for later tests
+  ansible.builtin.set_fact:
+    real_bgp_route_ext_id: "{{ real_list.response[0].ext_id }}"
+  when:
+    - real_list is defined
+    - real_list.skipped is not defined
+    - real_list.failed is defined
+    - not real_list.failed
+    - real_list.response is defined
+    - real_list.response | length > 0
+
+########################################################################################
+# 5. Positive list with limit=1 (when a real BGP session exists).
+########################################################################################
+
+- name: List BGP routes for the discovered BGP session with limit=1
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "{{ real_bgp_session_ext_id }}"
+    limit: 1
+  register: real_list_limit
+  ignore_errors: true
+  when: real_bgp_session_ext_id is defined
+
+- name: Assert limit=1 returns at most one route
+  ansible.builtin.assert:
+    that:
+      - real_list_limit is defined
+      - not real_list_limit.changed
+      - not real_list_limit.failed
+      - real_list_limit.response is defined
+      - real_list_limit.response | length <= 1
+    fail_msg: "List with limit=1 returned more than one route"
+    success_msg: "List with limit=1 honored the limit"
+  when:
+    - real_bgp_session_ext_id is defined
+    - real_list_limit is defined
+    - not real_list_limit.failed
+########################################################################################
+# 6. Positive list with orderby=name asc (when a real BGP session exists).
+########################################################################################
+
+- name: List BGP routes for the discovered BGP session with orderby=name asc
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "{{ real_bgp_session_ext_id }}"
+    orderby: "name asc"
+  register: real_list_orderby
+  ignore_errors: true
+  when: real_bgp_session_ext_id is defined
+
+- name: Assert orderby honors the info module contract
+  ansible.builtin.assert:
+    that:
+      - real_list_orderby is defined
+      - not real_list_orderby.changed
+      - not real_list_orderby.failed
+      - real_list_orderby.response is defined
+      - real_list_orderby.response is iterable
+    fail_msg: "List with orderby did not honor the info module contract"
+    success_msg: "List with orderby honored the info module contract"
+  when:
+    - real_bgp_session_ext_id is defined
+    - real_list_orderby is defined
+    - not real_list_orderby.failed
+########################################################################################
+# 7. Positive list with a filter for ADVERTISED routes only.
+########################################################################################
+
+- name: List BGP routes for the discovered BGP session filtered to ADVERTISED
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "{{ real_bgp_session_ext_id }}"
+    filter: "bgpRouteType eq Nutanix.Networking.Config.BgpRouteType'ADVERTISED'"
+  register: real_list_advertised
+  ignore_errors: true
+  when: real_bgp_session_ext_id is defined
+
+- name: Assert filtered list only contains ADVERTISED routes
+  ansible.builtin.assert:
+    that:
+      - item.bgp_route_type == "ADVERTISED"
+    fail_msg: "Filtered list contained a non-ADVERTISED route"
+    success_msg: "Filtered list only contained ADVERTISED routes"
+  loop: "{{ real_list_advertised.response | default([]) }}"
+  loop_control:
+    label: "{{ item.ext_id | default('<no-ext-id>') }}"
+  when:
+    - real_bgp_session_ext_id is defined
+    - real_list_advertised is defined
+    - not real_list_advertised.failed
+    - real_list_advertised.response is defined
+    - real_list_advertised.response | length > 0
+
+########################################################################################
+# 8. Positive fetch by ext_id (when a real BGP route exists).
+########################################################################################
+
+- name: Fetch the discovered BGP route by ext_id
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "{{ real_bgp_session_ext_id }}"
+    ext_id: "{{ real_bgp_route_ext_id }}"
+  register: real_get
+  ignore_errors: true
+  when:
+    - real_bgp_session_ext_id is defined
+    - real_bgp_route_ext_id is defined
+
+- name: Assert fetch-by-ext_id contract
+  ansible.builtin.assert:
+    that:
+      - real_get is defined
+      - not real_get.changed
+      - not real_get.failed
+      - real_get.ext_id == real_bgp_route_ext_id
+      - real_get.bgp_session_ext_id == real_bgp_session_ext_id
+      - real_get.response is defined
+      - real_get.response.ext_id == real_bgp_route_ext_id
+      - real_get.response.bgp_session_reference == real_bgp_session_ext_id
+      - real_get.response.bgp_route_type in ["ADVERTISED", "RECEIVED", "RECEIVED_AND_IGNORED"]
+    fail_msg: "Fetch-by-ext_id did not honor the info module contract"
+    success_msg: "Fetch-by-ext_id honored the info module contract"
+  when:
+    - real_bgp_session_ext_id is defined
+    - real_bgp_route_ext_id is defined
+    - real_get is defined
+    - not real_get.failed
+########################################################################################
+# 9. Negative: fetch a non-existent BGP route.
+########################################################################################
+
+- name: Fetch a non-existent BGP route by ext_id
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "{{ real_bgp_session_ext_id | default(fake_bgp_session_ext_id) }}"
+    ext_id: "{{ fake_route_ext_id }}"
+  register: bad_get
+  ignore_errors: true
+
+- name: Assert fetch of non-existent BGP route reports failed=true
+  ansible.builtin.assert:
+    that:
+      - bad_get is defined
+      - bad_get.failed
+      - not bad_get.changed
+    fail_msg: "Fetch of non-existent BGP route did not report failed=true"
+    success_msg: "Fetch of non-existent BGP route reported failed=true"
+
+########################################################################################
+# 10. Negative: list against a non-existent BGP session.
+########################################################################################
+
+- name: List BGP routes for a non-existent BGP session
+  nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2:
+    bgp_session_ext_id: "{{ fake_bgp_session_ext_id }}"
+  register: bad_list
+  ignore_errors: true
+
+- name: Assert list against non-existent BGP session reports failed=true
+  ansible.builtin.assert:
+    that:
+      - bad_list is defined
+      - bad_list.failed
+      - not bad_list.changed
+    fail_msg: "List against non-existent BGP session did not report failed=true"
+    success_msg: "List against non-existent BGP session reported failed=true"
+
+- name: End ntnx_routes_by_bgp_session_ids_info_v2 tests
+  ansible.builtin.debug:
+    msg: End ntnx_routes_by_bgp_session_ids_info_v2 tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**RoutesByBgpSessionId**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_routes_by_bgp_session_id_v2`, `ntnx_routes_by_bgp_session_ids_info_v2`
- API methods covered: `2` (`get_route_for_bgp_session_by_id`, `list_routes_by_bgp_session_id`)
- Fields in CRUD-shaped module spec: `4` (`state`, `wait`, `bgp_session_ext_id`, `ext_id`)
- Fields in info module spec: `6` (`bgp_session_ext_id`, `ext_id`, `page`, `limit`, `filter`, `orderby`)

Notes on shape:
- `RoutesByBgpSessionId` is a **read-only** collection surfaced by the BGP gateway
  serving the referenced BGP session. The SDK does not expose create / update / delete.
- `ntnx_routes_by_bgp_session_id_v2` is CRUD-shaped for consistency with the other v2
  modules and their generator template, but only truly supports `state=present` with
  both `bgp_session_ext_id` and `ext_id` (single-route read). `state=absent` and any
  create/update attempt fail fast with an explicit read-only error message pointing
  to the info module.
- `ntnx_routes_by_bgp_session_ids_info_v2` supports both single-route fetch
  (`bgp_session_ext_id` + `ext_id`) and full list with `filter` / `limit` / `page` /
  `orderby` for a given BGP session.

## Files changed

- `plugins/modules/`
  - `ntnx_routes_by_bgp_session_id_v2.py` (new — CRUD-shaped, read-only enforced)
  - `ntnx_routes_by_bgp_session_ids_info_v2.py` (new — info)
- `plugins/module_utils/v4/network/`
  - `api_client.py` (added `get_bgp_sessions_api_instance` and `get_bgp_routes_api_instance`)
  - `helpers.py` (added `get_bgp_route` helper)
- `meta/runtime.yml` (registered both new modules in the `ntnx` action group)
- `examples/networking/RoutesByBgpSessionId/`
  - `routes_by_bgp_session_id.yml` (new — example playbook)
  - `examples_run.log` (new — captured live playbook output)
- `tests/integration/targets/`
  - `ntnx_routes_by_bgp_session_id_v2/` (new — integration test role)
  - `ntnx_routes_by_bgp_session_ids_info_v2/` (new — integration test role)

## Test execution

| Metric              | Value                                                        |
|---------------------|--------------------------------------------------------------|
| Command             | `ansible-test integration --allow-unsupported ntnx_routes_by_bgp_session_id_v2 ntnx_routes_by_bgp_session_ids_info_v2` |
| Total tasks         | `70`                                                         |
| Passed (ok=)        | `32` (`18` + `14`)                                           |
| Failed              | `0`                                                          |
| Skipped             | `20` (`6` + `14`) — depend on a real BGP session on the PC   |
| Ignored             | `9` (`5` + `4`) — expected negative-path failures            |
| Duration            | `~00:00:20` per target                                       |
| Cluster (PC)        | `10.44.76.28:9440`                                           |

### Analysis

Both integration test roles complete with `failed=0`. The `skipped=*` tasks are
the ones gated on a real BGP session / BGP route being present on the target
Prism Central (the harness could not discover one via `list_bgp_sessions`, so
the positive discovery-based assertions were correctly skipped rather than
falsely passed). The `ignored=*` tasks are the intentional negative-path
assertions (missing required args, mutually-exclusive args, invalid `state`,
`create` / `delete` on a read-only entity, list / fetch against a non-existent
BGP session), which all failed as expected and were then verified with a
follow-up `ansible.builtin.assert`.

The example playbook was executed end-to-end against the same PC using the
credentials in `tests/integration/integration_config.yml`. It completes with
`failed=0`, with the read paths (list / get / list-with-limit / list-with-orderby /
filtered-list) ignoring the `NETWORKING-10060 "BGP session not found"` and
odata parse failures that come from the placeholder `bgp_session_ext_id` — the
same skip-on-missing-prereq behaviour documented in Step 7.2 of the code-gen
instructions.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
WARNING: Using locale "C.UTF-8" instead of "en_US.UTF-8". Tests which depend on the locale may behave unexpectedly.
Running ntnx_routes_by_bgp_session_id_v2 integration test role
[WARNING]: Found variable using reserved name: port

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_routes_by_bgp_session_id_v2 : Start ntnx_routes_by_bgp_session_id_v2 tests] ***
ok: [testhost] => {
    "msg": "Start ntnx_routes_by_bgp_session_id_v2 tests"
}

TASK [ntnx_routes_by_bgp_session_id_v2 : Generate random suffix for scoping test facts] ***
[WARNING]: Collection community.general does not support Ansible version 2.16.0
ok: [testhost]

TASK [ntnx_routes_by_bgp_session_id_v2 : Set static test facts (fake ext_ids used by negative paths)] ***
ok: [testhost]

TASK [ntnx_routes_by_bgp_session_id_v2 : Honor operator-supplied BGP session ext_id (if any)] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_id_v2 : Discover a BGP session via v4 REST (list_bgp_sessions)] ***
ok: [testhost]

TASK [ntnx_routes_by_bgp_session_id_v2 : Set real BGP session ext_id if discovered] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_id_v2 : Probe first available BGP route on the discovered BGP session] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_id_v2 : Set real BGP route ext_id if discovered] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_id_v2 : Check-mode fetch of a single BGP route] ***
ok: [testhost]

TASK [ntnx_routes_by_bgp_session_id_v2 : Assert check-mode fetch reports the intended action without touching state] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Check-mode fetch returned the expected preview result"
}

TASK [ntnx_routes_by_bgp_session_id_v2 : Positive fetch of a real BGP route (when discovered)] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_id_v2 : Assert positive fetch returned the requested route] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_id_v2 : Attempt to "create" a BGP route (unsupported by the API)] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": null, "msg": "BGP routes are read-only. The Nutanix networking v4 SDK does not expose create, update, or delete operations for routes advertised or received over a BGP session. Use nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2 to list or fetch BGP routes.", "response": null, "task_ext_id": null}
...ignoring

TASK [ntnx_routes_by_bgp_session_id_v2 : Assert create is blocked with a read-only error] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Create attempt correctly surfaced the read-only error"
}

TASK [ntnx_routes_by_bgp_session_id_v2 : Attempt to delete a BGP route (unsupported by the API)] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": null, "msg": "BGP routes are read-only. The Nutanix networking v4 SDK does not expose create, update, or delete operations for routes advertised or received over a BGP session. Use nutanix.ncp.ntnx_routes_by_bgp_session_ids_info_v2 to list or fetch BGP routes.", "response": null, "task_ext_id": null}
...ignoring

TASK [ntnx_routes_by_bgp_session_id_v2 : Assert delete is blocked with a read-only error] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Delete attempt correctly surfaced the read-only error"
}

TASK [ntnx_routes_by_bgp_session_id_v2 : Attempt to delete without ext_id (required_if)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_routes_by_bgp_session_id_v2 : Assert required_if rejects delete without ext_id] ***
ok: [testhost] => {
    "changed": false,
    "msg": "state=absent without ext_id was correctly rejected"
}

TASK [ntnx_routes_by_bgp_session_id_v2 : Fetch a non-existent BGP route to trigger an API not-found style error] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching BGP route info using ext_id and bgp_session_ext_id", "response": {"$dataItemDiscriminator": "networking.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "networking.v4.error.SchemaValidationError", "$objectType": "networking.v4.error.ErrorResponse", "error": {"$objectType": "networking.v4.error.SchemaValidationError", "error": "Bad Request", "path": "/api/networking/v4.4/config/bgp-sessions/00000000-0000-0000-0000-nyajlepeytkl/bgp-routes/11111111-1111-1111-1111-nyajlepeytkl", "statusCode": 400, "timestamp": "2026-07-21T06:14:25.252794566Z", "validationErrorMessages": [{"$objectType": "networking.v4.error.SchemaValidationErrorMessage", "location": "@path.extId", "message": "ECMA 262 regex \"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$\" does not match input string \"11111111-1111-1111-1111-nyajlepeytkl\""}, {"$objectType": "networking.v4.error.SchemaValidationErrorMessage", "location": "@path.bgpSessionExtId", "message": "ECMA 262 regex \"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$\" does not match input string \"00000000-0000-0000-0000-nyajlepeytkl\""}]}}}, "status": 400}
...ignoring

TASK [ntnx_routes_by_bgp_session_id_v2 : Assert not-found fetch is reported as failed] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch of a non-existent BGP route correctly reported failed=true"
}

TASK [ntnx_routes_by_bgp_session_id_v2 : Attempt to use an invalid state value] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of state must be one of: present, absent, got: bogus"}
...ignoring

TASK [ntnx_routes_by_bgp_session_id_v2 : Assert invalid state is rejected by argument-spec validation] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid state value was rejected by argument-spec validation"
}

TASK [ntnx_routes_by_bgp_session_id_v2 : End ntnx_routes_by_bgp_session_id_v2 tests] ***
ok: [testhost] => {
    "msg": "End ntnx_routes_by_bgp_session_id_v2 tests"
}

PLAY RECAP *********************************************************************
testhost                   : ok=18   changed=0    unreachable=0    failed=0    skipped=6    rescued=0    ignored=5   

Running ntnx_routes_by_bgp_session_ids_info_v2 integration test role
[WARNING]: Found variable using reserved name: port

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Start ntnx_routes_by_bgp_session_ids_info_v2 tests] ***
ok: [testhost] => {
    "msg": "Start ntnx_routes_by_bgp_session_ids_info_v2 tests"
}

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Generate random suffix for scoping test facts] ***
[WARNING]: Collection community.general does not support Ansible version 2.16.0
ok: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Set static test facts (fake ext_ids used by negative paths)] ***
ok: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Call info module without bgp_session_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: bgp_session_ext_id"}
...ignoring

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Assert missing bgp_session_ext_id is rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing bgp_session_ext_id was rejected as expected"
}

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Call info module with ext_id + filter (mutually exclusive)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Assert mutually exclusive rejection] ***
ok: [testhost] => {
    "changed": false,
    "msg": "ext_id + filter were rejected as mutually exclusive"
}

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Honor operator-supplied BGP session ext_id (if any)] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Discover a BGP session via v4 REST (list_bgp_sessions)] ***
ok: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Set real BGP session ext_id if discovered] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : List BGP routes for the discovered BGP session] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Assert real list contract] ******
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Assert per-route invariants when routes are present] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Set real BGP route ext_id (if any) for later tests] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : List BGP routes for the discovered BGP session with limit=1] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Assert limit=1 returns at most one route] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : List BGP routes for the discovered BGP session with orderby=name asc] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Assert orderby honors the info module contract] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : List BGP routes for the discovered BGP session filtered to ADVERTISED] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Assert filtered list only contains ADVERTISED routes] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Fetch the discovered BGP route by ext_id] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Assert fetch-by-ext_id contract] ***
skipping: [testhost]

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Fetch a non-existent BGP route by ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching BGP route info using ext_id and bgp_session_ext_id", "response": {"$dataItemDiscriminator": "networking.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "networking.v4.error.SchemaValidationError", "$objectType": "networking.v4.error.ErrorResponse", "error": {"$objectType": "networking.v4.error.SchemaValidationError", "error": "Bad Request", "path": "/api/networking/v4.4/config/bgp-sessions/00000000-0000-0000-0000-shvkctfaebyr/bgp-routes/11111111-1111-1111-1111-shvkctfaebyr", "statusCode": 400, "timestamp": "2026-07-21T06:14:35.103578195Z", "validationErrorMessages": [{"$objectType": "networking.v4.error.SchemaValidationErrorMessage", "location": "@path.bgpSessionExtId", "message": "ECMA 262 regex \"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$\" does not match input string \"00000000-0000-0000-0000-shvkctfaebyr\""}, {"$objectType": "networking.v4.error.SchemaValidationErrorMessage", "location": "@path.extId", "message": "ECMA 262 regex \"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$\" does not match input string \"11111111-1111-1111-1111-shvkctfaebyr\""}]}}}, "status": 400}
...ignoring

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Assert fetch of non-existent BGP route reports failed=true] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch of non-existent BGP route reported failed=true"
}

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : List BGP routes for a non-existent BGP session] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching BGP routes info", "response": {"$dataItemDiscriminator": "networking.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "networking.v4.error.SchemaValidationError", "$objectType": "networking.v4.error.ErrorResponse", "error": {"$objectType": "networking.v4.error.SchemaValidationError", "error": "Bad Request", "path": "/api/networking/v4.4/config/bgp-sessions/00000000-0000-0000-0000-shvkctfaebyr/bgp-routes", "statusCode": 400, "timestamp": "2026-07-21T06:14:37.035743189Z", "validationErrorMessages": [{"$objectType": "networking.v4.error.SchemaValidationErrorMessage", "location": "@path.bgpSessionExtId", "message": "ECMA 262 regex \"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$\" does not match input string \"00000000-0000-0000-0000-shvkctfaebyr\""}]}}}, "status": 400}
...ignoring

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : Assert list against non-existent BGP session reports failed=true] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List against non-existent BGP session reported failed=true"
}

TASK [ntnx_routes_by_bgp_session_ids_info_v2 : End ntnx_routes_by_bgp_session_ids_info_v2 tests] ***
ok: [testhost] => {
    "msg": "End ntnx_routes_by_bgp_session_ids_info_v2 tests"
}

PLAY RECAP *********************************************************************
testhost                   : ok=14   changed=0    unreachable=0    failed=0    skipped=14   rescued=0    ignored=4   

WARNING: Reviewing previous 1 warning(s):
WARNING: Using locale "C.UTF-8" instead of "en_US.UTF-8". Tests which depend on the locale may behave unexpectedly.
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
