### PR TITLE
AntivirusServer Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/files/AntivirusServer/antivirus_server.yml
+++ b/examples/files/AntivirusServer/antivirus_server.yml
@@ -1,0 +1,82 @@
+---
+# Summary:
+# This playbook will do:
+# 1. Create an antivirus (ICAP) server on a Nutanix Files file server
+# 2. Update the antivirus server
+# 3. Get the antivirus server using ext_id
+# 4. List all antivirus servers of the file server
+# 5. List antivirus servers with a filter
+# 6. List antivirus servers with a limit
+# 7. Delete the antivirus server
+#
+# Note: An existing Nutanix Files file server is required. Replace the
+# file_server_ext_id value below with the external ID of your file server.
+
+- name: Antivirus Server playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        file_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+
+    - name: Create antivirus server
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        description: "Antivirus server created by Ansible"
+        address:
+          ipv4:
+            value: "10.44.10.100"
+        port: 1344
+        partner_service_name: "avscan"
+      register: result
+
+    - name: Set antivirus server ext_id
+      ansible.builtin.set_fact:
+        antivirus_server_ext_id: "{{ result.ext_id }}"
+
+    - name: Update antivirus server
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ antivirus_server_ext_id }}"
+        description: "Antivirus server updated by Ansible"
+        partner_service_name: "avscan-updated"
+      register: result
+
+    - name: Get antivirus server using ext_id
+      nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ antivirus_server_ext_id }}"
+      register: result
+
+    - name: List all antivirus servers
+      nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+      register: result
+
+    - name: List antivirus servers with filter
+      nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        filter: "port eq 1344"
+      register: result
+
+    - name: List antivirus servers with limit
+      nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        limit: 1
+      register: result
+
+    - name: Delete antivirus server
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: absent
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ antivirus_server_ext_id }}"
+      register: result

--- a/examples/files/AntivirusServer/examples_run.log
+++ b/examples/files/AntivirusServer/examples_run.log
@@ -1,0 +1,23 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Antivirus Server playbook] ***********************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"file_server_ext_id": "18f78959-14a6-4c47-b5db-920460c4b668"}, "changed": false}
+
+TASK [Create antivirus server] *************************************************
+[ERROR]: Task failed: Module failed: Api Exception raised while creating antivirus server
+Origin: /tmp/codegen-artifacts.SQrFnp/antivirus_server_run.yml:29:7
+
+27         file_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+28
+29     - name: Create antivirus server
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while creating antivirus server", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -246,5 +246,7 @@ action_groups:
     - ntnx_iam_entities_info_v2
     - ntnx_virtual_switch_v2
     - ntnx_virtual_switches_info_v2
