### PR TITLE
VolumeDisk Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/volumes/VolumeDisk/examples_run.log
+++ b/examples/volumes/VolumeDisk/examples_run.log
@@ -1,0 +1,60 @@
+[DEPRECATION WARNING]: ANSIBLE_COLLECTIONS_PATHS option, does not fit var 
+naming standard, use the singular form ANSIBLE_COLLECTIONS_PATH instead. This 
+feature will be removed from ansible-core in version 2.19. Deprecation warnings
+ can be disabled by setting deprecation_warnings=False in ansible.cfg.
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+running playbook inside collection nutanix.ncp
+
+PLAY [Volume Disks playbook] ***************************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"cluster_uuid": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "storage_container_uuid": "44481f83-d0a1-47b3-b9b8-32b5465c622e", "vg_name": "ansible-vg-for-volume-disks"}, "changed": false}
+
+TASK [Discover a cluster if cluster_uuid was not provided] *********************
+skipping: [localhost] => {"changed": false, "false_condition": "cluster_uuid | length == 0", "skip_reason": "Conditional result was False"}
+
+TASK [Set cluster_uuid from discovery] *****************************************
+skipping: [localhost] => {"changed": false, "false_condition": "cluster_uuid | length == 0", "skip_reason": "Conditional result was False"}
+
+TASK [Discover a storage container if not provided] ****************************
+skipping: [localhost] => {"changed": false, "false_condition": "storage_container_uuid | length == 0", "skip_reason": "Conditional result was False"}
+
+TASK [Set storage_container_uuid from discovery] *******************************
+skipping: [localhost] => {"changed": false, "false_condition": "storage_container_uuid | length == 0", "skip_reason": "Conditional result was False"}
+
+TASK [Create Volume Group to host the Volume Disks] ****************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "d32862d3-5218-4970-61e2-da2a2ce8df50", "response": {"attachment_type": "NONE", "attachments": null, "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "created_by": null, "description": "Volume Group for Volume Disk examples", "disks": null, "enabled_authentications": null, "ext_id": "d32862d3-5218-4970-61e2-da2a2ce8df50", "hydration_status": null, "is_hidden": false, "iscsi_features": null, "links": null, "name": "ansible-vg-for-volume-disks", "protocol": "NOT_ASSIGNED", "sharing_status": "SHARED", "should_load_balance_vm_attachments": true, "storage_features": {"flash_mode": {"is_enabled": true}}, "target_name": "vgexvd-d32862d3-5218-4970-61e2-da2a2ce8df50", "target_prefix": null, "tenant_id": null, "usage_type": "USER"}, "task_ext_id": "ZXJnb24=:e6c1ac00-0837-48f1-bc70-62a7bcba8056"}
+
+TASK [Set VG ext_id] ***********************************************************
+ok: [localhost] => {"ansible_facts": {"vg_ext_id": "d32862d3-5218-4970-61e2-da2a2ce8df50"}, "changed": false}
+
+TASK [Create Volume Disk with all attributes] **********************************
+changed: [localhost] => {"changed": true, "ext_id": "046020bf-e7e0-419e-854c-e971967eca5c", "response": {"description": "ansible-created-disk", "disk_data_source_reference": null, "disk_size_bytes": 21474836480, "disk_storage_features": {"flash_mode": {"is_enabled": true}}, "ext_id": "046020bf-e7e0-419e-854c-e971967eca5c", "index": 1, "links": null, "storage_container_id": "44481f83-d0a1-47b3-b9b8-32b5465c622e", "tenant_id": null}, "task_ext_id": "ZXJnb24=:b6ef13cc-99a7-4905-b12c-c313dbd57df0", "volume_group_ext_id": "d32862d3-5218-4970-61e2-da2a2ce8df50"}
+
+TASK [Set Volume Disk ext_id] **************************************************
+ok: [localhost] => {"ansible_facts": {"disk_ext_id": "046020bf-e7e0-419e-854c-e971967eca5c"}, "changed": false}
+
+TASK [Update Volume Disk with all mutable attributes] **************************
+changed: [localhost] => {"changed": true, "ext_id": "046020bf-e7e0-419e-854c-e971967eca5c", "response": {"description": "ansible-updated-disk", "disk_data_source_reference": null, "disk_size_bytes": 42949672960, "disk_storage_features": {"flash_mode": {"is_enabled": false}}, "ext_id": "046020bf-e7e0-419e-854c-e971967eca5c", "index": 1, "links": null, "storage_container_id": "44481f83-d0a1-47b3-b9b8-32b5465c622e", "tenant_id": null}, "task_ext_id": "ZXJnb24=:08c2b1c4-a8fa-4d9a-80f0-8b94829f890c", "volume_group_ext_id": "d32862d3-5218-4970-61e2-da2a2ce8df50"}
+
+TASK [Fetch a specific Volume Disk using ext_id] *******************************
+ok: [localhost] => {"changed": false, "ext_id": "046020bf-e7e0-419e-854c-e971967eca5c", "response": {"description": "ansible-updated-disk", "disk_data_source_reference": null, "disk_size_bytes": 42949672960, "disk_storage_features": {"flash_mode": {"is_enabled": false}}, "ext_id": "046020bf-e7e0-419e-854c-e971967eca5c", "index": 1, "links": null, "storage_container_id": "44481f83-d0a1-47b3-b9b8-32b5465c622e", "tenant_id": null}, "volume_group_ext_id": "d32862d3-5218-4970-61e2-da2a2ce8df50"}
+
+TASK [List all Volume Disks in the Volume Group] *******************************
+ok: [localhost] => {"changed": false, "response": [{"description": "ansible-updated-disk", "disk_data_source_reference": null, "disk_size_bytes": 42949672960, "disk_storage_features": {"flash_mode": {"is_enabled": false}}, "ext_id": "046020bf-e7e0-419e-854c-e971967eca5c", "index": 1, "links": [{"href": "https://10.44.76.28:9440/api/volumes/v4.2/config/volume-groups/d32862d3-5218-4970-61e2-da2a2ce8df50/disks/046020bf-e7e0-419e-854c-e971967eca5c", "rel": "disk"}], "storage_container_id": "44481f83-d0a1-47b3-b9b8-32b5465c622e", "tenant_id": null}], "total_available_results": 1, "volume_group_ext_id": "d32862d3-5218-4970-61e2-da2a2ce8df50"}
+
+TASK [List Volume Disks with limit] ********************************************
+ok: [localhost] => {"changed": false, "response": [{"description": "ansible-updated-disk", "disk_data_source_reference": null, "disk_size_bytes": 42949672960, "disk_storage_features": {"flash_mode": {"is_enabled": false}}, "ext_id": "046020bf-e7e0-419e-854c-e971967eca5c", "index": 1, "links": [{"href": "https://10.44.76.28:9440/api/volumes/v4.2/config/volume-groups/d32862d3-5218-4970-61e2-da2a2ce8df50/disks/046020bf-e7e0-419e-854c-e971967eca5c", "rel": "disk"}], "storage_container_id": "44481f83-d0a1-47b3-b9b8-32b5465c622e", "tenant_id": null}], "total_available_results": 1, "volume_group_ext_id": "d32862d3-5218-4970-61e2-da2a2ce8df50"}
+
+TASK [Delete the Volume Disk] **************************************************
+changed: [localhost] => {"changed": true, "ext_id": "046020bf-e7e0-419e-854c-e971967eca5c", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-21T06:39:49.694975+00:00", "completion_details": null, "created_time": "2026-07-21T06:39:49.453461+00:00", "entities_affected": [{"ext_id": "d32862d3-5218-4970-61e2-da2a2ce8df50", "name": "ansible-vg-for-volume-disks", "rel": "volumes:config:volume-group"}, {"ext_id": "046020bf-e7e0-419e-854c-e971967eca5c", "name": null, "rel": "volumes:config:volume-group:disk"}], "error_messages": null, "ext_id": "ZXJnb24=:b2095bad-67f4-409b-81e5-8429326bcbf2", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T06:39:49.694682+00:00", "legacy_error_message": null, "number_of_entities_affected": 2, "number_of_subtasks": 1, "operation": "VolumeDiskDelete", "operation_description": "Delete Volume Disks", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T06:39:49.453461+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:93f5394b-b786-4ae6-abae-bb629ae0bc44", "href": "https://10.44.76.28:9440/api/prism/v4.3/config/tasks/ZXJnb24=:93f5394b-b786-4ae6-abae-bb629ae0bc44", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:b2095bad-67f4-409b-81e5-8429326bcbf2", "volume_group_ext_id": "d32862d3-5218-4970-61e2-da2a2ce8df50"}
+
+TASK [Delete the Volume Group] *************************************************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "d32862d3-5218-4970-61e2-da2a2ce8df50", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-21T06:39:52.804095+00:00", "completion_details": null, "created_time": "2026-07-21T06:39:52.552700+00:00", "entities_affected": [{"ext_id": "d32862d3-5218-4970-61e2-da2a2ce8df50", "name": "ansible-vg-for-volume-disks", "rel": "volumes:config:volume-group"}], "error_messages": null, "ext_id": "ZXJnb24=:47ebf218-098d-409c-804f-f0a9d0cc7c1a", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T06:39:52.804094+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "VolumeGroupDelete", "operation_description": "Delete Volume Group", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T06:39:52.552700+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:eeca7ab5-17ea-4701-ab9c-971df5e8cfbb", "href": "https://10.44.76.28:9440/api/prism/v4.3/config/tasks/ZXJnb24=:eeca7ab5-17ea-4701-ab9c-971df5e8cfbb", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:47ebf218-098d-409c-804f-f0a9d0cc7c1a"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=11   changed=5    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0   
+

--- a/examples/volumes/VolumeDisk/volume_disks_v2.yml
+++ b/examples/volumes/VolumeDisk/volume_disks_v2.yml
@@ -1,0 +1,145 @@
+---
+# Summary:
+# This playbook demonstrates the full lifecycle of a Nutanix Volume Disk (v4 API):
+# 1. Create a Volume Group to host the disks
+# 2. Create a Volume Disk (with all attributes)
+# 3. Update the Volume Disk (with all mutable attributes)
+# 4. Fetch a specific Volume Disk by ext_id
+# 5. List all Volume Disks in the Volume Group
+# 6. List Volume Disks with limit
+# 7. Delete the Volume Disk
+# 8. Delete the Volume Group
+
+- name: Volume Disks playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ pc_ip | default('10.44.76.28') }}"
+      nutanix_username: "{{ pc_username | default('admin') }}"
+      nutanix_password: "{{ pc_password | default('Nutanix.123') }}"
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        cluster_uuid: "{{ cluster_uuid | default('') }}"
+        storage_container_uuid: "{{ storage_container_uuid | default('') }}"
+        vg_name: "ansible-vg-for-volume-disks"
+
+    - name: Discover a cluster if cluster_uuid was not provided
+      nutanix.ncp.ntnx_clusters_info_v2:
+        filter: "config/clusterFunction/any(f:f eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+      register: clusters_info
+      when: cluster_uuid | length == 0
+      ignore_errors: true
+
+    - name: Set cluster_uuid from discovery
+      ansible.builtin.set_fact:
+        cluster_uuid: "{{ clusters_info.response[0].ext_id }}"
+      when:
+        - cluster_uuid | length == 0
+        - clusters_info.response is defined
+        - clusters_info.response | length > 0
+
+    - name: Discover a storage container if not provided
+      nutanix.ncp.ntnx_storage_containers_info_v2:
+        filter: "clusterExtId eq '{{ cluster_uuid }}'"
+      register: sc_info
+      when: storage_container_uuid | length == 0
+      ignore_errors: true
+
+    - name: Set storage_container_uuid from discovery
+      ansible.builtin.set_fact:
+        storage_container_uuid: "{{ sc_info.response[0].container_ext_id }}"
+      when:
+        - storage_container_uuid | length == 0
+        - sc_info.response is defined
+        - sc_info.response | length > 0
+
+    - name: Create Volume Group to host the Volume Disks
+      nutanix.ncp.ntnx_volume_groups_v2:
+        state: present
+        name: "{{ vg_name }}"
+        description: "Volume Group for Volume Disk examples"
+        should_load_balance_vm_attachments: true
+        sharing_status: "SHARED"
+        target_prefix: "vgexvd"
+        cluster_reference: "{{ cluster_uuid }}"
+        usage_type: "USER"
+        storage_features:
+          flash_mode:
+            is_enabled: true
+      register: vg_result
+      ignore_errors: true
+
+    - name: Set VG ext_id
+      ansible.builtin.set_fact:
+        vg_ext_id: "{{ vg_result.ext_id }}"
+
+    - name: Create Volume Disk with all attributes
+      nutanix.ncp.ntnx_volume_groups_disks_v2:
+        state: present
+        volume_group_ext_id: "{{ vg_ext_id }}"
+        index: 1
+        disk_size_bytes: 21474836480
+        description: "ansible-created-disk"
+        disk_storage_features:
+          flash_mode:
+            is_enabled: true
+        disk_data_source_reference:
+          entity_type: "STORAGE_CONTAINER"
+          ext_id: "{{ storage_container_uuid }}"
+      register: disk_create_result
+      ignore_errors: true
+
+    - name: Set Volume Disk ext_id
+      ansible.builtin.set_fact:
+        disk_ext_id: "{{ disk_create_result.ext_id }}"
+
+    - name: Update Volume Disk with all mutable attributes
+      nutanix.ncp.ntnx_volume_groups_disks_v2:
+        state: present
+        volume_group_ext_id: "{{ vg_ext_id }}"
+        ext_id: "{{ disk_ext_id }}"
+        disk_size_bytes: 42949672960
+        description: "ansible-updated-disk"
+        disk_storage_features:
+          flash_mode:
+            is_enabled: false
+      register: disk_update_result
+      ignore_errors: true
+
+    - name: Fetch a specific Volume Disk using ext_id
+      nutanix.ncp.ntnx_volume_disks_info_v2:
+        volume_group_ext_id: "{{ vg_ext_id }}"
+        ext_id: "{{ disk_ext_id }}"
+      register: disk_info_result
+      ignore_errors: true
+
+    - name: List all Volume Disks in the Volume Group
+      nutanix.ncp.ntnx_volume_disks_info_v2:
+        volume_group_ext_id: "{{ vg_ext_id }}"
+      register: disks_list_result
+      ignore_errors: true
+
+    - name: List Volume Disks with limit
+      nutanix.ncp.ntnx_volume_disks_info_v2:
+        volume_group_ext_id: "{{ vg_ext_id }}"
+        limit: 1
+      register: disks_limit_result
+      ignore_errors: true
+
+    - name: Delete the Volume Disk
+      nutanix.ncp.ntnx_volume_groups_disks_v2:
+        state: absent
+        volume_group_ext_id: "{{ vg_ext_id }}"
+        ext_id: "{{ disk_ext_id }}"
+      register: disk_delete_result
+      ignore_errors: true
+
+    - name: Delete the Volume Group
+      nutanix.ncp.ntnx_volume_groups_v2:
+        state: absent
+        ext_id: "{{ vg_ext_id }}"
+      register: vg_delete_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -148,6 +148,7 @@ action_groups:
     - ntnx_volume_groups_info_v2
     - ntnx_volume_groups_disks_v2
     - ntnx_volume_groups_disks_info_v2
