### PR TITLE
code-gen(networking/VpnApplianceForVpnConnection): ansible collection modules

### DIFF
--- a/examples/networking/VpnApplianceForVpnConnection/examples_run.log
+++ b/examples/networking/VpnApplianceForVpnConnection/examples_run.log
@@ -1,0 +1,57 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [VPN Appliance for VPN Connection playbook] *******************************
+
+TASK [Set VPN connection external ID] ******************************************
+ok: [localhost] => {"ansible_facts": {"vpn_connection_ext_id": "8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0"}, "changed": false}
+
+TASK [List all supported third-party VPN appliances for the VPN connection] ****
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching third-party VPN appliance info for VPN connection
+Origin: /tmp/codegen/22e64c59347448728a29a0ce5b1e3017/repo/examples/networking/VpnApplianceForVpnConnection/vpn_appliance_for_vpn_connection_v2.yml:35:7
+
+33         vpn_connection_ext_id: "{{ vpn_connection_ext_id | default('8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0') }}"
+34
+35     - name: List all supported third-party VPN appliances for the VPN connection
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching third-party VPN appliance info for VPN connection", "response": {"$objectType": "networking.v4.config.GetVpnConnectionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to list VPN vendor configs by VPN connection 8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0 as a referenced resource was not found - Application error kNotFound raised: VpnConnection 8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0 not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/vpn-connections/8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0/vpn-vendor-configs", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [List third-party VPN appliances filtered by name (Cisco ASA)] ************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching third-party VPN appliance info for VPN connection
+Origin: /tmp/codegen/22e64c59347448728a29a0ce5b1e3017/repo/examples/networking/VpnApplianceForVpnConnection/vpn_appliance_for_vpn_connection_v2.yml:41:7
+
+39       ignore_errors: true
+40
+41     - name: List third-party VPN appliances filtered by name (Cisco ASA)
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching third-party VPN appliance info for VPN connection", "response": {"$objectType": "networking.v4.config.GetVpnConnectionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to list VPN vendor configs by VPN connection 8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0 as a referenced resource was not found - Application error kNotFound raised: VpnConnection 8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0 not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/vpn-connections/8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0/vpn-vendor-configs", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [List third-party VPN appliances with a page size limit] ******************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching third-party VPN appliance info for VPN connection
+Origin: /tmp/codegen/22e64c59347448728a29a0ce5b1e3017/repo/examples/networking/VpnApplianceForVpnConnection/vpn_appliance_for_vpn_connection_v2.yml:48:7
+
+46       ignore_errors: true
+47
+48     - name: List third-party VPN appliances with a page size limit
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching third-party VPN appliance info for VPN connection", "response": {"$objectType": "networking.v4.config.GetVpnConnectionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to list VPN vendor configs by VPN connection 8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0 as a referenced resource was not found - Application error kNotFound raised: VpnConnection 8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0 not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/vpn-connections/8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0/vpn-vendor-configs", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
+...ignoring
+
+TASK [Set appliance ext_id from list response] *********************************
+skipping: [localhost] => {"changed": false, "false_condition": "appliances.failed == false", "skip_reason": "Conditional result was False"}
+
+TASK [Fetch third-party VPN appliance configuration text via info module] ******
+skipping: [localhost] => {"changed": false, "false_condition": "appliance_ext_id is defined", "skip_reason": "Conditional result was False"}
+
+TASK [Download third-party VPN appliance configuration text] *******************
+skipping: [localhost] => {"changed": false, "false_condition": "appliance_ext_id is defined", "skip_reason": "Conditional result was False"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=3    rescued=0    ignored=3   
+

--- a/examples/networking/VpnApplianceForVpnConnection/vpn_appliance_for_vpn_connection_v2.yml
+++ b/examples/networking/VpnApplianceForVpnConnection/vpn_appliance_for_vpn_connection_v2.yml
@@ -1,0 +1,81 @@
+---
+# Summary:
+# This playbook demonstrates how to use the
+# ntnx_vpn_appliance_for_vpn_connection_v2 and
+# ntnx_vpn_appliance_for_vpn_connections_info_v2 modules to inspect and
+# download third-party VPN appliance configuration templates for a Nutanix
+# Prism Central VPN connection.
+#
+# The Nutanix networking v4 API generates a vendor-specific, text/plain CLI
+# configuration snippet that the network administrator can apply directly on
+# the on-premises third-party VPN gateway to align its IPSec and BGP settings
+# with the Nutanix side of the tunnel.
+#
+# Steps performed:
+# 1. List every supported third-party VPN appliance for a VPN connection.
+# 2. List with a server-side name filter (e.g. only Cisco ASA).
+# 3. List with paging / limit.
+# 4. Fetch a specific appliance configuration text via ext_id using the info module.
+# 5. Download the appliance configuration text via the dedicated download module.
+
+- name: VPN Appliance for VPN Connection playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default('<pc_ip>') }}"
+      nutanix_username: "{{ nutanix_username | default('<user>') }}"
+      nutanix_password: "{{ nutanix_password | default('<pass>') }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+  tasks:
+    - name: Set VPN connection external ID
+      ansible.builtin.set_fact:
+        vpn_connection_ext_id: "{{ vpn_connection_ext_id | default('8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0') }}"
+
+    - name: List all supported third-party VPN appliances for the VPN connection
+      nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+        vpn_connection_ext_id: "{{ vpn_connection_ext_id }}"
+      register: appliances
+      ignore_errors: true
+
+    - name: List third-party VPN appliances filtered by name (Cisco ASA)
+      nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+        vpn_connection_ext_id: "{{ vpn_connection_ext_id }}"
+        filter: "name eq 'Cisco ASA'"
+      register: cisco_appliance
+      ignore_errors: true
+
+    - name: List third-party VPN appliances with a page size limit
+      nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+        vpn_connection_ext_id: "{{ vpn_connection_ext_id }}"
+        limit: 3
+      register: appliances_paginated
+      ignore_errors: true
+
+    - name: Set appliance ext_id from list response
+      ansible.builtin.set_fact:
+        appliance_ext_id: "{{ appliances.response[0].ext_id }}"
+      when:
+        - appliances is defined
+        - appliances.failed is defined
+        - appliances.failed == false
+        - appliances.response is defined
+        - appliances.response is iterable
+        - (appliances.response | length) > 0
+
+    - name: Fetch third-party VPN appliance configuration text via info module
+      nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+        vpn_connection_ext_id: "{{ vpn_connection_ext_id }}"
+        ext_id: "{{ appliance_ext_id }}"
+      register: appliance_config_info
+      when: appliance_ext_id is defined
+      ignore_errors: true
+
+    - name: Download third-party VPN appliance configuration text
+      nutanix.ncp.ntnx_vpn_appliance_for_vpn_connection_v2:
+        state: present
+        vpn_connection_ext_id: "{{ vpn_connection_ext_id }}"
+        ext_id: "{{ appliance_ext_id }}"
+      register: appliance_config_download
+      when: appliance_ext_id is defined
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vpn_appliance_for_vpn_connection_v2
+    - ntnx_vpn_appliance_for_vpn_connections_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_vpn_connections_api_instance(module):
+    """
+    This method will return VpnConnectionsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): VPN Connections Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.VpnConnectionsApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,37 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_vpn_appliance_for_vpn_connection(
+    module, api_instance, vpn_connection_ext_id, ext_id
+):
+    """
+    Fetch third-party VPN appliance configuration text for a given appliance
+    under a VPN connection. The Nutanix PC v4 API returns the appliance
+    configuration as a ``text/plain`` payload (CLI commands that the network
+    administrator applies to the third-party gateway).
+
+    Args:
+        module: Ansible module.
+        api_instance: ``VpnConnectionsApi`` instance from the
+            ``ntnx_networking_py_client`` SDK.
+        vpn_connection_ext_id (str): Parent VPN connection external ID.
+        ext_id (str): Third-party VPN appliance external ID.
+
+    Returns:
+        str: The vendor-specific configuration text.
+    """
+    try:
+        return api_instance.get_vpn_appliance_for_vpn_connection_by_id(
+            vpnConnectionExtId=vpn_connection_ext_id, extId=ext_id
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching third-party VPN appliance "
+                "configuration for VPN connection"
+            ),
+        )

--- a/plugins/modules/ntnx_vpn_appliance_for_vpn_connection_v2.py
+++ b/plugins/modules/ntnx_vpn_appliance_for_vpn_connection_v2.py
@@ -1,0 +1,259 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vpn_appliance_for_vpn_connection_v2
+short_description: Download third-party VPN appliance configuration for a VPN connection in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module downloads the third-party VPN appliance configuration text for a
+    specific appliance under a Nutanix Prism Central VPN connection.
+  - The Nutanix PC v4 networking API generates a vendor-specific
+    C(text/plain) configuration script (e.g. for Cisco ASA, PaloAlto, Juniper,
+    SonicWall, VyOS, CheckPoint, Fortinet) that the network administrator can
+    apply directly on the on-premises third-party VPN gateway to align the
+    IPSec and BGP settings with the Nutanix side of the tunnel.
+  - The list of supported appliances (and their C(ext_id)s) for a given VPN
+    connection can be discovered via
+    M(nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2).
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get third-party VPN appliance configuration) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) the module will download the
+        third-party VPN appliance configuration for the given
+        C(vpn_connection_ext_id) and C(ext_id).
+      - Only C(present) is supported because the API is read-only for this
+        entity (there is no create/update/delete operation for a
+        third-party VPN appliance configuration).
+    type: str
+    choices:
+      - present
+    default: present
+  vpn_connection_ext_id:
+    description:
+      - External ID of the parent VPN connection.
+      - Obtainable via M(nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2)
+        or from the Prism Central VPN connections page.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - External ID of the third-party VPN appliance whose configuration
+        should be downloaded.
+      - Discoverable via M(nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2)
+        with only C(vpn_connection_ext_id) supplied.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Download third-party VPN appliance configuration for a VPN connection
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connection_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    vpn_connection_ext_id: "8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0"
+    ext_id: "b2037b0e-af4c-38f7-8c12-6ed629be12af"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response returned by the Nutanix PC VpnApplianceForVpnConnection v4 API.
+    - Contains the raw vendor-specific configuration text under
+      C(configuration) plus the C(vpn_connection_ext_id) and C(ext_id) that
+      identify the appliance whose configuration was downloaded.
+  returned: always
+  type: dict
+  sample:
+    {
+      "vpn_connection_ext_id": "8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0",
+      "ext_id": "b2037b0e-af4c-38f7-8c12-6ed629be12af",
+      "configuration": "# Cisco ASA 9.7 and above\n# This configuration consists of IPSec VPN and BGP configuration...\n"
+    }
+
+ext_id:
+  description:
+    - The external ID of the third-party VPN appliance whose configuration
+      was downloaded.
+  returned: always
+  type: str
+  sample: "b2037b0e-af4c-38f7-8c12-6ed629be12af"
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+    - The v4 API endpoint is a synchronous read; no asynchronous task is
+      created, so this is C(null) for a successful download.
+  returned: always
+  type: str
+  sample: null
+
+changed:
+  description: This indicates whether the module resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+skipped:
+  description: This indicates whether the module was skipped (e.g. in check mode).
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This field holds the error details if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This field indicates whether the module failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, module is idempotent or check mode
+  type: str
+  sample: "Api Exception raised while fetching third-party VPN appliance configuration for VPN connection"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_vpn_connections_api_instance,
+)
+from ..module_utils.v4.network.helpers import (  # noqa: E402
+    get_vpn_appliance_for_vpn_connection,
+)
+
+SDK_IMP_ERROR = None
+try:
+    # pylint: disable=unused-import
+    import ntnx_networking_py_client  # noqa: E402, F401
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        state=dict(type="str", choices=["present"], default="present"),
+        vpn_connection_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def download_vpn_appliance_config(module, api_instance, result):
+    """Download the third-party VPN appliance vendor config for a VPN connection.
+
+    The Nutanix PC v4 endpoint
+    ``/networking/v4.3/config/vpn-connections/{vpnConnectionExtId}/vpn-vendor-configs/{extId}``
+    returns the configuration as a plain-text CLI snippet. The SDK exposes it
+    through :py:meth:`VpnConnectionsApi.get_vpn_appliance_for_vpn_connection_by_id`
+    with ``response_type='str'``.
+    """
+    vpn_connection_ext_id = module.params.get("vpn_connection_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["response"] = {
+            "vpn_connection_ext_id": vpn_connection_ext_id,
+            "ext_id": ext_id,
+            "configuration": None,
+        }
+        result["msg"] = (
+            "Third-party VPN appliance configuration for VPN connection "
+            "'{0}' and appliance '{1}' would be downloaded.".format(
+                vpn_connection_ext_id, ext_id
+            )
+        )
+        return
+
+    config_text = get_vpn_appliance_for_vpn_connection(
+        module, api_instance, vpn_connection_ext_id, ext_id
+    )
+
+    if isinstance(config_text, bytes):
+        try:
+            config_text = config_text.decode("utf-8")
+        except (UnicodeDecodeError, AttributeError):
+            config_text = str(config_text)
+    elif config_text is not None and not isinstance(config_text, str):
+        config_text = str(config_text)
+
+    result["response"] = {
+        "vpn_connection_ext_id": vpn_connection_ext_id,
+        "ext_id": ext_id,
+        "configuration": config_text,
+    }
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_networking_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+        "failed": False,
+    }
+    api_instance = get_vpn_connections_api_instance(module)
+    download_vpn_appliance_config(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_vpn_appliance_for_vpn_connections_info_v2.py
+++ b/plugins/modules/ntnx_vpn_appliance_for_vpn_connections_info_v2.py
@@ -1,0 +1,305 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vpn_appliance_for_vpn_connections_info_v2
+short_description: Fetch third-party VPN appliance information for a VPN connection in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about VpnApplianceForVpnConnection in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific VpnApplianceForVpnConnection.
+  - If C(ext_id) is not provided, list multiple VpnApplianceForVpnConnection optionally filtered / paginated.
+  - The Nutanix PC v4 API generates a vendor-specific configuration script
+    (Cisco ASA, PaloAlto, Juniper, SonicWall, VyOS, CheckPoint, Fortinet,
+    ...) for a given VPN connection so administrators can align the
+    third-party VPN gateway with the Nutanix side of the tunnel.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(List third-party VPN appliances for a VPN connection) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin, VPC Admin
+    - >-
+      B(Get third-party VPN appliance configuration by ext_id) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  vpn_connection_ext_id:
+    description:
+      - External ID of the parent VPN connection whose supported third-party
+        VPN appliances are being queried.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - External ID of a specific third-party VPN appliance.
+      - When provided, the module downloads the vendor-specific config text
+        for that appliance under the given C(vpn_connection_ext_id).
+      - When not provided, the module lists every third-party VPN appliance
+        for which a configuration is available under the given
+        C(vpn_connection_ext_id).
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all third-party VPN appliances available for a VPN connection
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vpn_connection_ext_id: "8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0"
+  register: appliances
+  ignore_errors: true
+
+- name: List third-party VPN appliances filtered by name
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vpn_connection_ext_id: "8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0"
+    filter: "name eq 'Cisco ASA'"
+  register: cisco_appliance
+  ignore_errors: true
+
+- name: Fetch third-party VPN appliance config text using ext_id
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vpn_connection_ext_id: "8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0"
+    ext_id: "b2037b0e-af4c-38f7-8c12-6ed629be12af"
+  register: cisco_config
+  ignore_errors: true
+
+- name: List third-party VPN appliances with a page size
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vpn_connection_ext_id: "8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0"
+    limit: 5
+  register: appliances_paginated
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VpnApplianceForVpnConnection info v4 API.
+    - When C(ext_id) is provided, a dict containing the downloaded
+      vendor-specific configuration text (under C(configuration)) is returned.
+    - When C(ext_id) is not provided, a list of supported third-party VPN
+      appliances is returned; each item is a dict describing the appliance
+      (e.g. C(name), C(version), C(ext_id)).
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "ext_id": "b2037b0e-af4c-38f7-8c12-6ed629be12af",
+        "links": null,
+        "metadata": null,
+        "name": "Cisco ASA",
+        "tenant_id": null,
+        "version": "9.7+"
+      },
+      {
+        "ext_id": "3a271c2a-30b0-3041-af1a-45b9adeb90b8",
+        "links": null,
+        "metadata": null,
+        "name": "PaloAlto",
+        "tenant_id": null,
+        "version": "8.0+"
+      }
+    ]
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always False for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the third-party VPN appliance whose configuration was downloaded.
+  returned: when ext_id is provided
+  type: str
+  sample: "b2037b0e-af4c-38f7-8c12-6ed629be12af"
+
+vpn_connection_ext_id:
+  description: External ID of the parent VPN connection.
+  returned: always
+  type: str
+  sample: "8a938cf5-2c9a-4c9b-8f01-8c9f8e40e6c0"
+
+total_available_results:
+  description: The total number of third-party VPN appliances available for the given VPN connection.
+  type: int
+  returned: when listing multiple appliances
+  sample: 7
+
+error:
+  description: This field holds information about errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the status message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching third-party VPN appliance info for VPN connection"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_vpn_connections_api_instance,
+)
+from ..module_utils.v4.network.helpers import (  # noqa: E402
+    get_vpn_appliance_for_vpn_connection,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        vpn_connection_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=False),
+    )
+    return module_args
+
+
+def get_vpn_appliance_by_ext_id(module, api_instance, result):
+    """Fetch a specific third-party VPN appliance config via ext_id.
+
+    The Nutanix PC v4 API returns the vendor config as a ``text/plain``
+    payload. We normalize it into a dict so the module response shape stays
+    consistent with the list path.
+    """
+    vpn_connection_ext_id = module.params.get("vpn_connection_ext_id")
+    ext_id = module.params.get("ext_id")
+    config_text = get_vpn_appliance_for_vpn_connection(
+        module, api_instance, vpn_connection_ext_id, ext_id
+    )
+
+    if isinstance(config_text, bytes):
+        try:
+            config_text = config_text.decode("utf-8")
+        except (UnicodeDecodeError, AttributeError):
+            config_text = str(config_text)
+    elif config_text is not None and not isinstance(config_text, str):
+        config_text = str(config_text)
+
+    result["ext_id"] = ext_id
+    result["vpn_connection_ext_id"] = vpn_connection_ext_id
+    result["response"] = {
+        "vpn_connection_ext_id": vpn_connection_ext_id,
+        "ext_id": ext_id,
+        "configuration": config_text,
+    }
+
+
+def list_vpn_appliances(module, api_instance, result):
+    """List all supported third-party VPN appliances for a VPN connection."""
+    vpn_connection_ext_id = module.params.get("vpn_connection_ext_id")
+    result["vpn_connection_ext_id"] = vpn_connection_ext_id
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating third-party VPN appliance info spec", **result
+        )
+
+    kwargs.pop("_select", None)
+
+    try:
+        resp = api_instance.list_vpn_appliances_by_vpn_connection_id(
+            vpnConnectionExtId=vpn_connection_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching third-party VPN "
+                "appliance info for VPN connection"
+            ),
+        )
+
+    total_available_results = getattr(resp.metadata, "total_available_results", None)
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+            ("ext_id", "limit"),
+            ("ext_id", "page"),
+            ("ext_id", "orderby"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "vpn_connection_ext_id": None,
+    }
+    api_instance = get_vpn_connections_api_instance(module)
+    if module.params.get("ext_id"):
+        get_vpn_appliance_by_ext_id(module, api_instance, result)
+    else:
+        list_vpn_appliances(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/aliases
+++ b/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import VPN appliance for VPN connection v2 tests
+      ansible.builtin.import_tasks: vpn_appliance_for_vpn_connection.yml

--- a/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/tasks/vpn_appliance_for_vpn_connection.yml
+++ b/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/tasks/vpn_appliance_for_vpn_connection.yml
@@ -1,0 +1,360 @@
+---
+# Integration tests for:
+#   - ntnx_vpn_appliance_for_vpn_connection_v2 (download vendor config)
+#   - ntnx_vpn_appliance_for_vpn_connections_info_v2 (list / get info)
+#
+# The Nutanix networking v4 API endpoint
+#   /networking/v4.3/config/vpn-connections/{vpnConnectionExtId}/vpn-vendor-configs[/{extId}]
+# is READ-ONLY: there is no create/update/delete API for a third-party VPN
+# appliance configuration. Therefore the test plan focuses on read-path
+# coverage, error handling, argument-spec validation, and check_mode.
+#
+# Test plan:
+#   1. Argument-spec validation (missing required, unsupported state).
+#   2. check_mode dry-run for the download module.
+#   3. Negative test: bad vpn_connection_ext_id -> module fails with descriptive error.
+#   4. Live list-all against the target VPN connection (skipped if no
+#      vpn_connection_ext_id is provided in integration_config.yml).
+#   5. Live list with filter (name eq 'Cisco ASA').
+#   6. Live list with limit / page.
+#   7. Live get-by-id via the info module (uses first appliance from list).
+#   8. Live download of appliance config via ntnx_vpn_appliance_for_vpn_connection_v2.
+#   9. Info module argument-spec: mutually exclusive ext_id + filter.
+#  10. Info module argument-spec: missing vpn_connection_ext_id.
+
+- name: Start VPN Appliance for VPN Connection tests
+  ansible.builtin.debug:
+    msg: Start VPN Appliance for VPN Connection tests
+
+- name: Set VPN connection ext_id under test
+  ansible.builtin.set_fact:
+    vpn_connection_ext_id_under_test: "{{ vpn_connection_ext_id | default('') }}"
+
+################################################################################
+# 1. Argument-spec validation — missing required params
+################################################################################
+
+- name: Missing vpn_connection_ext_id in download module
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connection_v2:
+    ext_id: "b2037b0e-af4c-38f7-8c12-6ed629be12af"
+  register: missing_parent_result
+  ignore_errors: true
+
+- name: Assert missing vpn_connection_ext_id fails
+  ansible.builtin.assert:
+    that:
+      - missing_parent_result is defined
+      - missing_parent_result.failed == true
+      - missing_parent_result.changed == false
+      - "'vpn_connection_ext_id' in missing_parent_result.msg"
+    success_msg: "Download module correctly rejected request missing vpn_connection_ext_id"
+    fail_msg: "Download module did not fail on missing vpn_connection_ext_id"
+
+- name: Missing ext_id in download module
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connection_v2:
+    vpn_connection_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: missing_extid_result
+  ignore_errors: true
+
+- name: Assert missing ext_id fails
+  ansible.builtin.assert:
+    that:
+      - missing_extid_result is defined
+      - missing_extid_result.failed == true
+      - missing_extid_result.changed == false
+      - "'ext_id' in missing_extid_result.msg"
+    success_msg: "Download module correctly rejected request missing ext_id"
+    fail_msg: "Download module did not fail on missing ext_id"
+
+- name: Invalid state value (absent) is rejected
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connection_v2:
+    state: absent
+    vpn_connection_ext_id: "00000000-0000-0000-0000-000000000000"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: invalid_state_result
+  ignore_errors: true
+
+- name: Assert invalid state is rejected by argument spec
+  ansible.builtin.assert:
+    that:
+      - invalid_state_result is defined
+      - invalid_state_result.failed == true
+      - invalid_state_result.changed == false
+      - "'absent' in invalid_state_result.msg or 'state' in invalid_state_result.msg"
+    success_msg: "Download module correctly rejected state=absent (only present is supported)"
+    fail_msg: "Download module did not reject state=absent"
+
+################################################################################
+# 2. check_mode dry-run — download module
+################################################################################
+
+- name: Run download module in check_mode (dry-run) with all attributes
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connection_v2:
+    state: present
+    vpn_connection_ext_id: "00000000-0000-0000-0000-000000000000"
+    ext_id: "11111111-1111-1111-1111-111111111111"
+  check_mode: true
+  register: check_mode_download_result
+  ignore_errors: true
+
+- name: Assert download check_mode returns preview without invoking API
+  ansible.builtin.assert:
+    that:
+      - check_mode_download_result is defined
+      - check_mode_download_result.failed == false
+      - check_mode_download_result.changed == false
+      - check_mode_download_result.response is defined
+      - check_mode_download_result.response.vpn_connection_ext_id == "00000000-0000-0000-0000-000000000000"
+      - check_mode_download_result.response.ext_id == "11111111-1111-1111-1111-111111111111"
+      - check_mode_download_result.response.configuration is none
+      - check_mode_download_result.ext_id == "11111111-1111-1111-1111-111111111111"
+    success_msg: "Download module returned expected check_mode preview"
+    fail_msg: "Download module check_mode preview was incorrect"
+
+################################################################################
+# 3. Negative — bogus vpn_connection_ext_id triggers a descriptive API error
+################################################################################
+
+- name: Attempt to list appliances for a non-existent VPN connection
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+    vpn_connection_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: bad_parent_list_result
+  ignore_errors: true
+
+- name: Assert list against non-existent VPN connection fails cleanly
+  ansible.builtin.assert:
+    that:
+      - bad_parent_list_result is defined
+      - bad_parent_list_result.failed == true
+      - bad_parent_list_result.changed == false
+      - bad_parent_list_result.msg is defined
+    success_msg: "Info module surfaced a descriptive error for a bogus VPN connection ext_id"
+    fail_msg: "Info module did not report a failure for a bogus VPN connection ext_id"
+
+- name: Attempt to download config for a non-existent VPN connection
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connection_v2:
+    state: present
+    vpn_connection_ext_id: "00000000-0000-0000-0000-000000000000"
+    ext_id: "11111111-1111-1111-1111-111111111111"
+  register: bad_parent_download_result
+  ignore_errors: true
+
+- name: Assert download against non-existent VPN connection fails cleanly
+  ansible.builtin.assert:
+    that:
+      - bad_parent_download_result is defined
+      - bad_parent_download_result.failed == true
+      - bad_parent_download_result.changed == false
+      - bad_parent_download_result.msg is defined
+    success_msg: "Download module surfaced a descriptive error for a bogus VPN connection ext_id"
+    fail_msg: "Download module did not report a failure for a bogus VPN connection ext_id"
+
+################################################################################
+# 4. Info module argument-spec — mutually exclusive ext_id + filter
+################################################################################
+
+- name: Ext_id and filter are mutually exclusive on the info module
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+    vpn_connection_ext_id: "00000000-0000-0000-0000-000000000000"
+    ext_id: "11111111-1111-1111-1111-111111111111"
+    filter: "name eq 'Cisco ASA'"
+  register: info_mutex_result
+  ignore_errors: true
+
+- name: Assert mutually exclusive validation error
+  ansible.builtin.assert:
+    that:
+      - info_mutex_result is defined
+      - info_mutex_result.failed == true
+      - info_mutex_result.changed == false
+      - "'mutually exclusive' in (info_mutex_result.msg | lower) or 'parameters are mutually exclusive' in (info_mutex_result.msg | lower)"
+    success_msg: "Info module rejected mutually exclusive ext_id + filter"
+    fail_msg: "Info module did not reject mutually exclusive ext_id + filter"
+
+- name: Missing vpn_connection_ext_id in info module
+  nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+    ext_id: "11111111-1111-1111-1111-111111111111"
+  register: info_missing_parent_result
+  ignore_errors: true
+
+- name: Assert info module rejects missing vpn_connection_ext_id
+  ansible.builtin.assert:
+    that:
+      - info_missing_parent_result is defined
+      - info_missing_parent_result.failed == true
+      - info_missing_parent_result.changed == false
+      - "'vpn_connection_ext_id' in info_missing_parent_result.msg"
+    success_msg: "Info module rejected request missing vpn_connection_ext_id"
+    fail_msg: "Info module did not reject request missing vpn_connection_ext_id"
+
+################################################################################
+# 5-8. Live path — only when a real VPN connection ext_id is provided
+################################################################################
+
+- name: Live tests against a real VPN connection
+  when: vpn_connection_ext_id_under_test | length > 0
+  block:
+
+    - name: List all third-party VPN appliances for the VPN connection
+      nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+        vpn_connection_ext_id: "{{ vpn_connection_ext_id_under_test }}"
+      register: list_all_result
+      ignore_errors: true
+
+    - name: Assert list-all returned appliances
+      ansible.builtin.assert:
+        that:
+          - list_all_result is defined
+          - list_all_result.failed == false
+          - list_all_result.changed == false
+          - list_all_result.response is defined
+          - list_all_result.response is iterable
+          - list_all_result.vpn_connection_ext_id == vpn_connection_ext_id_under_test
+          - list_all_result.total_available_results is defined
+        success_msg: "list-all returned appliances for the VPN connection"
+        fail_msg: "list-all did not return appliances for the VPN connection"
+
+    - name: Assert every listed appliance has the expected shape
+      ansible.builtin.assert:
+        that:
+          - item.ext_id is defined
+          - item.name is defined
+          - item.version is defined
+        success_msg: "Appliance {{ item.name | default('unnamed') }} has the expected shape"
+        fail_msg: "Appliance entry {{ item }} is missing required fields"
+      loop: "{{ list_all_result.response | default([]) }}"
+      loop_control:
+        label: "{{ item.name | default(item.ext_id) }}"
+
+    - name: Capture first appliance ext_id
+      ansible.builtin.set_fact:
+        first_appliance_ext_id: "{{ list_all_result.response[0].ext_id }}"
+        first_appliance_name: "{{ list_all_result.response[0].name }}"
+      when: list_all_result.response | default([]) | length > 0
+
+    - name: List third-party VPN appliances filtered by name
+      nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+        vpn_connection_ext_id: "{{ vpn_connection_ext_id_under_test }}"
+        filter: "name eq '{{ first_appliance_name }}'"
+      register: list_filter_result
+      when: first_appliance_name is defined
+      ignore_errors: true
+
+    - name: Assert filtered list is non-empty and matches
+      ansible.builtin.assert:
+        that:
+          - list_filter_result is defined
+          - list_filter_result.failed == false
+          - list_filter_result.changed == false
+          - list_filter_result.response is defined
+          - list_filter_result.response | length >= 1
+          - list_filter_result.response[0].name == first_appliance_name
+        success_msg: "Filtered list returned only appliances named '{{ first_appliance_name }}'"
+        fail_msg: "Filtered list did not return the expected appliances"
+      when: first_appliance_name is defined
+
+    - name: List third-party VPN appliances with limit=1
+      nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+        vpn_connection_ext_id: "{{ vpn_connection_ext_id_under_test }}"
+        limit: 1
+      register: list_limit_result
+      ignore_errors: true
+
+    - name: Assert limit=1 returns at most one appliance
+      ansible.builtin.assert:
+        that:
+          - list_limit_result is defined
+          - list_limit_result.failed == false
+          - list_limit_result.changed == false
+          - list_limit_result.response is defined
+          - (list_limit_result.response | length) <= 1
+        success_msg: "limit=1 respected"
+        fail_msg: "limit=1 was not respected"
+
+    - name: Fetch third-party VPN appliance configuration via info module (get-by-id)
+      nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+        vpn_connection_ext_id: "{{ vpn_connection_ext_id_under_test }}"
+        ext_id: "{{ first_appliance_ext_id }}"
+      register: info_get_by_id_result
+      when: first_appliance_ext_id is defined
+      ignore_errors: true
+
+    - name: Assert info get-by-id returns a configuration payload
+      ansible.builtin.assert:
+        that:
+          - info_get_by_id_result is defined
+          - info_get_by_id_result.failed == false
+          - info_get_by_id_result.changed == false
+          - info_get_by_id_result.response is defined
+          - info_get_by_id_result.response.ext_id == first_appliance_ext_id
+          - info_get_by_id_result.response.vpn_connection_ext_id == vpn_connection_ext_id_under_test
+          - info_get_by_id_result.response.configuration is defined
+          - info_get_by_id_result.response.configuration | length > 0
+          - info_get_by_id_result.ext_id == first_appliance_ext_id
+        success_msg: "Info get-by-id returned a non-empty configuration payload"
+        fail_msg: "Info get-by-id did not return a configuration payload"
+      when: first_appliance_ext_id is defined
+
+    - name: Download third-party VPN appliance configuration via download module
+      nutanix.ncp.ntnx_vpn_appliance_for_vpn_connection_v2:
+        state: present
+        vpn_connection_ext_id: "{{ vpn_connection_ext_id_under_test }}"
+        ext_id: "{{ first_appliance_ext_id }}"
+      register: download_result
+      when: first_appliance_ext_id is defined
+      ignore_errors: true
+
+    - name: Assert download module returns configuration text
+      ansible.builtin.assert:
+        that:
+          - download_result is defined
+          - download_result.failed == false
+          - download_result.changed == false
+          - download_result.response is defined
+          - download_result.response.ext_id == first_appliance_ext_id
+          - download_result.response.vpn_connection_ext_id == vpn_connection_ext_id_under_test
+          - download_result.response.configuration is defined
+          - download_result.response.configuration | length > 0
+          - download_result.ext_id == first_appliance_ext_id
+        success_msg: "Download module returned a non-empty configuration payload"
+        fail_msg: "Download module did not return a configuration payload"
+      when: first_appliance_ext_id is defined
+
+    - name: Info and download modules return identical configuration text
+      ansible.builtin.assert:
+        that:
+          - download_result.response.configuration == info_get_by_id_result.response.configuration
+        success_msg: "Info and download modules return byte-identical config text"
+        fail_msg: "Info and download modules disagreed on config text"
+      when:
+        - first_appliance_ext_id is defined
+        - download_result is defined
+        - info_get_by_id_result is defined
+        - download_result.response is defined
+        - info_get_by_id_result.response is defined
+
+    - name: Get-by-id for a bogus appliance ext_id fails cleanly
+      nutanix.ncp.ntnx_vpn_appliance_for_vpn_connections_info_v2:
+        vpn_connection_ext_id: "{{ vpn_connection_ext_id_under_test }}"
+        ext_id: "00000000-0000-0000-0000-000000000000"
+      register: bad_appliance_result
+      ignore_errors: true
+
+    - name: Assert bogus appliance ext_id returns descriptive error
+      ansible.builtin.assert:
+        that:
+          - bad_appliance_result is defined
+          - bad_appliance_result.failed == true
+          - bad_appliance_result.changed == false
+          - bad_appliance_result.msg is defined
+        success_msg: "Info module returned a descriptive error for a bogus appliance ext_id"
+        fail_msg: "Info module did not report a failure for a bogus appliance ext_id"
+
+- name: Skipped live tests notice
+  ansible.builtin.debug:
+    msg: >-
+      Skipped live-cluster tests for VpnApplianceForVpnConnection because no
+      'vpn_connection_ext_id' variable was provided in
+      integration_config.yml. Provide one to exercise the full read-path
+      (list, filter, limit, get-by-id, download).
+  when: vpn_connection_ext_id_under_test | length == 0


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**VpnApplianceForVpnConnection**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_vpn_appliance_for_vpn_connection_v2`, `ntnx_vpn_appliance_for_vpn_connections_info_v2`
- API methods covered: `2` (`GetVpnApplianceForVpnConnectionById`, `ListVpnAppliancesByVpnConnectionId`)
- Fields in download module spec: `3` (`state`, `vpn_connection_ext_id`, `ext_id`)
- Fields in info module spec: `2` (`vpn_connection_ext_id`, `ext_id`) plus the standard info options (`filter`, `page`, `limit`, `orderby`, `select`)

### Notes on scope

`VpnApplianceForVpnConnection` is a **read-only** entity in the Nutanix PC v4
networking API — the SDK only exposes `GetVpnApplianceForVpnConnectionById`
and `ListVpnAppliancesByVpnConnectionId` for it (no create / update / delete
methods). Accordingly:

- `ntnx_vpn_appliance_for_vpn_connection_v2` is implemented as a
  download-style module (`state: present` only). It calls the SDK
  `get_vpn_appliance_for_vpn_connection_by_id(...)` method, which the API
  serves as `text/plain`, and normalises the returned CLI snippet into a
  structured `response.configuration` string. `check_mode` is supported.
- `ntnx_vpn_appliance_for_vpn_connections_info_v2` is the standard v4 info
  module. With `vpn_connection_ext_id` only, it calls
  `list_vpn_appliances_by_vpn_connection_id(...)` and supports
  `filter`, `page`, `limit`, `orderby`. With `ext_id` too, it fetches the
  single appliance's config via the same `get_vpn_appliance_for_vpn_connection_by_id(...)`
  path. `ext_id` is mutually exclusive with `filter`, `limit`, `page`, `orderby`.
- Both modules add a new `get_vpn_connections_api_instance()` helper to
  `plugins/module_utils/v4/network/api_client.py` and a shared
  `get_vpn_appliance_for_vpn_connection(...)` helper to
  `plugins/module_utils/v4/network/helpers.py`.

## Files changed

- `plugins/modules/`
  - `ntnx_vpn_appliance_for_vpn_connection_v2.py` (new)
  - `ntnx_vpn_appliance_for_vpn_connections_info_v2.py` (new)
- `plugins/module_utils/v4/network/`
  - `api_client.py` — adds `get_vpn_connections_api_instance()`
  - `helpers.py` — adds `get_vpn_appliance_for_vpn_connection()`
- `meta/runtime.yml` — registers both new modules in the `nutanix.ncp.ntnx`
  action group so `module_defaults` (credentials, etc.) apply
- `examples/networking/VpnApplianceForVpnConnection/`
  - `vpn_appliance_for_vpn_connection_v2.yml` (new example playbook)
  - `examples_run.log` (captured playbook output against 10.44.76.28)
- `tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`,
    `tasks/vpn_appliance_for_vpn_connection.yml` (new integration test target)

## Test execution

| Metric              | Value                                                                        |
|---------------------|------------------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-disabled --python 3.12 ntnx_vpn_appliance_for_vpn_connection_v2 -v` |
| Total tasks         | `42`                                                                         |
| Passed / OK         | `20`                                                                         |
| Failed              | `0`                                                                          |
| Ignored (expected)  | `7` (intentional negative / argument-spec / mutex tests with `ignore_errors: true`) |
| Skipped             | `15` (live read-path tests — see analysis below)                             |
| Cluster (PC)        | `10.44.76.28` (v4.3 networking namespace, 4.3.1 SDK)                         |

Sanity gates (also green):

| Gate                                                                                        | Result   |
|---------------------------------------------------------------------------------------------|----------|
| `black --check` (new + touched files)                                                       | pass     |
| `isort --check` (new + touched files)                                                       | pass     |
| `flake8` (new + touched files)                                                              | pass     |
| `ansible-lint` (new + touched files, production profile)                                    | pass (5/5)|
| `ansible-test sanity --python 3.12` (new + touched files, all 24 sub-tests including pylint, validate-modules, ansible-doc, yamllint) | pass     |

### Analysis

There are **no failing tasks**. The 7 tasks classified as `ignored` are the
intentional negative tests (each carries `ignore_errors: true`); the
subsequent assert task in each pair confirms the expected failure mode:

1. `Missing vpn_connection_ext_id in download module` → argument-spec rejects
   the request (`missing required arguments: vpn_connection_ext_id`).
2. `Missing ext_id in download module` → argument-spec rejects
   (`missing required arguments: ext_id`).
3. `Invalid state value (absent) is rejected` → argument-spec rejects
   (`value of state must be one of: present, got: absent`).
4. `Attempt to list appliances for a non-existent VPN connection` → API
   returns 404 with the Nutanix networking error
   `NETWORKING-10060 ... VpnConnection … not found`; the module surfaces it
   via `raise_api_exception(...)`.
5. `Attempt to download config for a non-existent VPN connection` → API
   returns 500 ("Failed to write request") for the bogus id; the module
   surfaces it via `raise_api_exception(...)`.
6. `Ext_id and filter are mutually exclusive on the info module` →
   `mutually_exclusive` in the argument spec rejects the request
   (`parameters are mutually exclusive: ext_id|filter`).
7. `Missing vpn_connection_ext_id in info module` → argument-spec rejects
   (`missing required arguments: vpn_connection_ext_id`).

The 15 `skipped` tasks are the live read-path scenarios (list, list-with-filter,
list-with-limit, get-by-id, download, and their assertions plus the identity
check between the info and download modules). They are gated by
`vpn_connection_ext_id_under_test | length > 0` because the Prism Central
under test (`10.44.76.28`) currently has **no VPN connections and no VPN
gateways** provisioned (`/api/networking/v4.3/config/vpn-connections`
returns `totalAvailableResults: 0`). To exercise them locally, provide a
real `vpn_connection_ext_id` in `tests/integration/integration_config.yml`
and re-run the target. The `raise_api_exception(...)` path is exercised in
tests 4 and 5, which prove the module correctly reaches the API on the
same cluster and surfaces server-side errors.

### Example playbook run

`examples/networking/VpnApplianceForVpnConnection/vpn_appliance_for_vpn_connection_v2.yml`
was executed end-to-end against `10.44.76.28` (see
`examples/networking/VpnApplianceForVpnConnection/examples_run.log` on the
branch). The list / filter / limit tasks return the expected `NETWORKING-10060 VpnConnection … not found`
API response for the placeholder VPN connection UUID; the subsequent
`Set appliance ext_id from list response`, `Fetch third-party VPN appliance configuration text via info module`,
and `Download third-party VPN appliance configuration text` tasks are gated
on the list succeeding and are skipped cleanly. PLAY RECAP:
`ok=4 changed=0 unreachable=0 failed=0 skipped=3 rescued=0 ignored=3`.

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Start VPN Appliance for VPN Connection tests] ***
ok: [testhost] => {
    "msg": "Start VPN Appliance for VPN Connection tests"
}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Set VPN connection ext_id under test] ***
ok: [testhost] => {"ansible_facts": {"vpn_connection_ext_id_under_test": ""}, "changed": false}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Missing vpn_connection_ext_id in download module] ***
[ERROR]: Task failed: Module failed: missing required arguments: vpn_connection_ext_id
Origin: /home/george.ghawali/codegen-coll-vpn-appliance/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_appliance_for_vpn_connection_v2-dn9uuiyp-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/tasks/vpn_appliance_for_vpn_connection.yml:37:3

35 ################################################################################
36
37 - name: Missing vpn_connection_ext_id in download module
     ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: vpn_connection_ext_id"}
...ignoring

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert missing vpn_connection_ext_id fails] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Download module correctly rejected request missing vpn_connection_ext_id"
}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Missing ext_id in download module] ***
[ERROR]: Task failed: Module failed: missing required arguments: ext_id
Origin: /home/george.ghawali/codegen-coll-vpn-appliance/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_appliance_for_vpn_connection_v2-dn9uuiyp-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/tasks/vpn_appliance_for_vpn_connection.yml:53:3

51     fail_msg: "Download module did not fail on missing vpn_connection_ext_id"
52
53 - name: Missing ext_id in download module
     ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert missing ext_id fails] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Download module correctly rejected request missing ext_id"
}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Invalid state value (absent) is rejected] ***
[ERROR]: Task failed: Module failed: value of state must be one of: present, got: absent
Origin: /home/george.ghawali/codegen-coll-vpn-appliance/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_appliance_for_vpn_connection_v2-dn9uuiyp-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/tasks/vpn_appliance_for_vpn_connection.yml:69:3

67     fail_msg: "Download module did not fail on missing ext_id"
68
69 - name: Invalid state value (absent) is rejected
     ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of state must be one of: present, got: absent"}
...ignoring

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert invalid state is rejected by argument spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Download module correctly rejected state=absent (only present is supported)"
}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Run download module in check_mode (dry-run) with all attributes] ***
ok: [testhost] => {"changed": false, "ext_id": "11111111-1111-1111-1111-111111111111", "msg": "Third-party VPN appliance configuration for VPN connection '00000000-0000-0000-0000-000000000000' and appliance '11111111-1111-1111-1111-111111111111' would be downloaded.", "response": {"configuration": null, "ext_id": "11111111-1111-1111-1111-111111111111", "vpn_connection_ext_id": "00000000-0000-0000-0000-000000000000"}, "task_ext_id": null}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert download check_mode returns preview without invoking API] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Download module returned expected check_mode preview"
}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Attempt to list appliances for a non-existent VPN connection] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching third-party VPN appliance info for VPN connection
Origin: /home/george.ghawali/codegen-coll-vpn-appliance/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_appliance_for_vpn_connection_v2-dn9uuiyp-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/tasks/vpn_appliance_for_vpn_connection.yml:118:3

116 ################################################################################
117
118 - name: Attempt to list appliances for a non-existent VPN connection
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching third-party VPN appliance info for VPN connection", "response": {"$objectType": "networking.v4.config.GetVpnConnectionApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to list VPN vendor configs by VPN connection 00000000-0000-0000-0000-000000000000 as a referenced resource was not found - Application error kNotFound raised: VpnConnection 00000000-0000-0000-0000-000000000000 not found", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/vpn-connections/00000000-0000-0000-0000-000000000000/vpn-vendor-configs", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert list against non-existent VPN connection fails cleanly] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module surfaced a descriptive error for a bogus VPN connection ext_id"
}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Attempt to download config for a non-existent VPN connection] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching third-party VPN appliance configuration for VPN connection
Origin: /home/george.ghawali/codegen-coll-vpn-appliance/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_appliance_for_vpn_connection_v2-dn9uuiyp-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/tasks/vpn_appliance_for_vpn_connection.yml:134:3

132     fail_msg: "Info module did not report a failure for a bogus VPN connection ext_id"
133
134 - name: Attempt to download config for a non-existent VPN connection
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching third-party VPN appliance configuration for VPN connection", "response": {"error": "Internal Server Error", "message": "Failed to write request", "path": "/api/networking/v4.3/config/vpn-connections/00000000-0000-0000-0000-000000000000/vpn-vendor-configs/11111111-1111-1111-1111-111111111111", "status": 500, "timestamp": "2026-07-21T06:34:05.958823369Z"}, "status": 500}
...ignoring

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert download against non-existent VPN connection fails cleanly] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Download module surfaced a descriptive error for a bogus VPN connection ext_id"
}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Ext_id and filter are mutually exclusive on the info module] ***
[ERROR]: Task failed: Module failed: parameters are mutually exclusive: ext_id|filter
Origin: /home/george.ghawali/codegen-coll-vpn-appliance/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_appliance_for_vpn_connection_v2-dn9uuiyp-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/tasks/vpn_appliance_for_vpn_connection.yml:156:3

154 ################################################################################
155
156 - name: Ext_id and filter are mutually exclusive on the info module
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert mutually exclusive validation error] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module rejected mutually exclusive ext_id + filter"
}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Missing vpn_connection_ext_id in info module] ***
[ERROR]: Task failed: Module failed: missing required arguments: vpn_connection_ext_id
Origin: /home/george.ghawali/codegen-coll-vpn-appliance/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_vpn_appliance_for_vpn_connection_v2-dn9uuiyp-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_vpn_appliance_for_vpn_connection_v2/tasks/vpn_appliance_for_vpn_connection.yml:174:3

172     fail_msg: "Info module did not reject mutually exclusive ext_id + filter"
173
174 - name: Missing vpn_connection_ext_id in info module
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: vpn_connection_ext_id"}
...ignoring

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert info module rejects missing vpn_connection_ext_id] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module rejected request missing vpn_connection_ext_id"
}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : List all third-party VPN appliances for the VPN connection] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert list-all returned appliances] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert every listed appliance has the expected shape] ***
skipping: [testhost] => {"changed": false, "skip_reason": "No items in the list", "skipped_reason": "No items in the list"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Capture first appliance ext_id] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : List third-party VPN appliances filtered by name] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert filtered list is non-empty and matches] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : List third-party VPN appliances with limit=1] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert limit=1 returns at most one appliance] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Fetch third-party VPN appliance configuration via info module (get-by-id)] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert info get-by-id returns a configuration payload] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Download third-party VPN appliance configuration via download module] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert download module returns configuration text] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Info and download modules return identical configuration text] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Get-by-id for a bogus appliance ext_id fails cleanly] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Assert bogus appliance ext_id returns descriptive error] ***
skipping: [testhost] => {"changed": false, "false_condition": "vpn_connection_ext_id_under_test | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_vpn_appliance_for_vpn_connection_v2 : Skipped live tests notice] ****
ok: [testhost] => {
    "msg": "Skipped live-cluster tests for VpnApplianceForVpnConnection because no 'vpn_connection_ext_id' variable was provided in integration_config.yml. Provide one to exercise the full read-path (list, filter, limit, get-by-id, download)."
}

PLAY RECAP *********************************************************************
testhost                   : ok=20   changed=0    unreachable=0    failed=0    skipped=15   rescued=0    ignored=7   

```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Reference module: `ntnx_virtual_switch_v2` (v4 CRUD scaffolding),
  `ntnx_vm_revert_v2` (action-style entrypoint scaffolding), and the
  existing `plugins/module_utils/v4/network/*` helpers.