+    - ntnx_files_antivirus_server_v2
+    - ntnx_files_antivirus_servers_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,7 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        ANTIVIRUS_SERVER = "files:config:antivirus-server"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,104 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details.
+    Args:
+        module (object): Ansible module object
+    return:
+        client (object): api client object
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    client = ntnx_files_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    # Setup API logging if debug is enabled
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    return:
+        etag (str): etag value
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_antivirus_servers_api_instance(module):
+    """
+    This method will return AntivirusServersApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): antivirus servers api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.AntivirusServersApi(api_client=api_client)
+
+
+def get_file_servers_api_instance(module):
+    """
+    This method will return FileServersApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): file servers api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.FileServersApi(api_client=api_client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,31 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_antivirus_server(module, api_instance, ext_id, file_server_ext_id):
+    """
+    This method will return antivirus server info using its ext_id.
+    Args:
+        module (object): Ansible module object
+        api_instance (object): AntivirusServersApi instance from ntnx_files_py_client sdk
+        ext_id (str): antivirus server external ID
+        file_server_ext_id (str): external ID of the file server the antivirus server belongs to
+    return:
+        info (object): antivirus server info
+    """
+    try:
+        return api_instance.get_antivirus_server_by_id(
+            fileServerExtId=file_server_ext_id, extId=ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching antivirus server info using ext_id",
+        )

--- a/plugins/module_utils/v4/utils.py
+++ b/plugins/module_utils/v4/utils.py
@@ -304,5 +304,11 @@ def strip_read_only_fields(spec, fields=None):
 
     for field in fields:
         if hasattr(spec, field):
-            delattr(spec, field)
+            try:
+                delattr(spec, field)
+            except AttributeError:
+                # v4 SDK models expose fields as properties without deleters;
+                # setting them to None removes them from the serialized request
+                # body (None values are omitted during serialization).
+                setattr(spec, field, None)
     return spec

--- a/plugins/modules/ntnx_files_antivirus_server_v2.py
+++ b/plugins/modules/ntnx_files_antivirus_server_v2.py
@@ -1,0 +1,522 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_antivirus_server_v2
+short_description: Create, Update, Delete antivirus servers on a Nutanix Files file server
+version_added: 2.7.0
+description:
+  - This module allows you to create, update, and delete antivirus (ICAP) servers on a Nutanix Files file server in Nutanix Prism Central.
+  - An antivirus server configures the connection to an external ICAP appliance that Nutanix Files uses to scan files for viruses.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - This module requires an existing Nutanix Files file server. The antivirus server is configured under that file server.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will be to create an antivirus server.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be to update the antivirus server.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be to delete the antivirus server.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the antivirus server.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server on which the antivirus server is configured.
+      - Required for all operations.
+    type: str
+    required: true
+  description:
+    description:
+      - Antivirus server description.
+      - Maximum 180 characters.
+    type: str
+    required: false
+  address:
+    description:
+      - The address (IP or fully qualified domain name) of the antivirus server.
+      - Required for create operation only.
+      - This field cannot be modified during an update operation.
+    type: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - The IPv4 address of the antivirus server.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv4 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - The prefix length of the network to which the IPv4 address belongs.
+            type: int
+            required: false
+            default: 32
+      ipv6:
+        description:
+          - The IPv6 address of the antivirus server.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - The prefix length of the network to which the IPv6 address belongs.
+            type: int
+            required: false
+            default: 128
+      fqdn:
+        description:
+          - The fully qualified domain name of the antivirus server.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The fully qualified domain name value.
+            type: str
+            required: true
+  port:
+    description:
+      - The port on which the antivirus (ICAP) server listens.
+      - Required for create operation only.
+      - This field cannot be modified during an update operation.
+      - Value must be between 0 and 65535.
+    type: int
+    required: false
+  partner_service_name:
+    description:
+      - The Internet Content Adaptation Protocol (ICAP) service name of the antivirus server.
+      - Maximum 2048 characters.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create antivirus server with all attributes
+  nutanix.ncp.ntnx_files_antivirus_server_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    file_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    description: "Antivirus server created by Ansible"
+    address:
+      ipv4:
+        value: "10.44.10.100"
+    port: 1344
+    partner_service_name: "avscan"
+  register: result
+
+- name: Update antivirus server
+  nutanix.ncp.ntnx_files_antivirus_server_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    file_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    ext_id: "b1c2d3e4-14a6-4c47-b5db-920460c4b668"
+    description: "Antivirus server updated by Ansible"
+    partner_service_name: "avscan-updated"
+  register: result
+
+- name: Delete antivirus server
+  nutanix.ncp.ntnx_files_antivirus_server_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    file_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    ext_id: "b1c2d3e4-14a6-4c47-b5db-920460c4b668"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting an antivirus server.
+    - If the operation is create or update and C(wait) is true, it will return the antivirus server details.
+    - If the operation is create or update and C(wait) is false, it will return the task details.
+    - If the operation is delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "address": {
+          "fqdn": null,
+          "ipv4": {
+              "prefix_length": 32,
+              "value": "10.44.10.100"
+          },
+          "ipv6": null
+      },
+      "connection_status": "NOT_TESTED",
+      "description": "Antivirus server created by Ansible",
+      "ext_id": "b1c2d3e4-14a6-4c47-b5db-920460c4b668",
+      "links": null,
+      "partner_service_name": "avscan",
+      "port": 1344,
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the antivirus server.
+  returned: always
+  type: str
+  sample: "b1c2d3e4-14a6-4c47-b5db-920460c4b668"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Antivirus server with ext_id:b1c2d3e4-14a6-4c47-b5db-920460c4b668 will be deleted."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_antivirus_servers_api_instance,
+    get_etag,
+)
+from ..module_utils.v4.files.helpers import get_antivirus_server  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client as files_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as files_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+# Read-only fields populated by the server that must be stripped before an update request
+READ_ONLY_FIELDS = ["connection_status", "ext_id", "links", "tenant_id"]
+
+
+def get_module_spec():
+
+    ipv4_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=32),
+    )
+
+    ipv6_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=128),
+    )
+
+    fqdn_spec = dict(
+        value=dict(type="str", required=True),
+    )
+
+    address_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_spec,
+            required=False,
+            obj=files_sdk.IPv4Address,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_spec,
+            required=False,
+            obj=files_sdk.IPv6Address,
+        ),
+        fqdn=dict(
+            type="dict",
+            options=fqdn_spec,
+            required=False,
+            obj=files_sdk.FQDN,
+        ),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        file_server_ext_id=dict(type="str", required=True),
+        description=dict(type="str"),
+        address=dict(
+            type="dict",
+            options=address_spec,
+            mutually_exclusive=[("ipv4", "ipv6", "fqdn")],
+            obj=files_sdk.IPAddressOrFQDN,
+        ),
+        port=dict(type="int"),
+        partner_service_name=dict(type="str"),
+    )
+    return module_args
+
+
+def create_antivirus_server(module, result, api_instance):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    validate_required_params(module, ["address", "port"])
+    sg = SpecGenerator(module)
+    default_spec = files_sdk.AntivirusServer()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create antivirus server spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_antivirus_server(
+            fileServerExtId=file_server_ext_id, body=spec
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating antivirus server",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task_status, rel=TASK_CONSTANTS.RelEntityType.ANTIVIRUS_SERVER
+        )
+        if not ext_id:
+            ext_id = get_entity_ext_id_from_task(task_status)
+        if ext_id:
+            result["ext_id"] = ext_id
+            resp = get_antivirus_server(
+                module, api_instance, ext_id, file_server_ext_id
+            )
+            result["response"] = strip_internal_attributes(resp.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for Antivirus Server"
+                ),
+                msg="Failed to get entity ext_id from task for Antivirus Server",
+            )
+    result["changed"] = True
+
+
+def check_antivirus_server_idempotency(old_spec_dict, update_spec_dict):
+    old_spec_dict = strip_internal_attributes(old_spec_dict)
+    update_spec_dict = strip_internal_attributes(update_spec_dict)
+    for field in READ_ONLY_FIELDS:
+        old_spec_dict.pop(field, None)
+        update_spec_dict.pop(field, None)
+    return old_spec_dict == update_spec_dict
+
+
+def update_antivirus_server(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    result["ext_id"] = ext_id
+
+    old_spec = get_antivirus_server(module, api_instance, ext_id, file_server_ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            "Unable to fetch etag for updating antivirus server", **result
+        )
+    kwargs = {"if_match": etag}
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update antivirus server spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_antivirus_server_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.")
+
+    strip_read_only_fields(update_spec, fields=READ_ONLY_FIELDS)
+
+    resp = None
+    try:
+        resp = api_instance.update_antivirus_server_by_id(
+            fileServerExtId=file_server_ext_id, extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating antivirus server",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_antivirus_server(module, api_instance, ext_id, file_server_ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def delete_antivirus_server(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "Antivirus server with ext_id:{0} will be deleted.".format(
+            ext_id
+        )
+        return
+
+    old_spec = get_antivirus_server(module, api_instance, ext_id, file_server_ext_id)
+    etag = get_etag(data=old_spec)
+    kwargs = {"if_match": etag} if etag else {}
+
+    resp = None
+    try:
+        resp = api_instance.delete_antivirus_server_by_id(
+            fileServerExtId=file_server_ext_id, extId=ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting antivirus server",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_antivirus_servers_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_antivirus_server(module, result, api_instance)
+        else:
+            create_antivirus_server(module, result, api_instance)
+    else:
+        delete_antivirus_server(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_files_antivirus_servers_info_v2.py
+++ b/plugins/modules/ntnx_files_antivirus_servers_info_v2.py
@@ -1,0 +1,237 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_antivirus_servers_info_v2
+short_description: Fetch antivirus servers info of a Nutanix Files file server
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about AntivirusServer in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific AntivirusServer.
+  - If C(ext_id) is not provided, list multiple AntivirusServer optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - This module requires an existing Nutanix Files file server. The antivirus servers are configured under that file server.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  ext_id:
+    description:
+      - The external ID of the antivirus server.
+      - If provided, the specific antivirus server details are fetched.
+    type: str
+    required: false
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server on which the antivirus servers are configured.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch antivirus server using ext_id
+  nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    ext_id: "b1c2d3e4-14a6-4c47-b5db-920460c4b668"
+  register: result
+
+- name: List all antivirus servers of a file server
+  nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+  register: result
+
+- name: List antivirus servers with filter
+  nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    filter: "port eq 1344"
+  register: result
+
+- name: List antivirus servers with limit
+  nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    limit: 1
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC AntivirusServer info v4 API.
+    - It can be a single AntivirusServer if external ID is provided.
+    - List of multiple AntivirusServer if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "address": {
+          "fqdn": null,
+          "ipv4": {
+              "prefix_length": 32,
+              "value": "10.44.10.100"
+          },
+          "ipv6": null
+      },
+      "connection_status": "NOT_TESTED",
+      "description": "Antivirus server created by Ansible",
+      "ext_id": "b1c2d3e4-14a6-4c47-b5db-920460c4b668",
+      "links": null,
+      "partner_service_name": "avscan",
+      "port": 1344,
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching antivirus servers info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the antivirus server
+  type: str
+  returned: when external ID is provided
+  sample: "b1c2d3e4-14a6-4c47-b5db-920460c4b668"
+
+total_available_results:
+  description: The total number of available antivirus servers on the file server.
+  type: int
+  returned: when all antivirus servers are fetched
+  sample: 2
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_antivirus_servers_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_antivirus_server  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        file_server_ext_id=dict(type="str", required=True),
+    )
+
+    return module_args
+
+
+def get_antivirus_server_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    resp = get_antivirus_server(module, api_instance, ext_id, file_server_ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_antivirus_servers(module, api_instance, result):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating antivirus servers info spec", **result)
+
+    try:
+        resp = api_instance.list_antivirus_servers(
+            fileServerExtId=file_server_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching antivirus servers info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_antivirus_servers_api_instance(module)
+    if module.params.get("ext_id"):
+        get_antivirus_server_using_ext_id(module, api_instance, result)
+    else:
+        get_antivirus_servers(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_files_antivirus_server_v2/aliases
+++ b/tests/integration/targets/ntnx_files_antivirus_server_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_files_antivirus_server_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_files_antivirus_server_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_files_antivirus_server_v2/tasks/antivirus_servers.yml
+++ b/tests/integration/targets/ntnx_files_antivirus_server_v2/tasks/antivirus_servers.yml
@@ -1,0 +1,553 @@
+---
+# Test plan for Nutanix Files AntivirusServer (ntnx_files_antivirus_server_v2 /
+# ntnx_files_antivirus_servers_info_v2)
+#
+# An antivirus server configures the connection between a Nutanix Files file
+# server and an external ICAP scan appliance. It requires an existing file
+# server (fileServerExtId). The tests are organised in two groups:
+#
+# 1. Service-independent tests (always executed):
+#    - check_mode Create with ALL attributes (spec generation, no API call)
+#    - check_mode Delete (no API call before the check_mode short-circuit)
+#    - Negative / argument-validation tests:
+#         * missing file_server_ext_id (module required arg)
+#         * missing address AND port (validate_required_params in create)
+#         * address ipv4/ipv6/fqdn mutual exclusivity
+#         * state=absent with missing ext_id (required_if)
+#
+# 2. Live CRUD lifecycle tests (executed only when a file server is present on
+#    the cluster - gated on `file_server_ext_id`). These cover the real
+#    end-to-end workflow that a customer performs:
+#         * Create minimal (required fields only: address + port)
+#         * Create full (all fields, ipv4 address)
+#         * Create using an FQDN address
+#         * Create using an IPv6 address (expected to be rejected by the API)
+#         * Get by ext_id / List all / List with filter / List with limit
+#         * check_mode Update
+#         * Update (change scalar fields: description, partner_service_name)
+#         * Idempotent Update (second run reports "Nothing to change.")
+#         * Get / Update with a wrong ext_id (expected failure)
+#         * Delete (check_mode + real) and Delete with wrong ext_id
+#
+# Every field of get_module_spec() (description, address.ipv4/ipv6/fqdn, port,
+# partner_service_name, file_server_ext_id, ext_id) is exercised across the
+# check_mode and live tests.
+
+- name: Start Antivirus Server tests
+  ansible.builtin.debug:
+    msg: Start Antivirus Server tests
+
+- name: Generate random suffix and expected values
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    todelete: []
+
+- name: Set expected description strings
+  ansible.builtin.set_fact:
+    cm_description: "check_mode antivirus server {{ random_name }}"
+    full_description: "Antivirus server created by Ansible integration tests {{ random_name }}"
+    updated_description: "Antivirus server updated by Ansible integration tests {{ random_name }}"
+    dummy_file_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    dummy_ext_id: "b1c2d3e4-14a6-4c47-b5db-920460c4b668"
+    wrong_ext_id: "00000000-0000-0000-0000-000000000000"
+
+########################################################################################
+# Discover an existing file server (prerequisite for the live CRUD tests)
+########################################################################################
+
+- name: Try to discover an existing file server on the cluster
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default(9440) }}/api/files/v4.0/config/file-servers?$limit=1"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs | default(false) }}"
+    timeout: 30
+    status_code: [200, 400, 404, 500, 503]
+  register: fs_list
+  ignore_errors: true
+
+- name: Set file_server_ext_id when a file server is available
+  ansible.builtin.set_fact:
+    file_server_ext_id: "{{ fs_list.json.data[0].extId }}"
+  when:
+    - fs_list is defined
+    - fs_list.json is defined
+    - fs_list.json.data is defined
+    - fs_list.json.data | length > 0
+
+- name: Report file server discovery result
+  ansible.builtin.debug:
+    msg: >-
+      {{ 'Using file server ' ~ file_server_ext_id ~ ' for live CRUD tests.'
+         if file_server_ext_id is defined
+         else 'No file server available - live CRUD tests will be skipped. Only check_mode and negative tests run.' }}
+
+########################################################################################
+# Service-independent tests (always executed)
+########################################################################################
+
+- name: Generate spec for creating antivirus server using check mode with all attributes
+  nutanix.ncp.ntnx_files_antivirus_server_v2:
+    state: present
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+    description: "{{ cm_description }}"
+    address:
+      ipv4:
+        value: "10.44.10.100"
+        prefix_length: 32
+    port: 1344
+    partner_service_name: "avscan"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for creating antivirus server using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.description == cm_description
+      - 'result.response.address.ipv4.value == "10.44.10.100"'
+      - result.response.address.ipv4.prefix_length == 32
+      - result.response.port == 1344
+      - 'result.response.partner_service_name == "avscan"'
+    success_msg: "Spec for creating antivirus server using check mode with all attributes generated successfully"
+    fail_msg: "Spec for creating antivirus server using check mode with all attributes generation failed"
+
+- name: Create antivirus server with missing file_server_ext_id
+  nutanix.ncp.ntnx_files_antivirus_server_v2:
+    state: present
+    description: "missing file server"
+    address:
+      ipv4:
+        value: "10.44.10.101"
+    port: 1344
+  register: result
+  ignore_errors: true
+
+- name: Create antivirus server with missing file_server_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: file_server_ext_id' in result.msg"
+    success_msg: "Create antivirus server with missing file_server_ext_id failed as expected"
+    fail_msg: "Create antivirus server with missing file_server_ext_id did not fail as expected"
+
+- name: Create antivirus server with missing address and port
+  nutanix.ncp.ntnx_files_antivirus_server_v2:
+    state: present
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+    description: "missing address and port"
+  register: result
+  ignore_errors: true
+
+- name: Create antivirus server with missing address and port status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - '"Missing required parameter(s): address, port" in result.msg'
+    success_msg: "Create antivirus server with missing address and port failed as expected"
+    fail_msg: "Create antivirus server with missing address and port did not fail as expected"
+
+- name: Create antivirus server with both ipv4 and fqdn (mutually exclusive)
+  nutanix.ncp.ntnx_files_antivirus_server_v2:
+    state: present
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+    address:
+      ipv4:
+        value: "10.44.10.100"
+      fqdn:
+        value: "icap.example.com"
+    port: 1344
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Create antivirus server with both ipv4 and fqdn status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - '"parameters are mutually exclusive: ipv4|ipv6|fqdn found in address" in result.msg'
+    success_msg: "Create antivirus server with mutually exclusive address failed as expected"
+    fail_msg: "Create antivirus server with mutually exclusive address did not fail as expected"
+
+- name: Delete antivirus server with missing ext_id
+  nutanix.ncp.ntnx_files_antivirus_server_v2:
+    state: absent
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Delete antivirus server with missing ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete antivirus server with missing ext_id failed as expected"
+    fail_msg: "Delete antivirus server with missing ext_id did not fail as expected"
+
+- name: Delete antivirus server using check mode
+  nutanix.ncp.ntnx_files_antivirus_server_v2:
+    state: absent
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+    ext_id: "{{ dummy_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Delete antivirus server using check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+    success_msg: "Delete antivirus server using check mode passed"
+    fail_msg: "Delete antivirus server using check mode failed"
+
+########################################################################################
+# Live CRUD lifecycle tests (only when a file server is available)
+########################################################################################
+
+- name: Antivirus server live CRUD tests
+  when: file_server_ext_id is defined
+  block:
+    - name: Create antivirus server with minimum attributes (required only)
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        address:
+          ipv4:
+            value: "10.44.10.110"
+        port: 1344
+      register: result
+      ignore_errors: true
+
+    - name: Create antivirus server with minimum attributes status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.ext_id is defined
+          - result.task_ext_id is defined
+          - result.response is defined
+          - 'result.response.address.ipv4.value == "10.44.10.110"'
+          - result.response.port == 1344
+        success_msg: "Antivirus server with minimum attributes created successfully"
+        fail_msg: "Antivirus server with minimum attributes creation failed"
+
+    - name: Add antivirus server to todelete list
+      ansible.builtin.set_fact:
+        todelete: "{{ todelete + [result.ext_id] }}"
+
+    - name: Create antivirus server with all attributes
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        description: "{{ full_description }}"
+        address:
+          ipv4:
+            value: "10.44.10.111"
+        port: 1345
+        partner_service_name: "avscan"
+      register: result
+      ignore_errors: true
+
+    - name: Create antivirus server with all attributes status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.ext_id is defined
+          - result.task_ext_id is defined
+          - result.response is defined
+          - result.response.description == full_description
+          - 'result.response.address.ipv4.value == "10.44.10.111"'
+          - result.response.port == 1345
+          - 'result.response.partner_service_name == "avscan"'
+        success_msg: "Antivirus server with all attributes created successfully"
+        fail_msg: "Antivirus server with all attributes creation failed"
+
+    - name: Set full antivirus server ext_id
+      ansible.builtin.set_fact:
+        av_ext_id: "{{ result.ext_id }}"
+        todelete: "{{ todelete + [result.ext_id] }}"
+
+    - name: Create antivirus server using an FQDN address
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        description: "Antivirus server with fqdn address"
+        address:
+          fqdn:
+            value: "icap.example.com"
+        port: 1346
+      register: result
+      ignore_errors: true
+
+    - name: Create antivirus server using an FQDN address status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - 'result.response.address.fqdn.value == "icap.example.com"'
+          - result.response.port == 1346
+        success_msg: "Antivirus server using FQDN address created successfully"
+        fail_msg: "Antivirus server using FQDN address creation failed"
+
+    - name: Add fqdn antivirus server to todelete list
+      ansible.builtin.set_fact:
+        todelete: "{{ todelete + [result.ext_id] }}"
+
+    - name: Create antivirus server using an IPv6 address (expected to be rejected)
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        description: "Antivirus server with ipv6 address"
+        address:
+          ipv6:
+            value: "2001:db8::1"
+        port: 1347
+      register: result
+      ignore_errors: true
+
+    - name: Create antivirus server using an IPv6 address status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == true
+        success_msg: "Antivirus server using IPv6 address failed as expected (IPv6 not supported)"
+        fail_msg: "Antivirus server using IPv6 address did not fail as expected"
+
+    - name: Fetch antivirus server using external ID
+      nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ av_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Fetch antivirus server using external ID status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.ext_id == av_ext_id
+          - result.response is defined
+          - result.response.ext_id == av_ext_id
+          - 'result.response.address.ipv4.value == "10.44.10.111"'
+          - result.response.port == 1345
+          - 'result.response.partner_service_name == "avscan"'
+        success_msg: "Fetch antivirus server using external ID passed"
+        fail_msg: "Fetch antivirus server using external ID failed"
+
+    - name: List all antivirus servers
+      nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: List all antivirus servers status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response is defined
+          - result.response | length >= 3
+          - result.total_available_results is defined
+        success_msg: "List all antivirus servers passed"
+        fail_msg: "List all antivirus servers failed"
+
+    - name: List antivirus servers with filter
+      nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        filter: "port eq 1345"
+      register: result
+      ignore_errors: true
+
+    - name: List antivirus servers with filter status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response is defined
+          - result.response | length == 1
+          - result.response[0].port == 1345
+        success_msg: "List antivirus servers with filter passed"
+        fail_msg: "List antivirus servers with filter failed"
+
+    - name: List antivirus servers with limit
+      nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        limit: 1
+      register: result
+      ignore_errors: true
+
+    - name: List antivirus servers with limit status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response is defined
+          - result.response | length == 1
+        success_msg: "List antivirus servers with limit passed"
+        fail_msg: "List antivirus servers with limit failed"
+
+    - name: Generate spec for updating antivirus server using check mode
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ av_ext_id }}"
+        description: "Updated description check mode"
+        partner_service_name: "avscan-check"
+      check_mode: true
+      register: result
+      ignore_errors: true
+
+    - name: Generate spec for updating antivirus server using check mode status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.failed == false
+          - result.response is defined
+          - 'result.response.description == "Updated description check mode"'
+          - 'result.response.partner_service_name == "avscan-check"'
+        success_msg: "Spec for updating antivirus server using check mode generated successfully"
+        fail_msg: "Spec for updating antivirus server using check mode generation failed"
+
+    - name: Update antivirus server with all attributes
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ av_ext_id }}"
+        description: "{{ updated_description }}"
+        partner_service_name: "avscan-updated"
+      register: result
+      ignore_errors: true
+
+    - name: Update antivirus server with all attributes status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.response is defined
+          - result.response.description == updated_description
+          - 'result.response.partner_service_name == "avscan-updated"'
+          - 'result.response.address.ipv4.value == "10.44.10.111"'
+          - result.response.port == 1345
+        success_msg: "Update antivirus server with all attributes passed"
+        fail_msg: "Update antivirus server with all attributes failed"
+
+    - name: Update antivirus server with same values (idempotency test)
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ av_ext_id }}"
+        description: "{{ updated_description }}"
+        partner_service_name: "avscan-updated"
+      register: result
+      ignore_errors: true
+
+    - name: Update antivirus server with same values status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - 'result.msg == "Nothing to change."'
+        success_msg: "Update antivirus server idempotency test passed"
+        fail_msg: "Update antivirus server idempotency test failed"
+
+    - name: Fetch antivirus server using wrong external ID
+      nutanix.ncp.ntnx_files_antivirus_servers_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ wrong_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Fetch antivirus server using wrong external ID status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == true
+        success_msg: "Fetch antivirus server using wrong external ID failed as expected"
+        fail_msg: "Fetch antivirus server using wrong external ID did not fail as expected"
+
+    - name: Update antivirus server using wrong external ID
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ wrong_ext_id }}"
+        description: "wrong ext id"
+      register: result
+      ignore_errors: true
+
+    - name: Update antivirus server using wrong external ID status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == true
+        success_msg: "Update antivirus server using wrong external ID failed as expected"
+        fail_msg: "Update antivirus server using wrong external ID did not fail as expected"
+
+    - name: Delete all created antivirus servers
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: absent
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ item }}"
+      register: result
+      ignore_errors: true
+      loop: "{{ todelete }}"
+
+    - name: Deletion status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.results | length == todelete | length
+          - 'result.msg == "All items completed"'
+        success_msg: "All antivirus servers deleted successfully"
+        fail_msg: "Unable to delete all antivirus servers"
+
+    - name: Reset todelete list
+      ansible.builtin.set_fact:
+        todelete: []
+
+    - name: Delete antivirus server using wrong external ID
+      nutanix.ncp.ntnx_files_antivirus_server_v2:
+        state: absent
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ wrong_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Delete antivirus server using wrong external ID status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == true
+        success_msg: "Delete antivirus server using wrong external ID failed as expected"
+        fail_msg: "Delete antivirus server using wrong external ID did not fail as expected"