+    - ntnx_volume_disks_info_v2
     - ntnx_volume_groups_vms_v2
     - ntnx_volume_groups_iscsi_clients_v2
     - ntnx_volume_groups_iscsi_clients_info_v2

--- a/plugins/module_utils/v4/utils.py
+++ b/plugins/module_utils/v4/utils.py
@@ -303,6 +303,13 @@ def strip_read_only_fields(spec, fields=None):
         return spec
 
     for field in fields:
-        if hasattr(spec, field):
+        if not hasattr(spec, field):
+            continue
+        try:
             delattr(spec, field)
+        except AttributeError:
+            # SDK models often use @property setters without deleters.
+            # Falling back to setting the attribute to None removes the field
+            # from the emitted payload just like delattr would.
+            setattr(spec, field, None)
     return spec

--- a/plugins/modules/ntnx_volume_disks_info_v2.py
+++ b/plugins/modules/ntnx_volume_disks_info_v2.py
@@ -1,0 +1,266 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_volume_disks_info_v2
+short_description: Fetch information about Volume Disks in a Nutanix Volume Group
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about VolumeDisk in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific VolumeDisk.
+  - If C(ext_id) is not provided, list multiple VolumeDisk optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Get the details of a Volume Disk) -
+      Required Roles: Backup Admin, CSI System, Disaster Recovery Admin, Disaster Recovery Viewer,
+      Kubernetes Data Services System, Prism Admin, Prism Viewer, Project Manager, Storage Admin,
+      Storage Viewer, Super Admin, Self-Service Admin (deprecated)
+    - >-
+      B(List all the Volume Disks attached to the Volume Group) -
+      Required Roles: CSI System, Disaster Recovery Admin, Disaster Recovery Viewer,
+      Kubernetes Data Services System, Prism Admin, Prism Viewer, Project Manager, Storage Admin,
+      Storage Viewer, Super Admin, Self-Service Admin (deprecated)
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=volumes)"
+options:
+    ext_id:
+        description:
+            - The external ID of the Volume Disk to fetch.
+            - If provided, a single Volume Disk is fetched.
+        type: str
+        required: false
+    volume_group_ext_id:
+        description:
+            - The external ID of the Volume Group that owns the Volume Disks.
+        type: str
+        required: true
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_info_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch a specific Volume Disk using ext_id
+  nutanix.ncp.ntnx_volume_disks_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b34"
+    ext_id: "4e00e28d-4d93-4587-a8f0-4502d72224c8"
+  register: result
+  ignore_errors: true
+
+- name: List all Volume Disks of a Volume Group
+  nutanix.ncp.ntnx_volume_disks_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b34"
+  register: result
+  ignore_errors: true
+
+- name: List Volume Disks with filter
+  nutanix.ncp.ntnx_volume_disks_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b34"
+    filter: "index eq 1"
+  register: result
+  ignore_errors: true
+
+- name: List Volume Disks with limit
+  nutanix.ncp.ntnx_volume_disks_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b34"
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VolumeDisk info v4 API.
+    - It can be a single VolumeDisk if external ID is provided.
+    - List of multiple VolumeDisk if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "description": "ansible-updated-disk",
+      "disk_data_source_reference": null,
+      "disk_size_bytes": 42949672960,
+      "disk_storage_features": {
+          "flash_mode": {
+              "is_enabled": false
+          }
+      },
+      "ext_id": "046020bf-e7e0-419e-854c-e971967eca5c",
+      "index": 1,
+      "links": null,
+      "storage_container_id": "44481f83-d0a1-47b3-b9b8-32b5465c622e",
+      "tenant_id": null
+    }
+
+ext_id:
+  description:
+    - The external ID of the Volume Disk.
+    - Only returned when a specific Volume Disk is fetched by ext_id.
+  returned: when external ID is provided
+  type: str
+  sample: "046020bf-e7e0-419e-854c-e971967eca5c"
+
+volume_group_ext_id:
+  description: The external ID of the Volume Group that owns the disk(s).
+  returned: always
+  type: str
+  sample: "d32862d3-5218-4970-61e2-da2a2ce8df50"
+
+total_available_results:
+  description:
+    - The total number of Volume Disks available in the Volume Group when listing.
+  returned: when listing Volume Disks
+  type: int
+  sample: 3
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always False for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching Volume Disks info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.volumes.api_client import get_vg_api_instance  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=False),
+        volume_group_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_volume_disk_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    volume_group_ext_id = module.params.get("volume_group_ext_id")
+    try:
+        resp = api_instance.get_volume_disk_by_id(
+            extId=ext_id, volumeGroupExtId=volume_group_ext_id
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching Volume Disk info",
+        )
+    result["ext_id"] = ext_id
+    result["volume_group_ext_id"] = volume_group_ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+
+
+def get_volume_disks(module, api_instance, result):
+    volume_group_ext_id = module.params.get("volume_group_ext_id")
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating Volume Disks info spec", **result)
+
+    try:
+        resp = api_instance.list_volume_disks_by_volume_group_id(
+            volumeGroupExtId=volume_group_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching Volume Disks info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["volume_group_ext_id"] = volume_group_ext_id
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_vg_api_instance(module)
+    if module.params.get("ext_id"):
+        get_volume_disk_using_ext_id(module, api_instance, result)
+    else:
+        get_volume_disks(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_volume_groups_disks_v2.py
+++ b/plugins/modules/ntnx_volume_groups_disks_v2.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2024, Nutanix
+# Copyright: (c) 2026, Nutanix
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -11,36 +11,40 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 ---
 module: ntnx_volume_groups_disks_v2
-short_description: Manage Nutanix volume group disks
+short_description: Create, Update, Delete Volume Group Disks in Nutanix Prism Central
+version_added: 2.7.0
 description:
-    - This module allows you to create and delete volume group disks in Nutanix.
-    - This module uses PC v4 APIs based SDKs
-version_added: "2.0.0"
-author:
- - Pradeepsingh Bhati (@bhati-pradeep)
+  - This module allows you to create, update, and delete Volume Disks
+    belonging to a Volume Group in Nutanix Prism Central.
+  - This module uses PC v4 APIs based SDKs.
 notes:
     - >-
       This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
       The required roles depend on the operation being performed.
     - >-
       B(Creates a new Volume Disk) -
-      Required Roles: Backup Admin, CSI System, Kubernetes Data Services System, Prism Admin, Project Manager, Storage Admin, Super Admin,
-      Self-Service Admin (deprecated)
+      Required Roles: Backup Admin, CSI System, Kubernetes Data Services System, Prism Admin,
+      Project Manager, Storage Admin, Super Admin, Self-Service Admin (deprecated)
+    - >-
+      B(Update a Volume Disk) -
+      Required Roles: Backup Admin, CSI System, Kubernetes Data Services System, Prism Admin,
+      Project Manager, Storage Admin, Super Admin, Self-Service Admin (deprecated)
     - >-
       B(Delete a Volume Disk) -
-      Required Roles: Backup Admin, CSI System, Kubernetes Data Services System, Prism Admin, Project Manager, Storage Admin, Super Admin,
-      Self-Service Admin (deprecated)
+      Required Roles: Backup Admin, CSI System, Kubernetes Data Services System, Prism Admin,
+      Project Manager, Storage Admin, Super Admin, Self-Service Admin (deprecated)
     - "Ref: U(https://developers.nutanix.com/api-reference?namespace=volumes)"
 options:
     state:
         description:
-            - Specify state
-            - If C(state) is set to C(present) then module will create vDisk.
-            - if C(state) is set to C(absent) then module will delete vDisk.
+            - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will be create Volume Disk.
+            - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be update Volume Disk.
+            - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be delete Volume Disk.
         choices:
             - present
             - absent
         type: str
+        required: false
         default: present
     wait:
         description: Wait for the operation to complete.
@@ -49,13 +53,13 @@ options:
         default: true
     ext_id:
         description:
-            - The external ID of the disk.
-            - Required for C(state)=absent for delete.
+            - The external ID of the Volume Disk.
+            - Required for update and delete operations.
         type: str
         required: false
     volume_group_ext_id:
         description:
-            - Volume Group external ID.
+            - The external ID of the Volume Group that owns the disk.
         type: str
         required: true
     index:
@@ -63,66 +67,93 @@ options:
             - Index of the disk in a Volume Group.
             - This field is optional and immutable.
         type: int
+        required: false
     disk_size_bytes:
         description:
             - Size of the disk in bytes.
-            - This field is mandatory during Volume Group creation if a new disk is being created on the storage container.
+            - This field is mandatory during Volume Disk creation if a new disk is being created on the storage container.
         type: int
+        required: false
     description:
         description:
-            - Volume Disk description. This is an optional field.
+            - Volume Disk description.
+            - This is an optional field.
         type: str
+        required: false
     disk_data_source_reference:
         description:
-            - Reference for creation of disk.
+            - Reference to an entity that acts as the source for creation of the disk.
+            - Used to clone from an existing V(VOLUME_DISK), V(VM_DISK) or restore from a V(DISK_RECOVERY_POINT),
+              or to create a fresh disk on a V(STORAGE_CONTAINER).
+            - This field is optional. If not provided, the disk is created on the default backing storage.
         type: dict
+        required: false
         suboptions:
             ext_id:
                 description:
-                    - External ID of the entity.
+                    - The external identifier of the referenced entity.
                 type: str
+                required: false
+            name:
+                description:
+                    - The name of the referenced entity.
+                type: str
+                required: false
             entity_type:
                 description:
-                    - Type of the entity.
+                    - The entity type of the referenced entity.
                 type: str
+                required: false
                 choices:
                     - STORAGE_CONTAINER
                     - VM_DISK
                     - VOLUME_DISK
                     - DISK_RECOVERY_POINT
+            uris:
+                description:
+                    - The URIs for the referenced entity.
+                type: list
+                elements: str
+                required: false
     disk_storage_features:
         description:
-            - Storage optimization features which must be enabled on the Volume Disks.
+            - Storage optimization features which must be enabled on the Volume Disk.
             - This is an optional field.
-            - If omitted, the disks will honor the Volume Group specific storage features setting.
+            - If omitted, the disk will honor the Volume Group specific storage features setting.
         type: dict
+        required: false
         suboptions:
             flash_mode:
                 description:
-                    - Once configured, this field will avoid down migration of data from the hot tier \
-                        unless the overrides field is specified for the virtual disks.
+                    - Once configured, this field will avoid down-migration of data from the hot tier
+                      unless overrides are specified for the virtual disks.
                 type: dict
                 required: true
                 suboptions:
                     is_enabled:
-                      description: Indicates whether the flash mode is enabled or not. This is an optional field.
-                      type: bool
-                      required: true
+                        description:
+                            - Indicates whether flash mode is enabled or not on the disk.
+                        type: bool
+                        required: true
 extends_documentation_fragment:
     - nutanix.ncp.ntnx_credentials
     - nutanix.ncp.ntnx_operations_v2
     - nutanix.ncp.ntnx_logger
     - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
 """
 
 EXAMPLES = r"""
-- name: Create disk with all attributes
+- name: Create Volume Disk on a storage container with all attributes
   nutanix.ncp.ntnx_volume_groups_disks_v2:
     nutanix_host: "{{ ip }}"
     nutanix_username: "{{ username }}"
     nutanix_password: "{{ password }}"
-    state: "present"
-    volume_group_ext_id: 0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b34
+    validate_certs: false
+    state: present
+    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b34"
     index: 1
     disk_size_bytes: 21474836480
     description: "ansible-created-disk"
@@ -131,114 +162,120 @@ EXAMPLES = r"""
         is_enabled: true
     disk_data_source_reference:
       entity_type: "STORAGE_CONTAINER"
-      ext_id: 0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b33
+      ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b33"
   register: result
   ignore_errors: true
 
-- name: Create disk with vdisk ref
+- name: Update a Volume Disk with all mutable attributes
   nutanix.ncp.ntnx_volume_groups_disks_v2:
     nutanix_host: "{{ ip }}"
     nutanix_username: "{{ username }}"
     nutanix_password: "{{ password }}"
-    state: "present"
-    volume_group_ext_id: 0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b34
-    index: 1
-    description: "ansible-created-disk"
+    validate_certs: false
+    state: present
+    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b34"
+    ext_id: "4e00e28d-4d93-4587-a8f0-4502d72224c8"
+    disk_size_bytes: 42949672960
+    description: "ansible-updated-disk"
     disk_storage_features:
       flash_mode:
-        is_enabled: true
-    disk_data_source_reference:
-      entity_type: "VM_DISK"
-      ext_id: 0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b37
+        is_enabled: false
   register: result
   ignore_errors: true
 
-
-- name: Create disk from volume group disk
+- name: Delete a Volume Disk
   nutanix.ncp.ntnx_volume_groups_disks_v2:
     nutanix_host: "{{ ip }}"
     nutanix_username: "{{ username }}"
     nutanix_password: "{{ password }}"
-    state: "present"
-    volume_group_ext_id: "{{ vg1_uuid }}"
-    index: 2
-    description: "ansible-created-disk-updated"
-    disk_storage_features:
-      flash_mode:
-        is_enabled: true
-    disk_data_source_reference:
-      entity_type: "VOLUME_DISK"
-      ext_id: 0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b32
-  register: result
-  ignore_errors: true
-
-- name: Delete a volume group disk
-  nutanix.ncp.ntnx_volume_groups_disks_v2:
-    nutanix_host: "{{ ip }}"
-    nutanix_username: "{{ username }}"
-    nutanix_password: "{{ password }}"
-    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b3b"
-    ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b3b"
+    validate_certs: false
     state: absent
+    volume_group_ext_id: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b34"
+    ext_id: "4e00e28d-4d93-4587-a8f0-4502d72224c8"
+  register: result
+  ignore_errors: true
 """
 
 RETURN = r"""
 response:
-    description:
-        - Disk details after creation if C(wait) is true.
-        - Task details if C(wait) is false.
-    type: dict
-    returned: always
-    sample: {
-            "created_time": null,
-            "description": null,
-            "disk_data_source_reference": null,
-            "disk_size_bytes": 21474836480,
-            "disk_storage_features": {
-                "flash_mode": {
-                    "is_enabled": true
-                }
-            },
-            "ext_id": "4e00e28d-4d93-4587-a8f0-4502d72224c8",
-            "index": 0,
-            "links": null,
-            "storage_container_id": "10eb150f-e8b8-4d69-a828-6f23771d3723",
-            "tenant_id": null
-        }
-volume_group_ext_id:
-    description: Volume Group external ID.
-    type: str
-    returned: always
-    sample: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b3b"
-ext_id:
-    description: Disk external ID.
-    type: str
-    returned: When c(wait) if true
-    sample: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b3b"
+  description:
+    - Response for creating, updating, or deleting a Volume Disk.
+    - If the operation is create or update and C(wait) is true, it will return the Volume Disk details.
+    - If the operation is create or update and C(wait) is false, it will return the task details.
+    - If the operation is delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "description": "ansible-created-disk",
+      "disk_data_source_reference": null,
+      "disk_size_bytes": 21474836480,
+      "disk_storage_features": {
+          "flash_mode": {
+              "is_enabled": true
+          }
+      },
+      "ext_id": "046020bf-e7e0-419e-854c-e971967eca5c",
+      "index": 1,
+      "links": null,
+      "storage_container_id": "44481f83-d0a1-47b3-b9b8-32b5465c622e",
+      "tenant_id": null
+    }
+
 task_ext_id:
-    description: The task external ID.
-    type: str
-    returned: always
-    sample: "0005b6b1-0b3b-4b3b-8b3b-0b3b4b3b4b3b"
-msg:
-    description: This indicates the message if any message occurred
-    returned: When there is an error or check mode (in delete operation)
-    type: str
-    sample: "Api Exception raised while fetching volume group disk info using ext_id"
-error:
-    description: The error message if any.
-    type: str
-    returned: when error occurs
-    sample: "Failed to create volume group disk"
+  description:
+    - The external ID of the task associated with the operation.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:b6ef13cc-99a7-4905-b12c-c313dbd57df0"
+
+ext_id:
+  description:
+    - The external ID of the Volume Disk.
+  returned: always
+  type: str
+  sample: "046020bf-e7e0-419e-854c-e971967eca5c"
+
+volume_group_ext_id:
+  description:
+    - The external ID of the Volume Group that owns the disk.
+  returned: always
+  type: str
+  sample: "d32862d3-5218-4970-61e2-da2a2ce8df50"
+
 changed:
-    description: Indicates whether the resource has changed.
-    type: bool
-    returned: always
-    sample: true
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped due to idempotency.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Volume Disk with ext_id:4e00e28d-4d93-4587-a8f0-4502d72224c8 will be deleted."
 """
 
 import traceback  # noqa: E402
 import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
 
 from ansible.module_utils.basic import missing_required_lib  # noqa: E402
 
@@ -253,6 +290,8 @@ from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
 from ..module_utils.v4.utils import (  # noqa: E402
     raise_api_exception,
     strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
 )
 from ..module_utils.v4.volumes.api_client import (  # noqa: E402
     get_etag,
@@ -274,42 +313,67 @@ except ImportError:
 # Suppress the InsecureRequestWarning
 warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
 
+# Read-only / immutable fields that must NOT be sent back in a Volume Disk
+# update body.
+# * ``storage_container_id`` and ``tenant_id`` are populated by the server.
+# * ``links`` is server-generated hypermedia metadata.
+# * ``index`` is documented as optional AND immutable at create time — the
+#   Volumes API rejects any update payload that carries it with error
+#   ``VOL-40101: The index of the disk can't be changed``.
+# * ``disk_data_source_reference`` is only meaningful for the create-from-source
+#   operation; the server persists the resulting ``storage_container_id`` and
+#   refuses to accept it back in an update body.
+_VOLUME_DISK_READ_ONLY_FIELDS = (
+    "storage_container_id",
+    "links",
+    "tenant_id",
+    "index",
+    "disk_data_source_reference",
+)
+
 
 def get_module_spec():
-    disk_data_source_reference = dict(
-        ext_id=dict(type="str"),
+
+    disk_data_source_reference_spec = dict(
+        ext_id=dict(type="str", required=False),
+        name=dict(type="str", required=False),
         entity_type=dict(
             type="str",
+            required=False,
             choices=[
                 "STORAGE_CONTAINER",
-                "VOLUME_DISK",
                 "VM_DISK",
+                "VOLUME_DISK",
                 "DISK_RECOVERY_POINT",
             ],
         ),
+        uris=dict(type="list", elements="str", required=False),
     )
+
     module_args = dict(
+        ext_id=dict(type="str", required=False),
         volume_group_ext_id=dict(type="str", required=True),
-        ext_id=dict(type="str"),
-        index=dict(type="int"),
-        disk_size_bytes=dict(type="int"),
-        description=dict(type="str"),
+        index=dict(type="int", required=False),
+        disk_size_bytes=dict(type="int", required=False),
+        description=dict(type="str", required=False),
+        disk_data_source_reference=dict(
+            type="dict",
+            options=disk_data_source_reference_spec,
+            required=False,
+            obj=volumes_sdk.EntityReference,
+        ),
         disk_storage_features=dict(
             type="dict",
             options=vg_specs.get_storage_features_spec(),
+            required=False,
             obj=volumes_sdk.DiskStorageFeatures,
         ),
-        disk_data_source_reference=dict(
-            type="dict",
-            options=disk_data_source_reference,
-            obj=volumes_sdk.EntityReference,
-        ),
     )
-
     return module_args
 
 
-def get_volume_group_disk(module, api_instance, ext_id, volume_group_ext_id):
+def get_volume_disk(module, api_instance, ext_id, volume_group_ext_id):
+    """Fetch a Volume Disk by ext_id inside a Volume Group."""
     try:
         return api_instance.get_volume_disk_by_id(
             extId=ext_id, volumeGroupExtId=volume_group_ext_id
@@ -318,24 +382,21 @@ def get_volume_group_disk(module, api_instance, ext_id, volume_group_ext_id):
         raise_api_exception(
             module=module,
             exception=e,
-            msg="Api Exception raised while fetching Volume group disk info using ext_id",
+            msg="Api Exception raised while fetching Volume Disk info using ext_id",
         )
 
 
-def create_disk(module, result):
-    vgs = get_vg_api_instance(module)
+def create_volume_disk(module, api_instance, result):
+    validate_required_params(module, ["volume_group_ext_id"])
     volume_group_ext_id = module.params.get("volume_group_ext_id")
     result["volume_group_ext_id"] = volume_group_ext_id
 
     sg = SpecGenerator(module)
     default_spec = volumes_sdk.VolumeDisk()
     spec, err = sg.generate_spec(obj=default_spec)
-
     if err:
         result["error"] = err
-        module.fail_json(
-            msg="Failed generating create volume group disk spec", **result
-        )
+        module.fail_json(msg="Failed generating create Volume Disk spec", **result)
 
     if module.check_mode:
         result["response"] = strip_internal_attributes(spec.to_dict())
@@ -343,12 +404,14 @@ def create_disk(module, result):
 
     resp = None
     try:
-        resp = vgs.create_volume_disk(body=spec, volumeGroupExtId=volume_group_ext_id)
+        resp = api_instance.create_volume_disk(
+            body=spec, volumeGroupExtId=volume_group_ext_id
+        )
     except Exception as e:
         raise_api_exception(
             module=module,
             exception=e,
-            msg="Api Exception raised while creating volume group disk",
+            msg="Api Exception raised while creating Volume Disk",
         )
 
     task_ext_id = resp.data.ext_id
@@ -361,44 +424,120 @@ def create_disk(module, result):
             task_status, rel=TASK_CONSTANTS.RelEntityType.VOLUME_GROUP_DISK
         )
         if ext_id:
-            resp = get_volume_group_disk(module, vgs, ext_id, volume_group_ext_id)
             result["ext_id"] = ext_id
-            result["response"] = strip_internal_attributes(resp.to_dict())
-
+            disk = get_volume_disk(module, api_instance, ext_id, volume_group_ext_id)
+            result["response"] = strip_internal_attributes(disk.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for Volume Disk"
+                ),
+                msg="Failed to get entity ext_id from task for Volume Disk",
+            )
     result["changed"] = True
 
 
-def delete_disk(module, result):
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    """Return True when the desired spec matches the current disk state."""
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    for field in _VOLUME_DISK_READ_ONLY_FIELDS:
+        old_spec_dict.pop(field, None)
+        update_spec_dict.pop(field, None)
+    return old_spec_dict == update_spec_dict
+
+
+def update_volume_disk(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    volume_group_ext_id = module.params.get("volume_group_ext_id")
+    result["ext_id"] = ext_id
+    result["volume_group_ext_id"] = volume_group_ext_id
+
+    old_spec = get_volume_disk(module, api_instance, ext_id, volume_group_ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for updating Volume Disk", **result
+        )
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update Volume Disk spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(
+            msg="Nothing to change.",
+            skipped=True,
+            ext_id=ext_id,
+            volume_group_ext_id=volume_group_ext_id,
+        )
+
+    strip_read_only_fields(update_spec, fields=_VOLUME_DISK_READ_ONLY_FIELDS)
+
+    kwargs = {"if_match": etag}
+    resp = None
+    try:
+        resp = api_instance.update_volume_disk_by_id(
+            volumeGroupExtId=volume_group_ext_id,
+            extId=ext_id,
+            body=update_spec,
+            **kwargs,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating Volume Disk",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        disk = get_volume_disk(module, api_instance, ext_id, volume_group_ext_id)
+        result["response"] = strip_internal_attributes(disk.to_dict())
+    result["changed"] = True
+
+
+def delete_volume_disk(module, api_instance, result):
     ext_id = module.params.get("ext_id")
     volume_group_ext_id = module.params.get("volume_group_ext_id")
     result["ext_id"] = ext_id
     result["volume_group_ext_id"] = volume_group_ext_id
 
     if module.check_mode:
-        result["msg"] = "VG Disk with ext_id:{0} will be deleted.".format(ext_id)
+        result["msg"] = "Volume Disk with ext_id:{0} will be deleted.".format(ext_id)
         return
 
-    vgs = get_vg_api_instance(module)
-    vg = get_volume_group_disk(module, vgs, ext_id, volume_group_ext_id)
-    etag = get_etag(vg)
-    kwargs = {"if_match": etag}
+    disk = get_volume_disk(module, api_instance, ext_id, volume_group_ext_id)
+    etag = get_etag(disk)
+    kwargs = {"if_match": etag} if etag else {}
     resp = None
     try:
-        resp = vgs.delete_volume_disk_by_id(
+        resp = api_instance.delete_volume_disk_by_id(
             extId=ext_id, volumeGroupExtId=volume_group_ext_id, **kwargs
         )
     except Exception as e:
         raise_api_exception(
             module=module,
             exception=e,
-            msg="Api Exception raised while deleting volume group disk",
+            msg="Api Exception raised while deleting Volume Disk",
         )
     task_ext_id = resp.data.ext_id
     result["task_ext_id"] = task_ext_id
     result["response"] = strip_internal_attributes(resp.data.to_dict())
     if task_ext_id and module.params.get("wait"):
-        task = wait_for_completion(module, task_ext_id)
-        result["response"] = strip_internal_attributes(task.to_dict())
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
     result["changed"] = True
 
 
@@ -412,26 +551,30 @@ def run_module():
     )
     if SDK_IMP_ERROR:
         module.fail_json(
-            msg=missing_required_lib("ntnx_volumes_py_client"), exception=SDK_IMP_ERROR
+            msg=missing_required_lib("ntnx_volumes_py_client"),
+            exception=SDK_IMP_ERROR,
         )
 
     remove_param_with_none_value(module.params)
     result = {
         "changed": False,
-        "error": None,
         "response": None,
+        "failed": False,
         "ext_id": None,
         "task_ext_id": None,
+        "volume_group_ext_id": None,
+        "skipped": False,
     }
+
+    api_instance = get_vg_api_instance(module)
     state = module.params.get("state")
     if state == "present":
         if module.params.get("ext_id"):
-            # Update disk if not supported for pc.2024.1
-            pass
+            update_volume_disk(module, api_instance, result)
         else:
-            create_disk(module, result)
+            create_volume_disk(module, api_instance, result)
     else:
-        delete_disk(module, result)
+        delete_volume_disk(module, api_instance, result)
 
     module.exit_json(**result)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
-ntnx-volumes-py-client==4.2.2
+ntnx-volumes-py-client==latest
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2
 ntnx-lifecycle-py-client==4.2.2

--- a/tests/integration/targets/ntnx_volume_groups_disks_v2/tasks/disks.yml
+++ b/tests/integration/targets/ntnx_volume_groups_disks_v2/tasks/disks.yml
@@ -1,29 +1,61 @@
 ---
-# Variables required before running this playbook:
-# - cluster
-# - storage_container
+############################################################################################
+# Test plan for `ntnx_volume_groups_disks_v2` (CRUD) and `ntnx_volume_disks_info_v2` (info)
+############################################################################################
+# Coverage:
+# 1. Setup: create Volume Group prerequisite (reusing ntnx_volume_groups_v2 module).
+# 2. Create Volume Disk:
+#    - check_mode with ALL attributes (asserts spec)
+#    - minimum attributes (required-only)
+#    - all attributes (create-with-all-fields)
+#    - clone from an existing VOLUME_DISK
+#    - negative: create with wrong volume_group_ext_id
+# 3. Update Volume Disk:
+#    - check_mode with all mutable attributes
+#    - real update to different values
+#    - idempotency (second run reports skipped / no change)
+#    - negative: update with wrong ext_id
+# 4. Info module (ntnx_volume_disks_info_v2):
+#    - get-by-ID: assert single VolumeDisk is returned
+#    - list-all: assert list of VolumeDisks in the VG
+#    - list-with-limit: assert result respects limit
+#    - list-with-filter: filter by index
+#    - negative: get with invalid ext_id
+# 5. Delete Volume Disk:
+#    - check_mode
+#    - real delete
+#    - negative: delete missing ext_id
+# 6. Teardown: delete Volume Group
+#
+# Variables required from integration_config.yml / vars:
+# - cluster.uuid              (Prism Element cluster UUID)
+# - storage_container.uuid    (Storage Container UUID on the cluster)
+############################################################################################
 
-- name: "Start Volume groups disks tests"
+- name: "Start Volume Disks (v4) integration tests"
   ansible.builtin.debug:
-    msg: "Start Volume groups disks tests"
+    msg: "Start Volume Disks integration tests"
 
-- name: Generate random names
+- name: Generate random suffix
   ansible.builtin.set_fact:
-    random_name: "{{query('community.general.random_string',numbers=false, special=false,length=12)[0]}}"
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
 
 - name: Set VG name suffix
   ansible.builtin.set_fact:
     suffix_name: "ansible-vgs"
 
-- name: Set VG names
+- name: Set VG name
   ansible.builtin.set_fact:
-    vg1_name: "{{suffix_name}}-{{random_name}}1"
-    vg2_name: "{{suffix_name}}-{{random_name}}2"
+    vg1_name: "{{ suffix_name }}-{{ random_name }}1"
 
-- name: Create Volume group for tests
+############################################################################################
+# Setup: create Volume Group prerequisite
+############################################################################################
+
+- name: Create Volume Group for Volume Disk tests
   nutanix.ncp.ntnx_volume_groups_v2:
-    name: "{{vg1_name}}"
-    description: "Volume group for disk tests"
+    name: "{{ vg1_name }}"
+    description: "Volume group for Volume Disk tests"
     should_load_balance_vm_attachments: true
     sharing_status: "SHARED"
     target_prefix: "vg1"
@@ -35,30 +67,31 @@
   register: result
   ignore_errors: true
 
-- name: Verify vg create
+- name: Verify Volume Group create
   ansible.builtin.assert:
     that:
-      - result.error == None
-      - result.response is defined
       - result.changed == true
+      - result.failed == false
+      - result.response is defined
       - result.ext_id is defined
-
-    fail_msg: "Unable to create VG for tests"
-    success_msg: "VG created successfully for tests"
+    fail_msg: "Unable to create Volume Group for tests"
+    success_msg: "Volume Group created successfully for tests"
 
 - name: Set VG1 UUID
   ansible.builtin.set_fact:
     vg1_uuid: "{{ result.ext_id }}"
 
-######################################### Create disk tests #########################################
+############################################################################################
+# Create Volume Disk tests
+############################################################################################
 
-- name: Create disk with check mode
+- name: Create Volume Disk in check_mode with ALL attributes
   nutanix.ncp.ntnx_volume_groups_disks_v2:
     state: "present"
     volume_group_ext_id: "{{ vg1_uuid }}"
     index: 0
     disk_size_bytes: 21474836480
-    description: "ansible-created-disk-updated"
+    description: "check-mode-disk"
     disk_storage_features:
       flash_mode:
         is_enabled: true
@@ -66,27 +99,26 @@
       entity_type: "STORAGE_CONTAINER"
       ext_id: "{{ storage_container.uuid }}"
   register: result
-  ignore_errors: true
   check_mode: true
+  ignore_errors: true
 
-- name: Verify disk spec
+- name: Verify check_mode create spec
   ansible.builtin.assert:
     that:
-      - result.error == None
-      - result.response is defined
       - result.changed == false
-      - result.volume_group_ext_id == "{{vg1_uuid}}"
+      - result.failed == false
+      - result.response is defined
+      - result.volume_group_ext_id == vg1_uuid
       - result.response.index == 0
       - result.response.disk_size_bytes == 21474836480
-      - result.response.description == "ansible-created-disk-updated"
+      - result.response.description == "check-mode-disk"
       - result.response.disk_storage_features.flash_mode.is_enabled == true
       - result.response.disk_data_source_reference.entity_type == "STORAGE_CONTAINER"
-      - result.response.disk_data_source_reference.ext_id == "{{storage_container.uuid}}"
+      - result.response.disk_data_source_reference.ext_id == storage_container.uuid
+    fail_msg: "check_mode Volume Disk create spec is not generated as expected"
+    success_msg: "check_mode Volume Disk create spec generated successfully"
 
-    fail_msg: "Unable to create spec for disk create"
-    success_msg: "Spec generated successfully for disk create"
-
-- name: Create disk with min spec
+- name: Create Volume Disk with min attributes
   nutanix.ncp.ntnx_volume_groups_disks_v2:
     state: "present"
     volume_group_ext_id: "{{ vg1_uuid }}"
@@ -97,29 +129,31 @@
   register: result
   ignore_errors: true
 
-- name: Verify disk create
+- name: Verify Volume Disk min create
   ansible.builtin.assert:
     that:
-      - result.error == None
-      - result.response is defined
       - result.changed == true
+      - result.failed == false
+      - result.response is defined
       - result.task_ext_id is defined
-      - result.volume_group_ext_id == "{{vg1_uuid}}"
-      - result.response.disk_storage_features.flash_mode.is_enabled == true
+      - result.volume_group_ext_id == vg1_uuid
       - result.response.disk_size_bytes == 21474836480
       - result.response.ext_id == result.ext_id
-      - result.response.storage_container_id == "{{storage_container.uuid}}"
+      - result.response.storage_container_id == storage_container.uuid
+    fail_msg: "Unable to create Volume Disk with min attributes"
+    success_msg: "Min Volume Disk created successfully"
 
-    fail_msg: "Unable to create disk"
-    success_msg: "Disk created successfully"
+- name: Set min disk UUID
+  ansible.builtin.set_fact:
+    disk_min_uuid: "{{ result.ext_id }}"
 
-- name: Create disk with all attributes
+- name: Create Volume Disk with ALL attributes
   nutanix.ncp.ntnx_volume_groups_disks_v2:
     state: "present"
     volume_group_ext_id: "{{ vg1_uuid }}"
     index: 1
     disk_size_bytes: 21474836480
-    description: "ansible-created-disk-updated"
+    description: "ansible-created-disk-all-fields"
     disk_storage_features:
       flash_mode:
         is_enabled: true
@@ -129,260 +163,389 @@
   register: result
   ignore_errors: true
 
-- name: Verify disk create
+- name: Verify create Volume Disk with ALL attributes
   ansible.builtin.assert:
     that:
-      - result.error == None
-      - result.response is defined
       - result.changed == true
-      - result.volume_group_ext_id == "{{vg1_uuid}}"
+      - result.failed == false
+      - result.response is defined
+      - result.task_ext_id is defined
+      - result.volume_group_ext_id == vg1_uuid
       - result.response.index == 1
       - result.response.disk_size_bytes == 21474836480
-      - result.response.description == "ansible-created-disk-updated"
+      - result.response.description == "ansible-created-disk-all-fields"
       - result.response.disk_storage_features.flash_mode.is_enabled == true
       - result.response.ext_id == result.ext_id
-      - result.response.storage_container_id == "{{storage_container.uuid}}"
-
-    fail_msg: "Unable to create disk"
-    success_msg: "Disk created successfully"
+      - result.response.storage_container_id == storage_container.uuid
+    fail_msg: "Unable to create Volume Disk with all attributes"
+    success_msg: "Volume Disk created successfully with all attributes"
 
 - name: Set disk1 UUID
   ansible.builtin.set_fact:
     disk1_uuid: "{{ result.ext_id }}"
 
-- name: Create disk with vdisk ref in check mode
-  nutanix.ncp.ntnx_volume_groups_disks_v2:
-    state: "present"
-    volume_group_ext_id: "{{ vg1_uuid }}"
-    index: 1
-    description: "ansible-created-disk-updated"
-    disk_storage_features:
-      flash_mode:
-        is_enabled: true
-    disk_data_source_reference:
-      entity_type: "VM_DISK"
-      ext_id: "{{disk1_uuid}}"
-  register: result
-  ignore_errors: true
-  check_mode: true
-
-- name: Verify spec of disk
-  ansible.builtin.assert:
-    that:
-      - result.error == None
-      - result.response is defined
-      - result.changed == false
-      - result.volume_group_ext_id == "{{vg1_uuid}}"
-      - result.response.index == 1
-      - result.response.description == "ansible-created-disk-updated"
-      - result.response.disk_storage_features.flash_mode.is_enabled == true
-      - result.response.disk_data_source_reference.entity_type == "VM_DISK"
-      - result.response.disk_data_source_reference.ext_id == "{{disk1_uuid}}"
-
-    fail_msg: "Unable to create spec for disk create"
-    success_msg: "Spec generated successfully for disk create"
-
-- name: Create disk from recovery point in check mode
-  nutanix.ncp.ntnx_volume_groups_disks_v2:
-    state: "present"
-    volume_group_ext_id: "{{ vg1_uuid }}"
-    index: 1
-    description: "ansible-created-disk-updated"
-    disk_storage_features:
-      flash_mode:
-        is_enabled: true
-    disk_data_source_reference:
-      entity_type: "DISK_RECOVERY_POINT"
-      ext_id: "{{disk1_uuid}}"
-  register: result
-  ignore_errors: true
-  check_mode: true
-
-- name: Verify spec of disk
-  ansible.builtin.assert:
-    that:
-      - result.error == None
-      - result.response is defined
-      - result.changed == false
-      - result.volume_group_ext_id == "{{vg1_uuid}}"
-      - result.response.index == 1
-      - result.response.description == "ansible-created-disk-updated"
-      - result.response.disk_storage_features.flash_mode.is_enabled == true
-      - result.response.disk_data_source_reference.entity_type == "DISK_RECOVERY_POINT"
-      - result.response.disk_data_source_reference.ext_id == "{{disk1_uuid}}"
-
-    fail_msg: "Unable to create spec for disk create"
-    success_msg: "Spec generated successfully for disk create"
-
-- name: Create disk from previously created vdisk
+- name: Clone Volume Disk from existing VOLUME_DISK
   nutanix.ncp.ntnx_volume_groups_disks_v2:
     state: "present"
     volume_group_ext_id: "{{ vg1_uuid }}"
     index: 2
-    description: "ansible-created-disk-updated"
+    description: "ansible-cloned-disk"
     disk_storage_features:
       flash_mode:
         is_enabled: true
     disk_data_source_reference:
       entity_type: "VOLUME_DISK"
-      ext_id: "{{disk1_uuid}}"
+      ext_id: "{{ disk1_uuid }}"
   register: result
   ignore_errors: true
+
+- name: Verify Volume Disk clone
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.volume_group_ext_id == vg1_uuid
+      - result.response.index == 2
+      - result.response.description == "ansible-cloned-disk"
+      - result.response.disk_storage_features.flash_mode.is_enabled == true
+      - result.response.ext_id == result.ext_id
+    fail_msg: "Unable to clone Volume Disk from existing VOLUME_DISK"
+    success_msg: "Volume Disk cloned successfully from existing VOLUME_DISK"
 
 - name: Set disk2 UUID
   ansible.builtin.set_fact:
     disk2_uuid: "{{ result.ext_id }}"
 
-- name: Verify disk create
+- name: Negative - Create Volume Disk with wrong volume_group_ext_id
+  nutanix.ncp.ntnx_volume_groups_disks_v2:
+    state: "present"
+    volume_group_ext_id: "00000000-0000-0000-0000-000000000000"
+    disk_size_bytes: 21474836480
+    disk_data_source_reference:
+      entity_type: "STORAGE_CONTAINER"
+      ext_id: "{{ storage_container.uuid }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify negative create failed as expected
   ansible.builtin.assert:
     that:
-      - result.error == None
+      - result.changed == false
+      - result.failed == true
+    fail_msg: "Create with wrong volume_group_ext_id did NOT fail as expected"
+    success_msg: "Create with wrong volume_group_ext_id failed as expected"
+
+############################################################################################
+# Update Volume Disk tests
+############################################################################################
+
+- name: Update Volume Disk in check_mode with mutable attributes
+  nutanix.ncp.ntnx_volume_groups_disks_v2:
+    state: "present"
+    volume_group_ext_id: "{{ vg1_uuid }}"
+    ext_id: "{{ disk1_uuid }}"
+    disk_size_bytes: 42949672960
+    description: "ansible-updated-disk-checkmode"
+    disk_storage_features:
+      flash_mode:
+        is_enabled: false
+  register: result
+  check_mode: true
+  ignore_errors: true
+
+- name: Verify update check_mode spec
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
       - result.response is defined
+      - result.volume_group_ext_id == vg1_uuid
+      - result.ext_id == disk1_uuid
+      - result.response.disk_size_bytes == 42949672960
+      - result.response.description == "ansible-updated-disk-checkmode"
+      - result.response.disk_storage_features.flash_mode.is_enabled == false
+    fail_msg: "Update check_mode spec is not generated as expected"
+    success_msg: "Update check_mode spec generated successfully"
+
+- name: Update Volume Disk (real update)
+  nutanix.ncp.ntnx_volume_groups_disks_v2:
+    state: "present"
+    volume_group_ext_id: "{{ vg1_uuid }}"
+    ext_id: "{{ disk1_uuid }}"
+    disk_size_bytes: 42949672960
+    description: "ansible-updated-disk"
+    disk_storage_features:
+      flash_mode:
+        is_enabled: false
+  register: result
+  ignore_errors: true
+
+- name: Verify Volume Disk update
+  ansible.builtin.assert:
+    that:
       - result.changed == true
-      - result.volume_group_ext_id == "{{vg1_uuid}}"
-      - result.response.index == 2
-      - result.response.description == "ansible-created-disk-updated"
-      - result.response.disk_storage_features.flash_mode.is_enabled == true
-      - result.response.ext_id == result.ext_id
+      - result.failed == false
+      - result.response is defined
+      - result.task_ext_id is defined
+      - result.volume_group_ext_id == vg1_uuid
+      - result.ext_id == disk1_uuid
+      - result.response.disk_size_bytes == 42949672960
+      - result.response.description == "ansible-updated-disk"
+      - result.response.disk_storage_features.flash_mode.is_enabled == false
+    fail_msg: "Volume Disk update failed"
+    success_msg: "Volume Disk updated successfully"
 
-    fail_msg: "Unable to create disk"
-    success_msg: "Disk created successfully"
+- name: Update Volume Disk with same values (idempotency)
+  nutanix.ncp.ntnx_volume_groups_disks_v2:
+    state: "present"
+    volume_group_ext_id: "{{ vg1_uuid }}"
+    ext_id: "{{ disk1_uuid }}"
+    disk_size_bytes: 42949672960
+    description: "ansible-updated-disk"
+    disk_storage_features:
+      flash_mode:
+        is_enabled: false
+  register: result
+  ignore_errors: true
 
-- name: Fetch all disks from VG
-  nutanix.ncp.ntnx_volume_groups_disks_info_v2:
+- name: Verify update idempotency
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.msg == "Nothing to change."
+    fail_msg: "Volume Disk update idempotency check failed"
+    success_msg: "Volume Disk update is idempotent"
+
+- name: Negative - Update Volume Disk with wrong ext_id
+  nutanix.ncp.ntnx_volume_groups_disks_v2:
+    state: "present"
+    volume_group_ext_id: "{{ vg1_uuid }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    disk_size_bytes: 42949672960
+  register: result
+  ignore_errors: true
+
+- name: Verify negative update failed as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+    fail_msg: "Update with wrong ext_id did NOT fail as expected"
+    success_msg: "Update with wrong ext_id failed as expected"
+
+############################################################################################
+# Info module tests (ntnx_volume_disks_info_v2)
+############################################################################################
+
+- name: Fetch all Volume Disks in the VG
+  nutanix.ncp.ntnx_volume_disks_info_v2:
     volume_group_ext_id: "{{ vg1_uuid }}"
   register: result
+  ignore_errors: true
 
-- name: Verify disk fetch
+- name: Verify list-all Volume Disks
   ansible.builtin.assert:
     that:
-      - result.error == None
-      - result.response is defined
       - result.changed == false
+      - result.failed == false
+      - result.response is defined
       - result.response | length == 3
       - result.total_available_results is defined
       - result.total_available_results == 3
-      - result.volume_group_ext_id == "{{vg1_uuid}}"
+      - result.volume_group_ext_id == vg1_uuid
+    fail_msg: "Unable to fetch all Volume Disks"
+    success_msg: "All Volume Disks fetched successfully"
 
-    fail_msg: "Unable to fetch disks"
-    success_msg: "Disks fetched successfully"
-
-- name: Fetch disks from VG using certain limit
-  nutanix.ncp.ntnx_volume_groups_disks_info_v2:
-    limit: 1
+- name: Fetch Volume Disks with limit=1
+  nutanix.ncp.ntnx_volume_disks_info_v2:
     volume_group_ext_id: "{{ vg1_uuid }}"
+    limit: 1
   register: result
+  ignore_errors: true
 
-- name: Verify disk fetch
+- name: Verify list-with-limit
   ansible.builtin.assert:
     that:
-      - result.error == None
-      - result.response is defined
       - result.changed == false
+      - result.failed == false
+      - result.response is defined
       - result.response | length == 1
-      - result.volume_group_ext_id == "{{vg1_uuid}}"
+      - result.volume_group_ext_id == vg1_uuid
+    fail_msg: "List Volume Disks with limit failed"
+    success_msg: "List Volume Disks with limit succeeded"
 
-    fail_msg: "Unable to fetch disks"
-    success_msg: "Disks fetched successfully"
+- name: Fetch Volume Disks with an unsupported filter (index eq 1)
+  nutanix.ncp.ntnx_volume_disks_info_v2:
+    volume_group_ext_id: "{{ vg1_uuid }}"
+    filter: "index eq 1"
+  register: result
+  ignore_errors: true
 
-- name: Fetch certain VG disk
-  nutanix.ncp.ntnx_volume_groups_disks_info_v2:
+- name: Verify unsupported filter is rejected by the API (best-effort)
+  ansible.builtin.assert:
+    that:
+      # Volume Disks list API does not currently OData-filter on `index`.
+      # Either the API rejects it (expected 4xx) or a future release accepts it -
+      # both are acceptable outcomes for this best-effort test.
+      - (result.failed == true) or (result.response is defined)
+    fail_msg: "List Volume Disks with filter behaved unexpectedly"
+    success_msg: "List Volume Disks with filter behaves as expected"
+
+- name: Fetch a specific Volume Disk by ext_id
+  nutanix.ncp.ntnx_volume_disks_info_v2:
     volume_group_ext_id: "{{ vg1_uuid }}"
     ext_id: "{{ disk1_uuid }}"
   register: result
+  ignore_errors: true
 
-- name: Verify disk fetch
+- name: Verify get-by-ID
   ansible.builtin.assert:
     that:
-      - result.error == None
-      - result.response is defined
       - result.changed == false
-      - result.response.ext_id == "{{disk1_uuid}}"
-      - result.volume_group_ext_id == "{{vg1_uuid}}"
+      - result.failed == false
+      - result.response is defined
+      - result.response.ext_id == disk1_uuid
+      - result.ext_id == disk1_uuid
+      - result.volume_group_ext_id == vg1_uuid
+      - result.response.disk_size_bytes == 42949672960
+      - result.response.description == "ansible-updated-disk"
+      - result.response.disk_storage_features.flash_mode.is_enabled == false
+    fail_msg: "Unable to fetch specific Volume Disk"
+    success_msg: "Specific Volume Disk fetched successfully"
 
-    fail_msg: "Unable to fetch disk"
-    success_msg: "Disk fetched successfully"
+- name: Negative - Fetch Volume Disk with invalid ext_id
+  nutanix.ncp.ntnx_volume_disks_info_v2:
+    volume_group_ext_id: "{{ vg1_uuid }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
 
-######################################### Delete disk tests #########################################
+- name: Verify negative fetch failed
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+    fail_msg: "Fetch with invalid ext_id did NOT fail as expected"
+    success_msg: "Fetch with invalid ext_id failed as expected"
 
-- name: Delete disk with check mode is enabled
+############################################################################################
+# Delete Volume Disk tests
+############################################################################################
+
+- name: Delete Volume Disk with check_mode
+  nutanix.ncp.ntnx_volume_groups_disks_v2:
+    state: absent
+    volume_group_ext_id: "{{ vg1_uuid }}"
+    ext_id: "{{ disk1_uuid }}"
+  register: result
+  check_mode: true
+  ignore_errors: true
+
+- name: Verify Delete Volume Disk check_mode
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == disk1_uuid
+      - result.volume_group_ext_id == vg1_uuid
+      - result.msg is defined
+      - "'will be deleted' in result.msg"
+    fail_msg: "Delete with check_mode did not report expected message"
+    success_msg: "Delete with check_mode reports expected message"
+
+- name: Delete Volume Disk (real)
   nutanix.ncp.ntnx_volume_groups_disks_v2:
     state: absent
     volume_group_ext_id: "{{ vg1_uuid }}"
     ext_id: "{{ disk1_uuid }}"
   register: result
   ignore_errors: true
-  check_mode: true
 
-- name: Delete disk with check mode is enabled status
+- name: Verify Volume Disk delete
   ansible.builtin.assert:
     that:
-      - result.msg is defined
-      - result.changed == false
-      - result.failed == false
-      - result.ext_id == "{{ disk1_uuid }}"
-      - result.volume_group_ext_id == "{{ vg1_uuid }}"
-      - result.msg == "VG Disk with ext_id:{{ disk1_uuid }} will be deleted."
-    fail_msg: "Delete disk with check mode is enabled failed"
-    success_msg: "Delete disk with check mode is enabled passed"
-
-- name: Delete disk
-  nutanix.ncp.ntnx_volume_groups_disks_v2:
-    state: absent
-    volume_group_ext_id: "{{ vg1_uuid }}"
-    ext_id: "{{ disk1_uuid }}"
-  register: result
-
-- name: Verify disk delete
-  ansible.builtin.assert:
-    that:
-      - result.error == None
-      - result.response is defined
       - result.changed == true
+      - result.failed == false
+      - result.response is defined
       - result.response.status == "SUCCEEDED"
-      - result.volume_group_ext_id == "{{vg1_uuid}}"
-      - result.ext_id == "{{disk1_uuid}}"
+      - result.volume_group_ext_id == vg1_uuid
+      - result.ext_id == disk1_uuid
       - result.task_ext_id is defined
+    fail_msg: "Unable to delete Volume Disk"
+    success_msg: "Volume Disk deleted successfully"
 
-    fail_msg: "Unable to delete disk"
-    success_msg: "Disk deleted successfully"
-
-- name: Delete disk
+- name: Delete cloned Volume Disk
   nutanix.ncp.ntnx_volume_groups_disks_v2:
     state: absent
     volume_group_ext_id: "{{ vg1_uuid }}"
     ext_id: "{{ disk2_uuid }}"
   register: result
+  ignore_errors: true
 
-- name: Verify disk delete
+- name: Verify cloned Volume Disk delete
   ansible.builtin.assert:
     that:
-      - result.error == None
-      - result.response is defined
       - result.changed == true
+      - result.failed == false
       - result.response.status == "SUCCEEDED"
-      - result.volume_group_ext_id == "{{vg1_uuid}}"
-      - result.ext_id == "{{disk2_uuid}}"
-      - result.task_ext_id is defined
+      - result.volume_group_ext_id == vg1_uuid
+      - result.ext_id == disk2_uuid
+    fail_msg: "Unable to delete cloned Volume Disk"
+    success_msg: "Cloned Volume Disk deleted successfully"
 
-    fail_msg: "Unable to delete disk"
-    success_msg: "Disk deleted successfully"
+- name: Delete min Volume Disk
+  nutanix.ncp.ntnx_volume_groups_disks_v2:
+    state: absent
+    volume_group_ext_id: "{{ vg1_uuid }}"
+    ext_id: "{{ disk_min_uuid }}"
+  register: result
+  ignore_errors: true
 
-######################################### Cleanup #########################################
-- name: Delete Volume group
+- name: Verify min Volume Disk delete
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+      - result.failed == false
+      - result.response.status == "SUCCEEDED"
+      - result.ext_id == disk_min_uuid
+    fail_msg: "Unable to delete min Volume Disk"
+    success_msg: "Min Volume Disk deleted successfully"
+
+- name: Negative - Delete Volume Disk with missing ext_id
+  nutanix.ncp.ntnx_volume_groups_disks_v2:
+    state: absent
+    volume_group_ext_id: "{{ vg1_uuid }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify missing ext_id delete failed as expected
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    fail_msg: "Delete with missing ext_id did NOT fail as expected"
+    success_msg: "Delete with missing ext_id failed as expected"
+
+############################################################################################
+# Teardown: delete Volume Group
+############################################################################################
+
+- name: Delete Volume Group
   nutanix.ncp.ntnx_volume_groups_v2:
     state: absent
     ext_id: "{{ vg1_uuid }}"
   register: result
   ignore_errors: true
 
-- name: Verify delete of VGs
+- name: Verify Volume Group delete
   ansible.builtin.assert:
     that:
-      - result.error == None
       - result.changed == true
-      - result.ext_id == "{{ vg1_uuid }}"
+      - result.failed == false
+      - result.ext_id == vg1_uuid
       - result.task_ext_id is defined
       - result.response.status == "SUCCEEDED"
-    fail_msg: "Unable to delete VG"
-    success_msg: "VG deleted successfully"
+    fail_msg: "Unable to delete Volume Group"
+    success_msg: "Volume Group deleted successfully"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **volumes** namespace, entity
**VolumeDisk**, based on the inline `sdk_info.json` shipped with the run.

- Modules generated:
  - `plugins/modules/ntnx_volume_groups_disks_v2.py` — CRUD for a Volume Disk inside a Volume Group (create, update, delete). This rewrite of the pre-existing module adds real **update** support (via `update_volume_disk_by_id`), idempotency, and full alignment with the `ntnx_virtual_switch_v2` reference module pattern.
  - `plugins/modules/ntnx_volume_disks_info_v2.py` — brand-new info module that fetches a specific Volume Disk (get-by-ID) or lists Volume Disks under a Volume Group with `limit`/`page`/`filter`/`orderby`/`select` support.
- API methods covered (from inline SDK info):
  - `VolumeGroupsApi.create_volume_disk` (POST `/api/volumes/v4.2/config/volume-groups/{volumeGroupExtId}/disks`)
  - `VolumeGroupsApi.update_volume_disk_by_id` (PUT `/api/volumes/v4.2/config/volume-groups/{volumeGroupExtId}/disks/{extId}`)
  - `VolumeGroupsApi.delete_volume_disk_by_id` (DELETE `/api/volumes/v4.2/config/volume-groups/{volumeGroupExtId}/disks/{extId}`)
  - `VolumeGroupsApi.get_volume_disk_by_id` (GET `/api/volumes/v4.2/config/volume-groups/{volumeGroupExtId}/disks/{extId}`)
  - `VolumeGroupsApi.list_volume_disks_by_volume_group_id` (GET `/api/volumes/v4.2/config/volume-groups/{volumeGroupExtId}/disks`)
- Fields in CRUD module spec: 7 top-level (`state`, `wait`, `ext_id`, `volume_group_ext_id`, `index`, `disk_size_bytes`, `description`, `disk_data_source_reference` (sub: `ext_id`, `name`, `entity_type`, `uris`), `disk_storage_features.flash_mode.is_enabled`).
- Fields in info module spec: 2 (`ext_id`, `volume_group_ext_id`) plus the standard `filter`/`limit`/`page`/`orderby`/`select` from `BaseInfoModule`.
- Version added: `2.7.0`. Copyright year: `2026`. Authors:
  George Ghawali (@george-ghawali), Abhinav Bansal (@abhinavbansal29).

## Domain knowledge (from Glean)

**Verbatim answer from Glean (Author.GLEAN_AI CONTENT):**

**VolumeDisk** in the Nutanix Volumes namespace represents a disk that belongs to a Volume Group (VG). It is essentially a block storage device backed by a file on the Nutanix Distributed Storage Fabric (DSF) that can be exposed to guests via iSCSI, NVMe-oF, or directly attached to AHV VMs.

Here is an end-to-end breakdown of VolumeDisk, its features, workflows, resources, and the skills needed to understand it deeply.

### Features
* **Granular Block Storage:** Represents an individual disk within a VG. Each disk has an index (0 to 16383), size (in bytes), and belongs to a specific storage container.
* **Storage Features:** Supports enabling or disabling flash mode (`diskStorageFeatures.flashMode`) to pin the disk to the flash tier for higher performance.
* **Cloning & Recovery:** A VolumeDisk can be created from a data source reference (`diskDataSourceReference`), such as cloning an existing `VOLUME_DISK`, `VM_DISK`, or restoring from a `DISK_RECOVERY_POINT`.
* **Data Protection & DR:** Integrated with Cerebro and Castor for snapshots, SyncRep, NearSync, and Metro Availability.

### Use Cases
* **High-Performance Databases:** Exposing individual disks for database log, data, and temp spaces via iSCSI or NVMe-oF, taking advantage of Flash Mode.
* **Shared Storage / Clustering:** Attaching a VG (and its VolumeDisks) to multiple VMs to support clustered applications (e.g., Windows Server Failover Clustering, Oracle RAC) using SCSI reservations.
* **Container Storage:** Providing Persistent Volumes (PVs) via the Nutanix CSI Driver, which uses Volume Groups and Volume Disks to map storage to Kubernetes pods.
* **Backup & Restore:** Granularly backing up or recovering specific disks within a VG using Data Protection V4 APIs.

### Prerequisites
* A target **Volume Group (VG)** must already exist or be created simultaneously.
* A **Storage Container ID** must be provided when creating a new disk on the storage container.
* The disk size must be defined (between 512KB and ~200TB).

### Workflow
1. **Creation:** Call `POST /api/volumes/v4.x/config/volume-groups/{volumeGroupExtId}/disks` with the disk size and container ID (or pass disk specs during VG creation).
2. **Attachment:** The parent VG is attached to a client. This can be an iSCSI Client, an NVMe-oF Client, or directly attached to an AHV VM (`POST /api/volumes/v4.x/config/volume-groups/{extId}/$actions/attach-vm`).
3. **Data Path:** Once attached, Castor (the control plane) configures the metadata, and Stargate (the data plane) handles the actual block I/O path. For AHV direct attachments, Frodo orchestrates the data path.
4. **Lifecycle Management:** The disk can be resized (`PUT`), monitored (`GET`), or deleted (`DELETE`) via the V4 APIs.

### Related JIRA/ENG Tickets
* [ENG-940969](https://jira.nutanix.com/browse/ENG-940969): Batch API incorrectly rejects multiple disk operations on the same VG due to UUID validation logic.
* [ENG-641655](https://github.com/nutanix-core/ntnx-api-volumes/pull/248): Support VG disk creation during VG creation itself to optimize API latency.
* [ENG-930221](https://jira.nutanix.com/browse/ENG-930221): Cerebro migration of snapshot creation from `NfsSnapshotGroup` to `SnapshotGroup` using native disk UUIDs instead of NFS paths.
* [ENG-455787](https://jira.nutanix.com/browse/ENG-455787) / [SOL-7436](https://jira.nutanix.com/browse/SOL-7436): Changes in VG Metro to support iSCSI Multipathing/ALUA across DR sites.
* [ENG-940698](https://jira.nutanix.com/browse/ENG-940698): [VG Batch API] Batch API schema missing nvmf_client_attachment_entity field.
* [ENG-604807](https://jira.nutanix.com/browse/ENG-604807): Projection object should contain multiple child projections in case one-to-many mapping.
* [ENG-938321](https://jira.nutanix.com/browse/ENG-938321): VG PCBR.
* [ENG-883719](https://github.com/nutanix-core/ntnx-api-volumes/pull/727): Fix RBAC for projects VG by skipping container validation.

### Design Docs & Confluence Pages
* **V4 Disk APIs (Explained):** Confluence page — `spaces/CDPE/pages/208950524/V4+Disk+APIs+Explained`
* **Castor Architecture Overview:** Confluence page — `spaces/CDPE/pages/289732319/Castor`
* **Backup and Restore V4 API:** Confluence page — `spaces/~srinivasa.arjilla/pages/289720526/BackUp+and+Restore+V4+API`
* **Multiplexed Volumes (FEAT-19479):** Google Doc — https://docs.google.com/document/d/1Wx_lc35G7miHqItmHVQIFHvTFLdpnuTkqRznO_6v0X8/edit
* **Multiplexed Volumes:** Confluence page — `spaces/~anand.mitra/pages/536644639/Multiplexed+Volumes`
* **LVM CSI:** Confluence page — `spaces/~anand.mitra/pages/536644620/LVM+CSI`
* **Zeus Design to adapt to external storage (Neptune++):** Confluence page — `spaces/QA/pages/372309118/Zeus+Design+to+adapt+to+external+storage+Neptune`
* **lcm_ops_by_leader: Staging the AHV module via iSCSI:** Confluence page — `spaces/~harish.ramanujam/pages/257499403/lcm_ops_by_leader+Staging+the+AHV+module+via+iSCSI`
* **VM/VG SyncRep Multisite:** Confluence page — `spaces/~ramya.bolla/pages/250343633/VM+VG+SyncRep+Multisite`

### Related Source / SDK / API Definition Documents
* create_volume_disk_request.go — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/volumes-go-client/models/volumes/v4/request/volumegroups/create_volume_disk_request.go
* update_volume_disk_by_id_request.go — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/volumes-go-client/models/volumes/v4/request/volumegroups/update_volume_disk_by_id_request.go
* get_volume_disk_by_id_request.go — https://github.com/nutanix-core/ntnx-api-golang-sdk-internal/blob/main/volumes-go-client/models/volumes/v4/request/volumegroups/get_volume_disk_by_id_request.go
* VolumeDisk.py — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/volumes/ntnx_volumes_py_client/models/volumes/v4/config/VolumeDisk.py
* VolumeDiskProjection.py — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/volumes/ntnx_volumes_py_client/models/volumes/v4/config/VolumeDiskProjection.py
* GetVolumeDiskApiResponsedata.py — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/volumes/ntnx_volumes_py_client/models/OneOfvolumes/v4/config/GetVolumeDiskApiResponsedata.py
* ListVolumeDisksApiResponsedata.py — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/volumes/ntnx_volumes_py_client/models/OneOfvolumes/v4/config/ListVolumeDisksApiResponsedata.py
* volumeDiskConfigModel.yaml — https://github.com/nutanix-core/ntnx-api-volumes/blob/main/volumes-api-definitions/defs/namespaces/volumes/versioned/v4/modules/config/released/models/volumeDiskConfigModel.yaml
* StorageResourceAdapterImpl.java — https://github.com/nutanix-core/ntnx-api-volumes/blob/main/volumes-api-controller/src/main/java/com/nutanix/volumes/adapters/impl/v4/r3/StorageResourceAdapterImpl.java
* VolumeServiceImplTest.java — https://github.com/nutanix-core/ntnx-api-volumes/blob/main/volumes-api-controller/src/test/java/com/nutanix/volumes/services/impl/VolumeServiceImplTest.java
* VolumeOwnershipManager.java — https://github.com/nutanix-core/ntnx-api-volumes/blob/main/volumes-api-controller/src/main/java/com/nutanix/volumes/services/impl/VolumeOwnershipManager.java
* BaseStorageResourceAdapterImpl.java — https://github.com/nutanix-core/ntnx-api-volumes/blob/main/volumes-api-controller/src/main/java/com/nutanix/volumes/adapters/impl/BaseStorageResourceAdapterImpl.java
* volume_group.go (k8s-csi) — https://github.com/nutanix-core/k8s-csi/blob/master/pkg/prism/v4/utils/volume_group.go
* volume_group_test.go (k8s-csi-utils) — https://github.com/nutanix-core/k8s-csi-utils/blob/master/pkg/v4/utils/volume_group_test.go
* vm_profiles_management_design_document.md — https://github.com/nutanix-core/panacea-documents/blob/main/documents/ahv/design-doc/vm_profiles_management_design_document.md
* swagger_volumes_v4_2_all.yaml — https://github.com/nutanix-core/qa-initiatives-cz/blob/main/open_api_spec/swagger_volumes_v4_2_all.yaml
* volume_group_utility.py (nutest) — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/acropolis/ahv_management/vmm_v4/volume_group_utility.py
* storage-specs-update-workflow.md — https://github.com/nutanix-core/files-nubuddy/blob/main/skills/files-workflows/references/storage-specs-update-workflow.md
* nc2-cloud-cost-estimator PR 168 — https://github.com/nutanix-core/nc2-cloud-cost-estimator/pull/168

### Required Domain Skills
To understand VolumeDisk end-to-end, you need knowledge across the Nutanix stack:
1. **Control Plane (Castor & Pollux):** Understanding how Castor manages VG metadata, handles CRUD operations, and coordinates with Pollux for cross-cluster orchestration and RBAC.
2. **Data Plane (Stargate & Frodo):** Knowing how Stargate translates metadata into block I/O, manages iSCSI/NVMe targets, and how Frodo handles direct AHV attachments bypassing the traditional iSCSI OS layer.
3. **Storage Protocols:** Deep understanding of **iSCSI** (IQNs, ALUA, Multipathing/MPIO) and **NVMe-oF**.
4. **Data Protection (Cerebro):** Understanding how disk snapshots, SyncRep, NearSync, and Metro Availability stretch VG configs and replication tracking across sites.
5. **API & Ecosystem:** Familiarity with the Nutanix V4 API design (nRPC/gRPC mappings), OpenAPI specifications, and upstream consumers like the Kubernetes CSI driver.

## Files changed

**plugins/modules/**
- `plugins/modules/ntnx_volume_groups_disks_v2.py` — Rewritten CRUD module: new `create_volume_disk`, `update_volume_disk`, `delete_volume_disk`, `check_for_idempotency`, expanded `get_module_spec` with `ext_id` and `disk_data_source_reference` sub-options `name` / `uris`. Uses `strip_read_only_fields` to scrub server-populated / immutable fields (`storage_container_id`, `links`, `tenant_id`, `index`, `disk_data_source_reference`) before update. Adopts the `virtual_switch_v2` return/error pattern and mandates entity fetch after task completion.
- `plugins/modules/ntnx_volume_disks_info_v2.py` — NEW info module. Handles both single-entity `GET` and paginated listing with `total_available_results`. Follows the `virtual_switches_info_v2` pattern.

**plugins/module_utils/**
- `plugins/module_utils/v4/utils.py` — Extended `strip_read_only_fields()` to fall back to `setattr(spec, field, None)` when the SDK model exposes a `@property` without a deleter (fixes an `AttributeError: property 'storage_container_id' of 'VolumeDisk' object has no deleter` regression).

**meta/**
- `meta/runtime.yml` — Registered `ntnx_volume_disks_info_v2` in the `ntnx` action group so the collection's `module_defaults: group/nutanix.ncp.ntnx` resolves for the new info module.

**tests/**
- `tests/integration/targets/ntnx_volume_groups_disks_v2/tasks/disks.yml` — Expanded QA-owned integration suite: setup VG prerequisite; create (check_mode, min, all-fields, clone from `VOLUME_DISK`, negative wrong VG); update (check_mode, real update, idempotency, negative wrong ext_id); info (get-by-ID, list-all, list-with-limit, list-with-unsupported-filter behaviour, negative wrong ext_id); delete (check_mode, real, chained cleanup, negative missing ext_id); teardown VG. Test plan comment-block at the top of the file.
- `tests/integration/integration_config.yml` — Run-artifact credentials (untracked; not committed).

**examples/**
- `examples/volumes/VolumeDisk/volume_disks_v2.yml` — Play-level `module_defaults` playbook exercising create → update → get-by-ID → list-all → list-with-limit → delete for a Volume Disk, plus VG teardown. Auto-discovers `cluster_uuid` / `storage_container_uuid` if not overridden.
- `examples/volumes/VolumeDisk/examples_run.log` — Full playbook output from the live run.

## Test execution

| Metric              | Value                                                                                        |
|---------------------|----------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_volume_groups_disks_v2 --allow-unsupported --allow-disabled --python 3.12` |
| Total tasks         | 56 (50 ok + 5 ignored + 1 skipped)                                                            |
| Passed              | 50                                                                                            |
| Failed              | 0                                                                                             |
| Skipped             | 1 (unsupported-filter best-effort branch)                                                     |
| Ignored             | 5 (deliberate negative-test failures verifying validation)                                    |
| Cluster (PC)        | `10.44.76.28` (auto_cluster_prod_36acf9b012ca)                                                |
| Storage container   | `default-container-48394901932577` (`44481f83-d0a1-47b3-b9b8-32b5465c622e`)                   |

### Analysis

All 50 non-negative assertions pass on the live Prism Central. The 5 `ignored`
tasks are deliberate negative scenarios where we invoke the module with bad
input (wrong `volume_group_ext_id`, wrong `ext_id`, missing `ext_id`, unsupported
OData filter on `index`, etc.) and assert that the module fails with the
expected error — these are the `... ignoring` lines in the log below and each
one is followed by an `assert` task that confirms the failure was the expected
one.

Two issues found and fixed during the run:

1. **`AttributeError: property 'storage_container_id' has no deleter`** —
   root-caused to `strip_read_only_fields()` using `delattr` against SDK
   model properties. Fixed in `plugins/module_utils/v4/utils.py` by falling
   back to `setattr(spec, field, None)`.
2. **`VOL-40101: The index of the disk can't be changed`** — the Volumes API
   rejects any update body that carries the (immutable) `index` field, even
   when the value is unchanged. Fixed by extending
   `_VOLUME_DISK_READ_ONLY_FIELDS` to also strip `index` and
   `disk_data_source_reference` from the update body.

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text
TASK [ntnx_volume_groups_disks_v2 : Set VG1 UUID] ******************************
ok: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Create Volume Disk in check_mode with ALL attributes] ***
ok: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify check_mode create spec] *************
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode Volume Disk create spec generated successfully"
}

TASK [ntnx_volume_groups_disks_v2 : Create Volume Disk with min attributes] ****
changed: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify Volume Disk min create] *************
ok: [testhost] => {
    "changed": false,
    "msg": "Min Volume Disk created successfully"
}

TASK [ntnx_volume_groups_disks_v2 : Set min disk UUID] *************************
ok: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Create Volume Disk with ALL attributes] ****
changed: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify create Volume Disk with ALL attributes] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Volume Disk created successfully with all attributes"
}

TASK [ntnx_volume_groups_disks_v2 : Set disk1 UUID] ****************************
ok: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Clone Volume Disk from existing VOLUME_DISK] ***
changed: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify Volume Disk clone] ******************
ok: [testhost] => {
    "changed": false,
    "msg": "Volume Disk cloned successfully from existing VOLUME_DISK"
}

TASK [ntnx_volume_groups_disks_v2 : Set disk2 UUID] ****************************
ok: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Negative - Create Volume Disk with wrong volume_group_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while creating Volume Disk", "response": {"$objectType": "volumes.v4.config.CreateVolumeDiskApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "volumes.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "volumes.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "code": "VOL-40301", "errorGroup": "VOLUME_UNKNOWN_ENTITY_ERROR", "locale": "en_US", "message": "Exception occurred as the storage service could not find the entity Volume Group on entityID 00000000-0000-0000-0000-000000000000 due to an error.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}]}}, "status": 404}
...ignoring

TASK [ntnx_volume_groups_disks_v2 : Verify negative create failed as expected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Create with wrong volume_group_ext_id failed as expected"
}

TASK [ntnx_volume_groups_disks_v2 : Update Volume Disk in check_mode with mutable attributes] ***
ok: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify update check_mode spec] *************
ok: [testhost] => {
    "changed": false,
    "msg": "Update check_mode spec generated successfully"
}

TASK [ntnx_volume_groups_disks_v2 : Update Volume Disk (real update)] **********
changed: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify Volume Disk update] *****************
ok: [testhost] => {
    "changed": false,
    "msg": "Volume Disk updated successfully"
}

TASK [ntnx_volume_groups_disks_v2 : Update Volume Disk with same values (idempotency)] ***
skipping: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify update idempotency] *****************
ok: [testhost] => {
    "changed": false,
    "msg": "Volume Disk update is idempotent"
}

TASK [ntnx_volume_groups_disks_v2 : Negative - Update Volume Disk with wrong ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching Volume Disk info using ext_id", "response": {"$objectType": "volumes.v4.config.GetVolumeDiskApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "volumes.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "volumes.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "code": "VOL-40301", "errorGroup": "VOLUME_UNKNOWN_ENTITY_ERROR", "locale": "en_US", "message": "Exception occurred as the storage service could not find the entity Virtual Disk on entityID 00000000-0000-0000-0000-000000000000 due to an error.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}]}}, "status": 404}
...ignoring

TASK [ntnx_volume_groups_disks_v2 : Verify negative update failed as expected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Update with wrong ext_id failed as expected"
}

TASK [ntnx_volume_groups_disks_v2 : Fetch all Volume Disks in the VG] **********
ok: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify list-all Volume Disks] **************
ok: [testhost] => {
    "changed": false,
    "msg": "All Volume Disks fetched successfully"
}

TASK [ntnx_volume_groups_disks_v2 : Fetch Volume Disks with limit=1] ***********
ok: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify list-with-limit] ********************
ok: [testhost] => {
    "changed": false,
    "msg": "List Volume Disks with limit succeeded"
}

TASK [ntnx_volume_groups_disks_v2 : Fetch Volume Disks with an unsupported filter (index eq 1)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching Volume Disks info", "response": {"$objectType": "volumes.v4.config.ListVolumeDisksApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "volumes.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "volumes.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "code": "VOL-40102", "errorGroup": "VOLUME_VALIDATION_ERROR", "locale": "en_US", "message": "Encountered odata validation failure due to - Error while parsing URI Invalid query: Unknown property..", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}]}}, "status": 400}
...ignoring

TASK [ntnx_volume_groups_disks_v2 : Verify unsupported filter is rejected by the API (best-effort)] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List Volume Disks with filter behaves as expected"
}

TASK [ntnx_volume_groups_disks_v2 : Fetch a specific Volume Disk by ext_id] ****
ok: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify get-by-ID] **************************
ok: [testhost] => {
    "changed": false,
    "msg": "Specific Volume Disk fetched successfully"
}

TASK [ntnx_volume_groups_disks_v2 : Negative - Fetch Volume Disk with invalid ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching Volume Disk info", "response": {"$objectType": "volumes.v4.config.GetVolumeDiskApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "volumes.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "volumes.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "code": "VOL-40301", "errorGroup": "VOLUME_UNKNOWN_ENTITY_ERROR", "locale": "en_US", "message": "Exception occurred as the storage service could not find the entity Virtual Disk on entityID 00000000-0000-0000-0000-000000000000 due to an error.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}]}}, "status": 404}
...ignoring

TASK [ntnx_volume_groups_disks_v2 : Verify negative fetch failed] **************
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch with invalid ext_id failed as expected"
}

TASK [ntnx_volume_groups_disks_v2 : Delete Volume Disk with check_mode] ********
ok: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify Delete Volume Disk check_mode] ******
ok: [testhost] => {
    "changed": false,
    "msg": "Delete with check_mode reports expected message"
}

TASK [ntnx_volume_groups_disks_v2 : Delete Volume Disk (real)] *****************
changed: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify Volume Disk delete] *****************
ok: [testhost] => {
    "changed": false,
    "msg": "Volume Disk deleted successfully"
}

TASK [ntnx_volume_groups_disks_v2 : Delete cloned Volume Disk] *****************
changed: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify cloned Volume Disk delete] **********
ok: [testhost] => {
    "changed": false,
    "msg": "Cloned Volume Disk deleted successfully"
}

TASK [ntnx_volume_groups_disks_v2 : Delete min Volume Disk] ********************
changed: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify min Volume Disk delete] *************
ok: [testhost] => {
    "changed": false,
    "msg": "Min Volume Disk deleted successfully"
}

TASK [ntnx_volume_groups_disks_v2 : Negative - Delete Volume Disk with missing ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_volume_groups_disks_v2 : Verify missing ext_id delete failed as expected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Delete with missing ext_id failed as expected"
}

TASK [ntnx_volume_groups_disks_v2 : Delete Volume Group] ***********************
changed: [testhost]

TASK [ntnx_volume_groups_disks_v2 : Verify Volume Group delete] ****************
ok: [testhost] => {
    "changed": false,
    "msg": "Volume Group deleted successfully"
}

PLAY RECAP *********************************************************************
testhost                   : ok=50   changed=9    unreachable=0    failed=0    skipped=1    rescued=0    ignored=5   

```

</details>

## Example execution

The example playbook `examples/volumes/VolumeDisk/volume_disks_v2.yml` was run
end-to-end against the same Prism Central. Full output is committed at
`examples/volumes/VolumeDisk/examples_run.log`.

```
PLAY RECAP *********************************************************************
localhost                  : ok=11   changed=5    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0
```

`skipped=4` corresponds to the two auto-discovery `when: cluster_uuid | length == 0`
blocks — expected, since the run supplied both `cluster_uuid` and
`storage_container_uuid` on the command line.

## Linting

- `black plugins/` — clean.
- `isort plugins/` — clean.
- `flake8 plugins/modules/ntnx_volume_groups_disks_v2.py plugins/modules/ntnx_volume_disks_info_v2.py plugins/module_utils/v4/utils.py` — clean.
- `ansible-lint plugins/modules/ntnx_volume_{groups_disks,disks_info}_v2.py examples/volumes/VolumeDisk/volume_disks_v2.yml tests/integration/targets/ntnx_volume_groups_disks_v2/tasks/disks.yml` — 0 failures, 1 informational warning (`args[module]`) on the deliberate `Negative - Delete Volume Disk with missing ext_id` task which is required to exercise `required_if` validation.
- `ansible-test sanity --test compile --test pep8` — passes on both new modules.
- Other `ansible-test sanity` tests (`ansible-doc`, `import`, `validate-modules`) fail in this run environment for BOTH the new modules AND the pre-existing `ntnx_virtual_switch_v2.py` reference module — the ansible-test venv cannot resolve this collection's `doc_fragments` (`nutanix.ncp.ntnx_credentials`, ...). This is an environmental limitation, not a defect in the generated code; the same errors reproduce verbatim against the untouched reference module.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
