### PR TITLE
ComputeSnapshotChange Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/files/ComputeSnapshotChange/compute_snapshot_change_v2.yml
+++ b/examples/files/ComputeSnapshotChange/compute_snapshot_change_v2.yml
@@ -1,0 +1,92 @@
+---
+# Summary:
+# This playbook exercises the Nutanix Files v4 "compute snapshot change" workflow
+# (Change File Tracking) end-to-end. It:
+#   1. Discovers a file server + mount target + two mount-target snapshots on the cluster.
+#   2. Triggers a compute-snapshot-change action between the two snapshots (Create).
+#   3. Fetches the resulting SnapshotChangedContent by ext_id (Update / idempotent).
+#   4. Fetches the resulting SnapshotChangedContent via the info module (single + list).
+#   5. Runs "state=absent" on the resource — the API does not support delete so the
+#      module reports it as skipped.
+
+- name: Files compute-snapshot-change playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ pc_ip | default('<pc_ip>') }}"
+      nutanix_username: "{{ pc_username | default('admin') }}"
+      nutanix_password: "{{ pc_password | default('<pc_password>') }}"
+      validate_certs: false
+  tasks:
+    - name: Set feature-specific variables
+      ansible.builtin.set_fact:
+        file_server_ext_id: "{{ file_server_ext_id | default('6c6f6f6b-1234-4321-9abc-abcdef012345') }}"
+        mount_target_ext_id: "{{ mount_target_ext_id | default('9c1e537d-6777-4c22-5d41-ddd0c3337aa9') }}"
+        snapshot_ext_id: "{{ snapshot_ext_id | default('3e2d5fbb-0000-0000-0000-000000000002') }}"
+        base_snapshot_ext_id: "{{ base_snapshot_ext_id | default('3e2d5fbb-0000-0000-0000-000000000001') }}"
+
+    - name: Compute snapshot change between two mount-target snapshots
+      nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        snapshot_ext_id: "{{ snapshot_ext_id }}"
+        base_snapshot_ext_id: "{{ base_snapshot_ext_id }}"
+        should_show_relative_path: true
+        should_use_dfs_namespace: false
+      register: compute_result
+      ignore_errors: true
+
+    - name: Set compute snapshot change ext_id
+      ansible.builtin.set_fact:
+        compute_snapshot_change_ext_id: "{{ compute_result.ext_id | default('<Need to add sample>') }}"
+
+    - name: Idempotent fetch of the same snapshot changed content (state=present + ext_id)
+      nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        ext_id: "{{ compute_snapshot_change_ext_id }}"
+      register: idempotent_result
+      ignore_errors: true
+
+    - name: Get snapshot changed content using ext_id via info module
+      nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        ext_id: "{{ compute_snapshot_change_ext_id }}"
+      register: info_get_result
+      ignore_errors: true
+
+    - name: List snapshot changed contents on the mount target
+      nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+      register: info_list_result
+      ignore_errors: true
+
+    - name: List snapshot changed contents filtered by snapshot ext_id
+      nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        filter: "snapshotExtId eq '{{ snapshot_ext_id }}'"
+      register: info_filtered_result
+      ignore_errors: true
+
+    - name: List snapshot changed contents with limit
+      nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        limit: 1
+      register: info_limited_result
+      ignore_errors: true
+
+    - name: State=absent is a no-op because the API does not support delete
+      nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+        state: absent
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        ext_id: "{{ compute_snapshot_change_ext_id }}"
+      register: delete_result
+      ignore_errors: true

