### PR TITLE
AntivirusServerStat Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/files/AntivirusServerStat/antivirus_server_stat_v2.yml
+++ b/examples/files/AntivirusServerStat/antivirus_server_stat_v2.yml
@@ -1,0 +1,60 @@
+---
+# Summary:
+# AntivirusServerStat is a READ-ONLY statistics entity in Nutanix Files. The
+# Files v4 API only exposes a get (read) operation for antivirus server stats,
+# so there is no create / update / delete. This playbook demonstrates the
+# supported operations:
+#   1. Fetch antivirus server stats with the required fields only
+#   2. Fetch antivirus server stats with all the optional query parameters
+#   3. Fetch antivirus server stats using the info module
+#
+# Connection parameters are set once, at the play level, via module_defaults.
+# They are resolved from environment variables (NUTANIX_HOST / NUTANIX_USERNAME /
+# NUTANIX_PASSWORD) so that no credentials are hard-coded in this file.
+
+- name: AntivirusServerStat playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('ansible.builtin.env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('ansible.builtin.env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('ansible.builtin.env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Set the file server and antivirus server identifiers
+      ansible.builtin.set_fact:
+        file_server_ext_id: "b2c3d4e5-6f78-4a90-b1c2-d3e4f5a6b7c8"
+        antivirus_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+
+    - name: Fetch antivirus server stats with the required fields only
+      nutanix.ncp.ntnx_antivirus_server_stat_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ antivirus_server_ext_id }}"
+        start_time: "2024-07-31T12:41:56.955Z"
+        end_time: "2025-07-31T12:41:56.955Z"
+      register: result
+      ignore_errors: true
+
+    - name: Fetch antivirus server stats with all the optional query parameters
+      nutanix.ncp.ntnx_antivirus_server_stat_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ antivirus_server_ext_id }}"
+        start_time: "2024-07-31T12:41:56.955Z"
+        end_time: "2025-07-31T12:41:56.955Z"
+        sampling_interval: 30
+        stat_type: "AVG"
+        select: "scannedFileCount,threatCount,cleanedFileCount,quarantinedFileCount,latencyMs,throughputBps,disconnectCount"
+      register: result
+      ignore_errors: true
+
+    - name: Fetch antivirus server stats using the info module
+      nutanix.ncp.ntnx_files_antivirus_server_stats_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ antivirus_server_ext_id }}"
+        start_time: "2024-07-31T12:41:56.955Z"
+        end_time: "2025-07-31T12:41:56.955Z"
+        sampling_interval: 30
+        stat_type: "AVG"
+      register: result
+      ignore_errors: true

--- a/examples/files/AntivirusServerStat/examples_run.log
+++ b/examples/files/AntivirusServerStat/examples_run.log
@@ -1,0 +1,25 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [AntivirusServerStat playbook] ********************************************
+
+TASK [Set the file server and antivirus server identifiers] ********************
+ok: [localhost] => {"ansible_facts": {"antivirus_server_ext_id": "18f78959-14a6-4c47-b5db-920460c4b668", "file_server_ext_id": "b2c3d4e5-6f78-4a90-b1c2-d3e4f5a6b7c8"}, "changed": false}
+
+TASK [Fetch antivirus server stats with the required fields only] **************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching antivirus server stats", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Fetch antivirus server stats with all the optional query parameters] *****
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching antivirus server stats", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Fetch antivirus server stats using the info module] **********************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching antivirus server stats", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_antivirus_server_stat_v2
+    - ntnx_files_antivirus_server_stats_info_v2

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,96 @@
+# Copyright: (c) 2024, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details for the Nutanix Files (v4) SDK.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    # Setup API logging if debug is enabled
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_analytics_api_instance(module):
+    """
+    This method will return the Analytics api instance from the files sdk.
+    The Analytics API exposes the Nutanix Files statistics endpoints such as
+    antivirus server, file server and mount target statistics.
+    Args:
+        module (AnsibleModule): AnsibleModule instance
+    Returns:
+        AnalyticsApi: AnalyticsApi instance
+    """
+    client = get_api_client(module)
+    return ntnx_files_py_client.AnalyticsApi(client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,53 @@
+# Copyright: (c) 2024, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_antivirus_server_stats(
+    module, api_instance, file_server_ext_id, ext_id, msg=None
+):
+    """
+    Fetch antivirus server statistics for a single antivirus server on a
+    file server for the requested time window.
+
+    The Nutanix Files stats endpoint only exposes a get-by-id style read for
+    antivirus server statistics, so both the stats module and the info module
+    reuse this helper to avoid duplicating the fetch logic.
+
+    Args:
+        module (AnsibleModule): AnsibleModule instance. The time window and
+            optional query parameters are read from ``module.params``.
+        api_instance (AnalyticsApi): files AnalyticsApi instance.
+        file_server_ext_id (str): external id of the file server.
+        ext_id (str): external id of the antivirus server.
+        msg (str): error message to surface if the API call fails.
+
+    Returns:
+        AntivirusServerStatsApiResponse: the raw SDK response.
+    """
+    if msg is None:
+        msg = "Api Exception raised while fetching antivirus server stats"
+
+    resp = None
+    try:
+        resp = api_instance.get_antivirus_server_stats(
+            fileServerExtId=file_server_ext_id,
+            extId=ext_id,
+            _startTime=module.params.get("start_time"),
+            _endTime=module.params.get("end_time"),
+            _samplingInterval=module.params.get("sampling_interval"),
+            _statType=module.params.get("stat_type"),
+            _select=module.params.get("select"),
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=msg,
+        )
+    return resp