--- a/tests/integration/targets/ntnx_files_antivirus_server_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_files_antivirus_server_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import antivirus_servers.yml
+      ansible.builtin.import_tasks: antivirus_servers.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **files** namespace, entity
**AntivirusServer**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_files_antivirus_server_v2` (CRUD), `ntnx_files_antivirus_servers_info_v2` (info)
- API methods covered: create, get-by-id, list, update, delete (`AntivirusServersApi`)
- Fields in CRUD module spec: 6 top-level (`ext_id`, `file_server_ext_id`, `description`, `address`, `port`, `partner_service_name`); `address` is a mutually-exclusive `ipv4` / `ipv6` / `fqdn` sub-spec.
- Fields in info module spec: 2 (`ext_id`, `file_server_ext_id`) plus the inherited info filters (`filter`, `limit`, `page`, `order_by`, `select`).

## Domain knowledge (from Glean)

> Note: per repo policy, no internal links, Jira keys, or Confluence URLs are reproduced here — only the distilled functional context needed to review the modules.

- **What it is:** An *Antivirus Server* configures the connection between a Nutanix
  Files **file server** and an external **ICAP** scan appliance (a "partner"
  antivirus/malware scanning service). Files streams file data to the ICAP endpoint
  for scanning; the antivirus server object holds the endpoint address, port and
  partner service identity used for that integration.
- **Parenting / prerequisite:** An antivirus server always belongs to an existing
  **file server**, so `file_server_ext_id` is required on every operation (create,
  get, list, update, delete). A running Nutanix Files (minerva) service and at least
  one deployed file server are hard prerequisites — they cannot be provisioned from
  this collection.
- **Address model:** The endpoint address is an `IPAddressOrFQDN` — exactly one of
  `ipv4`, `ipv6`, or `fqdn` (mutually exclusive). In practice ICAP appliances are
  reached over IPv4 or FQDN.
- **Read-only / server-populated fields:** `connection_status`
  (enum, e.g. `OK` / `NOT_TESTED` / `NOT_REACHABLE`), `ext_id`, `links`, and
  `tenant_id` are populated by the server and must be stripped from update request
  bodies.
- **Async model:** Create / update / delete are **task-based** — the API returns a
  task reference which the module polls to completion (and from which the created
  entity `ext_id` is extracted), and mutations require an ETag captured from a prior
  GET.

## Files changed

**plugins/modules/** (new)
- `ntnx_files_antivirus_server_v2.py` — CRUD module (522 lines): create / update / delete with check_mode, idempotency, task polling, ETag handling, and full DOCUMENTATION/EXAMPLES/RETURN.
- `ntnx_files_antivirus_servers_info_v2.py` — info module (237 lines): get-by-id and list (filter / limit / page / order_by / select).

**plugins/module_utils/v4/files/** (new)
- `api_client.py` — `ntnx_files_py_client` API client + ETag helper + `AntivirusServersApi` / `FileServersApi` instance factories.
- `helpers.py` — `get_antivirus_server()` lookup helper.

**plugins/module_utils/v4/** (modified)
- `constants.py` — added `Tasks.RelEntityType.ANTIVIRUS_SERVER = "files:config:antivirus-server"`.
- `utils.py` — made `strip_read_only_fields()` robust for v4 SDK property-backed models (falls back to `setattr(None)` when a property has no deleter, so read-only fields are omitted from the serialized body).

**meta/runtime.yml** (modified)
- Registered both new modules in the `action_groups.ntnx` list.

**examples/files/AntivirusServer/** (new)
- `antivirus_server.yml` — create (all fields) / update (all fields) / get / list / list+filter / list+limit / delete.
- `examples_run.log` — real playbook output captured against the live PC (credentials sanitized).

**tests/integration/targets/ntnx_files_antivirus_server_v2/** (new)
- `tasks/antivirus_servers.yml` (553 lines) — full test plan (see below), `meta/main.yml`, `tasks/main.yml`, `aliases` (`disabled`, matching other live-cluster targets in this repo).

**.gitignore** (modified)
- Ignore `tests/integration/integration_config.yml` (contains credentials, must never be committed).

## Test execution

| Metric        | Value                                                                         |
|---------------|-------------------------------------------------------------------------------|
| Command       | `ansible-test integration ntnx_files_antivirus_server_v2 --allow-disabled --python 3.11 -v` |
| Total tasks   | 57 (`ok=18`, `skipped=35`, `ignored=4`, `failed=0`)                           |
| Passed        | All executed assertions passed (0 failures)                                   |
| Failed        | 0                                                                             |
| Skipped       | 35 (live CRUD block — gated behind file-server availability, see below)       |
| Duration      | ~0:00:07                                                                      |
| Cluster (PC)  | `10.44.76.28` (PC 7.6)                                                         |

Lint gate (all green before opening PR):

| Check                | Result                                            |
|----------------------|---------------------------------------------------|
| `black --check`      | pass (6 files unchanged)                          |
| `isort --check`      | pass                                              |
| `flake8`             | pass (0 issues)                                   |
| `ansible-lint`       | pass — Rating 5/5, 0 failures (warnings are the standard `nutanix_host`-from-`module_defaults` pattern shared by every target in this repo) |
| `ansible-test sanity`| pass (24 sanity tests, exit 0, Python 3.11)       |

### Analysis

The target cluster (`10.44.76.28`, PC 7.6) does **not** have the Nutanix Files
(minerva) service running, so the `/api/files/v4.0/...` endpoints return
**HTTP 503 SERVICE UNAVAILABLE** (`endpoint 0:127.0.0.1:7509 ... Response status: 2`).
Antivirus servers require an existing **file server**, which in turn requires the
Files service — a cluster prerequisite that cannot be provisioned from this
collection. This was confirmed by a live probe of both the info and CRUD modules.

To keep the suite meaningful under this constraint, the test target is split:

- **Service-independent tests (executed, all passed):**
  - check_mode Create with **all** attributes — asserts the generated spec
    (`description`, `address.ipv4.value` + `prefix_length`, `port`,
    `partner_service_name`).
  - check_mode Delete — asserts the `"... will be deleted."` message with no API call.
  - Negative / arg-validation: missing `file_server_ext_id`; missing `address` **and**
    `port` (`"Missing required parameter(s): address, port"`); `address` `ipv4`/`fqdn`
    mutual-exclusivity (`"parameters are mutually exclusive: ipv4|ipv6|fqdn ..."`);
    `state=absent` with missing `ext_id` (`required_if`).

- **Live CRUD lifecycle tests (present but skipped here):** minimal create, full
  create, FQDN-address create, IPv6-address create (expected reject), get-by-id,
  list-all, list+filter, list+limit, check_mode update, real update, idempotent
  update (`"Nothing to change."`), get/update/delete with wrong `ext_id`, and
  loop-delete with per-item assertions. These are gated on
  `when: file_server_ext_id is defined`; the target auto-discovers a file server via
  the Files v4 API and only runs them when one exists. On a cluster with Files
  enabled they execute end-to-end.

**Known issues / not run (environment prerequisite):** the live CRUD block (35
skipped tasks) and the example playbook's mutating tasks could not be executed
because the Files service is not running on the supplied PC. The example run log
therefore shows the real HTTP 503 the modules surface (proving client
instantiation → API call → error handling all work). RETURN `sample:` blocks reflect
the SDK schema and the check_mode-generated response shape rather than a live create
response.

### Test logs (tail)

<details>
<summary>ansible-test integration — PLAY RECAP + representative assertions</summary>

```text
TASK [ntnx_files_antivirus_server_v2 : Generate spec for creating antivirus server using check mode with all attributes status] ***
ok: [testhost] => msg: "Spec ... generated successfully"
TASK [ntnx_files_antivirus_server_v2 : Create antivirus server with missing file_server_ext_id status] ***
ok: [testhost] => msg: "... failed as expected"
TASK [ntnx_files_antivirus_server_v2 : Create antivirus server with missing address and port status] ***
ok: [testhost] => msg: "... failed as expected"   # "Missing required parameter(s): address, port"
TASK [ntnx_files_antivirus_server_v2 : Create antivirus server with both ipv4 and fqdn status] ***
ok: [testhost] => msg: "... mutually exclusive address failed as expected"
TASK [ntnx_files_antivirus_server_v2 : Delete antivirus server with missing ext_id status] ***
ok: [testhost] => msg: "... failed as expected"
TASK [ntnx_files_antivirus_server_v2 : Delete antivirus server using check mode status] ***
ok: [testhost] => msg: "Delete antivirus server using check mode passed"

... (live CRUD block skipped: file_server_ext_id is not defined — Files service unavailable) ...

PLAY RECAP *********************************************************************
testhost                   : ok=18   changed=0    unreachable=0    failed=0    skipped=35   rescued=0    ignored=4
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Modules follow the existing `ntnx_virtual_switch_v2` / `..._info_v2` patterns
  (argument spec, `SpecGenerator`, task polling, check_mode, idempotency).