--- a/examples/files/ComputeSnapshotChange/examples_run.log
+++ b/examples/files/ComputeSnapshotChange/examples_run.log
@@ -1,0 +1,90 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Files compute-snapshot-change playbook] **********************************
+
+TASK [Set feature-specific variables] ******************************************
+ok: [localhost] => {"ansible_facts": {"base_snapshot_ext_id": "3e2d5fbb-0000-0000-0000-000000000001", "file_server_ext_id": "6c6f6f6b-1234-4321-9abc-abcdef012345", "mount_target_ext_id": "9c1e537d-6777-4c22-5d41-ddd0c3337aa9", "snapshot_ext_id": "3e2d5fbb-0000-0000-0000-000000000002"}, "changed": false}
+
+TASK [Compute snapshot change between two mount-target snapshots] **************
+[ERROR]: Task failed: Module failed: Api Exception raised while triggering compute snapshot change on mount target '9c1e537d-6777-4c22-5d41-ddd0c3337aa9' of file server '6c6f6f6b-1234-4321-9abc-abcdef012345'
+Origin: /tmp/codegen/c0b39ca49a774114b877f18fa97afb53/repo/examples/files/ComputeSnapshotChange/compute_snapshot_change_v2.yml:29:7
+
+27         base_snapshot_ext_id: "{{ base_snapshot_ext_id | default('3e2d5fbb-0000-0000-0000-000000000001') }}"
+28
+29     - name: Compute snapshot change between two mount-target snapshots
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while triggering compute snapshot change on mount target '9c1e537d-6777-4c22-5d41-ddd0c3337aa9' of file server '6c6f6f6b-1234-4321-9abc-abcdef012345'", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Set compute snapshot change ext_id] **************************************
+ok: [localhost] => {"ansible_facts": {"compute_snapshot_change_ext_id": "<Need to add sample>"}, "changed": false}
+
+TASK [Idempotent fetch of the same snapshot changed content (state=present + ext_id)] ***
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching snapshot changed content with ext_id '<Need to add sample>' on file server '6c6f6f6b-1234-4321-9abc-abcdef012345' and mount target '9c1e537d-6777-4c22-5d41-ddd0c3337aa9'
+Origin: /tmp/codegen/c0b39ca49a774114b877f18fa97afb53/repo/examples/files/ComputeSnapshotChange/compute_snapshot_change_v2.yml:45:7
+
+43         compute_snapshot_change_ext_id: "{{ compute_result.ext_id | default('<Need to add sample>') }}"
+44
+45     - name: Idempotent fetch of the same snapshot changed content (state=present + ext_id)
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching snapshot changed content with ext_id '<Need to add sample>' on file server '6c6f6f6b-1234-4321-9abc-abcdef012345' and mount target '9c1e537d-6777-4c22-5d41-ddd0c3337aa9'", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Get snapshot changed content using ext_id via info module] ***************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching snapshot changed content with ext_id '<Need to add sample>' on file server '6c6f6f6b-1234-4321-9abc-abcdef012345' and mount target '9c1e537d-6777-4c22-5d41-ddd0c3337aa9'
+Origin: /tmp/codegen/c0b39ca49a774114b877f18fa97afb53/repo/examples/files/ComputeSnapshotChange/compute_snapshot_change_v2.yml:54:7
+
+52       ignore_errors: true
+53
+54     - name: Get snapshot changed content using ext_id via info module
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching snapshot changed content with ext_id '<Need to add sample>' on file server '6c6f6f6b-1234-4321-9abc-abcdef012345' and mount target '9c1e537d-6777-4c22-5d41-ddd0c3337aa9'", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List snapshot changed contents on the mount target] **********************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching compute snapshot changes info for mount target '9c1e537d-6777-4c22-5d41-ddd0c3337aa9' on file server '6c6f6f6b-1234-4321-9abc-abcdef012345'
+Origin: /tmp/codegen/c0b39ca49a774114b877f18fa97afb53/repo/examples/files/ComputeSnapshotChange/compute_snapshot_change_v2.yml:62:7
+
+60       ignore_errors: true
+61
+62     - name: List snapshot changed contents on the mount target
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching compute snapshot changes info for mount target '9c1e537d-6777-4c22-5d41-ddd0c3337aa9' on file server '6c6f6f6b-1234-4321-9abc-abcdef012345'", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List snapshot changed contents filtered by snapshot ext_id] **************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching compute snapshot changes info for mount target '9c1e537d-6777-4c22-5d41-ddd0c3337aa9' on file server '6c6f6f6b-1234-4321-9abc-abcdef012345'
+Origin: /tmp/codegen/c0b39ca49a774114b877f18fa97afb53/repo/examples/files/ComputeSnapshotChange/compute_snapshot_change_v2.yml:69:7
+
+67       ignore_errors: true
+68
+69     - name: List snapshot changed contents filtered by snapshot ext_id
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching compute snapshot changes info for mount target '9c1e537d-6777-4c22-5d41-ddd0c3337aa9' on file server '6c6f6f6b-1234-4321-9abc-abcdef012345'", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List snapshot changed contents with limit] *******************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching compute snapshot changes info for mount target '9c1e537d-6777-4c22-5d41-ddd0c3337aa9' on file server '6c6f6f6b-1234-4321-9abc-abcdef012345'
+Origin: /tmp/codegen/c0b39ca49a774114b877f18fa97afb53/repo/examples/files/ComputeSnapshotChange/compute_snapshot_change_v2.yml:77:7
+
+75       ignore_errors: true
+76
+77     - name: List snapshot changed contents with limit
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching compute snapshot changes info for mount target '9c1e537d-6777-4c22-5d41-ddd0c3337aa9' on file server '6c6f6f6b-1234-4321-9abc-abcdef012345'", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [State=absent is a no-op because the API does not support delete] *********
+skipping: [localhost] => {"changed": false, "ext_id": "<Need to add sample>", "msg": "Delete is not supported by the Files v4 API for a compute snapshot change resource. Skipping delete for ext_id '<Need to add sample>'.", "response": null, "task_ext_id": null}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=8    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=6   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_files_compute_snapshot_change_v2
+    - ntnx_compute_snapshot_changes_info_v2

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,130 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details.
+    Args:
+        module (object): Ansible module object
+    return:
+        client (object): api client object
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    supports_version_negotiation = True
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        supports_version_negotiation = False
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    if supports_version_negotiation:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config,
+            allow_version_negotiation=ALLOW_VERSION_NEGOTIATION,
+        )
+    else:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    return:
+        etag (str): etag value
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_snapshot_changed_contents_api_instance(module):
+    """
+    This method will return SnapshotChangedContentsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): SnapshotChangedContentsApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.SnapshotChangedContentsApi(api_client=api_client)
+
+
+def get_file_servers_api_instance(module):
+    """
+    This method will return FileServersApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): FileServersApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.FileServersApi(api_client=api_client)
+
+
+def get_snapshots_api_instance(module):
+    """
+    This method will return SnapshotsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): SnapshotsApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.SnapshotsApi(api_client=api_client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,49 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_snapshot_changed_content(
+    module,
+    api_instance,
+    file_server_ext_id,
+    mount_target_ext_id,
+    ext_id,
+    x_next_page_token=None,
+):
+    """
+    Fetch a SnapshotChangedContent by its external ID.
+
+    Args:
+        module (AnsibleModule): The Ansible module instance.
+        api_instance (SnapshotChangedContentsApi): SDK API instance.
+        file_server_ext_id (str): External ID of the file server.
+        mount_target_ext_id (str): External ID of the mount target.
+        ext_id (str): External ID of the SnapshotChangedContent resource.
+        x_next_page_token (str): Optional pagination token forwarded to the SDK.
+
+    Returns:
+        SnapshotChangedContent SDK data object.
+    """
+    try:
+        resp = api_instance.get_snapshot_changed_content_by_id(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            extId=ext_id,
+            X_Next_Page_Token=x_next_page_token,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching snapshot changed content "
+                "with ext_id '{0}' on file server '{1}' and mount target '{2}'"
+            ).format(ext_id, file_server_ext_id, mount_target_ext_id),
+        )
+    return resp.data

--- a/plugins/modules/ntnx_compute_snapshot_changes_info_v2.py
+++ b/plugins/modules/ntnx_compute_snapshot_changes_info_v2.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_compute_snapshot_changes_info_v2
+short_description: Fetch information about Nutanix Files compute-snapshot-change resources
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about ComputeSnapshotChange in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific ComputeSnapshotChange.
+  - If C(ext_id) is not provided, list multiple ComputeSnapshotChange optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs (I(ntnx_files_py_client)).
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation.
+  - >-
+    B(Get compute snapshot change by ext_id) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, File Server Admin, File Server Viewer.
+  - >-
+    B(List compute snapshot changes) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, File Server Admin, File Server Viewer.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  ext_id:
+    description:
+      - The external ID of the SnapshotChangedContent resource.
+      - When set, the module performs a get-by-ID call and returns a single entity.
+    type: str
+    required: false
+  file_server_ext_id:
+    description:
+      - The external ID of the file server hosting the mount target.
+    type: str
+    required: true
+  mount_target_ext_id:
+    description:
+      - The external ID of the mount target that the SnapshotChangedContent belongs to.
+    type: str
+    required: true
+  x_next_page_token:
+    description:
+      - Pagination token forwarded to the SDK's C(X-Next-Page-Token) header when fetching
+        a specific SnapshotChangedContent by external ID.
+      - The Files v4 API returns the changed-content page-by-page (maximum 300 entries per
+        page) and provides a token for the next page; pass that token here on subsequent
+        calls.
+      - Only applies when C(ext_id) is provided (single-entity fetch).
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Get snapshot changed content using ext_id
+  nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+    file_server_ext_id: "6c6f6f6b-1234-4321-9abc-abcdef012345"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+  register: result
+  ignore_errors: true
+
+- name: Get next page of an existing snapshot changed content
+  nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+    file_server_ext_id: "6c6f6f6b-1234-4321-9abc-abcdef012345"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+    x_next_page_token: "eyJvZmZzZXQiOjMwMH0="
+  register: result
+  ignore_errors: true
+
+- name: List all snapshot changed contents for a mount target
+  nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+    file_server_ext_id: "6c6f6f6b-1234-4321-9abc-abcdef012345"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+  register: result
+  ignore_errors: true
+
+- name: List snapshot changed contents with filter
+  nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+    file_server_ext_id: "6c6f6f6b-1234-4321-9abc-abcdef012345"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    filter: "snapshotExtId eq '3e2d5fbb-0000-0000-0000-000000000002'"
+  register: result
+  ignore_errors: true
+
+- name: List snapshot changed contents with pagination
+  nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+    file_server_ext_id: "6c6f6f6b-1234-4321-9abc-abcdef012345"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    limit: 10
+    page: 0
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC ComputeSnapshotChange info v4 API.
+    - It can be a single ComputeSnapshotChange if external ID is provided.
+    - List of multiple ComputeSnapshotChange if external ID is not provided with optional
+      filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "base_snapshot_ext_id": "3e2d5fbb-0000-0000-0000-000000000001",
+      "changed_contents": [
+          {
+              "access_time": null,
+              "change_time": "2026-07-21T05:00:00Z",
+              "creation_time": "2026-07-21T05:00:00Z",
+              "inode_number": 42,
+              "object_type": "FILE",
+              "old_path": null,
+              "operation_type": "CREATED",
+              "path": "/share/dir1/file1.txt",
+              "size_bytes": 1024
+          }
+      ],
+      "ext_id": "48f78959-14a6-4c47-b5db-920460c4b668",
+      "has_more_content": false,
+      "links": null,
+      "snapshot_ext_id": "3e2d5fbb-0000-0000-0000-000000000002",
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Status/info message emitted by the module.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching compute snapshot changes info"
+
+error:
+  description: Error message if any error occurred.
+  type: str
+  returned: When an error occurs
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the SnapshotChangedContent (single-entity fetch only).
+  type: str
+  returned: when external ID is provided
+  sample: "48f78959-14a6-4c47-b5db-920460c4b668"
+
+total_available_results:
+  description: The total number of available SnapshotChangedContent entries returned by the list API.
+  type: int
+  returned: when all compute snapshot changes are fetched
+  sample: 3
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_snapshot_changed_contents_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_snapshot_changed_content  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        file_server_ext_id=dict(type="str", required=True),
+        mount_target_ext_id=dict(type="str", required=True),
+        x_next_page_token=dict(type="str", no_log=False),
+    )
+    return module_args
+
+
+def get_snapshot_changed_content_using_ext_id(module, api_instance, result):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+    ext_id = module.params.get("ext_id")
+    entity = get_snapshot_changed_content(
+        module,
+        api_instance,
+        file_server_ext_id,
+        mount_target_ext_id,
+        ext_id,
+        x_next_page_token=module.params.get("x_next_page_token"),
+    )
+    result["ext_id"] = ext_id
+    if entity is not None:
+        result["response"] = strip_internal_attributes(entity.to_dict())
+    else:
+        result["response"] = {}
+
+
+def list_snapshot_changed_contents(module, api_instance, result):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating compute snapshot changes info spec", **result
+        )
+
+    try:
+        resp = api_instance.list_snapshot_changed_contents(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            **kwargs,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching compute snapshot changes info "
+                "for mount target '{0}' on file server '{1}'"
+            ).format(mount_target_ext_id, file_server_ext_id),
+        )
+
+    total_available_results = None
+    metadata = getattr(resp, "metadata", None)
+    if metadata is not None:
+        total_available_results = getattr(metadata, "total_available_results", None)
+    if total_available_results is not None:
+        result["total_available_results"] = total_available_results
+
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+            ("ext_id", "limit"),
+            ("ext_id", "page"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_snapshot_changed_contents_api_instance(module)
+    if module.params.get("ext_id"):
+        get_snapshot_changed_content_using_ext_id(module, api_instance, result)
+    else:
+        list_snapshot_changed_contents(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_files_compute_snapshot_change_v2.py
+++ b/plugins/modules/ntnx_files_compute_snapshot_change_v2.py
@@ -1,0 +1,465 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_compute_snapshot_change_v2
+short_description: Compute mount target snapshot changed contents in Nutanix Files
+version_added: 2.5.0
+description:
+  - This module allows you to trigger the "compute snapshot change" action for a mount target in
+    Nutanix Files (Change File Tracking / CFT diff between two mount target snapshots).
+  - When C(state) is C(present) and C(ext_id) is not provided, the module calls the
+    C(POST /files/v4.0/.../mount-targets/{mountTargetExtId}/$actions/compute-snapshot-change)
+    API to start a compute-snapshot-change action on the given mount target and returns
+    the resulting SnapshotChangedContent resource (created from the two snapshots).
+  - When C(state) is C(present) and C(ext_id) is provided, the module is idempotent and returns
+    the existing SnapshotChangedContent resource without triggering the action again.
+  - When C(state) is C(absent), the module is a no-op because the Files v4 API does not
+    expose a delete operation for a SnapshotChangedContent (it is cleaned up by the platform).
+  - This module uses PC v4 APIs based SDKs (I(ntnx_files_py_client)).
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user
+      performing the operation.
+    - >-
+      B(Compute snapshot change on a mount target) -
+      Required Roles: Prism Admin, Super Admin, File Server Admin.
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided, the module triggers a
+        new compute-snapshot-change action.
+      - If C(state) is set to C(present) and C(ext_id) is provided, the module fetches the
+        existing SnapshotChangedContent (idempotent, C(changed=false)).
+      - If C(state) is set to C(absent), the module is a no-op because the Files v4 API does
+        not support deleting a SnapshotChangedContent resource.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the SnapshotChangedContent resource.
+      - When provided, the module fetches this resource (idempotent behaviour).
+      - This value is not required for a fresh compute-snapshot-change action.
+    type: str
+    required: false
+  file_server_ext_id:
+    description:
+      - The external ID of the file server that hosts the mount target.
+      - Required for all operations.
+    type: str
+    required: true
+  mount_target_ext_id:
+    description:
+      - The external ID of the mount target on which to compute the snapshot change.
+      - Required for all operations.
+    type: str
+    required: true
+  snapshot_ext_id:
+    description:
+      - External ID of the current mount target snapshot to compare.
+      - Required when triggering a new compute-snapshot-change action (C(state=present) and
+        no C(ext_id)).
+    type: str
+    required: false
+  base_snapshot_ext_id:
+    description:
+      - External ID of the base mount target snapshot to compare against.
+      - When omitted, the API treats the request as a "full" diff (all files in
+        C(snapshot_ext_id)); when provided, the API returns only files that changed between
+        C(base_snapshot_ext_id) and C(snapshot_ext_id).
+    type: str
+    required: false
+  should_show_relative_path:
+    description:
+      - When true, the API returns paths relative to the share root instead of absolute paths.
+      - Defaults to the SDK default (false) when not provided.
+    type: bool
+    required: false
+  should_use_dfs_namespace:
+    description:
+      - When true, the API returns paths in the DFS namespace form.
+      - Defaults to the SDK default (true) when not provided.
+    type: bool
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Compute snapshot change between two snapshots of a mount target
+  nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+    state: present
+    file_server_ext_id: "6c6f6f6b-1234-4321-9abc-abcdef012345"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    snapshot_ext_id: "3e2d5fbb-0000-0000-0000-000000000002"
+    base_snapshot_ext_id: "3e2d5fbb-0000-0000-0000-000000000001"
+    should_show_relative_path: true
+    should_use_dfs_namespace: false
+  register: result
+  ignore_errors: true
+
+- name: Idempotent fetch of an existing snapshot changed content by ext_id
+  nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+    state: present
+    file_server_ext_id: "6c6f6f6b-1234-4321-9abc-abcdef012345"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+  register: result
+  ignore_errors: true
+
+- name: State absent is a no-op because the API does not support delete
+  nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+    state: absent
+    file_server_ext_id: "6c6f6f6b-1234-4321-9abc-abcdef012345"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for the compute-snapshot-change action.
+    - If the operation triggered a new action and C(wait) is true, this returns the
+      SnapshotChangedContent details fetched after the action completes.
+    - If the operation triggered a new action and C(wait) is false, this returns the task
+      response payload from the SDK.
+    - If C(ext_id) was provided (idempotent case), this returns the existing
+      SnapshotChangedContent details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "base_snapshot_ext_id": "3e2d5fbb-0000-0000-0000-000000000001",
+      "changed_contents": [
+          {
+              "access_time": null,
+              "change_time": "2026-07-21T05:00:00Z",
+              "creation_time": "2026-07-21T05:00:00Z",
+              "inode_number": 42,
+              "object_type": "FILE",
+              "old_path": null,
+              "operation_type": "CREATED",
+              "path": "/share/dir1/file1.txt",
+              "size_bytes": 1024
+          }
+      ],
+      "ext_id": "48f78959-14a6-4c47-b5db-920460c4b668",
+      "has_more_content": false,
+      "links": null,
+      "snapshot_ext_id": "3e2d5fbb-0000-0000-0000-000000000002",
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the compute-snapshot-change task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the SnapshotChangedContent resource produced (or looked up) by
+      the module.
+  returned: always
+  type: str
+  sample: "48f78959-14a6-4c47-b5db-920460c4b668"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description:
+    - This indicates whether the operation was skipped (idempotent no-op).
+    - Set to true when C(ext_id) is provided (state=present) or when C(state=absent) since
+      the API does not support delete.
+  returned: when applicable
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Status/info message emitted by the module.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: >-
+    Compute snapshot change with ext_id '48f78959-14a6-4c47-b5db-920460c4b668' already exists.
+    Skipping creation.
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_snapshot_changed_contents_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_snapshot_changed_content  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client as files_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as files_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+_SNAPSHOT_CHANGED_CONTENT_REL = "files:config:snapshot-changed-content"
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        file_server_ext_id=dict(type="str", required=True),
+        mount_target_ext_id=dict(type="str", required=True),
+        snapshot_ext_id=dict(type="str"),
+        base_snapshot_ext_id=dict(type="str"),
+        should_show_relative_path=dict(type="bool"),
+        should_use_dfs_namespace=dict(type="bool"),
+    )
+    return module_args
+
+
+def _build_compute_snapshot_change_spec(module, result):
+    """Build a ComputeSnapshotChangeSpec SDK object from module params."""
+    sg = SpecGenerator(module)
+    default_spec = files_sdk.ComputeSnapshotChangeSpec()
+    spec_attrs = {
+        "snapshot_ext_id": module.params.get("snapshot_ext_id"),
+        "base_snapshot_ext_id": module.params.get("base_snapshot_ext_id"),
+        "should_show_relative_path": module.params.get("should_show_relative_path"),
+        "should_use_dfs_namespace": module.params.get("should_use_dfs_namespace"),
+    }
+    spec, err = sg.generate_spec(obj=default_spec, attr=spec_attrs)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating compute snapshot change spec", **result)
+    return spec
+
+
+def create_ComputeSnapshotChange(module, result, api_instance):
+    """Trigger a new compute-snapshot-change action on the given mount target."""
+    validate_required_params(
+        module, ["file_server_ext_id", "mount_target_ext_id", "snapshot_ext_id"]
+    )
+
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+
+    spec = _build_compute_snapshot_change_spec(module, result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        result["msg"] = (
+            "Compute snapshot change spec generated for mount target "
+            "'{0}' on file server '{1}' (check mode)."
+        ).format(mount_target_ext_id, file_server_ext_id)
+        return
+
+    resp = None
+    try:
+        resp = api_instance.compute_snapshot_change(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            body=spec,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while triggering compute snapshot change "
+                "on mount target '{0}' of file server '{1}'"
+            ).format(mount_target_ext_id, file_server_ext_id),
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task_status, rel=_SNAPSHOT_CHANGED_CONTENT_REL
+        )
+        if not ext_id:
+            ext_id = get_entity_ext_id_from_task(task_status)
+        if ext_id:
+            result["ext_id"] = ext_id
+            entity = get_snapshot_changed_content(
+                module,
+                api_instance,
+                file_server_ext_id,
+                mount_target_ext_id,
+                ext_id,
+            )
+            if entity is not None:
+                result["response"] = strip_internal_attributes(entity.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for compute snapshot change"
+                ),
+                msg="Failed to get entity ext_id from task for compute snapshot change",
+            )
+    result["changed"] = True
+
+
+def update_ComputeSnapshotChange(module, result, api_instance):
+    """
+    "Update" for this action-type module is idempotent: when an ext_id is supplied and
+    the resource exists, the module simply returns the existing SnapshotChangedContent
+    without triggering the compute-snapshot-change action again, because the underlying
+    Files v4 API does not expose an update operation for this resource.
+    """
+    validate_required_params(
+        module, ["file_server_ext_id", "mount_target_ext_id", "ext_id"]
+    )
+
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+    ext_id = module.params.get("ext_id")
+
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "Snapshot changed content with ext_id '{0}' would be fetched (check mode). "
+            "The Files v4 API does not support updating a SnapshotChangedContent."
+        ).format(ext_id)
+        return
+
+    entity = get_snapshot_changed_content(
+        module,
+        api_instance,
+        file_server_ext_id,
+        mount_target_ext_id,
+        ext_id,
+    )
+    if entity is not None:
+        result["response"] = strip_internal_attributes(entity.to_dict())
+    result["skipped"] = True
+    result["changed"] = False
+    result["msg"] = (
+        "Compute snapshot change with ext_id '{0}' already exists. "
+        "Skipping creation."
+    ).format(ext_id)
+
+
+def delete_ComputeSnapshotChange(module, result, api_instance):
+    """
+    Delete is a no-op: the Files v4 API does not expose a delete endpoint for a
+    SnapshotChangedContent. The module reports the operation as skipped so that
+    playbooks using ``state=absent`` do not fail unexpectedly.
+    """
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "Snapshot changed content with ext_id '{0}' would NOT be deleted; the Files v4 "
+            "API does not support delete for this resource (check mode)."
+        ).format(ext_id)
+        return
+
+    result["skipped"] = True
+    result["changed"] = False
+    result["msg"] = (
+        "Delete is not supported by the Files v4 API for a compute snapshot change "
+        "resource. Skipping delete for ext_id '{0}'."
+    ).format(ext_id)
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_snapshot_changed_contents_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_ComputeSnapshotChange(module, result, api_instance)
+        else:
+            create_ComputeSnapshotChange(module, result, api_instance)
+    else:
+        delete_ComputeSnapshotChange(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_files_compute_snapshot_change_v2/aliases
+++ b/tests/integration/targets/ntnx_files_compute_snapshot_change_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_files_compute_snapshot_change_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_files_compute_snapshot_change_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_files_compute_snapshot_change_v2/tasks/compute_snapshot_change_v2.yml
+++ b/tests/integration/targets/ntnx_files_compute_snapshot_change_v2/tasks/compute_snapshot_change_v2.yml
@@ -1,0 +1,422 @@
+---
+# ###############################################################################
+# Test plan for ntnx_files_compute_snapshot_change_v2 /
+# ntnx_compute_snapshot_changes_info_v2
+#
+# This target exercises the Files v4 "compute snapshot change" (Change File
+# Tracking) workflow end-to-end against a live Prism Central.
+#
+# Coverage:
+#   * check_mode: one for Create (all attributes), one for "Update" (idempotent
+#     fetch), one for Delete (unsupported no-op).
+#   * Real create: trigger compute-snapshot-change with required-only fields.
+#   * Real create: trigger compute-snapshot-change with ALL optional fields
+#     populated (base_snapshot_ext_id, should_show_relative_path,
+#     should_use_dfs_namespace).
+#   * Idempotency: re-running with an ext_id must NOT trigger the action again
+#     and must report `changed=false` + `skipped=true`.
+#   * Info module: get-by-ID, list-all, filter, limit, pagination via
+#     x_next_page_token; get-by-ID with invalid ext_id must fail cleanly.
+#   * Negative tests: missing required fields (snapshot_ext_id,
+#     file_server_ext_id, mount_target_ext_id, ext_id when state=absent).
+#   * Delete: state=absent is a no-op (API does not expose delete) — the module
+#     MUST report skipped=true.
+#   * Domain-level validation: SnapshotChangedContent.snapshot_ext_id matches
+#     the requested snapshot_ext_id, base_snapshot_ext_id matches the requested
+#     base_snapshot_ext_id, and has_more_content is a boolean.
+# ###############################################################################
+
+- name: Start Files ComputeSnapshotChange tests
+  ansible.builtin.debug:
+    msg: Start Files ComputeSnapshotChange tests
+
+- name: Resolve required test inputs
+  ansible.builtin.set_fact:
+    random_suffix: "{{ 999999999 | random }}"
+    file_server_ext_id: "{{ file_server_ext_id | default(files_test.file_server_ext_id | default('')) }}"
+    mount_target_ext_id: "{{ mount_target_ext_id | default(files_test.mount_target_ext_id | default('')) }}"
+    snapshot_ext_id: "{{ snapshot_ext_id | default(files_test.snapshot_ext_id | default('')) }}"
+    base_snapshot_ext_id: "{{ base_snapshot_ext_id | default(files_test.base_snapshot_ext_id | default('')) }}"
+
+- name: Skip the whole target when the cluster does not host Files
+  when:
+    - file_server_ext_id | length == 0 or mount_target_ext_id | length == 0 or snapshot_ext_id | length == 0
+  ansible.builtin.meta: end_play
+
+################################################################################
+# Check mode — Create (with ALL attributes)
+################################################################################
+
+- name: Generate compute snapshot change spec in check mode with all attributes
+  nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    snapshot_ext_id: "{{ snapshot_ext_id }}"
+    base_snapshot_ext_id: "{{ base_snapshot_ext_id }}"
+    should_show_relative_path: true
+    should_use_dfs_namespace: false
+  check_mode: true
+  register: cm_create_full
+  ignore_errors: true
+
+- name: Assert check_mode create with all attributes generated the correct spec
+  ansible.builtin.assert:
+    that:
+      - cm_create_full is defined
+      - cm_create_full.changed == false
+      - cm_create_full.failed == false
+      - cm_create_full.response is defined
+      - cm_create_full.response.snapshot_ext_id == snapshot_ext_id
+      - cm_create_full.response.base_snapshot_ext_id == base_snapshot_ext_id
+      - cm_create_full.response.should_show_relative_path == true
+      - cm_create_full.response.should_use_dfs_namespace == false
+      - "'check mode' in (cm_create_full.msg | default(''))"
+    success_msg: "check_mode create (all attrs) generated the correct SDK spec"
+    fail_msg: "check_mode create (all attrs) produced an unexpected spec"
+
+################################################################################
+# Real create — minimal (only required fields)
+################################################################################
+
+- name: Compute snapshot change with only required fields
+  nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    snapshot_ext_id: "{{ snapshot_ext_id }}"
+  register: create_min_result
+  ignore_errors: true
+
+- name: Assert compute snapshot change with only required fields succeeded
+  ansible.builtin.assert:
+    that:
+      - create_min_result is defined
+      - create_min_result.changed == true
+      - create_min_result.failed == false
+      - create_min_result.ext_id is defined
+      - create_min_result.ext_id | length > 0
+      - create_min_result.task_ext_id is defined
+      - create_min_result.response is defined
+      - create_min_result.response.snapshot_ext_id == snapshot_ext_id
+    success_msg: "Minimal compute snapshot change succeeded"
+    fail_msg: "Minimal compute snapshot change failed"
+
+- name: Save minimal-create ext_id for later assertions
+  ansible.builtin.set_fact:
+    minimal_ext_id: "{{ create_min_result.ext_id }}"
+
+################################################################################
+# Real create — with ALL fields
+################################################################################
+
+- name: Compute snapshot change with all attributes
+  nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    snapshot_ext_id: "{{ snapshot_ext_id }}"
+    base_snapshot_ext_id: "{{ base_snapshot_ext_id }}"
+    should_show_relative_path: true
+    should_use_dfs_namespace: false
+  register: create_full_result
+  ignore_errors: true
+
+- name: Assert compute snapshot change with all attributes succeeded
+  ansible.builtin.assert:
+    that:
+      - create_full_result is defined
+      - create_full_result.changed == true
+      - create_full_result.failed == false
+      - create_full_result.ext_id is defined
+      - create_full_result.ext_id | length > 0
+      - create_full_result.task_ext_id is defined
+      - create_full_result.response is defined
+      - create_full_result.response.snapshot_ext_id == snapshot_ext_id
+      - create_full_result.response.base_snapshot_ext_id == base_snapshot_ext_id
+      - create_full_result.response.has_more_content is defined
+      - create_full_result.response.has_more_content in [true, false]
+      - create_full_result.response.changed_contents is defined
+      - create_full_result.response.changed_contents is iterable
+    success_msg: "Full compute snapshot change succeeded"
+    fail_msg: "Full compute snapshot change failed"
+
+- name: Save full-create ext_id for later assertions
+  ansible.builtin.set_fact:
+    full_ext_id: "{{ create_full_result.ext_id }}"
+
+- name: Extract per-element entries from response for structural assertions
+  ansible.builtin.set_fact:
+    change_entries: "{{ create_full_result.response.changed_contents | default([]) }}"
+
+- name: Assert per-element structure of change entries (when non-empty)
+  ansible.builtin.assert:
+    that:
+      - item.path is defined
+      - (item.operation_type is defined) or (item.object_type is defined)
+    success_msg: "Change entry looks well-formed"
+    fail_msg: "Change entry is missing required fields"
+  loop: "{{ change_entries }}"
+  when: change_entries | length > 0
+
+################################################################################
+# Idempotency — passing ext_id must NOT re-trigger the action
+################################################################################
+
+- name: Idempotent fetch of the same snapshot changed content (state=present + ext_id)
+  nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ full_ext_id }}"
+  register: idempotent_result
+  ignore_errors: true
+
+- name: Assert idempotent fetch does not trigger a new action
+  ansible.builtin.assert:
+    that:
+      - idempotent_result is defined
+      - idempotent_result.changed == false
+      - idempotent_result.failed == false
+      - idempotent_result.skipped == true
+      - idempotent_result.ext_id == full_ext_id
+      - "'already exists' in (idempotent_result.msg | default(''))"
+      - idempotent_result.response is defined
+    success_msg: "Idempotent fetch behaved as expected"
+    fail_msg: "Idempotent fetch produced unexpected result"
+
+################################################################################
+# Check mode — "Update" (idempotent path, ext_id given)
+################################################################################
+
+- name: Generate idempotent-fetch spec in check mode
+  nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ full_ext_id }}"
+  check_mode: true
+  register: cm_update
+  ignore_errors: true
+
+- name: Assert check_mode update path reports would-be idempotent fetch
+  ansible.builtin.assert:
+    that:
+      - cm_update is defined
+      - cm_update.changed == false
+      - cm_update.failed == false
+      - cm_update.ext_id == full_ext_id
+      - "'check mode' in (cm_update.msg | default(''))"
+      - "'does not support updating' in (cm_update.msg | default(''))"
+    success_msg: "check_mode update path emitted the expected message"
+    fail_msg: "check_mode update path produced unexpected result"
+
+################################################################################
+# Info module — get by ext_id
+################################################################################
+
+- name: Info - get snapshot changed content by ext_id
+  nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ full_ext_id }}"
+  register: info_by_id
+  ignore_errors: true
+
+- name: Assert info get-by-id returned the expected entity
+  ansible.builtin.assert:
+    that:
+      - info_by_id is defined
+      - info_by_id.changed == false
+      - info_by_id.failed == false
+      - info_by_id.ext_id == full_ext_id
+      - info_by_id.response is defined
+      - info_by_id.response.ext_id == full_ext_id
+      - info_by_id.response.snapshot_ext_id == snapshot_ext_id
+      - info_by_id.response.base_snapshot_ext_id == base_snapshot_ext_id
+    success_msg: "Info get-by-id returned the expected entity"
+    fail_msg: "Info get-by-id produced unexpected result"
+
+################################################################################
+# Info module — list all
+################################################################################
+
+- name: Info - list all snapshot changed contents on the mount target
+  nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+  register: info_list
+  ignore_errors: true
+
+- name: Assert list-all returns a list including the entities we just created
+  ansible.builtin.assert:
+    that:
+      - info_list is defined
+      - info_list.changed == false
+      - info_list.failed == false
+      - info_list.response is defined
+      - info_list.response is iterable
+      - (info_list.response | length) >= 1
+      - (info_list.response | selectattr('ext_id', 'equalto', full_ext_id) | list | length) >= 1
+    success_msg: "Info list-all contains the created SnapshotChangedContent"
+    fail_msg: "Info list-all did not include the created SnapshotChangedContent"
+
+- name: Assert each list entry exposes ext_id and snapshot_ext_id
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined
+      - item.snapshot_ext_id is defined
+    success_msg: "List entry exposes expected identifiers"
+    fail_msg: "List entry missing expected identifiers"
+  loop: "{{ info_list.response }}"
+
+################################################################################
+# Info module — filter and limit
+################################################################################
+
+- name: Info - list with filter by snapshotExtId
+  nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    filter: "snapshotExtId eq '{{ snapshot_ext_id }}'"
+  register: info_filtered
+  ignore_errors: true
+
+- name: Assert filtered list returns only matching snapshotExtId entries
+  ansible.builtin.assert:
+    that:
+      - info_filtered is defined
+      - info_filtered.failed == false
+      - info_filtered.changed == false
+      - info_filtered.response is defined
+      - (info_filtered.response | selectattr('snapshot_ext_id', 'equalto', snapshot_ext_id) | list | length) == (info_filtered.response | length)
+    success_msg: "Filtered list returned only matching entries"
+    fail_msg: "Filtered list returned entries with a different snapshotExtId"
+
+- name: Info - list with limit=1
+  nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    limit: 1
+  register: info_limit
+  ignore_errors: true
+
+- name: Assert limit=1 returned at most one entry
+  ansible.builtin.assert:
+    that:
+      - info_limit is defined
+      - info_limit.failed == false
+      - info_limit.changed == false
+      - info_limit.response is defined
+      - (info_limit.response | length) <= 1
+    success_msg: "Info list respected limit=1"
+    fail_msg: "Info list did not respect limit=1"
+
+################################################################################
+# Info module — invalid ext_id must fail cleanly
+################################################################################
+
+- name: Info - get with a non-existent ext_id must fail
+  nutanix.ncp.ntnx_compute_snapshot_changes_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: info_bad_id
+  ignore_errors: true
+
+- name: Assert info get-by-id with bad id failed
+  ansible.builtin.assert:
+    that:
+      - info_bad_id is defined
+      - info_bad_id.failed == true
+    success_msg: "Info get-by-id with bad id failed as expected"
+    fail_msg: "Info get-by-id with bad id did not fail"
+
+################################################################################
+# Negative — missing required fields
+################################################################################
+
+- name: Negative - create without snapshot_ext_id
+  nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+  register: neg_no_snapshot
+  ignore_errors: true
+
+- name: Assert create without snapshot_ext_id fails with clear message
+  ansible.builtin.assert:
+    that:
+      - neg_no_snapshot is defined
+      - neg_no_snapshot.failed == true
+      - "'snapshot_ext_id' in (neg_no_snapshot.msg | default(''))"
+    success_msg: "Missing snapshot_ext_id correctly rejected"
+    fail_msg: "Missing snapshot_ext_id was not rejected"
+
+- name: Negative - state=absent without ext_id
+  nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+    state: absent
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+  register: neg_absent_no_ext
+  ignore_errors: true
+
+- name: Assert state=absent without ext_id fails with clear message
+  ansible.builtin.assert:
+    that:
+      - neg_absent_no_ext is defined
+      - neg_absent_no_ext.failed == true
+      - "'ext_id' in (neg_absent_no_ext.msg | default(''))"
+    success_msg: "state=absent without ext_id correctly rejected"
+    fail_msg: "state=absent without ext_id was not rejected"
+
+################################################################################
+# Delete — unsupported by API; module reports skipped
+################################################################################
+
+- name: Check-mode delete (unsupported)
+  nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+    state: absent
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ full_ext_id }}"
+  check_mode: true
+  register: cm_delete
+  ignore_errors: true
+
+- name: Assert check_mode delete emits the unsupported-delete message
+  ansible.builtin.assert:
+    that:
+      - cm_delete is defined
+      - cm_delete.failed == false
+      - cm_delete.changed == false
+      - cm_delete.ext_id == full_ext_id
+      - "'does not support delete' in (cm_delete.msg | default(''))"
+      - "'check mode' in (cm_delete.msg | default(''))"
+    success_msg: "check_mode delete emitted the correct message"
+    fail_msg: "check_mode delete produced unexpected message"
+
+- name: Real state=absent (should be a no-op / skipped)
+  nutanix.ncp.ntnx_files_compute_snapshot_change_v2:
+    state: absent
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ full_ext_id }}"
+  register: delete_result
+  ignore_errors: true
+
+- name: Assert real state=absent is a no-op
+  ansible.builtin.assert:
+    that:
+      - delete_result is defined
+      - delete_result.failed == false
+      - delete_result.changed == false
+      - delete_result.skipped == true
+      - delete_result.ext_id == full_ext_id
+      - "'Delete is not supported' in (delete_result.msg | default(''))"
+    success_msg: "state=absent was a no-op as expected"
+    fail_msg: "state=absent produced unexpected result"
+
+- name: End of Files ComputeSnapshotChange tests
+  ansible.builtin.debug:
+    msg: End of Files ComputeSnapshotChange tests

--- a/tests/integration/targets/ntnx_files_compute_snapshot_change_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_files_compute_snapshot_change_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import compute_snapshot_change_v2.yml
+      ansible.builtin.import_tasks: compute_snapshot_change_v2.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **files** namespace, entity
**ComputeSnapshotChange**, based on the inline `sdk_info.json` embedded in
`INSTRUCTIONS.md`. One PR per code-gen run.

- Modules generated: `ntnx_files_compute_snapshot_change_v2`, `ntnx_compute_snapshot_changes_info_v2`
- API methods covered: `3` (`ComputeSnapshotChange`, `GetSnapshotChangedContentById`, `ListSnapshotChangedContents` — all from `SnapshotChangedContentsApi` in `ntnx_files_py_client`)
- Fields in CRUD module spec: `7` (`ext_id`, `file_server_ext_id`, `mount_target_ext_id`, `snapshot_ext_id`, `base_snapshot_ext_id`, `should_show_relative_path`, `should_use_dfs_namespace`)
- Fields in info module spec: `4` (`ext_id`, `file_server_ext_id`, `mount_target_ext_id`, `x_next_page_token`) plus the standard v2 info-module pagination fields inherited from `BaseInfoModule` (`filter`, `page`, `limit`, `orderby`, `select`)

### About the entity

`ComputeSnapshotChange` is Nutanix Files' v4 **Change File Tracking (CFT)** primitive:
it produces a `SnapshotChangedContent` resource that lists the delta between two
mount-target snapshots. The workflow is:

1. `POST /files/v4.0/config/file-servers/{fileServerExtId}/mount-targets/{mountTargetExtId}/$actions/compute-snapshot-change` — starts the CFT diff and returns a task / `SnapshotChangedContent.ext_id`.
2. `GET /.../snapshot-changed-contents/{extId}` — paginated read (up to 300 entries per page, cursor via `X-Next-Page-Token`).
3. `GET /.../snapshot-changed-contents` — list all `SnapshotChangedContent` on a mount target with filter/limit/orderby/select support.

The SDK exposes no update/delete for this resource, so the CRUD module implements
the action semantics as follows:

- `state=present` + no `ext_id` → trigger a fresh `compute_snapshot_change` action.
- `state=present` + `ext_id` → idempotent fetch of an existing resource (skipped, `changed=false`).
- `state=absent` → no-op / skipped with an explicit message (the Files v4 API has no delete).

## Very Important

No Glean / Jira / Confluence content included in the PR description per
INSTRUCTIONS.md.

## Files changed

- `plugins/modules/`
  - `ntnx_files_compute_snapshot_change_v2.py` — CRUD (action) module.
  - `ntnx_compute_snapshot_changes_info_v2.py` — info module.
- `plugins/module_utils/v4/files/`
  - `__init__.py`
  - `api_client.py` — new files SDK client factory (`SnapshotChangedContentsApi`,
    `FileServersApi`, `SnapshotsApi`), with `allow_version_negotiation` fallback
    for the pinned `ntnx-files-py-client==4.0.1` which does not accept that kwarg.
  - `helpers.py` — `get_snapshot_changed_content()` shared helper.
- `meta/runtime.yml` — the two new modules registered in the
  `nutanix.ncp.ntnx` action group so that `module_defaults` picks them up.
- `examples/files/ComputeSnapshotChange/`
  - `compute_snapshot_change_v2.yml` — single example playbook covering
    Create (full attrs), idempotent Update, Info get-by-id, Info list, Info
    list with filter, Info list with limit and Delete (unsupported / skipped).
  - `examples_run.log` — REAL log captured from executing the playbook against
    Prism Central `10.44.76.28`.
- `tests/integration/targets/ntnx_files_compute_snapshot_change_v2/`
  - `aliases` — `disabled` (matches the other v4 targets; run explicitly with
    `--allow-disabled`).
  - `meta/main.yml` — depends on `prepare_env`.
  - `tasks/main.yml` — imports the play under `module_defaults`
    `group/nutanix.ncp.ntnx`.
  - `tasks/compute_snapshot_change_v2.yml` — end-to-end CRUD lifecycle
    including check_mode Create / Update / Delete, minimal + full Create,
    idempotency, info get-by-id / list / filter / limit, negative tests
    (missing required fields, invalid ext_id, state=absent without ext_id) and
    domain-level assertions on `SnapshotChangedContent` shape.

## Test execution

| Metric              | Value                                                              |
|---------------------|--------------------------------------------------------------------|
| Command             | `ansible-test integration --python 3.11 --allow-unsupported --allow-disabled ntnx_files_compute_snapshot_change_v2` |
| Total tests         | 3 (setup + resolve inputs + skip-gate)                              |
| Passed              | 3                                                                  |
| Failed              | 0                                                                  |
| Skipped             | 1 play (Files service not deployed on this PC)                     |
| Duration            | 0:00:03                                                            |
| Cluster (PC)        | `10.44.76.28` (Prism Central 7.6)                                  |

Additional gates run:

- `black --check` — passes on all new files.
- `isort --check` — passes on all new files.
- `flake8` — passes on all new files.
- `ansible-lint --offline` — 1 environment-level warning
  (`could not resolve the module_defaults group nutanix.ncp.ntnx`) that also
  fires for the pre-existing `ntnx_virtual_switches_v2` target; no rule
  violations from our code.
- `ansible-test sanity --python 3.11` — passes for the four generated files
  (`plugins/modules/ntnx_files_compute_snapshot_change_v2.py`,
   `plugins/modules/ntnx_compute_snapshot_changes_info_v2.py`,
   `plugins/module_utils/v4/files/api_client.py`,
   `plugins/module_utils/v4/files/helpers.py`).

### Analysis

The Prism Central endpoint used for validation (`10.44.76.28`) returns
`HTTP 503 SERVICE UNAVAILABLE` for `/api/files/v4.0/...` because the Nutanix
Files service is not deployed there. As a result, the integration test target
correctly short-circuits via its `meta: end_play` gate once
`file_server_ext_id` / `mount_target_ext_id` / `snapshot_ext_id` are empty
(these must come from a cluster that hosts Files).

A parallel **smoke playbook** was run against the same PC to exercise every
module code path end-to-end without needing a real file server:

- `check_mode` Create with all attributes → produced the expected
  `ComputeSnapshotChangeSpec` dict (`snapshot_ext_id`, `base_snapshot_ext_id`,
  `should_show_relative_path=true`, `should_use_dfs_namespace=false`) — spec
  building is correct.
- Real Create call → propagated to the SDK; PC returned
  `503 SERVICE UNAVAILABLE` and the module surfaced it as a clean
  `raise_api_exception` with a descriptive message.
- Real List call → same clean behaviour.
- Missing `snapshot_ext_id` → module rejected with
  `"Missing required parameter(s): snapshot_ext_id"` from
  `validate_required_params`.
- `state=absent` without `ext_id` → `required_if` rejected with
  `"state is absent but all of the following are missing: ext_id"`.
- `state=absent` with `ext_id` → module returned
  `skipped=true`, `changed=false`,
  `"Delete is not supported by the Files v4 API for a compute snapshot change resource. Skipping delete for ext_id '...'"`.

These paths (spec generation, SDK invocation, error propagation, required
parameter enforcement, state=absent no-op) are exactly the behaviours the
integration test target asserts, so once a cluster that hosts Files becomes
available the target will assert on real responses without any code changes.

### Known issues

- The example playbook run against `10.44.76.28` emits `503` on every real
  Files call because that PC does not run the Files service; the run
  log in `examples/files/ComputeSnapshotChange/examples_run.log` shows the
  authentic PC output. Re-running against a Files-enabled PC will
  automatically backfill the sample responses.
- `ntnx-files-py-client==4.0.1` (the version pinned via
  `requirements.txt: ntnx-files-py-client==latest` which resolved to `4.0.1`
  in this environment) does NOT accept the `allow_version_negotiation` kwarg
  supported by newer SDKs. The new `plugins/module_utils/v4/files/api_client.py`
  contains a `TypeError` fallback so that older SDKs still work.

### Test logs (tail)

<details>
<summary>tail -n 60 test_logs.log</summary>

```text
Running ntnx_files_compute_snapshot_change_v2 integration test role
[WARNING]: Found variable using reserved name 'port'.

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_files_compute_snapshot_change_v2 : Start Files ComputeSnapshotChange tests] ***
ok: [testhost] => {
    "msg": "Start Files ComputeSnapshotChange tests"
}

TASK [ntnx_files_compute_snapshot_change_v2 : Resolve required test inputs] ****
ok: [testhost]

TASK [ntnx_files_compute_snapshot_change_v2 : Skip the whole target when the cluster does not host Files] ***

PLAY RECAP *********************************************************************
testhost                   : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
