### PR TITLE
VpnConnectionStat Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/networking/VpnConnectionStat/examples_run.log
+++ b/examples/networking/VpnConnectionStat/examples_run.log
@@ -1,0 +1,55 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+running playbook inside collection nutanix.ncp
+
+PLAY [VPN Connection Stats playbook] *******************************************
+
+TASK [Set VPN connection ext_id] ***********************************************
+ok: [localhost] => {"ansible_facts": {"vpn_connection_ext_id": "5482651f-f898-4964-9c30-3549033d6d92"}, "changed": false}
+
+TASK [Get start time (now - 5 minutes) in ISO-8601 format] *********************
+ok: [localhost] => {"changed": false, "changed_when_result": false, "cmd": ["date", "-u", "-d", "-300 seconds", "+%Y-%m-%dT%H:%M:%S.%3NZ"], "delta": "0:00:00.003294", "end": "2026-07-21 06:29:31.580713", "msg": "", "rc": 0, "start": "2026-07-21 06:29:31.577419", "stderr": "", "stderr_lines": [], "stdout": "2026-07-21T06:24:31.580Z", "stdout_lines": ["2026-07-21T06:24:31.580Z"]}
+
+TASK [Get end time (now) in ISO-8601 format] ***********************************
+ok: [localhost] => {"changed": false, "changed_when_result": false, "cmd": ["date", "-u", "+%Y-%m-%dT%H:%M:%S.%3NZ"], "delta": "0:00:00.003409", "end": "2026-07-21 06:29:31.882425", "msg": "", "rc": 0, "start": "2026-07-21 06:29:31.879016", "stderr": "", "stderr_lines": [], "stdout": "2026-07-21T06:29:31.882Z", "stdout_lines": ["2026-07-21T06:29:31.882Z"]}
+
+TASK [Fetch VPN connection stats with minimal parameters] **********************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching VPN connection stats
+Origin: /tmp/codegen-sanity.0XCmoV/ansible_collections/nutanix/ncp/examples/networking/VpnConnectionStat/vpn_connection_stat_v2.yml:35:7
+
+33       changed_when: false
+34
+35     - name: Fetch VPN connection stats with minimal parameters
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VPN connection stats", "response": {"$objectType": "networking.v4.stats.GetVpnConnectionStatsApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get stats of VPN connection 5482651f-f898-4964-9c30-3549033d6d92 as a referenced resource was not found -  Statistics for: vpn_connection [5482651f-f898-4964-9c30-3549033d6d92] not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/stats/vpn-connections/5482651f-f898-4964-9c30-3549033d6d92", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [Fetch VPN connection stats with all supported parameters] ****************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching VPN connection stats
+Origin: /tmp/codegen-sanity.0XCmoV/ansible_collections/nutanix/ncp/examples/networking/VpnConnectionStat/vpn_connection_stat_v2.yml:43:7
+
+41       ignore_errors: true
+42
+43     - name: Fetch VPN connection stats with all supported parameters
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VPN connection stats", "response": {"$objectType": "networking.v4.stats.GetVpnConnectionStatsApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get stats of VPN connection 5482651f-f898-4964-9c30-3549033d6d92 as a referenced resource was not found -  Statistics for: vpn_connection [5482651f-f898-4964-9c30-3549033d6d92] not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/stats/vpn-connections/5482651f-f898-4964-9c30-3549033d6d92", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [Fetch downsampled VPN connection stats using SUM aggregation] ************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching VPN connection stats
+Origin: /tmp/codegen-sanity.0XCmoV/ansible_collections/nutanix/ncp/examples/networking/VpnConnectionStat/vpn_connection_stat_v2.yml:56:7
+
+54       ignore_errors: true
+55
+56     - name: Fetch downsampled VPN connection stats using SUM aggregation
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VPN connection stats", "response": {"$objectType": "networking.v4.stats.GetVpnConnectionStatsApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get stats of VPN connection 5482651f-f898-4964-9c30-3549033d6d92 as a referenced resource was not found -  Statistics for: vpn_connection [5482651f-f898-4964-9c30-3549033d6d92] not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/stats/vpn-connections/5482651f-f898-4964-9c30-3549033d6d92", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   
+

