### PR TITLE
code-gen(networking/UplinkBond): ansible collection modules

### DIFF
--- a/examples/networking/UplinkBond/examples_run.log
+++ b/examples/networking/UplinkBond/examples_run.log
@@ -1,0 +1,154 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [UplinkBond info playbook] ************************************************
+
+TASK [List all uplink bonds] ***************************************************
+ok: [localhost] => {"changed": false, "response": [{"cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "host_nic_references": ["94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c", "084af8fb-87f8-46e6-a2f4-cabeffc81850", "efc40201-750e-49b1-9e52-f64c05121b61", "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"], "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "lacp_status": "NIL", "links": null, "metadata": null, "name": "br0-up", "tenant_id": null, "type": "ACTIVE_BACKUP", "virtual_switch_info": {"name": "vs0", "reference": "22672efd-210f-41dc-9934-d3cb5908b727"}}], "total_available_results": 1}
+
+TASK [Show list result] ********************************************************
+ok: [localhost] => {
+    "uplink_bonds_list": {
+        "changed": false,
+        "failed": false,
+        "response": [
+            {
+                "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+                "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689",
+                "host_nic_references": [
+                    "94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c",
+                    "084af8fb-87f8-46e6-a2f4-cabeffc81850",
+                    "efc40201-750e-49b1-9e52-f64c05121b61",
+                    "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"
+                ],
+                "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b",
+                "lacp_status": "NIL",
+                "links": null,
+                "metadata": null,
+                "name": "br0-up",
+                "tenant_id": null,
+                "type": "ACTIVE_BACKUP",
+                "virtual_switch_info": {
+                    "name": "vs0",
+                    "reference": "22672efd-210f-41dc-9934-d3cb5908b727"
+                }
+            }
+        ],
+        "total_available_results": 1
+    }
+}
+
+TASK [Fail if no uplink bonds are present] *************************************
+skipping: [localhost] => {"changed": false, "false_condition": "uplink_bonds_list.response | length == 0", "skip_reason": "Conditional result was False"}
+
+TASK [Capture first uplink bond ext_id] ****************************************
+ok: [localhost] => {"ansible_facts": {"uplink_bond_ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "uplink_bond_name": "br0-up"}, "changed": false}
+
+TASK [Get uplink bond using ext_id] ********************************************
+ok: [localhost] => {"changed": false, "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "response": {"cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "host_nic_references": ["94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c", "084af8fb-87f8-46e6-a2f4-cabeffc81850", "efc40201-750e-49b1-9e52-f64c05121b61", "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"], "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "lacp_status": "NIL", "links": null, "metadata": null, "name": "br0-up", "tenant_id": null, "type": "ACTIVE_BACKUP", "virtual_switch_info": {"name": "vs0", "reference": "22672efd-210f-41dc-9934-d3cb5908b727"}}}
+
+TASK [Show get-by-ext_id result] ***********************************************
+ok: [localhost] => {
+    "uplink_bond_get": {
+        "changed": false,
+        "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689",
+        "failed": false,
+        "response": {
+            "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+            "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689",
+            "host_nic_references": [
+                "94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c",
+                "084af8fb-87f8-46e6-a2f4-cabeffc81850",
+                "efc40201-750e-49b1-9e52-f64c05121b61",
+                "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"
+            ],
+            "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b",
+            "lacp_status": "NIL",
+            "links": null,
+            "metadata": null,
+            "name": "br0-up",
+            "tenant_id": null,
+            "type": "ACTIVE_BACKUP",
+            "virtual_switch_info": {
+                "name": "vs0",
+                "reference": "22672efd-210f-41dc-9934-d3cb5908b727"
+            }
+        }
+    }
+}
+
+TASK [List uplink bonds with limit] ********************************************
+ok: [localhost] => {"changed": false, "response": [{"cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "host_nic_references": ["94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c", "084af8fb-87f8-46e6-a2f4-cabeffc81850", "efc40201-750e-49b1-9e52-f64c05121b61", "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"], "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "lacp_status": "NIL", "links": null, "metadata": null, "name": "br0-up", "tenant_id": null, "type": "ACTIVE_BACKUP", "virtual_switch_info": {"name": "vs0", "reference": "22672efd-210f-41dc-9934-d3cb5908b727"}}], "total_available_results": 1}
+
+TASK [Show limit result] *******************************************************
+ok: [localhost] => {
+    "uplink_bonds_limit": {
+        "changed": false,
+        "failed": false,
+        "response": [
+            {
+                "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+                "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689",
+                "host_nic_references": [
+                    "94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c",
+                    "084af8fb-87f8-46e6-a2f4-cabeffc81850",
+                    "efc40201-750e-49b1-9e52-f64c05121b61",
+                    "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"
+                ],
+                "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b",
+                "lacp_status": "NIL",
+                "links": null,
+                "metadata": null,
+                "name": "br0-up",
+                "tenant_id": null,
+                "type": "ACTIVE_BACKUP",
+                "virtual_switch_info": {
+                    "name": "vs0",
+                    "reference": "22672efd-210f-41dc-9934-d3cb5908b727"
+                }
+            }
+        ],
+        "total_available_results": 1
+    }
+}
+
+TASK [List uplink bonds sorted by name] ****************************************
+ok: [localhost] => {"changed": false, "response": [{"cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "host_nic_references": ["94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c", "084af8fb-87f8-46e6-a2f4-cabeffc81850", "efc40201-750e-49b1-9e52-f64c05121b61", "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"], "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "lacp_status": "NIL", "links": null, "metadata": null, "name": "br0-up", "tenant_id": null, "type": "ACTIVE_BACKUP", "virtual_switch_info": {"name": "vs0", "reference": "22672efd-210f-41dc-9934-d3cb5908b727"}}], "total_available_results": 1}
+
+TASK [Show orderby result] *****************************************************
+ok: [localhost] => {
+    "uplink_bonds_orderby": {
+        "changed": false,
+        "failed": false,
+        "response": [
+            {
+                "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+                "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689",
+                "host_nic_references": [
+                    "94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c",
+                    "084af8fb-87f8-46e6-a2f4-cabeffc81850",
+                    "efc40201-750e-49b1-9e52-f64c05121b61",
+                    "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"
+                ],
+                "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b",
+                "lacp_status": "NIL",
+                "links": null,
+                "metadata": null,
+                "name": "br0-up",
+                "tenant_id": null,
+                "type": "ACTIVE_BACKUP",
+                "virtual_switch_info": {
+                    "name": "vs0",
+                    "reference": "22672efd-210f-41dc-9934-d3cb5908b727"
+                }
+            }
+        ],
+        "total_available_results": 1
+    }
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=9    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
+

--- a/examples/networking/UplinkBond/uplink_bonds_v2.yml
+++ b/examples/networking/UplinkBond/uplink_bonds_v2.yml
@@ -1,0 +1,71 @@
+---
+# Summary:
+# This playbook demonstrates the available operations for UplinkBond entities.
+# UplinkBond is a read-only entity in the Nutanix Networking v4 SDK; only
+# get-by-ext_id and list operations are supported.
+#
+# The playbook covers:
+# 1. List all uplink bonds available in Prism Central.
+# 2. Fetch a specific uplink bond by ext_id.
+# 3. List uplink bonds paginated with a limit.
+# 4. List uplink bonds sorted by name.
+#
+# NOTE: The Nutanix Networking v4 UplinkBonds list API accepts $orderby, $page
+# and $limit query parameters. $filter is declared in the SDK signature but is
+# rejected by the server for this entity in PC 7.6 (returns "Odata Error:
+# Error while parsing URI"); it is therefore intentionally omitted here.
+
+- name: UplinkBond info playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ pc_ip | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ pc_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ pc_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: List all uplink bonds
+      nutanix.ncp.ntnx_uplink_bonds_info_v2:
+      register: uplink_bonds_list
+
+    - name: Show list result
+      ansible.builtin.debug:
+        var: uplink_bonds_list
+
+    - name: Fail if no uplink bonds are present
+      ansible.builtin.fail:
+        msg: "No uplink bonds discovered on this cluster; downstream tasks require at least one."
+      when: uplink_bonds_list.response | length == 0
+
+    - name: Capture first uplink bond ext_id
+      ansible.builtin.set_fact:
+        uplink_bond_ext_id: "{{ uplink_bonds_list.response[0].ext_id }}"
+        uplink_bond_name: "{{ uplink_bonds_list.response[0].name }}"
+
+    - name: Get uplink bond using ext_id
+      nutanix.ncp.ntnx_uplink_bonds_info_v2:
+        ext_id: "{{ uplink_bond_ext_id }}"
+      register: uplink_bond_get
+
+    - name: Show get-by-ext_id result
+      ansible.builtin.debug:
+        var: uplink_bond_get
+
+    - name: List uplink bonds with limit
+      nutanix.ncp.ntnx_uplink_bonds_info_v2:
+        limit: 1
+      register: uplink_bonds_limit
+
+    - name: Show limit result
+      ansible.builtin.debug:
+        var: uplink_bonds_limit
+
+    - name: List uplink bonds sorted by name
+      nutanix.ncp.ntnx_uplink_bonds_info_v2:
+        orderby: "name"
+      register: uplink_bonds_orderby
+
+    - name: Show orderby result
+      ansible.builtin.debug:
+        var: uplink_bonds_orderby

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -246,5 +246,6 @@ action_groups:
     - ntnx_iam_entities_info_v2
     - ntnx_virtual_switch_v2
     - ntnx_virtual_switches_info_v2
+    - ntnx_uplink_bonds_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,15 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_uplink_bonds_api_instance(module):
+    """
+    This method will return UplinkBondsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Uplink Bonds Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.UplinkBondsApi(api_client=api_client)

--- a/plugins/module_utils/v4/network/helpers.py
+++ b/plugins/module_utils/v4/network/helpers.py
@@ -170,3 +170,23 @@ def get_virtual_switch(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching virtual switch info using ext_id",
         )
+
+
+def get_uplink_bond(module, api_instance, ext_id):
+    """
+    This method will return uplink bond info using its ext_id
+    Args:
+        module: Ansible module
+        api_instance: UplinkBondsApi instance from ntnx_networking_py_client sdk
+        ext_id (str): uplink bond external ID
+    return:
+        info (object): uplink bond info
+    """
+    try:
+        return api_instance.get_uplink_bond_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching uplink bond info using ext_id",
+        )

--- a/plugins/modules/ntnx_uplink_bonds_info_v2.py
+++ b/plugins/modules/ntnx_uplink_bonds_info_v2.py
@@ -1,0 +1,227 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_uplink_bonds_info_v2
+short_description: Fetch uplink bonds info in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about UplinkBond in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific UplinkBond.
+  - If C(ext_id) is not provided, list multiple UplinkBond optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get uplink bond by ext_id) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin, Virtual Machine Admin,
+      Virtual Machine Operator, Virtual Machine Viewer, VPC Admin
+    - >-
+      B(Get list of Uplink Bonds) -
+      Required Roles: Consumer, Developer, Network Infra Admin, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin, Virtual Machine Admin,
+      Virtual Machine Operator, Virtual Machine Viewer, VPC Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  ext_id:
+    description:
+      - The external ID (UUID) of the uplink bond.
+      - If provided, fetch details of the specific uplink bond.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Get uplink bond using ext_id
+  nutanix.ncp.ntnx_uplink_bonds_info_v2:
+    ext_id: "b46b8d21-79ad-4cd2-a770-181a97e9e689"
+  register: result
+  ignore_errors: true
+
+- name: List all uplink bonds
+  nutanix.ncp.ntnx_uplink_bonds_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List uplink bonds with filter
+  nutanix.ncp.ntnx_uplink_bonds_info_v2:
+    filter: "name eq 'br0-up'"
+  register: result
+  ignore_errors: true
+
+- name: List uplink bonds with limit
+  nutanix.ncp.ntnx_uplink_bonds_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC UplinkBond info v4 API.
+    - It can be a single UplinkBond if external ID is provided.
+    - List of multiple UplinkBond if external ID is not provided.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+      "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689",
+      "host_nic_references": [
+          "94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c",
+          "084af8fb-87f8-46e6-a2f4-cabeffc81850",
+          "efc40201-750e-49b1-9e52-f64c05121b61",
+          "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"
+      ],
+      "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b",
+      "lacp_status": "NIL",
+      "links": null,
+      "metadata": null,
+      "name": "br0-up",
+      "project_ext_id": null,
+      "tenant_id": null,
+      "type": "ACTIVE_BACKUP",
+      "virtual_switch_info": {
+          "name": "vs0",
+          "reference": "22672efd-210f-41dc-9934-d3cb5908b727"
+      }
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error.
+  type: str
+  sample: "Api Exception raised while fetching uplink bonds info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the uplink bond.
+  type: str
+  returned: when external ID is provided
+  sample: "b46b8d21-79ad-4cd2-a770-181a97e9e689"
+
+total_available_results:
+  description: The total number of available uplink bonds in PC.
+  type: int
+  returned: when all uplink bonds are fetched
+  sample: 1
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_uplink_bonds_api_instance,
+)
+from ..module_utils.v4.network.helpers import get_uplink_bond  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_uplink_bond_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_uplink_bond(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_uplink_bonds(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating uplink bonds info spec", **result)
+
+    try:
+        resp = api_instance.list_uplink_bonds(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching uplink bonds info",
+        )
+
+    resp = strip_internal_attributes(resp.to_dict())
+    total_available_results = resp.get("metadata", {}).get("total_available_results")
+    result["total_available_results"] = total_available_results
+    resp = resp.get("data")
+
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_uplink_bonds_api_instance(module)
+    if module.params.get("ext_id"):
+        get_uplink_bond_using_ext_id(module, api_instance, result)
+    else:
+        get_uplink_bonds(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_uplink_bonds_info_v2/aliases
+++ b/tests/integration/targets/ntnx_uplink_bonds_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_uplink_bonds_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_uplink_bonds_info_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_uplink_bonds_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_uplink_bonds_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import uplink_bonds.yml
+      ansible.builtin.import_tasks: uplink_bonds.yml

--- a/tests/integration/targets/ntnx_uplink_bonds_info_v2/tasks/uplink_bonds.yml
+++ b/tests/integration/targets/ntnx_uplink_bonds_info_v2/tasks/uplink_bonds.yml
@@ -1,0 +1,238 @@
+---
+# ============================================================================
+# Test plan for ntnx_uplink_bonds_info_v2
+# ----------------------------------------------------------------------------
+# UplinkBond is a READ-ONLY entity in the Nutanix Networking v4 SDK; the only
+# public API methods are GetUplinkBondById and ListUplinkBonds. There is no
+# Create/Update/Delete/Action API, therefore there is no `state`-based CRUD
+# module and no check_mode surface to exercise. All tests below cover the two
+# supported read operations plus their negative branches and query options.
+#
+# Scenarios covered:
+#   1.  List all uplink bonds — expect >= 1 entry on a healthy cluster and
+#       assert every schema field exists on the returned entities.
+#   2.  Extract a bond ext_id from step 1 and Get the bond by ext_id; assert
+#       the response payload matches the entry from the list.
+#   3.  List with filter (name eq '<name>') — server currently rejects
+#       $filter with "Odata Error"; asserted as a negative test.
+#   4.  List with limit=1 — assert exactly one row is returned.
+#   5.  List with page=0 combined with limit=1 — assert pagination works.
+#   6.  List with orderby=name — assert response is returned (server-side
+#       ordering; we do not re-sort locally).
+#   7.  Get by wrong ext_id — expect failed=true with descriptive error.
+#   8.  Providing both ext_id and filter together — expect argument-spec
+#       validation to fail (mutually_exclusive).
+#   9.  Enum sanity: assert `type` is one of the SDK-declared UplinkBondType
+#       values and `lacp_status` is one of the SDK-declared UplinkBondLacpStatus
+#       values for every discovered bond.
+# ============================================================================
+
+- name: Start UplinkBond info module tests
+  ansible.builtin.debug:
+    msg: Start UplinkBond info module tests
+
+########################################################################################
+# 1. List all uplink bonds
+########################################################################################
+
+- name: List all uplink bonds
+  nutanix.ncp.ntnx_uplink_bonds_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List all uplink bonds status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 1
+      - result.total_available_results is defined
+      - result.total_available_results >= 1
+      - result.response[0].ext_id is defined
+      - result.response[0].name is defined
+      - result.response[0].type is defined
+      - result.response[0].lacp_status is defined
+      - result.response[0].cluster_reference is defined
+      - result.response[0].host_reference is defined
+      - result.response[0].host_nic_references is defined
+    success_msg: "List all uplink bonds passed"
+    fail_msg: "List all uplink bonds failed"
+
+- name: Assert enum values for every discovered uplink bond
+  ansible.builtin.assert:
+    that:
+      - item.type in ['ACTIVE_BACKUP', 'BALANCE_SLB', 'BALANCE_TCP']
+      - item.lacp_status in ['CONFIGURED', 'NEGOTIATED', 'NIL']
+    success_msg: "Uplink bond {{ item.ext_id }} carries valid enum values"
+    fail_msg: "Uplink bond {{ item.ext_id }} carries unexpected enum values"
+  loop: "{{ result.response }}"
+  loop_control:
+    label: "{{ item.ext_id }}"
+
+- name: Capture first uplink bond for subsequent tests
+  ansible.builtin.set_fact:
+    uplink_bond_ext_id: "{{ result.response[0].ext_id }}"
+    uplink_bond_name: "{{ result.response[0].name }}"
+    uplink_bond_type: "{{ result.response[0].type }}"
+    uplink_bond_cluster_ref: "{{ result.response[0].cluster_reference }}"
+
+########################################################################################
+# 2. Get uplink bond by ext_id
+########################################################################################
+
+- name: Get uplink bond using ext_id
+  nutanix.ncp.ntnx_uplink_bonds_info_v2:
+    ext_id: "{{ uplink_bond_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Get uplink bond using ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == uplink_bond_ext_id
+      - result.response is defined
+      - result.response.ext_id == uplink_bond_ext_id
+      - result.response.name == uplink_bond_name
+      - result.response.type == uplink_bond_type
+      - result.response.cluster_reference == uplink_bond_cluster_ref
+      - result.response.host_nic_references is defined
+      - result.response.host_reference is defined
+    success_msg: "Get uplink bond using ext_id passed"
+    fail_msg: "Get uplink bond using ext_id failed"
+
+########################################################################################
+# 3. List with filter (server-side $filter is currently rejected by PC 7.6 for
+#    the UplinkBonds endpoint even though the SDK method signature declares the
+#    parameter; treat this as a negative test until the server adds support.)
+########################################################################################
+
+- name: List uplink bonds with filter by name (currently unsupported by PC)
+  nutanix.ncp.ntnx_uplink_bonds_info_v2:
+    filter: "name eq '{{ uplink_bond_name }}'"
+  register: result
+  ignore_errors: true
+
+- name: List uplink bonds with filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching uplink bonds info"
+      - "'Odata Error' in (result.response.data.error[0].message | default(''))"
+    success_msg: "Filter rejection surfaced with a descriptive error as expected"
+    fail_msg: "Expected the server to reject $filter on UplinkBonds, but got a different response"
+
+########################################################################################
+# 4. List with limit
+########################################################################################
+
+- name: List uplink bonds with limit=1
+  nutanix.ncp.ntnx_uplink_bonds_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List uplink bonds with limit status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    success_msg: "List uplink bonds with limit passed"
+    fail_msg: "List uplink bonds with limit failed"
+
+########################################################################################
+# 5. List with page + limit
+########################################################################################
+
+- name: List uplink bonds with page=0 and limit=1
+  nutanix.ncp.ntnx_uplink_bonds_info_v2:
+    page: 0
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List uplink bonds with page and limit status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    success_msg: "List uplink bonds with page + limit passed"
+    fail_msg: "List uplink bonds with page + limit failed"
+
+########################################################################################
+# 6. List with orderby
+########################################################################################
+
+- name: List uplink bonds with orderby=name
+  nutanix.ncp.ntnx_uplink_bonds_info_v2:
+    orderby: "name"
+  register: result
+  ignore_errors: true
+
+- name: List uplink bonds with orderby status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 1
+    success_msg: "List uplink bonds with orderby passed"
+    fail_msg: "List uplink bonds with orderby failed"
+
+########################################################################################
+# 7. Negative test: get with wrong ext_id
+########################################################################################
+
+- name: Fetch uplink bond using wrong external ID
+  nutanix.ncp.ntnx_uplink_bonds_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Fetch uplink bond using wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg is defined
+    success_msg: "Fetch uplink bond using wrong external ID failed as expected"
+    fail_msg: "Fetch uplink bond using wrong external ID did not fail as expected"
+
+########################################################################################
+# 8. Negative test: mutually exclusive ext_id + filter
+########################################################################################
+
+- name: Fetch uplink bond with both ext_id and filter (should fail)
+  nutanix.ncp.ntnx_uplink_bonds_info_v2:
+    ext_id: "{{ uplink_bond_ext_id }}"
+    filter: "name eq '{{ uplink_bond_name }}'"
+  register: result
+  ignore_errors: true
+
+- name: Fetch uplink bond with both ext_id and filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'mutually exclusive' in result.msg"
+    success_msg: "Fetch uplink bond with ext_id+filter failed as expected"
+    fail_msg: "Fetch uplink bond with ext_id+filter did not fail as expected"
+
+- name: Finish UplinkBond info module tests
+  ansible.builtin.debug:
+    msg: Finish UplinkBond info module tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**UplinkBond**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_uplink_bonds_info_v2` (info)
- Module NOT generated: `ntnx_uplink_bond_v2` (CRUD) — the SDK exposes only
  `get_uplink_bond_by_id` and `list_uplink_bonds`; there are **no Create /
  Update / Delete / action** methods on `UplinkBondsApi` in
  `ntnx_networking_py_client`. UplinkBonds are managed via the parent
  `VirtualSwitch` API (`ntnx_virtual_switch_v2`), so a stand-alone CRUD
  module for this entity would have nothing to call.
- API methods covered: 2 of 2 available (`GetUplinkBondById`, `ListUplinkBonds`)
- Fields in CRUD module spec: N/A (no CRUD module generated)
- Fields in info module spec: 1 module-specific (`ext_id`) + 5 base info args
  (`filter`, `page`, `limit`, `orderby`, `select`) inherited from
  `BaseInfoModule`

## Files changed

**plugins/**
- `plugins/modules/ntnx_uplink_bonds_info_v2.py` (new info module)
- `plugins/module_utils/v4/network/api_client.py` (added
  `get_uplink_bonds_api_instance`)
- `plugins/module_utils/v4/network/helpers.py` (added `get_uplink_bond`)

**meta/**
- `meta/runtime.yml` (registered `ntnx_uplink_bonds_info_v2` in the
  `ntnx` action_group so `module_defaults: group/nutanix.ncp.ntnx` works)

**examples/**
- `examples/networking/UplinkBond/uplink_bonds_v2.yml` (single-file example
  playbook covering list, get-by-ext_id, limit-paginate, orderby)
- `examples/networking/UplinkBond/examples_run.log` (captured, real playbook
  output from a live PC run — 9/9 tasks OK, 1 skipped due to a defensive
  \"no bonds present\" guard that is not triggered on this cluster)

**tests/**
- `tests/integration/targets/ntnx_uplink_bonds_info_v2/aliases`
- `tests/integration/targets/ntnx_uplink_bonds_info_v2/meta/main.yml`
- `tests/integration/targets/ntnx_uplink_bonds_info_v2/tasks/main.yml`
- `tests/integration/targets/ntnx_uplink_bonds_info_v2/tasks/uplink_bonds.yml`

## Test execution

| Metric              | Value                                                                              |
|---------------------|------------------------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-unsupported --allow-disabled ntnx_uplink_bonds_info_v2 -v` |
| Total tasks         | 24 (21 asserted OK + 3 API-level failures asserted as expected negatives)          |
| Passed              | 21                                                                                 |
| Failed              | 0                                                                                  |
| Ignored (as designed)| 3 (negative tests: wrong ext_id, ext_id+filter mutually exclusive, $filter rejected server-side) |
| Skipped             | 0                                                                                  |
| Cluster (PC)        | 10.44.76.28 (pc.7.6 / networking API v4.3)                                         |

Scenarios covered:
1. **List all uplink bonds** — asserts `>= 1`, checks every schema field
   (`ext_id`, `name`, `type`, `lacp_status`, `cluster_reference`,
   `host_reference`, `host_nic_references`) is present.
2. **Enum sanity per bond** — asserts `type in {ACTIVE_BACKUP, BALANCE_SLB,
   BALANCE_TCP}` and `lacp_status in {CONFIGURED, NEGOTIATED, NIL}`, matching
   the SDK enums, for every discovered bond.
3. **Get by ext_id** — cross-checks the response against the entity discovered
   in step 1.
4. **List with $filter** — currently rejected by PC 7.6 with
   \"Odata Error: Error while parsing URI\"; asserted as a negative test with
   the exact error surface. See Known issues below.
5. **List with limit=1** — asserts response length `== 1`.
6. **List with page=0 + limit=1** — asserts pagination works.
7. **List with orderby=name** — server-side sort accepted; asserts response.
8. **Get by wrong ext_id** — asserts `failed=true` and a descriptive message.
9. **ext_id + filter mutually exclusive** — asserts argument-spec validation
   fails with `\"mutually exclusive\"` message.

### Analysis

All CRUD-style tests are intentionally absent because the entity has no CRUD
surface in the SDK; every applicable info scenario is covered and every one
passes. The three \"failed\" tasks reported inside the run are the three
negative assertions above and are wrapped in `ignore_errors: true`; the
`assert` immediately after each verifies the failure was the expected one.

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text
Configured locale: C.UTF-8
WARNING: Using locale "C.UTF-8" instead of "en_US.UTF-8". Tests which depend on the locale may behave unexpectedly.
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /usr/bin/python3.10
Creating container database.
Run command: /usr/bin/python3.10 /home/george2/.local/lib/python3.10/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_uplink_bonds_info_v2 integration test role
Initializing "/tmp/ansible-test-jce5inb2-injector" as the temporary injector directory.
Injecting "/tmp/python-tfwi9m_b-ansible/python" as a execv wrapper for the "/usr/bin/python3.10" interpreter.
Stream command: ansible-playbook ntnx_uplink_bonds_info_v2-vyy4bwu_.yml -i inventory -v
[WARNING]: Found variable using reserved name: port
Using /tmp/anscol/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_uplink_bonds_info_v2-n6r8scv9-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_uplink_bonds_info_v2 : Start UplinkBond info module tests] **********
ok: [testhost] => {
    "msg": "Start UplinkBond info module tests"
}

TASK [ntnx_uplink_bonds_info_v2 : List all uplink bonds] ***********************
ok: [testhost] => {"changed": false, "response": [{"cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "host_nic_references": ["94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c", "084af8fb-87f8-46e6-a2f4-cabeffc81850", "efc40201-750e-49b1-9e52-f64c05121b61", "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"], "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "lacp_status": "NIL", "links": null, "metadata": null, "name": "br0-up", "tenant_id": null, "type": "ACTIVE_BACKUP", "virtual_switch_info": {"name": "vs0", "reference": "22672efd-210f-41dc-9934-d3cb5908b727"}}], "total_available_results": 1}

TASK [ntnx_uplink_bonds_info_v2 : List all uplink bonds status] ****************
ok: [testhost] => {
    "changed": false,
    "msg": "List all uplink bonds passed"
}

TASK [ntnx_uplink_bonds_info_v2 : Assert enum values for every discovered uplink bond] ***
ok: [testhost] => (item=b46b8d21-79ad-4cd2-a770-181a97e9e689) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
        "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689",
        "host_nic_references": [
            "94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c",
            "084af8fb-87f8-46e6-a2f4-cabeffc81850",
            "efc40201-750e-49b1-9e52-f64c05121b61",
            "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"
        ],
        "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b",
        "lacp_status": "NIL",
        "links": null,
        "metadata": null,
        "name": "br0-up",
        "tenant_id": null,
        "type": "ACTIVE_BACKUP",
        "virtual_switch_info": {
            "name": "vs0",
            "reference": "22672efd-210f-41dc-9934-d3cb5908b727"
        }
    },
    "msg": "Uplink bond b46b8d21-79ad-4cd2-a770-181a97e9e689 carries valid enum values"
}

TASK [ntnx_uplink_bonds_info_v2 : Capture first uplink bond for subsequent tests] ***
ok: [testhost] => {"ansible_facts": {"uplink_bond_cluster_ref": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "uplink_bond_ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "uplink_bond_name": "br0-up", "uplink_bond_type": "ACTIVE_BACKUP"}, "changed": false}

TASK [ntnx_uplink_bonds_info_v2 : Get uplink bond using ext_id] ****************
ok: [testhost] => {"changed": false, "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "response": {"cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "host_nic_references": ["94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c", "084af8fb-87f8-46e6-a2f4-cabeffc81850", "efc40201-750e-49b1-9e52-f64c05121b61", "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"], "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "lacp_status": "NIL", "links": null, "metadata": null, "name": "br0-up", "tenant_id": null, "type": "ACTIVE_BACKUP", "virtual_switch_info": {"name": "vs0", "reference": "22672efd-210f-41dc-9934-d3cb5908b727"}}}

TASK [ntnx_uplink_bonds_info_v2 : Get uplink bond using ext_id status] *********
ok: [testhost] => {
    "changed": false,
    "msg": "Get uplink bond using ext_id passed"
}

TASK [ntnx_uplink_bonds_info_v2 : List uplink bonds with filter by name (currently unsupported by PC)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching uplink bonds info", "response": {"$objectType": "networking.v4.config.GetUplinkBondApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10002", "locale": "en_US", "message": "Failed to list uplink bonds due to a bad request - Odata Error: Error while parsing URI", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/uplink-bonds", "rel": "self"}], "totalAvailableResults": 0}}, "status": 400}
...ignoring

TASK [ntnx_uplink_bonds_info_v2 : List uplink bonds with filter status] ********
ok: [testhost] => {
    "changed": false,
    "msg": "Filter rejection surfaced with a descriptive error as expected"
}

TASK [ntnx_uplink_bonds_info_v2 : List uplink bonds with limit=1] **************
ok: [testhost] => {"changed": false, "response": [{"cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "host_nic_references": ["94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c", "084af8fb-87f8-46e6-a2f4-cabeffc81850", "efc40201-750e-49b1-9e52-f64c05121b61", "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"], "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "lacp_status": "NIL", "links": null, "metadata": null, "name": "br0-up", "tenant_id": null, "type": "ACTIVE_BACKUP", "virtual_switch_info": {"name": "vs0", "reference": "22672efd-210f-41dc-9934-d3cb5908b727"}}], "total_available_results": 1}

TASK [ntnx_uplink_bonds_info_v2 : List uplink bonds with limit status] *********
ok: [testhost] => {
    "changed": false,
    "msg": "List uplink bonds with limit passed"
}

TASK [ntnx_uplink_bonds_info_v2 : List uplink bonds with page=0 and limit=1] ***
ok: [testhost] => {"changed": false, "response": [{"cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "host_nic_references": ["94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c", "084af8fb-87f8-46e6-a2f4-cabeffc81850", "efc40201-750e-49b1-9e52-f64c05121b61", "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"], "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "lacp_status": "NIL", "links": null, "metadata": null, "name": "br0-up", "tenant_id": null, "type": "ACTIVE_BACKUP", "virtual_switch_info": {"name": "vs0", "reference": "22672efd-210f-41dc-9934-d3cb5908b727"}}], "total_available_results": 1}

TASK [ntnx_uplink_bonds_info_v2 : List uplink bonds with page and limit status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List uplink bonds with page + limit passed"
}

TASK [ntnx_uplink_bonds_info_v2 : List uplink bonds with orderby=name] *********
ok: [testhost] => {"changed": false, "response": [{"cluster_reference": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "b46b8d21-79ad-4cd2-a770-181a97e9e689", "host_nic_references": ["94b24cd7-f4ff-4164-ba7a-fc69e35f8b6c", "084af8fb-87f8-46e6-a2f4-cabeffc81850", "efc40201-750e-49b1-9e52-f64c05121b61", "8ae64a0e-bf81-4424-b57f-5cbc8e8f24ac"], "host_reference": "adf0c9e0-4051-4cd2-9f6f-ca9f962e941b", "lacp_status": "NIL", "links": null, "metadata": null, "name": "br0-up", "tenant_id": null, "type": "ACTIVE_BACKUP", "virtual_switch_info": {"name": "vs0", "reference": "22672efd-210f-41dc-9934-d3cb5908b727"}}], "total_available_results": 1}

TASK [ntnx_uplink_bonds_info_v2 : List uplink bonds with orderby status] *******
ok: [testhost] => {
    "changed": false,
    "msg": "List uplink bonds with orderby passed"
}

TASK [ntnx_uplink_bonds_info_v2 : Fetch uplink bond using wrong external ID] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching uplink bond info using ext_id", "response": {"$objectType": "networking.v4.config.GetUplinkBondApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to get uplink bond 00000000-0000-0000-0000-000000000000 as a referenced resource was not found - Uplink bond not found.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/uplink-bonds/00000000-0000-0000-0000-000000000000", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [ntnx_uplink_bonds_info_v2 : Fetch uplink bond using wrong external ID status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch uplink bond using wrong external ID failed as expected"
}

TASK [ntnx_uplink_bonds_info_v2 : Fetch uplink bond with both ext_id and filter (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_uplink_bonds_info_v2 : Fetch uplink bond with both ext_id and filter status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch uplink bond with ext_id+filter failed as expected"
}

TASK [ntnx_uplink_bonds_info_v2 : Finish UplinkBond info module tests] *********
ok: [testhost] => {
    "msg": "Finish UplinkBond info module tests"
}

PLAY RECAP *********************************************************************
testhost                   : ok=21   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   

WARNING: Reviewing previous 1 warning(s):
WARNING: Using locale "C.UTF-8" instead of "en_US.UTF-8". Tests which depend on the locale may behave unexpectedly.
```

</details>

## Example execution

- Playbook: `examples/networking/UplinkBond/uplink_bonds_v2.yml`
- Command: `ansible-playbook examples/networking/UplinkBond/uplink_bonds_v2.yml -v`
- Result: `ok=9 changed=0 unreachable=0 failed=0 skipped=1`
- The single skipped task is the defensive `fail` guard that only triggers
  when a cluster has zero uplink bonds; the live cluster has 1 bond so it
  correctly skips.
- Real API responses have been backfilled into the module's `RETURN` sample
  (single bond `br0-up` on cluster `0006555e-4e63-4a5e-185b-ac1f6b6f97e2`).

## Known issues / limitations

- **UplinkBond has no CRUD** in the current SDK — see Summary. No
  `ntnx_uplink_bond_v2` module is shipped.
- **`$filter` is server-side unsupported** on the UplinkBonds list endpoint
  in PC 7.6 (both v4.3 and v4.4 return
  `NETWORKING-10002 - Odata Error: Error while parsing URI` for any filter
  expression). The module still exposes the `filter` option because
  `ntnx_networking_py_client.UplinkBondsApi.list_uplink_bonds` declares
  `_filter` in its signature and future PC releases are expected to accept
  it; the integration test asserts the current rejection as a negative case so
  the check will start failing (and thus force a follow-up) as soon as the
  server begins accepting filters.
- **`ansible-lint syntax-check[unknown-module]`** reports \"couldn't resolve
  module/action 'nutanix.ncp.ntnx_uplink_bonds_info_v2'\" against the test
  file. This is a false positive tied to how ansible-lint resolves collection
  paths in this workspace (shared symlink race with parallel code-gen runs);
  the module is correctly discovered by `ansible-doc`,
  `ansible-playbook --syntax-check`, `ansible-test sanity`, and the actual
  playbook + integration runs. `ansible-test sanity` was run against the new
  module, api_client, helpers, and `meta/runtime.yml` and passes cleanly.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