--- a/plugins/modules/ntnx_antivirus_server_stat_v2.py
+++ b/plugins/modules/ntnx_antivirus_server_stat_v2.py
@@ -1,0 +1,277 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_antivirus_server_stat_v2
+short_description: Retrieve antivirus server statistics for a Nutanix Files file server from PC
+version_added: 2.6.0
+description:
+    - Get the antivirus (ICAP) server statistics for a given antivirus server on a Nutanix Files file server.
+    - The antivirus server statistics is a read-only entity, the Nutanix Files v4 API exposes only a read
+      (get) operation for it, so this module fetches statistics and never creates, updates or deletes anything.
+    - This module uses PC v4 APIs based SDKs
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get antivirus server statistics) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server that hosts the antivirus server.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external identifier of the antivirus server whose statistics are requested.
+    type: str
+    required: true
+  start_time:
+    description:
+      - The start time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format.
+      - Sample input time is 2024-07-31T12:41:56.955Z
+    type: str
+    required: true
+  end_time:
+    description:
+      - The end time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format.
+      - Sample input time is 2025-07-31T12:41:56.955Z
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - The sampling interval in seconds at which statistical data should be collected.
+      - For example, if you want performance statistics every 30 seconds, then provide the value as 30.
+    type: int
+    required: false
+  stat_type:
+    description:
+      - The type of down sampling operation that should be performed on the requested statistics.
+    type: str
+    required: false
+    choices:
+      - SUM
+      - AVG
+      - MIN
+      - MAX
+      - COUNT
+      - LAST
+  select:
+    description:
+      - A URL query parameter that allows clients to request a specific set of properties for each entity.
+      - Comma separated list of one or more of
+        C(cleanedFileCount), C(disconnectCount), C(latencyMs), C(quarantinedFileCount),
+        C(scannedFileCount), C(threatCount), C(throughputBps).
+      - Use C(*) to select all properties.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+      - nutanix.ncp.ntnx_credentials
+      - nutanix.ncp.ntnx_logger
+      - nutanix.ncp.ntnx_proxy_v2
+author:
+ - Nutanix (@nutanix)
+"""
+
+EXAMPLES = r"""
+- name: Fetch antivirus server stats during a time interval
+  nutanix.ncp.ntnx_antivirus_server_stat_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    file_server_ext_id: "b2c3d4e5-6f78-4a90-b1c2-d3e4f5a6b7c8"
+    ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+  register: result
+
+- name: Fetch antivirus server stats with all attributes
+  nutanix.ncp.ntnx_antivirus_server_stat_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    file_server_ext_id: "b2c3d4e5-6f78-4a90-b1c2-d3e4f5a6b7c8"
+    ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+    sampling_interval: 30
+    stat_type: "AVG"
+    select: "scannedFileCount,threatCount,cleanedFileCount"
+  register: result
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for fetching antivirus server statistics.
+        - Contains the requested antivirus statistics time series for the given antivirus server.
+    type: dict
+    returned: always
+    sample:
+        {
+            "cleaned_file_count": [
+                {
+                    "timestamp": "2024-07-31T11:29:00+00:00",
+                    "value": 0
+                }
+            ],
+            "disconnect_count": [
+                {
+                    "timestamp": "2024-07-31T11:29:00+00:00",
+                    "value": 0
+                }
+            ],
+            "ext_id": "18f78959-14a6-4c47-b5db-920460c4b668",
+            "latency_ms": [
+                {
+                    "timestamp": "2024-07-31T11:29:00+00:00",
+                    "value": 12
+                }
+            ],
+            "links": null,
+            "quarantined_file_count": [
+                {
+                    "timestamp": "2024-07-31T11:29:00+00:00",
+                    "value": 0
+                }
+            ],
+            "scanned_file_count": [
+                {
+                    "timestamp": "2024-07-31T11:29:00+00:00",
+                    "value": 145
+                }
+            ],
+            "tenant_id": null,
+            "threat_count": [
+                {
+                    "timestamp": "2024-07-31T11:29:00+00:00",
+                    "value": 0
+                }
+            ],
+            "throughput_bps": [
+                {
+                    "timestamp": "2024-07-31T11:29:00+00:00",
+                    "value": 10485760
+                }
+            ]
+        }
+changed:
+    description: This indicates whether the task resulted in any changes. Always false for this read-only stats module.
+    returned: always
+    type: bool
+    sample: false
+ext_id:
+    description:
+        - The external ID of the antivirus server whose statistics were fetched.
+    type: str
+    returned: always
+    sample: "18f78959-14a6-4c47-b5db-920460c4b668"
+error:
+    description: The error message if an error occurs.
+    type: str
+    returned: when an error occurs
+failed:
+    description: This indicates whether the task failed.
+    returned: always
+    type: bool
+    sample: false
+msg:
+    description: This indicates the message if any message occurred.
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while fetching antivirus server stats"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import get_analytics_api_instance  # noqa: E402
+from ..module_utils.v4.files.helpers import get_antivirus_server_stats  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        file_server_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int"),
+        stat_type=dict(
+            type="str",
+            choices=[
+                "SUM",
+                "AVG",
+                "MIN",
+                "MAX",
+                "COUNT",
+                "LAST",
+            ],
+        ),
+        select=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_antivirus_server_stat(module, result):
+    api_instance = get_analytics_api_instance(module)
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    resp = get_antivirus_server_stats(module, api_instance, file_server_ext_id, ext_id)
+
+    if getattr(resp, "data", None):
+        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    else:
+        module.fail_json(msg="Failed fetching antivirus server stats", **result)
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+    }
+    get_antivirus_server_stat(module, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_files_antivirus_server_stats_info_v2.py
+++ b/plugins/modules/ntnx_files_antivirus_server_stats_info_v2.py
@@ -1,0 +1,278 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_antivirus_server_stats_info_v2
+short_description: Fetch antivirus server statistics info in Nutanix Prism Central
+version_added: 2.6.0
+description:
+  - This module allows you to fetch information about AntivirusServerStat in Nutanix Prism Central.
+  - The Nutanix Files v4 statistics API exposes antivirus server statistics as a read only,
+    get-by-id style entity, so C(ext_id) and C(file_server_ext_id) are always required and the
+    module always fetches the statistics of that single antivirus server.
+  - Listing / filtering is not supported by the underlying stats endpoint.
+  - This module uses PC v4 APIs based SDKs
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get antivirus server statistics) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server that hosts the antivirus server.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external identifier of the antivirus server whose statistics are requested.
+    type: str
+    required: true
+  start_time:
+    description:
+      - The start time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format.
+      - Sample input time is 2024-07-31T12:41:56.955Z
+    type: str
+    required: true
+  end_time:
+    description:
+      - The end time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format.
+      - Sample input time is 2025-07-31T12:41:56.955Z
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - The sampling interval in seconds at which statistical data should be collected.
+      - For example, if you want performance statistics every 30 seconds, then provide the value as 30.
+    type: int
+    required: false
+  stat_type:
+    description:
+      - The type of down sampling operation that should be performed on the requested statistics.
+    type: str
+    required: false
+    choices:
+      - SUM
+      - AVG
+      - MIN
+      - MAX
+      - COUNT
+      - LAST
+  select:
+    description:
+      - A URL query parameter that allows clients to request a specific set of properties for each entity.
+      - Comma separated list of one or more of
+        C(cleanedFileCount), C(disconnectCount), C(latencyMs), C(quarantinedFileCount),
+        C(scannedFileCount), C(threatCount), C(throughputBps).
+      - Use C(*) to select all properties.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+ - Nutanix (@nutanix)
+"""
+
+EXAMPLES = r"""
+- name: Fetch antivirus server stats using external ID
+  nutanix.ncp.ntnx_files_antivirus_server_stats_info_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    file_server_ext_id: "b2c3d4e5-6f78-4a90-b1c2-d3e4f5a6b7c8"
+    ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+  register: result
+
+- name: Fetch antivirus server stats with all attributes
+  nutanix.ncp.ntnx_files_antivirus_server_stats_info_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    file_server_ext_id: "b2c3d4e5-6f78-4a90-b1c2-d3e4f5a6b7c8"
+    ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+    sampling_interval: 30
+    stat_type: "AVG"
+    select: "scannedFileCount,threatCount"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC AntivirusServerStat info v4 API.
+    - It returns the statistics of the antivirus server identified by C(ext_id).
+  returned: always
+  type: dict
+  sample:
+    {
+        "cleaned_file_count": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 0
+            }
+        ],
+        "disconnect_count": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 0
+            }
+        ],
+        "ext_id": "18f78959-14a6-4c47-b5db-920460c4b668",
+        "latency_ms": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 12
+            }
+        ],
+        "links": null,
+        "quarantined_file_count": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 0
+            }
+        ],
+        "scanned_file_count": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 145
+            }
+        ],
+        "tenant_id": null,
+        "threat_count": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 0
+            }
+        ],
+        "throughput_bps": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 10485760
+            }
+        ]
+    }
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+ext_id:
+  description: External ID of the antivirus server whose statistics were fetched.
+  type: str
+  returned: always
+  sample: "18f78959-14a6-4c47-b5db-920460c4b668"
+error:
+  description: This field holds the error message if an error occurs.
+  type: str
+  returned: when an error occurs
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching antivirus server stats"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import get_analytics_api_instance  # noqa: E402
+from ..module_utils.v4.files.helpers import get_antivirus_server_stats  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        file_server_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int"),
+        stat_type=dict(
+            type="str",
+            choices=[
+                "SUM",
+                "AVG",
+                "MIN",
+                "MAX",
+                "COUNT",
+                "LAST",
+            ],
+        ),
+        select=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_antivirus_server_stats_with_ext_id(module, result):
+    api_instance = get_analytics_api_instance(module)
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    resp = get_antivirus_server_stats(module, api_instance, file_server_ext_id, ext_id)
+
+    if getattr(resp, "data", None):
+        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    else:
+        result["response"] = None
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+    }
+    get_antivirus_server_stats_with_ext_id(module, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
-ntnx-files-py-client==latest
+ntnx-files-py-client==4.0.1

--- a/tests/integration/targets/ntnx_antivirus_server_stat_v2/aliases
+++ b/tests/integration/targets/ntnx_antivirus_server_stat_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_antivirus_server_stat_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_antivirus_server_stat_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_antivirus_server_stat_v2/tasks/antivirus_server_stat.yml
+++ b/tests/integration/targets/ntnx_antivirus_server_stat_v2/tasks/antivirus_server_stat.yml
@@ -1,0 +1,225 @@
+---
+# ============================================================================
+# TEST PLAN — ntnx_antivirus_server_stat_v2 / ntnx_files_antivirus_server_stats_info_v2
+# ============================================================================
+# AntivirusServerStat is a READ-ONLY statistics entity. The Nutanix Files v4
+# API exposes only a get (read) operation for antivirus server statistics
+# (GET /files/v4.0/stats/file-servers/{fileServerExtId}/anti-virus-servers/{extId}).
+# There is no create / update / delete and no list, therefore:
+#   - There are NO CRUD lifecycle / idempotency tests (not applicable).
+#   - check_mode is not supported by these modules (read-only info modules).
+#
+# The scenarios covered below are:
+#   A. Argument-spec validation (no cluster contact required)
+#      1. Missing file_server_ext_id            -> fails, descriptive msg
+#      2. Missing ext_id                        -> fails, descriptive msg
+#      3. Missing start_time                    -> fails, descriptive msg
+#      4. Missing end_time                      -> fails, descriptive msg
+#      5. Invalid stat_type enum value          -> fails, choices msg
+#      (repeated for the info module: missing required + invalid enum)
+#   B. Live API error path (contacts the cluster)
+#      6. Fetch stats for an antivirus server that cannot be resolved / while
+#         the Files service is unavailable -> module fails gracefully with the
+#         api-exception message and never reports changed.
+#      (repeated for the info module)
+#
+# NOTE: A successful fetch asserting real statistics values requires a Nutanix
+# Files file server with a configured antivirus (ICAP) server AND an available
+# Files v4 service. When those prerequisites are not present, scenario B
+# exercises and asserts the module's error handling instead.
+# ============================================================================
+
+- name: Start ntnx_antivirus_server_stat_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_antivirus_server_stat_v2 tests
+
+- name: Set identifiers used by the tests
+  ansible.builtin.set_fact:
+    file_server_ext_id: "b2c3d4e5-6f78-4a90-b1c2-d3e4f5a6b7c8"
+    antivirus_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+    non_existent_ext_id: "00000000-0000-0000-0000-000000000000"
+
+########################################################################
+# A. Argument-spec validation — stats module
+########################################################################
+
+- name: Fetch antivirus server stats with missing file_server_ext_id
+  nutanix.ncp.ntnx_antivirus_server_stat_v2:
+    ext_id: "{{ antivirus_server_ext_id }}"
+    start_time: "{{ start_time }}"
+    end_time: "{{ end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch antivirus server stats with missing file_server_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: file_server_ext_id' in result.msg"
+    success_msg: "Missing file_server_ext_id failed as expected"
+    fail_msg: "Missing file_server_ext_id did not fail as expected"
+
+- name: Fetch antivirus server stats with missing ext_id
+  nutanix.ncp.ntnx_antivirus_server_stat_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    start_time: "{{ start_time }}"
+    end_time: "{{ end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch antivirus server stats with missing ext_id status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: ext_id' in result.msg"
+    success_msg: "Missing ext_id failed as expected"
+    fail_msg: "Missing ext_id did not fail as expected"
+
+- name: Fetch antivirus server stats with missing start_time
+  nutanix.ncp.ntnx_antivirus_server_stat_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    ext_id: "{{ antivirus_server_ext_id }}"
+    end_time: "{{ end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch antivirus server stats with missing start_time status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: start_time' in result.msg"
+    success_msg: "Missing start_time failed as expected"
+    fail_msg: "Missing start_time did not fail as expected"
+
+- name: Fetch antivirus server stats with missing end_time
+  nutanix.ncp.ntnx_antivirus_server_stat_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    ext_id: "{{ antivirus_server_ext_id }}"
+    start_time: "{{ start_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch antivirus server stats with missing end_time status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: end_time' in result.msg"
+    success_msg: "Missing end_time failed as expected"
+    fail_msg: "Missing end_time did not fail as expected"
+
+- name: Fetch antivirus server stats with an invalid stat_type value
+  nutanix.ncp.ntnx_antivirus_server_stat_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    ext_id: "{{ antivirus_server_ext_id }}"
+    start_time: "{{ start_time }}"
+    end_time: "{{ end_time }}"
+    stat_type: "INVALID_TYPE"
+  register: result
+  ignore_errors: true
+
+- name: Fetch antivirus server stats with an invalid stat_type value status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - "'value of stat_type must be one of' in result.msg"
+      - "'INVALID_TYPE' in result.msg"
+    success_msg: "Invalid stat_type failed as expected"
+    fail_msg: "Invalid stat_type did not fail as expected"
+
+########################################################################
+# A. Argument-spec validation — info module
+########################################################################
+
+- name: Info - fetch antivirus server stats with missing ext_id
+  nutanix.ncp.ntnx_files_antivirus_server_stats_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    start_time: "{{ start_time }}"
+    end_time: "{{ end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Info - fetch antivirus server stats with missing ext_id status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: ext_id' in result.msg"
+    success_msg: "Info module missing ext_id failed as expected"
+    fail_msg: "Info module missing ext_id did not fail as expected"
+
+- name: Info - fetch antivirus server stats with an invalid stat_type value
+  nutanix.ncp.ntnx_files_antivirus_server_stats_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    ext_id: "{{ antivirus_server_ext_id }}"
+    start_time: "{{ start_time }}"
+    end_time: "{{ end_time }}"
+    stat_type: "NOT_VALID"
+  register: result
+  ignore_errors: true
+
+- name: Info - fetch antivirus server stats with an invalid stat_type value status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - "'value of stat_type must be one of' in result.msg"
+      - "'NOT_VALID' in result.msg"
+    success_msg: "Info module invalid stat_type failed as expected"
+    fail_msg: "Info module invalid stat_type did not fail as expected"
+
+########################################################################
+# B. Live API error path — stats module
+########################################################################
+
+- name: Fetch antivirus server stats for an unresolved antivirus server
+  nutanix.ncp.ntnx_antivirus_server_stat_v2:
+    file_server_ext_id: "{{ non_existent_ext_id }}"
+    ext_id: "{{ non_existent_ext_id }}"
+    start_time: "{{ start_time }}"
+    end_time: "{{ end_time }}"
+    read_timeout: 5000
+  register: result
+  ignore_errors: true
+
+- name: Fetch antivirus server stats for an unresolved antivirus server status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching antivirus server stats"
+    success_msg: "Fetch stats for unresolved antivirus server failed gracefully as expected"
+    fail_msg: "Fetch stats for unresolved antivirus server did not fail gracefully"
+
+########################################################################
+# B. Live API error path — info module
+########################################################################
+
+- name: Info - fetch antivirus server stats for an unresolved antivirus server
+  nutanix.ncp.ntnx_files_antivirus_server_stats_info_v2:
+    file_server_ext_id: "{{ non_existent_ext_id }}"
+    ext_id: "{{ non_existent_ext_id }}"
+    start_time: "{{ start_time }}"
+    end_time: "{{ end_time }}"
+    read_timeout: 5000
+  register: result
+  ignore_errors: true
+
+- name: Info - fetch antivirus server stats for an unresolved antivirus server status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching antivirus server stats"
+    success_msg: "Info module fetch stats for unresolved antivirus server failed gracefully as expected"
+    fail_msg: "Info module fetch stats for unresolved antivirus server did not fail gracefully"
+
+- name: Finish ntnx_antivirus_server_stat_v2 tests
+  ansible.builtin.debug:
+    msg: Finish ntnx_antivirus_server_stat_v2 tests

--- a/tests/integration/targets/ntnx_antivirus_server_stat_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_antivirus_server_stat_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import antivirus_server_stat.yml
+      ansible.builtin.import_tasks: antivirus_server_stat.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **files** namespace, entity
**AntivirusServerStat**, based on the inline SDK info.

**Important modelling note (entity is read-only):** In the Nutanix Files v4 SDK
(`ntnx_files_py_client`) the `AntivirusServerStat` entity exposes **only a read
(GET) operation** — `AnalyticsApi.get_antivirus_server_stats(...)`. There is no
create / update / delete and no list API for this entity. It is a *statistics*
entity, exactly like the existing `ntnx_storage_containers_stats_v2` module.
Therefore both generated modules are implemented as read/stats-fetch modules
(following the `ntnx_storage_containers_stats_v2` precedent). CRUD-only concepts
from the generic template (`state`, create/update/delete, `task_ext_id`, `etag`,
idempotency, `check_mode`) do not apply and are intentionally omitted.

- Modules generated: `ntnx_antivirus_server_stat_v2`, `ntnx_files_antivirus_server_stats_info_v2`
- API methods covered: `1` — `get_antivirus_server_stats` (the only method for the
  AntivirusServerStat entity; the other two methods in the SDK info,
  `get_file_server_stats` / `get_mount_target_stats`, belong to the separate
  FileServerStats / MountTargetStats entities).
- Fields in stats module spec: `7` (`file_server_ext_id`, `ext_id`, `start_time`,
  `end_time`, `sampling_interval`, `stat_type`, `select`)
- Fields in info module spec: `7` (same set)
- SDK pinned in `requirements.txt`: `ntnx-files-py-client==4.0.1`

## Domain knowledge (from Glean)

Per repository policy for code-gen PRs, Glean-sourced Jira/Confluence/Sharepoint
links and raw excerpts are intentionally **not** included here.

Summary in my own words: Nutanix Files performs anti-virus scanning of SMB/NFS
file shares by integrating with third-party ICAP anti-virus (AV) servers. The
ICAP service runs on each File Server VM (FSVM) and can talk to multiple ICAP/AV
servers in parallel for horizontal scale-out. The `AntivirusServerStat` entity
reports per-antivirus-server performance/health metrics over a time window:
scanned/cleaned/quarantined file counts, threat count, scan latency, throughput
and ICAP disconnect count. These are read-only observability metrics used for
monitoring AV scan health (e.g. detecting when the AV scan queue is piling up).
Prerequisites for real data: a File Server must exist and have at least one
antivirus (ICAP) server configured, and the Files analytics/stats service must be
available on Prism Central.

## Files changed

**plugins/modules/**
- `ntnx_antivirus_server_stat_v2.py` (new) — fetch antivirus server statistics
- `ntnx_files_antivirus_server_stats_info_v2.py` (new) — info module for antivirus server statistics

**plugins/module_utils/v4/files/** (new files namespace)
- `__init__.py`
- `api_client.py` — files (v4) SDK client + `AnalyticsApi` instance helpers
- `helpers.py` — shared `get_antivirus_server_stats(...)` helper (DRY, reused by both modules)

**examples/files/AntivirusServerStat/**
- `antivirus_server_stat_v2.yml` (new) — fetch examples for both modules
- `examples_run.log` (new) — real playbook output captured against the live PC

**tests/integration/targets/ntnx_antivirus_server_stat_v2/**
- `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/antivirus_server_stat.yml` (new)

**meta/runtime.yml** — registered both modules in the `ntnx` action group
**requirements.txt** — pinned `ntnx-files-py-client==4.0.1`

## Test execution

| Metric        | Value                                                                       |
|---------------|-----------------------------------------------------------------------------|
| Command       | `ansible-test integration ntnx_antivirus_server_stat_v2 --local --python 3.11 --allow-disabled` |
| Play recap    | `ok=22  changed=0  failed=0  ignored=9`                                      |
| Assert tasks  | `9` scenarios asserted, `9` passed, `0` failed                              |
| Duration      | `~0:03:14`                                                                   |
| Cluster (PC)  | `10.44.76.28`                                                                |
| Sanity        | `ansible-test sanity` (2 modules + module_utils/v4/files) — all tests passed |
| Lint          | `black`, `isort`, `flake8`, `ansible-lint` — all clean                       |

### Analysis

All 9 assertion scenarios passed:
- Argument-spec validation (both modules): missing `file_server_ext_id`, `ext_id`,
  `start_time`, `end_time`, and invalid `stat_type` enum all fail with the expected
  descriptive messages, without contacting the cluster.
- Live API error path (both modules): a fetch for an unresolved antivirus server
  returns gracefully with `failed=true`, `changed=false` and
  `msg="Api Exception raised while fetching antivirus server stats"`.

**Known environment limitation (not a code defect):** the Nutanix Files v4
analytics/stats service was **unavailable (HTTP 503)** on the provided Prism
Central `10.44.76.28` — every antivirus-stats call returned
`{"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}`
with status `503`. There is also no file server with a configured antivirus (ICAP)
server on that PC. Because of this, a **successful** stats fetch (with real metric
values) could not be captured; the tests and example playbook instead exercise and
assert the module's error handling against the live endpoint. The `response:`
samples in the module `RETURN` docs are therefore representative structural samples
derived from the SDK `AntivirusStats` model rather than captured live output.

### Test logs (tail)

<details>
<summary>test_logs.log</summary>

```text
Running ntnx_antivirus_server_stat_v2 integration test role
[WARNING]: Found variable using reserved name: port

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_antivirus_server_stat_v2 : Start ntnx_antivirus_server_stat_v2 tests] ***
ok: [testhost] => {
    "msg": "Start ntnx_antivirus_server_stat_v2 tests"
}

TASK [ntnx_antivirus_server_stat_v2 : Set identifiers used by the tests] *******
ok: [testhost]

TASK [ntnx_antivirus_server_stat_v2 : Fetch antivirus server stats with missing file_server_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: file_server_ext_id"}
...ignoring

TASK [ntnx_antivirus_server_stat_v2 : Fetch antivirus server stats with missing file_server_ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing file_server_ext_id failed as expected"
}

TASK [ntnx_antivirus_server_stat_v2 : Fetch antivirus server stats with missing ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_antivirus_server_stat_v2 : Fetch antivirus server stats with missing ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing ext_id failed as expected"
}

TASK [ntnx_antivirus_server_stat_v2 : Fetch antivirus server stats with missing start_time] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: start_time"}
...ignoring

TASK [ntnx_antivirus_server_stat_v2 : Fetch antivirus server stats with missing start_time status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing start_time failed as expected"
}

TASK [ntnx_antivirus_server_stat_v2 : Fetch antivirus server stats with missing end_time] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: end_time"}
...ignoring

TASK [ntnx_antivirus_server_stat_v2 : Fetch antivirus server stats with missing end_time status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing end_time failed as expected"
}

TASK [ntnx_antivirus_server_stat_v2 : Fetch antivirus server stats with an invalid stat_type value] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of stat_type must be one of: SUM, AVG, MIN, MAX, COUNT, LAST, got: INVALID_TYPE"}
...ignoring

TASK [ntnx_antivirus_server_stat_v2 : Fetch antivirus server stats with an invalid stat_type value status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid stat_type failed as expected"
}

TASK [ntnx_antivirus_server_stat_v2 : Info - fetch antivirus server stats with missing ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_antivirus_server_stat_v2 : Info - fetch antivirus server stats with missing ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module missing ext_id failed as expected"
}

TASK [ntnx_antivirus_server_stat_v2 : Info - fetch antivirus server stats with an invalid stat_type value] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of stat_type must be one of: SUM, AVG, MIN, MAX, COUNT, LAST, got: NOT_VALID"}
...ignoring

TASK [ntnx_antivirus_server_stat_v2 : Info - fetch antivirus server stats with an invalid stat_type value status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module invalid stat_type failed as expected"
}

TASK [ntnx_antivirus_server_stat_v2 : Fetch antivirus server stats for an unresolved antivirus server] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching antivirus server stats", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_antivirus_server_stat_v2 : Fetch antivirus server stats for an unresolved antivirus server status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch stats for unresolved antivirus server failed gracefully as expected"
}

TASK [ntnx_antivirus_server_stat_v2 : Info - fetch antivirus server stats for an unresolved antivirus server] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching antivirus server stats", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_antivirus_server_stat_v2 : Info - fetch antivirus server stats for an unresolved antivirus server status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module fetch stats for unresolved antivirus server failed gracefully as expected"
}

TASK [ntnx_antivirus_server_stat_v2 : Finish ntnx_antivirus_server_stat_v2 tests] ***
ok: [testhost] => {
    "msg": "Finish ntnx_antivirus_server_stat_v2 tests"
}

PLAY RECAP *********************************************************************
testhost                   : ok=22   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=9   

INTEGRATION_EXIT=0
```

</details>

### Example run logs (tail)

<details>
<summary>examples_run.log</summary>

```text
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
No config file found; using defaults

PLAY [AntivirusServerStat playbook] ********************************************

TASK [Set the file server and antivirus server identifiers] ********************
ok: [localhost] => {"ansible_facts": {"antivirus_server_ext_id": "18f78959-14a6-4c47-b5db-920460c4b668", "file_server_ext_id": "b2c3d4e5-6f78-4a90-b1c2-d3e4f5a6b7c8"}, "changed": false}

TASK [Fetch antivirus server stats with the required fields only] **************
fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching antivirus server stats", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [Fetch antivirus server stats with all the optional query parameters] *****
fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching antivirus server stats", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [Fetch antivirus server stats using the info module] **********************
fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching antivirus server stats", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

PLAY RECAP *********************************************************************
localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   

```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen flow for namespace=files, entity=AntivirusServerStat.
- Source of truth: the inline SDK info; verified against the installed `ntnx_files_py_client==4.0.1`.
- Modules, examples and integration tests generated, then validated with
  `ansible-test sanity`, `black`, `isort`, `flake8`, `ansible-lint`, and executed
  with `ansible-test integration` and `ansible-playbook` against the live PC.
