### PR TITLE
code-gen(networking/TrafficMirrorStat): ansible collection modules

### DIFF
--- a/examples/networking/TrafficMirrorStat/examples_run.log
+++ b/examples/networking/TrafficMirrorStat/examples_run.log
@@ -1,0 +1,19 @@
+No config file found; using defaults
+
+PLAY [Traffic Mirror Stat playbook] ********************************************
+
+TASK [Compute stats time window (last 5 minutes)] ******************************
+ok: [localhost] => {"ansible_facts": {"stats_end_time": "2026-07-21T06:30:54.014Z", "stats_start_time": "2026-07-21T06:25:54.018Z"}, "changed": false}
+
+TASK [Fetch traffic mirror session stats (minimal spec)] ***********************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7", "response": {"ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7", "links": null, "stat_type": "LAST", "tenant_id": null, "transmit_byte_count": [0], "transmit_packet_count": [0]}}
+
+TASK [Fetch traffic mirror session stats with all attributes] ******************
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7", "response": {"ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7", "links": null, "stat_type": "LAST", "tenant_id": null, "transmit_byte_count": null, "transmit_packet_count": null}}
+
+TASK [Fetch traffic mirror session stats info (info module, single entity)] ****
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7", "response": {"ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7", "links": null, "stat_type": "LAST", "tenant_id": null, "transmit_byte_count": [0], "transmit_packet_count": [0]}}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/networking/TrafficMirrorStat/traffic_mirror_stat_v2.yml
+++ b/examples/networking/TrafficMirrorStat/traffic_mirror_stat_v2.yml
@@ -1,0 +1,51 @@
+---
+# Summary:
+# This playbook demonstrates how to work with traffic mirror session statistics
+# using the Nutanix Ansible collection v4 modules:
+#
+# 1. Discover an existing traffic mirror session on the cluster (prerequisite).
+# 2. Fetch stats for that session over a time window (Module 1).
+# 3. Fetch stats with a specific sampling interval and down-sampling operator.
+# 4. Fetch stats and only project selected properties via $select.
+# 5. Fetch stats info via the info module (Module 2) for the same session.
+
+- name: Traffic Mirror Stat playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Compute stats time window (last 5 minutes)
+      ansible.builtin.set_fact:
+        stats_end_time: "{{ lookup('pipe', 'date -u +\"%Y-%m-%dT%H:%M:%S.%3NZ\"') }}"
+        stats_start_time: "{{ lookup('pipe', 'date -u -d \"-300 seconds\" +\"%Y-%m-%dT%H:%M:%S.%3NZ\"') }}"
+
+    - name: Fetch traffic mirror session stats (minimal spec)
+      nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+        ext_id: "{{ traffic_mirror_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+      register: minimal_stats
+
+    - name: Fetch traffic mirror session stats with all attributes
+      nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+        ext_id: "{{ traffic_mirror_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+        sampling_interval: 30
+        stat_type: LAST
+        select: "*"
+      register: full_stats
+
+    - name: Fetch traffic mirror session stats info (info module, single entity)
+      nutanix.ncp.ntnx_traffic_mirror_stats_info_v2:
+        ext_id: "{{ traffic_mirror_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+        sampling_interval: 30
+        stat_type: LAST
+      register: stats_info

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_traffic_mirror_stats_api_instance(module):
+    """
+    This method will return TrafficMirrorStatsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Traffic Mirror Stats Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.TrafficMirrorStatsApi(api_client=api_client)

--- a/plugins/modules/ntnx_traffic_mirror_stat_v2.py
+++ b/plugins/modules/ntnx_traffic_mirror_stat_v2.py
@@ -1,0 +1,295 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_traffic_mirror_stat_v2
+short_description: Retrieve traffic mirror session statistics from Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - Fetch statistics for a Nutanix traffic mirror session using its external ID.
+  - The API returns time-series values for C(transmit_packet_count) and
+    C(transmit_byte_count) collected during the requested time window.
+  - Both C(start_time) and C(end_time) are mandatory ISO-8601 timestamps.
+  - Optional C(sampling_interval) controls the resolution of the returned series
+    and C(stat_type) controls how the values are aggregated
+    (SUM, MIN, MAX, AVG, COUNT, LAST).
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get Traffic mirror session statistics) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin, Network Infra Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID (UUID) of the traffic mirror session.
+    type: str
+    required: true
+  start_time:
+    description:
+      - The start time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format.
+      - "sample input time is 2024-07-31T12:41:56.955Z"
+    type: str
+    required: true
+  end_time:
+    description:
+      - The end time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format.
+      - "sample input time is 2025-07-31T12:41:56.955Z"
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - The sampling interval in seconds at which statistical data should be
+        collected. For example, if you want performance statistics every 30
+        seconds, then provide the value as 30.
+    type: int
+    required: false
+  stat_type:
+    description:
+      - The down-sampling operator to apply on the returned stats values.
+    type: str
+    required: false
+    choices:
+      - SUM
+      - AVG
+      - MIN
+      - MAX
+      - COUNT
+      - LAST
+  select:
+    description:
+      - A URL query parameter that allows clients to request a specific set of
+        properties for each entity or complex type. Expression specified with the
+        $select must conform to the OData V4.01 URL conventions. If a $select
+        expression consists of a single select item that is an asterisk
+        (i.e., '*'), then all properties on the matching resource will be
+        returned.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch traffic mirror session stats for the last 5 minutes
+  nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "cae2b71d-e46d-4d10-8c8b-1c9c6f2f7501"
+    start_time: "2026-07-21T05:00:00.000Z"
+    end_time: "2026-07-21T05:05:00.000Z"
+  register: result
+
+- name: Fetch traffic mirror session stats with sampling interval and stat type
+  nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "cae2b71d-e46d-4d10-8c8b-1c9c6f2f7501"
+    start_time: "2026-07-21T05:00:00.000Z"
+    end_time: "2026-07-21T05:05:00.000Z"
+    sampling_interval: 30
+    stat_type: "SUM"
+  register: result
+
+- name: Fetch traffic mirror session stats and only return transmit_packet_count
+  nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "cae2b71d-e46d-4d10-8c8b-1c9c6f2f7501"
+    start_time: "2026-07-21T05:00:00.000Z"
+    end_time: "2026-07-21T05:05:00.000Z"
+    sampling_interval: 30
+    stat_type: "AVG"
+    select: "transmitPacketCount"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for fetching traffic mirror session statistics.
+    - Contains time-series arrays for C(transmit_packet_count) and
+      C(transmit_byte_count) along with C(stat_type), C(ext_id), C(links)
+      and C(tenant_id).
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "cae2b71d-e46d-4d10-8c8b-1c9c6f2f7501",
+      "links": null,
+      "stat_type": "LAST",
+      "tenant_id": null,
+      "transmit_byte_count": [0],
+      "transmit_packet_count": [0]
+    }
+
+ext_id:
+  description:
+    - The external ID of the traffic mirror session.
+  returned: always
+  type: str
+  sample: "cae2b71d-e46d-4d10-8c8b-1c9c6f2f7501"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching traffic mirror session stats"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_traffic_mirror_stats_api_instance,
+)
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int", required=False),
+        stat_type=dict(
+            type="str",
+            required=False,
+            choices=[
+                "SUM",
+                "AVG",
+                "MIN",
+                "MAX",
+                "COUNT",
+                "LAST",
+            ],
+        ),
+        select=dict(type="str", required=False),
+    )
+
+    return module_args
+
+
+def get_traffic_mirror_stat(module, api_instance, result):
+    """Fetch traffic mirror session stats for the given ext_id.
+
+    Args:
+        module: Ansible module instance.
+        api_instance: TrafficMirrorStatsApi SDK instance.
+        result: mutable result dict updated in place.
+    """
+    validate_required_params(module, ["ext_id", "start_time", "end_time"])
+
+    ext_id = module.params.get("ext_id")
+    start_time = module.params.get("start_time")
+    end_time = module.params.get("end_time")
+    sampling_interval = module.params.get("sampling_interval")
+    stat_type = module.params.get("stat_type")
+    select = module.params.get("select")
+
+    result["ext_id"] = ext_id
+
+    try:
+        resp = api_instance.get_traffic_mirror_stats(
+            extId=ext_id,
+            _startTime=start_time,
+            _endTime=end_time,
+            _samplingInterval=sampling_interval,
+            _statType=stat_type,
+            _select=select,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching traffic mirror session stats",
+        )
+
+    if getattr(resp, "data", None) is None:
+        result["response"] = None
+        module.fail_json(msg="Failed fetching traffic mirror session stats", **result)
+
+    result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_traffic_mirror_stats_api_instance(module)
+    get_traffic_mirror_stat(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_traffic_mirror_stats_info_v2.py
+++ b/plugins/modules/ntnx_traffic_mirror_stats_info_v2.py
@@ -1,0 +1,274 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_traffic_mirror_stats_info_v2
+short_description: Fetch traffic mirror session statistics info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about TrafficMirrorStat in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific TrafficMirrorStat.
+  - The Networking v4 API only exposes a get-by-ID stats endpoint for traffic
+    mirror sessions, therefore this module requires C(ext_id), C(start_time)
+    and C(end_time).
+  - Optional C(sampling_interval), C(stat_type) and C(select) allow shaping of
+    the returned time series data.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get Traffic mirror session statistics) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin, Network Infra Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID (UUID) of the traffic mirror session.
+    type: str
+    required: true
+  start_time:
+    description:
+      - The start time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format.
+      - "sample input time is 2024-07-31T12:41:56.955Z"
+    type: str
+    required: true
+  end_time:
+    description:
+      - The end time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format.
+      - "sample input time is 2025-07-31T12:41:56.955Z"
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - The sampling interval in seconds at which statistical data should be
+        collected. For example, if you want performance statistics every 30
+        seconds, then provide the value as 30.
+    type: int
+    required: false
+  stat_type:
+    description:
+      - The down-sampling operator to apply on the returned stats values.
+    type: str
+    required: false
+    choices:
+      - SUM
+      - AVG
+      - MIN
+      - MAX
+      - COUNT
+      - LAST
+  select:
+    description:
+      - A URL query parameter that allows clients to request a specific set of
+        properties for each entity or complex type. Expression specified with the
+        $select must conform to the OData V4.01 URL conventions.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch traffic mirror session stats info by ext_id
+  nutanix.ncp.ntnx_traffic_mirror_stats_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "cae2b71d-e46d-4d10-8c8b-1c9c6f2f7501"
+    start_time: "2026-07-21T05:00:00.000Z"
+    end_time: "2026-07-21T05:05:00.000Z"
+  register: result
+
+- name: Fetch traffic mirror session stats info with sampling interval and stat type
+  nutanix.ncp.ntnx_traffic_mirror_stats_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "cae2b71d-e46d-4d10-8c8b-1c9c6f2f7501"
+    start_time: "2026-07-21T05:00:00.000Z"
+    end_time: "2026-07-21T05:05:00.000Z"
+    sampling_interval: 30
+    stat_type: "AVG"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC TrafficMirrorStat info v4 API.
+    - It returns the single traffic mirror session statistics for the provided
+      external ID.
+    - The Networking v4 API only exposes a get-by-ID stats endpoint for traffic
+      mirror sessions, so filter, limit, page and orderby are not supported.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "cae2b71d-e46d-4d10-8c8b-1c9c6f2f7501",
+      "links": null,
+      "stat_type": "LAST",
+      "tenant_id": null,
+      "transmit_byte_count": [0],
+      "transmit_packet_count": [0]
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching traffic mirror session stats info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the traffic mirror session.
+  type: str
+  returned: when external ID is provided
+  sample: "cae2b71d-e46d-4d10-8c8b-1c9c6f2f7501"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_traffic_mirror_stats_api_instance,
+)
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int", required=False),
+        stat_type=dict(
+            type="str",
+            required=False,
+            choices=[
+                "SUM",
+                "AVG",
+                "MIN",
+                "MAX",
+                "COUNT",
+                "LAST",
+            ],
+        ),
+        select=dict(type="str", required=False),
+    )
+
+    return module_args
+
+
+def get_traffic_mirror_stats_using_ext_id(module, api_instance, result):
+    """Fetch traffic mirror session stats for the given ext_id and time window."""
+    validate_required_params(module, ["ext_id", "start_time", "end_time"])
+
+    ext_id = module.params.get("ext_id")
+    start_time = module.params.get("start_time")
+    end_time = module.params.get("end_time")
+    sampling_interval = module.params.get("sampling_interval")
+    stat_type = module.params.get("stat_type")
+    select = module.params.get("select")
+
+    result["ext_id"] = ext_id
+
+    try:
+        resp = api_instance.get_traffic_mirror_stats(
+            extId=ext_id,
+            _startTime=start_time,
+            _endTime=end_time,
+            _samplingInterval=sampling_interval,
+            _statType=stat_type,
+            _select=select,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching traffic mirror session stats info",
+        )
+
+    if getattr(resp, "data", None) is None:
+        result["response"] = None
+        module.fail_json(
+            msg="Failed fetching traffic mirror session stats info", **result
+        )
+
+    result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_traffic_mirror_stats_api_instance(module)
+    get_traffic_mirror_stats_using_ext_id(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_traffic_mirror_stat_v2/aliases
+++ b/tests/integration/targets/ntnx_traffic_mirror_stat_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_traffic_mirror_stat_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_traffic_mirror_stat_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_traffic_mirror_stat_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_traffic_mirror_stat_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import traffic mirror stat tests
+      ansible.builtin.import_tasks: traffic_mirror_stat.yml

--- a/tests/integration/targets/ntnx_traffic_mirror_stat_v2/tasks/traffic_mirror_stat.yml
+++ b/tests/integration/targets/ntnx_traffic_mirror_stat_v2/tasks/traffic_mirror_stat.yml
@@ -1,0 +1,379 @@
+---
+# TEST PLAN for ntnx_traffic_mirror_stat_v2 and ntnx_traffic_mirror_stats_info_v2
+# =============================================================================
+# The Networking v4 SDK only exposes a single API for TrafficMirrorStat:
+#   GET /api/networking/v4.3/stats/traffic-mirrors/{extId}
+# It is a stats retrieval endpoint that requires the traffic mirror session
+# UUID plus a time window (start_time, end_time). Optional inputs shape the
+# returned time series (sampling_interval, stat_type, select).
+#
+# Prerequisite: a Traffic Mirror session must already exist on the target
+# Prism Central. The Nutanix Ansible collection does not (yet) ship a CRUD
+# module to create one, so we discover an existing session by calling the
+# Networking v4 List API directly with ansible.builtin.uri and reuse its
+# ext_id. If no session exists on the cluster, all positive tests are
+# skipped with a clear msg and the negative tests still run so the module's
+# argument validation and error paths are exercised.
+#
+# Coverage:
+#   1. Positive: minimal spec (ext_id + time window) -> stats retrieved.
+#   2. Positive: full spec (all attributes populated) -> stats retrieved.
+#   3. Positive: stats retrieved for every DownSamplingOperator value
+#      (SUM, AVG, MIN, MAX, COUNT, LAST).
+#   4. Positive: $select projection is applied.
+#   5. Info module: get-by-ext_id returns the same stats data as Module 1
+#      and reports changed == false.
+#   6. Negative: invalid stat_type is rejected by argument_spec.
+#   7. Negative: missing required params (ext_id / start_time / end_time)
+#      are rejected by argument_spec.
+#   8. Negative: non-existent ext_id returns an API error.
+#   9. Idempotency: two consecutive calls with the same params both return
+#      changed == false (info calls never mutate state).
+
+- name: Start ntnx_traffic_mirror_stat_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_traffic_mirror_stat_v2 tests
+
+- name: Set traffic mirror stat test facts
+  ansible.builtin.set_fact:
+    invalid_traffic_mirror_ext_id: "not-a-valid-uuid-value"
+    # All valid DownSamplingOperator values accepted by the module's argspec.
+    # Only a subset (typically LAST) is served at runtime by the cluster;
+    # the tests below tolerate a "not currently supported" API error for
+    # unsupported operators.
+    traffic_mirror_stat_types:
+      - SUM
+      - AVG
+      - MIN
+      - MAX
+      - COUNT
+      - LAST
+
+########################################################################
+# Discover an existing traffic mirror session on the target cluster.
+########################################################################
+- name: List existing traffic mirror sessions on the cluster
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/networking/v4.3/config/traffic-mirrors?$limit=1"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    status_code: [200, 404]
+    return_content: true
+  register: traffic_mirror_list
+  ignore_errors: true
+
+- name: Extract first traffic mirror ext_id (if any exists)
+  ansible.builtin.set_fact:
+    traffic_mirror_ext_id: >-
+      {{
+        (
+          traffic_mirror_list.json.data
+          if (traffic_mirror_list.json is defined
+              and traffic_mirror_list.json.data is defined
+              and traffic_mirror_list.json.data | length > 0)
+          else []
+        )
+        | map(attribute='extId', default=none)
+        | reject('none')
+        | list
+        | first
+        | default('')
+      }}
+    have_traffic_mirror: >-
+      {{
+        traffic_mirror_list.json is defined
+        and traffic_mirror_list.json.data is defined
+        and traffic_mirror_list.json.data | length > 0
+      }}
+
+- name: Compute stats time window (last 5 minutes)
+  ansible.builtin.set_fact:
+    stats_end_time: >-
+      {{ lookup('pipe', 'date -u +"%Y-%m-%dT%H:%M:%S.%3NZ"') }}
+    stats_start_time: >-
+      {{ lookup('pipe', 'date -u -d "-300 seconds" +"%Y-%m-%dT%H:%M:%S.%3NZ"') }}
+
+########################################################################
+# Positive tests — only when a traffic mirror session exists on cluster.
+########################################################################
+- name: Positive traffic mirror stat tests
+  when: have_traffic_mirror | bool
+  block:
+    - name: Fetch traffic mirror session stats with minimal spec
+      nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+        ext_id: "{{ traffic_mirror_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+      register: minimal_stats_result
+      ignore_errors: true
+
+    - name: Check minimal traffic mirror stats result
+      ansible.builtin.assert:
+        that:
+          - minimal_stats_result.changed == false
+          - minimal_stats_result.failed == false
+          - minimal_stats_result.response is defined
+          - minimal_stats_result.response.ext_id == traffic_mirror_ext_id
+          - minimal_stats_result.ext_id == traffic_mirror_ext_id
+          - minimal_stats_result.response.transmit_packet_count is defined
+          - minimal_stats_result.response.transmit_byte_count is defined
+        fail_msg: "Unable to fetch traffic mirror stats with minimal spec"
+        success_msg: "Traffic mirror stats fetched with minimal spec"
+
+    - name: Fetch traffic mirror session stats with all attributes
+      nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+        ext_id: "{{ traffic_mirror_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+        sampling_interval: 30
+        stat_type: LAST
+        select: "*"
+      register: full_stats_result
+      ignore_errors: true
+
+    - name: Check full traffic mirror stats result
+      ansible.builtin.assert:
+        that:
+          - full_stats_result.changed == false
+          - full_stats_result.failed == false
+          - full_stats_result.response is defined
+          - full_stats_result.response.ext_id == traffic_mirror_ext_id
+          - full_stats_result.ext_id == traffic_mirror_ext_id
+          - full_stats_result.response.stat_type == "LAST"
+          - full_stats_result.response.transmit_packet_count is defined
+          - full_stats_result.response.transmit_byte_count is defined
+        fail_msg: "Unable to fetch traffic mirror stats with all attributes"
+        success_msg: "Traffic mirror stats fetched with all attributes"
+
+    - name: Fetch traffic mirror stats for every down-sampling operator
+      nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+        ext_id: "{{ traffic_mirror_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+        sampling_interval: 30
+        stat_type: "{{ item }}"
+      register: stat_type_results
+      loop: "{{ traffic_mirror_stat_types }}"
+      ignore_errors: true
+
+    - name: Check per-stat_type results (accept "not supported" API errors)
+      ansible.builtin.assert:
+        that:
+          - >-
+            (item.failed == false and item.changed == false
+             and item.response is defined
+             and item.response.ext_id == traffic_mirror_ext_id
+             and item.response.stat_type == item.invocation.module_args.stat_type)
+            or
+            (item.failed == true
+             and (item.response | to_json | string) is search('not currently supported')
+             and (item.response | to_json | string) is search(item.invocation.module_args.stat_type))
+        fail_msg: >-
+          Unexpected result for stat_type={{ item.invocation.module_args.stat_type }}:
+          {{ item }}
+        success_msg: "Traffic mirror stats behaved as expected for stat_type={{ item.invocation.module_args.stat_type }}"
+      loop: "{{ stat_type_results.results }}"
+      loop_control:
+        label: "{{ item.item | default(item.invocation.module_args.stat_type | default('unknown')) }}"
+
+    - name: Fetch traffic mirror stats with $select projection
+      nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+        ext_id: "{{ traffic_mirror_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+        sampling_interval: 30
+        stat_type: LAST
+        select: "transmitPacketCount"
+      register: select_stats_result
+      ignore_errors: true
+
+    - name: Check $select traffic mirror stats result
+      ansible.builtin.assert:
+        that:
+          - select_stats_result.changed == false
+          - select_stats_result.failed == false
+          - select_stats_result.response is defined
+          - select_stats_result.response.ext_id == traffic_mirror_ext_id
+        fail_msg: "Unable to fetch traffic mirror stats with $select"
+        success_msg: "Traffic mirror stats fetched with $select"
+
+    - name: Fetch traffic mirror stats via info module (single entity)
+      nutanix.ncp.ntnx_traffic_mirror_stats_info_v2:
+        ext_id: "{{ traffic_mirror_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+        sampling_interval: 30
+        stat_type: LAST
+      register: info_stats_result
+      ignore_errors: true
+
+    - name: Check info module traffic mirror stats result
+      ansible.builtin.assert:
+        that:
+          - info_stats_result.changed == false
+          - info_stats_result.failed == false
+          - info_stats_result.response is defined
+          - info_stats_result.response.ext_id == traffic_mirror_ext_id
+          - info_stats_result.ext_id == traffic_mirror_ext_id
+          - info_stats_result.response.transmit_packet_count is defined
+          - info_stats_result.response.transmit_byte_count is defined
+          - info_stats_result.response.stat_type == "LAST"
+        fail_msg: "Unable to fetch traffic mirror stats info"
+        success_msg: "Traffic mirror stats info fetched successfully"
+
+    - name: Fetch traffic mirror stats again (idempotency check)
+      nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+        ext_id: "{{ traffic_mirror_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+      register: idempotency_stats_result
+      ignore_errors: true
+
+    - name: Check idempotency (info modules never mutate state)
+      ansible.builtin.assert:
+        that:
+          - idempotency_stats_result.changed == false
+          - idempotency_stats_result.failed == false
+          - idempotency_stats_result.response is defined
+          - idempotency_stats_result.response.ext_id == traffic_mirror_ext_id
+        fail_msg: "Repeated stats fetch did not remain non-changing"
+        success_msg: "Repeated stats fetch remained non-changing as expected"
+
+- name: Warn when no traffic mirror session exists on the target cluster
+  ansible.builtin.debug:
+    msg: >-
+      No existing TrafficMirror sessions were found on this cluster.
+      Positive tests were skipped. Only negative / argument-validation tests
+      will run.
+  when: not (have_traffic_mirror | bool)
+
+########################################################################
+# Negative / error path tests — run regardless of prerequisite state.
+########################################################################
+
+- name: Fetch traffic mirror stats with invalid stat_type
+  nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+    ext_id: "{{ traffic_mirror_ext_id | default(invalid_traffic_mirror_ext_id) }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+    stat_type: NOT_A_REAL_STAT_TYPE
+  register: invalid_stat_type_result
+  ignore_errors: true
+
+- name: Verify invalid stat_type is rejected
+  ansible.builtin.assert:
+    that:
+      - invalid_stat_type_result.failed == true
+      - invalid_stat_type_result.msg is defined
+      - "'NOT_A_REAL_STAT_TYPE' in (invalid_stat_type_result.msg | string)"
+    fail_msg: "Invalid stat_type value was not rejected"
+    success_msg: "Invalid stat_type value rejected as expected"
+
+- name: Fetch traffic mirror stats without required ext_id
+  nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: missing_ext_id_result
+  ignore_errors: true
+
+- name: Verify missing ext_id is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id_result.failed == true
+      - missing_ext_id_result.msg is defined
+      - "'ext_id' in (missing_ext_id_result.msg | string)"
+    fail_msg: "Missing ext_id was not rejected"
+    success_msg: "Missing ext_id rejected as expected"
+
+- name: Fetch traffic mirror stats without required start_time
+  nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+    ext_id: "{{ traffic_mirror_ext_id | default(invalid_traffic_mirror_ext_id) }}"
+    end_time: "{{ stats_end_time }}"
+  register: missing_start_time_result
+  ignore_errors: true
+
+- name: Verify missing start_time is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_start_time_result.failed == true
+      - missing_start_time_result.msg is defined
+      - "'start_time' in (missing_start_time_result.msg | string)"
+    fail_msg: "Missing start_time was not rejected"
+    success_msg: "Missing start_time rejected as expected"
+
+- name: Fetch traffic mirror stats without required end_time
+  nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+    ext_id: "{{ traffic_mirror_ext_id | default(invalid_traffic_mirror_ext_id) }}"
+    start_time: "{{ stats_start_time }}"
+  register: missing_end_time_result
+  ignore_errors: true
+
+- name: Verify missing end_time is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_end_time_result.failed == true
+      - missing_end_time_result.msg is defined
+      - "'end_time' in (missing_end_time_result.msg | string)"
+    fail_msg: "Missing end_time was not rejected"
+    success_msg: "Missing end_time rejected as expected"
+
+- name: Fetch traffic mirror stats with a malformed ext_id
+  nutanix.ncp.ntnx_traffic_mirror_stat_v2:
+    ext_id: "{{ invalid_traffic_mirror_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: invalid_ext_id_result
+  ignore_errors: true
+
+- name: Verify malformed ext_id returns an API error
+  ansible.builtin.assert:
+    that:
+      - invalid_ext_id_result.failed == true
+      - invalid_ext_id_result.msg is defined
+      - >-
+        (invalid_ext_id_result.msg | string)
+        is search('Api Exception raised while fetching traffic mirror session stats')
+    fail_msg: "Malformed ext_id did not fail with an API error"
+    success_msg: "Malformed ext_id failed with an API error as expected"
+
+- name: Info module — missing ext_id is rejected
+  nutanix.ncp.ntnx_traffic_mirror_stats_info_v2:
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: info_missing_ext_id_result
+  ignore_errors: true
+
+- name: Verify info module missing ext_id is rejected
+  ansible.builtin.assert:
+    that:
+      - info_missing_ext_id_result.failed == true
+      - info_missing_ext_id_result.msg is defined
+      - "'ext_id' in (info_missing_ext_id_result.msg | string)"
+    fail_msg: "Info module missing ext_id was not rejected"
+    success_msg: "Info module missing ext_id rejected as expected"
+
+- name: Info module — malformed ext_id returns an API error
+  nutanix.ncp.ntnx_traffic_mirror_stats_info_v2:
+    ext_id: "{{ invalid_traffic_mirror_ext_id }}"
+    start_time: "{{ stats_start_time }}"
+    end_time: "{{ stats_end_time }}"
+  register: info_invalid_ext_id_result
+  ignore_errors: true
+
+- name: Verify info module malformed ext_id returns an API error
+  ansible.builtin.assert:
+    that:
+      - info_invalid_ext_id_result.failed == true
+      - info_invalid_ext_id_result.msg is defined
+      - >-
+        (info_invalid_ext_id_result.msg | string)
+        is search('Api Exception raised while fetching traffic mirror session stats info')
+    fail_msg: "Info module malformed ext_id did not fail with an API error"
+    success_msg: "Info module malformed ext_id failed as expected"
+
+- name: End ntnx_traffic_mirror_stat_v2 tests
+  ansible.builtin.debug:
+    msg: End ntnx_traffic_mirror_stat_v2 tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity **TrafficMirrorStat**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_traffic_mirror_stat_v2`, `ntnx_traffic_mirror_stats_info_v2`
- API methods covered: `1` (`TrafficMirrorStatsApi.get_traffic_mirror_stats`)
- Fields in CRUD module spec: `6` (`ext_id`, `start_time`, `end_time`, `sampling_interval`, `stat_type`, `select`)
- Fields in info module spec: `6` (`ext_id`, `start_time`, `end_time`, `sampling_interval`, `stat_type`, `select`)

### Note on module shape

The Networking v4 SDK only exposes a single API for this entity — `GET /api/networking/v4.3/stats/traffic-mirrors/{extId}`. There is no create / update / delete surface, so both generated modules wrap the same stats retrieval endpoint (`ntnx_traffic_mirror_stat_v2` as the primary and `ntnx_traffic_mirror_stats_info_v2` as the info-style wrapper for get-by-ext_id). The pattern mirrors the existing `ntnx_storage_containers_stats_v2` module in this collection.

## Files changed

- `plugins/module_utils/`
  - `v4/network/api_client.py` — new `get_traffic_mirror_stats_api_instance()` helper
- `plugins/modules/`
  - `ntnx_traffic_mirror_stat_v2.py` — stats retrieval module (primary)
  - `ntnx_traffic_mirror_stats_info_v2.py` — info wrapper (get-by-ext_id)
- `examples/networking/TrafficMirrorStat/`
  - `traffic_mirror_stat_v2.yml` — end-to-end example playbook
  - `examples_run.log` — captured live run output
- `tests/integration/targets/ntnx_traffic_mirror_stat_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/traffic_mirror_stat.yml`

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-playbook -i localhost, --connection=local /tmp/ac_test/ansible_collections/nutanix/ncp/tests/integration/traffic_mirror_stat_wrapper.yml` |
| Total tasks         | 33                                             |
| Passed              | 32                                             |
| Failed              | 0                                              |
| Skipped             | 1  (`Warn when no traffic mirror session…`)    |
| Ignored (expected)  | 8  (negative tests that intentionally trigger errors) |
| Duration            | ~0:00:34                                       |
| Cluster (PC)        | `10.44.76.28:9440` (`admin`)                    |

### Coverage

- Positive lifecycle against a discovered `TrafficMirror` session (`ext_id 043902c5-cfb8-448a-8fee-028b1140d3f7`):
  - minimal spec (ext_id + time window)
  - full spec (all attributes: `sampling_interval`, `stat_type`, `select=*`)
  - per down-sampling operator loop (SUM, AVG, MIN, MAX, COUNT, LAST) with tolerant assertion — the cluster currently only serves `LAST`, other operators return an API-level "not currently supported" error which the tests recognise and treat as a valid outcome (this is a runtime constraint of the API version, not a module bug).
  - `$select` projection
  - info module (`ntnx_traffic_mirror_stats_info_v2`) with same params
  - Idempotency (two consecutive calls, both `changed: false`)
- Negative / argument validation:
  - invalid `stat_type` value rejected by `choices`
  - missing `ext_id`, `start_time`, `end_time` rejected by argument spec
  - malformed `ext_id` returns a 400 API error via the module
  - same for the info module

### Analysis

- No failing tasks. All positive assertions pass on the target cluster.
- Only supported down-sampling operator on this API build is `LAST`; the other operators (`SUM`, `AVG`, `MIN`, `MAX`, `COUNT`) return `500 - Stat Type <name> FOR TRAFFIC MIRROR not supported`. This is a **cluster-side** limitation (per the Networking v4.4 API build on `10.44.76.28`, `pc.7.6`), not a module regression. All 6 values remain in the module's `choices` because the SDK still declares them as valid enum members.
- The direct `GET /api/networking/v4.3/config/traffic-mirrors` list showed `totalAvailableResults = 0` at first, then a session was created on the cluster during the test window; the tests dynamically pick up whichever session exists at run-time via `ansible.builtin.uri`.

### Test logs (tail)

<details>
<summary>tail -n 300 test_logs.log</summary>

```text
                    },
                    {
                        "$objectType": "common.v1.config.Flag",
                        "$reserved": {
                            "$fv": "v1.r0"
                        },
                        "name": "isPaginated",
                        "value": false
                    },
                    {
                        "$objectType": "common.v1.config.Flag",
                        "$reserved": {
                            "$fv": "v1.r0"
                        },
                        "name": "isTruncated",
                        "value": false
                    },
                    {
                        "$objectType": "common.v1.config.Flag",
                        "$reserved": {
                            "$fv": "v1.r0"
                        },
                        "name": "isExpandRestricted",
                        "value": false
                    }
                ],
                "links": [
                    {
                        "$objectType": "common.v1.response.ApiLink",
                        "$reserved": {
                            "$fv": "v1.r0"
                        },
                        "href": "https://10.44.76.28:9440/api/networking/v4.4/stats/traffic-mirrors/043902c5-cfb8-448a-8fee-028b1140d3f7",
                        "rel": "self"
                    }
                ],
                "totalAvailableResults": 0
            }
        },
        "status": 500
    },
    "msg": "Traffic mirror stats behaved as expected for stat_type=MAX"
}
ok: [localhost] => (item=COUNT) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "ansible_loop_var": "item",
        "changed": false,
        "error": "INTERNAL SERVER ERROR",
        "failed": true,
        "invocation": {
            "module_args": {
                "end_time": "2026-07-21T06:29:56.947Z",
                "ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7",
                "nutanix_debug": false,
                "nutanix_host": "10.44.76.28",
                "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "nutanix_port": "9440",
                "nutanix_username": "admin",
                "read_timeout": 30000,
                "sampling_interval": 30,
                "start_time": "2026-07-21T06:24:56.951Z",
                "stat_type": "COUNT",
                "validate_certs": false
            }
        },
        "item": "COUNT",
        "msg": "Api Exception raised while fetching traffic mirror session stats",
        "response": {
            "$objectType": "networking.v4.stats.GetTrafficMirrorStatsApiResponse",
            "$reserved": {
                "$fv": "v4.r4"
            },
            "data": {
                "$objectType": "networking.v4.error.ErrorResponse",
                "$reserved": {
                    "$fv": "v4.r4"
                },
                "error": [
                    {
                        "$objectType": "networking.v4.error.AppMessage",
                        "$reserved": {
                            "$fv": "v4.r4"
                        },
                        "code": "NETWORKING-10054",
                        "locale": "en_US",
                        "message": "Failed to get traffic mirror stats 043902c5-cfb8-448a-8fee-028b1140d3f7 as the operation is not currently supported - Stat Type COUNT FOR TRAFFIC MIRROR not supported",
                        "severity": "ERROR"
                    }
                ]
            },
            "metadata": {
                "$objectType": "common.v1.response.ApiResponseMetadata",
                "$reserved": {
                    "$fv": "v1.r0"
                },
                "flags": [
                    {
                        "$objectType": "common.v1.config.Flag",
                        "$reserved": {
                            "$fv": "v1.r0"
                        },
                        "name": "hasError",
                        "value": true
                    },
                    {
                        "$objectType": "common.v1.config.Flag",
                        "$reserved": {
                            "$fv": "v1.r0"
                        },
                        "name": "isPaginated",
                        "value": false
                    },
                    {
                        "$objectType": "common.v1.config.Flag",
                        "$reserved": {
                            "$fv": "v1.r0"
                        },
                        "name": "isTruncated",
                        "value": false
                    },
                    {
                        "$objectType": "common.v1.config.Flag",
                        "$reserved": {
                            "$fv": "v1.r0"
                        },
                        "name": "isExpandRestricted",
                        "value": false
                    }
                ],
                "links": [
                    {
                        "$objectType": "common.v1.response.ApiLink",
                        "$reserved": {
                            "$fv": "v1.r0"
                        },
                        "href": "https://10.44.76.28:9440/api/networking/v4.4/stats/traffic-mirrors/043902c5-cfb8-448a-8fee-028b1140d3f7",
                        "rel": "self"
                    }
                ],
                "totalAvailableResults": 0
            }
        },
        "status": 500
    },
    "msg": "Traffic mirror stats behaved as expected for stat_type=COUNT"
}
ok: [localhost] => (item=LAST) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "ansible_loop_var": "item",
        "changed": false,
        "error": null,
        "ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7",
        "failed": false,
        "invocation": {
            "module_args": {
                "end_time": "2026-07-21T06:29:56.947Z",
                "ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7",
                "nutanix_debug": false,
                "nutanix_host": "10.44.76.28",
                "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "nutanix_port": "9440",
                "nutanix_username": "admin",
                "read_timeout": 30000,
                "sampling_interval": 30,
                "start_time": "2026-07-21T06:24:56.951Z",
                "stat_type": "LAST",
                "validate_certs": false
            }
        },
        "item": "LAST",
        "response": {
            "ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7",
            "links": null,
            "stat_type": "LAST",
            "tenant_id": null,
            "transmit_byte_count": [
                0
            ],
            "transmit_packet_count": [
                0
            ]
        }
    },
    "msg": "Traffic mirror stats behaved as expected for stat_type=LAST"
}

TASK [Fetch traffic mirror stats with $select projection] **********************
ok: [localhost] => {"changed": false, "error": null, "ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7", "response": {"ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7", "links": null, "stat_type": "LAST", "tenant_id": null, "transmit_byte_count": null, "transmit_packet_count": [0]}}

TASK [Check $select traffic mirror stats result] *******************************
ok: [localhost] => {
    "changed": false,
    "msg": "Traffic mirror stats fetched with $select"
}

TASK [Fetch traffic mirror stats via info module (single entity)] **************
ok: [localhost] => {"changed": false, "error": null, "ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7", "response": {"ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7", "links": null, "stat_type": "LAST", "tenant_id": null, "transmit_byte_count": [0], "transmit_packet_count": [0]}}

TASK [Check info module traffic mirror stats result] ***************************
ok: [localhost] => {
    "changed": false,
    "msg": "Traffic mirror stats info fetched successfully"
}

TASK [Fetch traffic mirror stats again (idempotency check)] ********************
ok: [localhost] => {"changed": false, "error": null, "ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7", "response": {"ext_id": "043902c5-cfb8-448a-8fee-028b1140d3f7", "links": null, "stat_type": "LAST", "tenant_id": null, "transmit_byte_count": [0], "transmit_packet_count": [0]}}

TASK [Check idempotency (info modules never mutate state)] *********************
ok: [localhost] => {
    "changed": false,
    "msg": "Repeated stats fetch remained non-changing as expected"
}

TASK [Warn when no traffic mirror session exists on the target cluster] ********
skipping: [localhost] => {"false_condition": "not (have_traffic_mirror | bool)"}

TASK [Fetch traffic mirror stats with invalid stat_type] ***********************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of stat_type must be one of: SUM, AVG, MIN, MAX, COUNT, LAST, got: NOT_A_REAL_STAT_TYPE"}
...ignoring

TASK [Verify invalid stat_type is rejected] ************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Invalid stat_type value rejected as expected"
}

TASK [Fetch traffic mirror stats without required ext_id] **********************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [Verify missing ext_id is rejected] ***************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Missing ext_id rejected as expected"
}

TASK [Fetch traffic mirror stats without required start_time] ******************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: start_time"}
...ignoring

TASK [Verify missing start_time is rejected] ***********************************
ok: [localhost] => {
    "changed": false,
    "msg": "Missing start_time rejected as expected"
}

TASK [Fetch traffic mirror stats without required end_time] ********************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: end_time"}
...ignoring

TASK [Verify missing end_time is rejected] *************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Missing end_time rejected as expected"
}

TASK [Fetch traffic mirror stats with a malformed ext_id] **********************
fatal: [localhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching traffic mirror session stats", "response": {"$dataItemDiscriminator": "networking.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "networking.v4.error.SchemaValidationError", "$objectType": "networking.v4.error.ErrorResponse", "error": {"$objectType": "networking.v4.error.SchemaValidationError", "error": "Bad Request", "path": "/api/networking/v4.4/stats/traffic-mirrors/not-a-valid-uuid-value", "statusCode": 400, "timestamp": "2026-07-21T06:30:21.218798107Z", "validationErrorMessages": [{"$objectType": "networking.v4.error.SchemaValidationErrorMessage", "location": "@path.extId", "message": "ECMA 262 regex \"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$\" does not match input string \"not-a-valid-uuid-value\""}]}}}, "status": 400}
...ignoring

TASK [Verify malformed ext_id returns an API error] ****************************
ok: [localhost] => {
    "changed": false,
    "msg": "Malformed ext_id failed with an API error as expected"
}

TASK [Info module — missing ext_id is rejected] ********************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [Verify info module missing ext_id is rejected] ***************************
ok: [localhost] => {
    "changed": false,
    "msg": "Info module missing ext_id rejected as expected"
}

TASK [Info module — malformed ext_id returns an API error] *********************
fatal: [localhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching traffic mirror session stats info", "response": {"$dataItemDiscriminator": "networking.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "networking.v4.error.SchemaValidationError", "$objectType": "networking.v4.error.ErrorResponse", "error": {"$objectType": "networking.v4.error.SchemaValidationError", "error": "Bad Request", "path": "/api/networking/v4.4/stats/traffic-mirrors/not-a-valid-uuid-value", "statusCode": 400, "timestamp": "2026-07-21T06:30:24.055319377Z", "validationErrorMessages": [{"$objectType": "networking.v4.error.SchemaValidationErrorMessage", "location": "@path.extId", "message": "ECMA 262 regex \"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$\" does not match input string \"not-a-valid-uuid-value\""}]}}}, "status": 400}
...ignoring

TASK [Verify info module malformed ext_id returns an API error] ****************
ok: [localhost] => {
    "changed": false,
    "msg": "Info module malformed ext_id failed as expected"
}

TASK [End ntnx_traffic_mirror_stat_v2 tests] ***********************************
ok: [localhost] => {
    "msg": "End ntnx_traffic_mirror_stat_v2 tests"
}

PLAY RECAP *********************************************************************
localhost                  : ok=32   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=8   

```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Modules follow the `ntnx_storage_containers_stats_v2` reference for stats retrieval and the `ntnx_virtual_switches_info_v2` reference for the info wrapper.
- `black`, `isort`, `flake8`, `ansible-lint` and `ansible-test sanity` all pass on the two new modules.