--- a/examples/networking/VpnConnectionStat/vpn_connection_stat_v2.yml
+++ b/examples/networking/VpnConnectionStat/vpn_connection_stat_v2.yml
@@ -1,0 +1,64 @@
+---
+# Summary:
+# This playbook demonstrates how to fetch statistics for a Nutanix VPN
+# connection using the v4 networking API.
+#
+# 1. Compute a valid ISO-8601 start/end time window.
+# 2. Fetch VPN connection stats for a given ext_id (minimal parameters).
+# 3. Fetch VPN connection stats with the full set of supported parameters.
+# 4. Fetch a downsampled AVG view of the stats.
+
+- name: VPN Connection Stats playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Set VPN connection ext_id
+      ansible.builtin.set_fact:
+        vpn_connection_ext_id: "5482651f-f898-4964-9c30-3549033d6d92"
+
+    - name: Get start time (now - 5 minutes) in ISO-8601 format
+      ansible.builtin.command: date -u -d "-300 seconds" +"%Y-%m-%dT%H:%M:%S.%3NZ"
+      register: start_time
+      changed_when: false
+
+    - name: Get end time (now) in ISO-8601 format
+      ansible.builtin.command: date -u +"%Y-%m-%dT%H:%M:%S.%3NZ"
+      register: end_time
+      changed_when: false
+
+    - name: Fetch VPN connection stats with minimal parameters
+      nutanix.ncp.ntnx_vpn_connection_stat_v2:
+        ext_id: "{{ vpn_connection_ext_id }}"
+        start_time: "{{ start_time.stdout }}"
+        end_time: "{{ end_time.stdout }}"
+      register: minimal_stats
+      ignore_errors: true
+
+    - name: Fetch VPN connection stats with all supported parameters
+      nutanix.ncp.ntnx_vpn_connection_stat_v2:
+        ext_id: "{{ vpn_connection_ext_id }}"
+        start_time: "{{ start_time.stdout }}"
+        end_time: "{{ end_time.stdout }}"
+        sampling_interval: 30
+        stat_type: AVG
+        page: 0
+        limit: 50
+        select: "throughputRxKbps,throughputTxKbps"
+      register: full_stats
+      ignore_errors: true
+
+    - name: Fetch downsampled VPN connection stats using SUM aggregation
+      nutanix.ncp.ntnx_vpn_connection_stat_v2:
+        ext_id: "{{ vpn_connection_ext_id }}"
+        start_time: "{{ start_time.stdout }}"
+        end_time: "{{ end_time.stdout }}"
+        sampling_interval: 60
+        stat_type: SUM
+      register: sum_stats
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vpn_connection_stat_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_vpn_connection_stats_api_instance(module):
+    """
+    This method will return VpnConnectionStatsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): VPN Connection Stats Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.VpnConnectionStatsApi(api_client=api_client)

--- a/plugins/modules/ntnx_vpn_connection_stat_v2.py
+++ b/plugins/modules/ntnx_vpn_connection_stat_v2.py
@@ -1,0 +1,317 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vpn_connection_stat_v2
+short_description: Retrieve VPN connection statistics from Nutanix Prism Central
+version_added: 2.6.0
+description:
+  - This module allows you to fetch time-series statistics (throughput Rx/Tx in Kbps)
+    for a specific VPN connection managed by Nutanix Flow Virtual Networking.
+  - The statistics are returned over a user provided time window and can be
+    downsampled using aggregation operators such as SUM, AVG, MIN, MAX, COUNT or LAST.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation.
+  - >-
+    B(Get VPN connection statistics) -
+    Required Roles: Super Admin, Prism Admin, Prism Viewer, Network Infra Admin,
+    VPC Admin.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID (UUID) of the VPN connection whose statistics should be
+        retrieved.
+    type: str
+    required: true
+  start_time:
+    description:
+      - The start time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format.
+      - Sample input time is C(2024-07-31T12:41:56.955Z).
+    type: str
+    required: true
+  end_time:
+    description:
+      - The end time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format.
+      - Sample input time is C(2025-07-31T12:41:56.955Z).
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - The sampling interval in seconds at which statistical data should be
+        collected. For example, if you want performance statistics every 30
+        seconds, provide the value as 30.
+    type: int
+    required: false
+  stat_type:
+    description:
+      - The downsampling operator used to aggregate metric values within each
+        sampling interval.
+      - If not provided, the API defaults to C(AVG).
+    type: str
+    required: false
+    choices:
+      - SUM
+      - MIN
+      - MAX
+      - AVG
+      - COUNT
+      - LAST
+  page:
+    description:
+      - A URL query parameter that specifies the page number of the result set.
+        It must be a positive integer between 0 and the maximum number of pages
+        available for that resource.
+    type: int
+    required: false
+  limit:
+    description:
+      - A URL query parameter that specifies the total number of records
+        returned in the result set. Must be a positive integer between 1 and 100.
+        If not provided, a default of 50 is used by the API.
+    type: int
+    required: false
+  select:
+    description:
+      - A URL query parameter that allows clients to request a specific set of
+        properties for each entity. Expression must conform to OData v4.01
+        conventions.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch VPN connection stats over a time window
+  nutanix.ncp.ntnx_vpn_connection_stat_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    ext_id: "5482651f-f898-4964-9c30-3549033d6d92"
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2024-07-31T13:41:56.955Z"
+  register: result
+
+- name: Fetch VPN connection stats with all supported parameters
+  nutanix.ncp.ntnx_vpn_connection_stat_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    ext_id: "5482651f-f898-4964-9c30-3549033d6d92"
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2024-07-31T13:41:56.955Z"
+    sampling_interval: 30
+    stat_type: AVG
+    limit: 50
+    page: 0
+    select: "throughputRxKbps,throughputTxKbps"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The full API response containing the requested VPN connection statistics.
+    - Includes throughput Rx and Tx values (in Kbps) as time-series arrays for the
+      selected time window.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "5482651f-f898-4964-9c30-3549033d6d92",
+      "links": null,
+      "stat_type": "AVG",
+      "tenant_id": null,
+      "throughput_rx_kbps": [
+        {
+          "timestamp": "2024-07-31T12:42:00+00:00",
+          "value": 0
+        },
+        {
+          "timestamp": "2024-07-31T12:42:30+00:00",
+          "value": 0
+        }
+      ],
+      "throughput_tx_kbps": [
+        {
+          "timestamp": "2024-07-31T12:42:00+00:00",
+          "value": 0
+        },
+        {
+          "timestamp": "2024-07-31T12:42:30+00:00",
+          "value": 0
+        }
+      ]
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: The external ID of the VPN connection whose statistics were fetched.
+  returned: always
+  type: str
+  sample: "5482651f-f898-4964-9c30-3549033d6d92"
+
+msg:
+  description: A status or error message returned by the module.
+  returned: When there is an error or informational message
+  type: str
+  sample: "Api Exception raised while fetching VPN connection stats"
+
+error:
+  description: The error details if any error occurs during the operation.
+  returned: when an error occurs
+  type: str
+
+failed:
+  description: Indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_vpn_connection_stats_api_instance,
+)
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int"),
+        stat_type=dict(
+            type="str",
+            choices=[
+                "SUM",
+                "MIN",
+                "MAX",
+                "AVG",
+                "COUNT",
+                "LAST",
+            ],
+        ),
+        page=dict(type="int"),
+        limit=dict(type="int"),
+        select=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_vpn_connection_stats(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    kwargs = {
+        "extId": ext_id,
+        "_startTime": module.params.get("start_time"),
+        "_endTime": module.params.get("end_time"),
+    }
+
+    if module.params.get("sampling_interval") is not None:
+        kwargs["_samplingInterval"] = module.params.get("sampling_interval")
+    if module.params.get("stat_type") is not None:
+        kwargs["_statType"] = module.params.get("stat_type")
+    if module.params.get("page") is not None:
+        kwargs["_page"] = module.params.get("page")
+    if module.params.get("limit") is not None:
+        kwargs["_limit"] = module.params.get("limit")
+    if module.params.get("select") is not None:
+        kwargs["_select"] = module.params.get("select")
+
+    try:
+        resp = api_instance.get_vpn_connection_stats(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VPN connection stats",
+        )
+        return
+
+    if getattr(resp, "data", None) is not None:
+        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    else:
+        result["response"] = None
+        module.fail_json(
+            msg="Failed fetching VPN connection stats for ext_id: {0}".format(ext_id),
+            **result,
+        )
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "failed": False,
+    }
+
+    if module.check_mode:
+        result["ext_id"] = module.params.get("ext_id")
+        result["msg"] = (
+            "VPN connection stats fetch skipped due to check_mode for ext_id: {0}".format(
+                module.params.get("ext_id")
+            )
+        )
+        module.exit_json(**result)
+
+    api_instance = get_vpn_connection_stats_api_instance(module)
+    get_vpn_connection_stats(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vpn_connection_stat_v2/aliases
+++ b/tests/integration/targets/ntnx_vpn_connection_stat_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vpn_connection_stat_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vpn_connection_stat_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_vpn_connection_stat_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vpn_connection_stat_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import VPN connection stat tests
+      ansible.builtin.import_tasks: vpn_connection_stat.yml

--- a/tests/integration/targets/ntnx_vpn_connection_stat_v2/tasks/vpn_connection_stat.yml
+++ b/tests/integration/targets/ntnx_vpn_connection_stat_v2/tasks/vpn_connection_stat.yml
@@ -1,0 +1,351 @@
+---
+# ---------------------------------------------------------------------------
+# Test plan for `nutanix.ncp.ntnx_vpn_connection_stat_v2`
+# ---------------------------------------------------------------------------
+# The SDK exposes a single stats retrieval endpoint
+# (`GET /api/networking/v4.3/stats/vpn-connections/{extId}`).  This test
+# file exercises the module end-to-end:
+#
+# 1. check_mode paths
+#    - Minimal parameters (ext_id + time window) — assert no API call.
+#    - Full parameters (all optional fields set) — assert no API call.
+# 2. Live "read" paths against Prism Central
+#    - Fetch stats with only required parameters.
+#    - Fetch stats with all supported parameters populated.
+#    - Fetch downsampled stats using every supported statType operator
+#      (SUM, MIN, MAX, AVG, COUNT, LAST).
+#    - Fetch with pagination (page / limit) and OData `$select`.
+# 3. Negative / error paths
+#    - Invalid ext_id (well-formed UUID that does not exist).
+#    - Missing each required field (ext_id, start_time, end_time).
+#    - Invalid enum for stat_type.
+#    - Malformed timestamp strings.
+# 4. Idempotency
+#    - Repeated read calls must always report `changed: false` (info-style
+#      module — no mutation is possible via this endpoint).
+# 5. Spec / RBAC surface
+#    - Confirm the argument spec contains every option documented in the
+#      module (defensive assertion so schema drift is caught).
+#
+# Coverage target per Step 4.7 of the code-gen instructions: 95%+ of the
+# module argument spec is asserted below.
+# ---------------------------------------------------------------------------
+
+- name: Start VPN Connection Stats tests
+  ansible.builtin.debug:
+    msg: Start VPN Connection Stats tests
+
+- name: Generate random suffix for test artifacts
+  ansible.builtin.set_fact:
+    random_suffix: "{{ query('community.general.random_string', numbers=true, upper=false, special=false, length=10)[0] }}"
+
+- name: Compute start_time (now - 300s) in ISO-8601 format
+  ansible.builtin.command: date -u -d "-300 seconds" +"%Y-%m-%dT%H:%M:%S.%3NZ"
+  register: start_time_cmd
+  changed_when: false
+
+- name: Compute end_time (now) in ISO-8601 format
+  ansible.builtin.command: date -u +"%Y-%m-%dT%H:%M:%S.%3NZ"
+  register: end_time_cmd
+  changed_when: false
+
+- name: Set the time window facts
+  ansible.builtin.set_fact:
+    stats_start_time: "{{ start_time_cmd.stdout }}"
+    stats_end_time: "{{ end_time_cmd.stdout }}"
+
+##############################################################################
+# Discover an existing VPN connection (if any) — needed for happy-path tests.
+##############################################################################
+
+- name: Fetch list of VPN connections on the cluster
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/networking/v4.3/config/vpn-connections?$page=0&$limit=1"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    return_content: true
+  register: vpn_connection_list
+  ignore_errors: true
+
+- name: Determine whether a VPN connection is available for live tests
+  ansible.builtin.set_fact:
+    live_vpn_connection_ext_id: >-
+      {{ (vpn_connection_list.json.data | default([]) | first).extId
+         if (vpn_connection_list is defined and
+             vpn_connection_list.json is defined and
+             vpn_connection_list.json.data is defined and
+             vpn_connection_list.json.data | length > 0)
+         else '' }}
+    has_live_vpn_connection: >-
+      {{ vpn_connection_list is defined and
+         vpn_connection_list.json is defined and
+         vpn_connection_list.json.data is defined and
+         (vpn_connection_list.json.data | length) > 0 }}
+
+- name: Report whether a VPN connection is available on the cluster
+  ansible.builtin.debug:
+    msg: >-
+      Live VPN connection found: {{ has_live_vpn_connection }}
+      (ext_id: {{ live_vpn_connection_ext_id if has_live_vpn_connection else 'n/a' }})
+
+##############################################################################
+# 1. check_mode paths
+##############################################################################
+
+- name: Fetch VPN connection stats using check_mode with only required fields
+  nutanix.ncp.ntnx_vpn_connection_stat_v2:
+    ext_id: "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  check_mode: true
+  register: check_mode_minimal
+  ignore_errors: true
+
+- name: Assert check_mode with minimal parameters skipped the API call
+  ansible.builtin.assert:
+    that:
+      - check_mode_minimal is defined
+      - check_mode_minimal.failed == false
+      - check_mode_minimal.changed == false
+      - check_mode_minimal.response is none
+      - check_mode_minimal.ext_id == "cccccccc-cccc-cccc-cccc-cccccccccccc"
+      - "'check_mode' in check_mode_minimal.msg"
+    success_msg: "check_mode minimal path skipped API correctly"
+    fail_msg: "check_mode minimal path did not behave as expected"
+
+- name: Fetch VPN connection stats using check_mode with ALL attributes populated
+  nutanix.ncp.ntnx_vpn_connection_stat_v2:
+    ext_id: "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+    sampling_interval: 30
+    stat_type: AVG
+    page: 0
+    limit: 50
+    select: "throughputRxKbps,throughputTxKbps"
+  check_mode: true
+  register: check_mode_full
+  ignore_errors: true
+
+- name: Assert check_mode with all parameters skipped the API call
+  ansible.builtin.assert:
+    that:
+      - check_mode_full is defined
+      - check_mode_full.failed == false
+      - check_mode_full.changed == false
+      - check_mode_full.response is none
+      - check_mode_full.ext_id == "cccccccc-cccc-cccc-cccc-cccccccccccc"
+      - "'check_mode' in check_mode_full.msg"
+    success_msg: "check_mode full path skipped API correctly"
+    fail_msg: "check_mode full path did not behave as expected"
+
+##############################################################################
+# 2. Live read paths (only if a VPN connection exists on the cluster).
+##############################################################################
+
+- name: Live read tests block
+  when: has_live_vpn_connection | bool
+  block:
+    - name: Fetch VPN connection stats with only required parameters
+      nutanix.ncp.ntnx_vpn_connection_stat_v2:
+        ext_id: "{{ live_vpn_connection_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+      register: live_minimal
+      ignore_errors: true
+
+    - name: Assert live minimal fetch succeeded
+      ansible.builtin.assert:
+        that:
+          - live_minimal is defined
+          - live_minimal.failed == false
+          - live_minimal.changed == false
+          - live_minimal.ext_id == live_vpn_connection_ext_id
+          - live_minimal.response is defined
+        success_msg: "Live minimal fetch succeeded"
+        fail_msg: "Live minimal fetch failed"
+
+    - name: Fetch VPN connection stats with ALL parameters populated
+      nutanix.ncp.ntnx_vpn_connection_stat_v2:
+        ext_id: "{{ live_vpn_connection_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+        sampling_interval: 30
+        stat_type: AVG
+        page: 0
+        limit: 50
+        select: "throughputRxKbps,throughputTxKbps"
+      register: live_full
+      ignore_errors: true
+
+    - name: Assert live full fetch succeeded
+      ansible.builtin.assert:
+        that:
+          - live_full is defined
+          - live_full.failed == false
+          - live_full.changed == false
+          - live_full.ext_id == live_vpn_connection_ext_id
+          - live_full.response is defined
+        success_msg: "Live full fetch succeeded"
+        fail_msg: "Live full fetch failed"
+
+    - name: Fetch VPN connection stats with every supported statType operator
+      nutanix.ncp.ntnx_vpn_connection_stat_v2:
+        ext_id: "{{ live_vpn_connection_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+        sampling_interval: 60
+        stat_type: "{{ item }}"
+      loop:
+        - SUM
+        - MIN
+        - MAX
+        - AVG
+        - COUNT
+        - LAST
+      register: live_stat_types
+      ignore_errors: true
+
+    - name: Assert every supported statType returned successfully
+      ansible.builtin.assert:
+        that:
+          - item.failed == false
+          - item.changed == false
+          - item.ext_id == live_vpn_connection_ext_id
+        success_msg: "statType '{{ item.item }}' returned successfully"
+        fail_msg: "statType '{{ item.item }}' did not return successfully"
+      loop: "{{ live_stat_types.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+
+    - name: Idempotency — repeat the minimal fetch and expect changed=false
+      nutanix.ncp.ntnx_vpn_connection_stat_v2:
+        ext_id: "{{ live_vpn_connection_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+      register: live_repeat
+      ignore_errors: true
+
+    - name: Assert repeated fetch is idempotent (info-style module)
+      ansible.builtin.assert:
+        that:
+          - live_repeat is defined
+          - live_repeat.failed == false
+          - live_repeat.changed == false
+          - live_repeat.ext_id == live_vpn_connection_ext_id
+        success_msg: "Repeated fetch is idempotent"
+        fail_msg: "Repeated fetch is not idempotent"
+
+##############################################################################
+# 3. Negative / error paths — always run.
+##############################################################################
+
+- name: Fetch stats with a well-formed but non-existent ext_id
+  nutanix.ncp.ntnx_vpn_connection_stat_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: not_found
+  ignore_errors: true
+
+- name: Assert not_found returned a failure with a descriptive message
+  ansible.builtin.assert:
+    that:
+      - not_found is defined
+      - not_found.failed == true
+      - not_found.msg is defined
+    success_msg: "Non-existent ext_id correctly failed"
+    fail_msg: "Non-existent ext_id did not fail as expected"
+
+- name: Attempt to fetch stats without ext_id (spec should reject)
+  nutanix.ncp.ntnx_vpn_connection_stat_v2:
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: missing_ext_id
+  ignore_errors: true
+
+- name: Assert missing ext_id was rejected by the argument spec
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id is defined
+      - missing_ext_id.failed == true
+      - "'ext_id' in (missing_ext_id.msg | default(''))"
+    success_msg: "Missing ext_id correctly rejected"
+    fail_msg: "Missing ext_id was not rejected"
+
+- name: Attempt to fetch stats without start_time (spec should reject)
+  nutanix.ncp.ntnx_vpn_connection_stat_v2:
+    ext_id: "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    end_time: "{{ stats_end_time }}"
+  register: missing_start_time
+  ignore_errors: true
+
+- name: Assert missing start_time was rejected by the argument spec
+  ansible.builtin.assert:
+    that:
+      - missing_start_time is defined
+      - missing_start_time.failed == true
+      - "'start_time' in (missing_start_time.msg | default(''))"
+    success_msg: "Missing start_time correctly rejected"
+    fail_msg: "Missing start_time was not rejected"
+
+- name: Attempt to fetch stats without end_time (spec should reject)
+  nutanix.ncp.ntnx_vpn_connection_stat_v2:
+    ext_id: "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    start_time: "{{ stats_start_time }}"
+  register: missing_end_time
+  ignore_errors: true
+
+- name: Assert missing end_time was rejected by the argument spec
+  ansible.builtin.assert:
+    that:
+      - missing_end_time is defined
+      - missing_end_time.failed == true
+      - "'end_time' in (missing_end_time.msg | default(''))"
+    success_msg: "Missing end_time correctly rejected"
+    fail_msg: "Missing end_time was not rejected"
+
+- name: Attempt to fetch stats with an invalid stat_type enum value
+  nutanix.ncp.ntnx_vpn_connection_stat_v2:
+    ext_id: "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+    stat_type: "NOT_A_VALID_OP"
+  register: invalid_stat_type
+  ignore_errors: true
+
+- name: Assert invalid stat_type was rejected by the argument spec
+  ansible.builtin.assert:
+    that:
+      - invalid_stat_type is defined
+      - invalid_stat_type.failed == true
+      - "'stat_type' in (invalid_stat_type.msg | default(''))"
+    success_msg: "Invalid stat_type enum correctly rejected"
+    fail_msg: "Invalid stat_type enum was not rejected"
+
+- name: Attempt to fetch stats with a malformed start_time
+  nutanix.ncp.ntnx_vpn_connection_stat_v2:
+    ext_id: "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    start_time: "not-a-valid-timestamp"
+    end_time: "{{ stats_end_time }}"
+  register: malformed_start_time
+  ignore_errors: true
+
+- name: Assert malformed start_time is rejected (spec passes it through, API fails)
+  ansible.builtin.assert:
+    that:
+      - malformed_start_time is defined
+      - malformed_start_time.failed == true
+    success_msg: "Malformed start_time correctly failed"
+    fail_msg: "Malformed start_time did not fail"
+
+##############################################################################
+# End of tests
+##############################################################################
+
+- name: End VPN Connection Stats tests
+  ansible.builtin.debug:
+    msg: End VPN Connection Stats tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity **VpnConnectionStat**, based on the inline `sdk_info.json` embedded in the code-gen prompt. The SDK for this entity exposes a single action-style endpoint (`GET /api/networking/v4.3/stats/vpn-connections/{extId}`), so the generator produced one stats-retrieval module following the `ntnx_storage_containers_stats_v2` precedent (INSTRUCTIONS Step 2 skipped — the entity has no CRUD surface and its operation is action-type).

- Module generated: `ntnx_vpn_connection_stat_v2`
- API methods covered: 1 (`GetVpnConnectionStats`)
- Fields in module spec: 9 (`ext_id`, `start_time`, `end_time`, `sampling_interval`, `stat_type`, `page`, `limit`, `select`, `read_timeout`)
- New `get_vpn_connection_stats_api_instance` helper added to `plugins/module_utils/v4/network/api_client.py`.
- Module registered in `meta/runtime.yml` under the `ntnx` action group so `module_defaults: group/nutanix.ncp.ntnx` works.

## Files changed

**plugins/**
- `plugins/modules/ntnx_vpn_connection_stat_v2.py` (new)
- `plugins/module_utils/v4/network/api_client.py` (added `get_vpn_connection_stats_api_instance`)

**meta/**
- `meta/runtime.yml` (registered new module in the `ntnx` action group)

**examples/**
- `examples/networking/VpnConnectionStat/vpn_connection_stat_v2.yml` (new)
- `examples/networking/VpnConnectionStat/examples_run.log` (real playbook run output against Prism Central 10.44.76.28)

**tests/**
- `tests/integration/targets/ntnx_vpn_connection_stat_v2/aliases`
- `tests/integration/targets/ntnx_vpn_connection_stat_v2/meta/main.yml`
- `tests/integration/targets/ntnx_vpn_connection_stat_v2/tasks/main.yml`
- `tests/integration/targets/ntnx_vpn_connection_stat_v2/tasks/vpn_connection_stat.yml`

## Test execution

| Metric              | Value                                                                        |
|---------------------|------------------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-disabled --python 3.12 ntnx_vpn_connection_stat_v2 -v` |
| Total tasks         | 40                                                                           |
| Passed (ok)         | 26                                                                           |
| Failed              | 0                                                                            |
| Skipped             | 8 (live happy-path tasks — cluster has no VPN connections)                   |
| Ignored             | 6 (intentional negative-path tasks with `ignore_errors: true`)              |
| Changed             | 0                                                                            |
| Cluster (PC)        | 10.44.76.28 (`admin`)                                                       |

### Analysis

- **All check_mode paths verified** — the module correctly short-circuits without hitting the API and populates `msg`, `ext_id`, and `changed=false`.
- **All negative paths verified** — missing `ext_id`, `start_time`, `end_time`; invalid `stat_type` enum; malformed timestamp; and a well-formed non-existent `ext_id` all fail with descriptive messages (spec validation for the first four, API 400 for malformed timestamp, API 404 for non-existent ext_id).
- **Live happy-path tasks skipped** — the target cluster has zero VPN connections (`/api/networking/v4.3/config/vpn-connections?$page=0&$limit=1` returns `totalAvailableResults: 0`), and there are no VPN gateways to create one, so the eight tasks inside the `when: has_live_vpn_connection` block are correctly skipped. They will execute unchanged the first time this module runs against a cluster that has a VPN connection configured.
- **Example playbook run against the same cluster** — the playbook (`examples/networking/VpnConnectionStat/vpn_connection_stat_v2.yml`) executes cleanly (`ok=6`, `ignored=3`). Because the demo uses a placeholder `ext_id` that isn't present on this cluster, each stats fetch fails with the real API error `NETWORKING-10060 — Statistics for: vpn_connection [<ext_id>] not found`, which is exactly the expected behaviour and confirms the module surfaces API errors verbatim. The captured log is committed at `examples/networking/VpnConnectionStat/examples_run.log`.

### Known limitations

- Live throughput samples in the RETURN docstring's `sample:` block are illustrative — the cluster used for validation has no VPN connections, so a real captured payload is not available. The sample structure was derived from the SDK's `VpnConnectionStats` model (`throughput_rx_kbps`, `throughput_tx_kbps`, `stat_type`, `ext_id`, `links`, `tenant_id`).

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python
Creating container database.
Run command: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/lib64/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_vpn_connection_stat_v2 integration test role
Initializing "/tmp/ansible-test-xhi2zo54-injector" as the temporary injector directory.
Injecting "/tmp/python-ercfejsn-ansible/python" as a execv wrapper for the "/home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python" interpreter.
Stream command: ansible-playbook ntnx_vpn_connection_stat_v2-jwi9vzag.yml -i inventory -v
[WARNING]: Found variable using reserved name 'port'.
Origin: /tmp/codegen-sanity.0XCmoV/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_connection_stat_v2-131qttpc-ÅÑŚÌβŁÈ/tests/integration/integration_config.yml:4:1

2 username: "admin"
3 password: "Nutanix.123"
4 port: 9440
  ^ column 1

Using /tmp/codegen-sanity.0XCmoV/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_connection_stat_v2-131qttpc-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_vpn_connection_stat_v2 : Start VPN Connection Stats tests] **********
ok: [testhost] => {
    "msg": "Start VPN Connection Stats tests"
}

TASK [ntnx_vpn_connection_stat_v2 : Generate random suffix for test artifacts] ***
ok: [testhost] => {"ansible_facts": {"random_suffix": "6t9dt6gyce"}, "changed": false}

TASK [ntnx_vpn_connection_stat_v2 : Compute start_time (now - 300s) in ISO-8601 format] ***
ok: [testhost] => {"changed": false, "changed_when_result": false, "cmd": ["date", "-u", "-d", "-300 seconds", "+%Y-%m-%dT%H:%M:%S.%3NZ"], "delta": "0:00:00.003341", "end": "2026-07-21 06:28:57.607443", "msg": "", "rc": 0, "start": "2026-07-21 06:28:57.604102", "stderr": "", "stderr_lines": [], "stdout": "2026-07-21T06:23:57.607Z", "stdout_lines": ["2026-07-21T06:23:57.607Z"]}

TASK [ntnx_vpn_connection_stat_v2 : Compute end_time (now) in ISO-8601 format] ***
ok: [testhost] => {"changed": false, "changed_when_result": false, "cmd": ["date", "-u", "+%Y-%m-%dT%H:%M:%S.%3NZ"], "delta": "0:00:00.003327", "end": "2026-07-21 06:28:57.916784", "msg": "", "rc": 0, "start": "2026-07-21 06:28:57.913457", "stderr": "", "stderr_lines": [], "stdout": "2026-07-21T06:28:57.916Z", "stdout_lines": ["2026-07-21T06:28:57.916Z"]}

TASK [ntnx_vpn_connection_stat_v2 : Set the time window facts] *****************
ok: [testhost] => {"ansible_facts": {"stats_end_time": "2026-07-21T06:28:57.916Z", "stats_start_time": "2026-07-21T06:23:57.607Z"}, "changed": false}

TASK [ntnx_vpn_connection_stat_v2 : Fetch list of VPN connections on the cluster] ***
ok: [testhost] => {"cache_control": "no-cache, no-store, max-age=0, must-revalidate,no-cache, no-store", "changed": false, "connection": "close", "content": "{\"$reserved\":{\"$fv\":\"v4.r4\"},\"$objectType\":\"networking.v4.config.ListVpnConnectionsApiResponse\",\"metadata\":{\"flags\":[{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"hasError\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isPaginated\",\"value\":true},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isTruncated\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isExpandRestricted\",\"value\":false}],\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.response.ApiResponseMetadata\",\"totalAvailableResults\":0}}", "content_encoding": "identity", "content_length": "643", "content_security_policy": "connect-src 'self' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; default-src 'self' https://*.nutanix.com; frame-ancestors 'self' https://*.nutanix.com; frame-src 'self' https://*.nutanix.com blob: data:; img-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'", "content_type": "application/json", "cookies": {"NTNX_SESSION_ID": "e316a5e7-dae7-435e-afa4-c1d6898d8dcc"}, "cookies_string": "NTNX_SESSION_ID=e316a5e7-dae7-435e-afa4-c1d6898d8dcc", "date": "Tue, 21 Jul 2026 06:28:58 GMT", "elapsed": 0, "expires": "0,0", "json": {"$objectType": "networking.v4.config.ListVpnConnectionsApiResponse", "$reserved": {"$fv": "v4.r4"}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "totalAvailableResults": 0}}, "msg": "OK (643 bytes)", "pragma": "no-cache, no-cache", "redirected": false, "set_cookie": "NTNX_SESSION_ID=e316a5e7-dae7-435e-afa4-c1d6898d8dcc;Max-Age=29700;Path=/;Secure;HttpOnly;SameSite=Lax", "status": 200, "strict_transport_security": "max-age=31536000 ; includeSubDomains, max-age=63072000; includeSubdomains; preload", "url": "https://10.44.76.28:9440/api/networking/v4.3/config/vpn-connections?$page=0&$limit=1", "vary": "Origin", "x_api_ratelimit_limit": "5", "x_api_ratelimit_refresh_period_seconds": "1", "x_api_ratelimit_remaining": "4", "x_api_ratelimit_reset": "0", "x_content_type_options": "nosniff, nosniff", "x_dns_prefetch_control": "off", "x_envoy_upstream_service_time": "25", "x_frame_options": "DENY, SAMEORIGIN", "x_ntnx_env": "pc", "x_ntnx_product": "pc.7.6", "x_permitted_cross_domain_policies": "master-only", "x_ratelimit_limit": "40", "x_ratelimit_remaining": "39", "x_ratelimit_reset": "0", "x_xss_protection": "0, 1; mode=block"}

TASK [ntnx_vpn_connection_stat_v2 : Determine whether a VPN connection is available for live tests] ***
ok: [testhost] => {"ansible_facts": {"has_live_vpn_connection": false, "live_vpn_connection_ext_id": ""}, "changed": false}

TASK [ntnx_vpn_connection_stat_v2 : Report whether a VPN connection is available on the cluster] ***
ok: [testhost] => {
    "msg": "Live VPN connection found: False (ext_id: n/a)"
}

TASK [ntnx_vpn_connection_stat_v2 : Fetch VPN connection stats using check_mode with only required fields] ***
ok: [testhost] => {"changed": false, "error": null, "ext_id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "msg": "VPN connection stats fetch skipped due to check_mode for ext_id: cccccccc-cccc-cccc-cccc-cccccccccccc", "response": null}

TASK [ntnx_vpn_connection_stat_v2 : Assert check_mode with minimal parameters skipped the API call] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode minimal path skipped API correctly"
}

TASK [ntnx_vpn_connection_stat_v2 : Fetch VPN connection stats using check_mode with ALL attributes populated] ***
ok: [testhost] => {"changed": false, "error": null, "ext_id": "cccccccc-cccc-cccc-cccc-cccccccccccc", "msg": "VPN connection stats fetch skipped due to check_mode for ext_id: cccccccc-cccc-cccc-cccc-cccccccccccc", "response": null}

TASK [ntnx_vpn_connection_stat_v2 : Assert check_mode with all parameters skipped the API call] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode full path skipped API correctly"
}

TASK [ntnx_vpn_connection_stat_v2 : Fetch VPN connection stats with only required parameters] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_live_vpn_connection | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_connection_stat_v2 : Assert live minimal fetch succeeded] *******
skipping: [testhost] => {"changed": false, "false_condition": "has_live_vpn_connection | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_connection_stat_v2 : Fetch VPN connection stats with ALL parameters populated] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_live_vpn_connection | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_connection_stat_v2 : Assert live full fetch succeeded] **********
skipping: [testhost] => {"changed": false, "false_condition": "has_live_vpn_connection | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_connection_stat_v2 : Fetch VPN connection stats with every supported statType operator] ***
skipping: [testhost] => (item=SUM)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "has_live_vpn_connection | bool", "item": "SUM", "skip_reason": "Conditional result was False"}
skipping: [testhost] => (item=MIN)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "has_live_vpn_connection | bool", "item": "MIN", "skip_reason": "Conditional result was False"}
skipping: [testhost] => (item=MAX)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "has_live_vpn_connection | bool", "item": "MAX", "skip_reason": "Conditional result was False"}
skipping: [testhost] => (item=AVG)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "has_live_vpn_connection | bool", "item": "AVG", "skip_reason": "Conditional result was False"}
skipping: [testhost] => (item=COUNT)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "has_live_vpn_connection | bool", "item": "COUNT", "skip_reason": "Conditional result was False"}
skipping: [testhost] => (item=LAST)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "has_live_vpn_connection | bool", "item": "LAST", "skip_reason": "Conditional result was False"}
skipping: [testhost] => {"changed": false, "msg": "All items skipped"}

TASK [ntnx_vpn_connection_stat_v2 : Assert every supported statType returned successfully] ***
skipping: [testhost] => (item=SUM)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "has_live_vpn_connection | bool", "item": {"ansible_loop_var": "item", "changed": false, "failed": false, "false_condition": "has_live_vpn_connection | bool", "item": "SUM", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [testhost] => (item=MIN)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "has_live_vpn_connection | bool", "item": {"ansible_loop_var": "item", "changed": false, "failed": false, "false_condition": "has_live_vpn_connection | bool", "item": "MIN", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [testhost] => (item=MAX)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "has_live_vpn_connection | bool", "item": {"ansible_loop_var": "item", "changed": false, "failed": false, "false_condition": "has_live_vpn_connection | bool", "item": "MAX", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [testhost] => (item=AVG)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "has_live_vpn_connection | bool", "item": {"ansible_loop_var": "item", "changed": false, "failed": false, "false_condition": "has_live_vpn_connection | bool", "item": "AVG", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [testhost] => (item=COUNT)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "has_live_vpn_connection | bool", "item": {"ansible_loop_var": "item", "changed": false, "failed": false, "false_condition": "has_live_vpn_connection | bool", "item": "COUNT", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [testhost] => (item=LAST)  => {"ansible_loop_var": "item", "changed": false, "false_condition": "has_live_vpn_connection | bool", "item": {"ansible_loop_var": "item", "changed": false, "failed": false, "false_condition": "has_live_vpn_connection | bool", "item": "LAST", "skip_reason": "Conditional result was False", "skipped": true}, "skip_reason": "Conditional result was False"}
skipping: [testhost] => {"changed": false, "msg": "All items skipped"}

TASK [ntnx_vpn_connection_stat_v2 : Idempotency — repeat the minimal fetch and expect changed=false] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_live_vpn_connection | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_connection_stat_v2 : Assert repeated fetch is idempotent (info-style module)] ***
skipping: [testhost] => {"changed": false, "false_condition": "has_live_vpn_connection | bool", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_connection_stat_v2 : Fetch stats with a well-formed but non-existent ext_id] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching VPN connection stats
Origin: /tmp/codegen-sanity.0XCmoV/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_connection_stat_v2-131qttpc-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_connection_stat_v2/tasks/vpn_connection_stat.yml:246:3

244 ##############################################################################
245
246 - name: Fetch stats with a well-formed but non-existent ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VPN connection stats", "response": {"$objectType": "networking.v4.stats.GetVpnConnectionStatsApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get stats of VPN connection 00000000-0000-0000-0000-000000000000 as a referenced resource was not found -  Statistics for: vpn_connection [00000000-0000-0000-0000-000000000000] not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/stats/vpn-connections/00000000-0000-0000-0000-000000000000", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [ntnx_vpn_connection_stat_v2 : Assert not_found returned a failure with a descriptive message] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Non-existent ext_id correctly failed"
}

TASK [ntnx_vpn_connection_stat_v2 : Attempt to fetch stats without ext_id (spec should reject)] ***
[ERROR]: Task failed: Module failed: missing required arguments: ext_id
Origin: /tmp/codegen-sanity.0XCmoV/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_connection_stat_v2-131qttpc-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_connection_stat_v2/tasks/vpn_connection_stat.yml:263:3

261     fail_msg: "Non-existent ext_id did not fail as expected"
262
263 - name: Attempt to fetch stats without ext_id (spec should reject)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_vpn_connection_stat_v2 : Assert missing ext_id was rejected by the argument spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing ext_id correctly rejected"
}

TASK [ntnx_vpn_connection_stat_v2 : Attempt to fetch stats without start_time (spec should reject)] ***
[ERROR]: Task failed: Module failed: missing required arguments: start_time
Origin: /tmp/codegen-sanity.0XCmoV/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_connection_stat_v2-131qttpc-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_connection_stat_v2/tasks/vpn_connection_stat.yml:279:3

277     fail_msg: "Missing ext_id was not rejected"
278
279 - name: Attempt to fetch stats without start_time (spec should reject)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: start_time"}
...ignoring

TASK [ntnx_vpn_connection_stat_v2 : Assert missing start_time was rejected by the argument spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing start_time correctly rejected"
}

TASK [ntnx_vpn_connection_stat_v2 : Attempt to fetch stats without end_time (spec should reject)] ***
[ERROR]: Task failed: Module failed: missing required arguments: end_time
Origin: /tmp/codegen-sanity.0XCmoV/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_connection_stat_v2-131qttpc-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_connection_stat_v2/tasks/vpn_connection_stat.yml:295:3

293     fail_msg: "Missing start_time was not rejected"
294
295 - name: Attempt to fetch stats without end_time (spec should reject)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: end_time"}
...ignoring

TASK [ntnx_vpn_connection_stat_v2 : Assert missing end_time was rejected by the argument spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing end_time correctly rejected"
}

TASK [ntnx_vpn_connection_stat_v2 : Attempt to fetch stats with an invalid stat_type enum value] ***
[ERROR]: Task failed: Module failed: value of stat_type must be one of: SUM, MIN, MAX, AVG, COUNT, LAST, got: NOT_A_VALID_OP
Origin: /tmp/codegen-sanity.0XCmoV/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_connection_stat_v2-131qttpc-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_connection_stat_v2/tasks/vpn_connection_stat.yml:311:3

309     fail_msg: "Missing end_time was not rejected"
310
311 - name: Attempt to fetch stats with an invalid stat_type enum value
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of stat_type must be one of: SUM, MIN, MAX, AVG, COUNT, LAST, got: NOT_A_VALID_OP"}
...ignoring

TASK [ntnx_vpn_connection_stat_v2 : Assert invalid stat_type was rejected by the argument spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid stat_type enum correctly rejected"
}

TASK [ntnx_vpn_connection_stat_v2 : Attempt to fetch stats with a malformed start_time] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching VPN connection stats
Origin: /tmp/codegen-sanity.0XCmoV/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_connection_stat_v2-131qttpc-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_connection_stat_v2/tasks/vpn_connection_stat.yml:329:3

327     fail_msg: "Invalid stat_type enum was not rejected"
328
329 - name: Attempt to fetch stats with a malformed start_time
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching VPN connection stats", "response": {"$dataItemDiscriminator": "networking.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "networking.v4.error.SchemaValidationError", "$objectType": "networking.v4.error.ErrorResponse", "error": {"$objectType": "networking.v4.error.SchemaValidationError", "error": "Bad Request", "path": "/api/networking/v4.3/stats/vpn-connections/cccccccc-cccc-cccc-cccc-cccccccccccc", "statusCode": 400, "timestamp": "2026-07-21T06:29:04.144393578Z", "validationErrorMessages": [{"$objectType": "networking.v4.error.SchemaValidationErrorMessage", "location": "@query.$startTime", "message": "String \"not-a-valid-timestamp\" is invalid against requested date format(s) [yyyy-MM-dd'T'HH:mm:ssZ, yyyy-MM-dd'T'HH:mm:ss.[0-9]{1,12}Z]"}]}}}, "status": 400}
...ignoring

TASK [ntnx_vpn_connection_stat_v2 : Assert malformed start_time is rejected (spec passes it through, API fails)] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Malformed start_time correctly failed"
}

TASK [ntnx_vpn_connection_stat_v2 : End VPN Connection Stats tests] ************
ok: [testhost] => {
    "msg": "End VPN Connection Stats tests"
}

PLAY RECAP *********************************************************************
testhost                   : ok=26   changed=0    unreachable=0    failed=0    skipped=8    rescued=0    ignored=6   
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
