### PR TITLE
code-gen(networking/UnreserveIpsBySubnetId): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/networking/UnreserveIpsBySubnetId/unreserve_ips_by_subnet_id.yml
+++ b/examples/networking/UnreserveIpsBySubnetId/unreserve_ips_by_subnet_id.yml
@@ -1,0 +1,103 @@
+---
+# Summary:
+# This playbook exercises the Nutanix Prism Central "Unreserve IPs on a subnet"
+# v4 action. It:
+#   1. Lists the IPs that are currently reserved on the target subnet
+#      via the info module (ntnx_unreserve_ips_by_subnet_ids_info_v2).
+#   2. Unreserves a specific list of IPs via unreserve_type=IP_ADDRESS_LIST.
+#   3. Unreserves a range of IPs via unreserve_type=IP_ADDRESS_RANGE.
+#   4. Unreserves every IP tagged with a client_context via unreserve_type=CONTEXT.
+#   5. Re-lists to confirm the subnet is clean.
+#
+# NOTE: This playbook assumes IPs have already been reserved on the target
+# subnet (for example via the Prism Central UI or via a direct
+# /subnets/{extId}/addresses/$actions/reserve v4 REST call). The unreserve
+# action is a one-shot POST that always reports changed=True on success.
+#
+# Every task uses the module_defaults block for connection parameters — do NOT
+# repeat nutanix_host/username/password/validate_certs on individual tasks.
+
+- name: Unreserve IPs by Subnet ID playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username }}"
+      nutanix_password: "{{ password }}"
+      validate_certs: false
+  tasks:
+    - name: Setting variables
+      ansible.builtin.set_fact:
+        subnet_ext_id: "61959708-6efc-4d80-8c86-92c01f080672"
+
+    - name: List reserved IPs before unreserving (all attributes)
+      nutanix.ncp.ntnx_unreserve_ips_by_subnet_ids_info_v2:
+        subnet_ext_id: "{{ subnet_ext_id }}"
+        limit: 100
+        filter: "clientContext ne null"
+        orderby: "ipv4Address asc"
+      register: reserved_before
+      ignore_errors: true
+
+    ###################################################################
+    # Unreserve a specific list of IPs (IP_ADDRESS_LIST)
+    # If the IPs were originally reserved with a client_context tag, the
+    # same tag must be supplied here — the underlying legacy reservation
+    # engine matches the cookie to authorise the release.
+    ###################################################################
+    - name: Unreserve a specific list of IPs from the subnet
+      nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+        state: present
+        ext_id: "{{ subnet_ext_id }}"
+        unreserve_type: IP_ADDRESS_LIST
+        ip_addresses:
+          - ipv4:
+              value: "10.30.30.70"
+              prefix_length: 32
+          - ipv4:
+              value: "10.30.30.71"
+              prefix_length: 32
+        client_context: "example-list-setup"
+      register: unreserve_list_result
+      ignore_errors: true
+
+    ###################################################################
+    # Unreserve a range of IPs (IP_ADDRESS_RANGE)
+    # As with IP_ADDRESS_LIST, pass the matching client_context if the
+    # original reservation was tagged.
+    ###################################################################
+    - name: Unreserve a range of IPs from the subnet
+      nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+        state: present
+        ext_id: "{{ subnet_ext_id }}"
+        unreserve_type: IP_ADDRESS_RANGE
+        start_ip_address:
+          ipv4:
+            value: "10.30.30.60"
+            prefix_length: 32
+        count: 3
+        client_context: "example-range-setup"
+      register: unreserve_range_result
+      ignore_errors: true
+
+    ###################################################################
+    # Unreserve every IP owned by a client_context (CONTEXT)
+    ###################################################################
+    - name: Unreserve every IP owned by a client_context
+      nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+        state: present
+        ext_id: "{{ subnet_ext_id }}"
+        unreserve_type: CONTEXT
+        client_context: "ansible-unreserve-example-context"
+      register: unreserve_context_result
+      ignore_errors: true
+
+    ###################################################################
+    # Re-list to confirm the subnet is clean.
+    ###################################################################
+    - name: List reserved IPs after unreserve actions
+      nutanix.ncp.ntnx_unreserve_ips_by_subnet_ids_info_v2:
+        subnet_ext_id: "{{ subnet_ext_id }}"
+      register: reserved_after
+      ignore_errors: true

--- a/plugins/module_utils/v4/network/api_client.py
+++ b/plugins/module_utils/v4/network/api_client.py
@@ -195,3 +195,16 @@ def get_bridges_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_networking_py_client.BridgesApi(api_client=api_client)
+
+
+def get_subnet_ip_reservation_api_instance(module):
+    """
+    This method will return SubnetIPReservationApi instance for reserving and
+    unreserving IP addresses on managed subnets.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Subnet IP Reservation Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_networking_py_client.SubnetIPReservationApi(api_client=api_client)

--- a/plugins/modules/ntnx_unreserve_ips_by_subnet_id_v2.py
+++ b/plugins/modules/ntnx_unreserve_ips_by_subnet_id_v2.py
@@ -1,0 +1,499 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_unreserve_ips_by_subnet_id_v2
+short_description: Unreserve IP addresses on a managed subnet in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to unreserve IP addresses on a managed subnet in Nutanix Prism Central.
+  - The unreserve action supports three modes selected via C(unreserve_type).
+  - C(IP_ADDRESS_LIST) releases a specific list of previously reserved IPs.
+  - C(IP_ADDRESS_RANGE) releases C(count) consecutive IPs starting from C(start_ip_address).
+  - C(CONTEXT) releases every reservation that was originally created with the supplied C(client_context) tag.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    The required roles depend on the operation being performed.
+  - >-
+    B(Unreserve IP addresses on a subnet) -
+    Required Roles: Account Owner, Administrator, Prism Admin, Project Admin, Super Admin, VPC Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) the module performs the unreserve action against the given subnet.
+      - C(absent) is not supported for this action module and will fail with a descriptive error.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - External ID (UUID) of the subnet on which the IP addresses are unreserved.
+      - Required for the unreserve action.
+    type: str
+    required: true
+  unreserve_type:
+    description:
+      - Selects the unreserve mode.
+      - C(IP_ADDRESS_LIST) requires C(ip_addresses).
+      - C(IP_ADDRESS_RANGE) requires C(start_ip_address) and C(count).
+      - C(CONTEXT) requires C(client_context).
+    type: str
+    required: true
+    choices:
+      - IP_ADDRESS_LIST
+      - IP_ADDRESS_RANGE
+      - CONTEXT
+  count:
+    description:
+      - Number of IP addresses to unreserve.
+      - Required when C(unreserve_type) is C(IP_ADDRESS_RANGE).
+      - Ignored for other unreserve types.
+    type: int
+    required: false
+  start_ip_address:
+    description:
+      - Starting IP address of the range to unreserve.
+      - Required when C(unreserve_type) is C(IP_ADDRESS_RANGE).
+    type: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 address specification.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv4 address value in dotted decimal notation.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the network.
+            type: int
+            required: false
+            default: 32
+      ipv6:
+        description:
+          - IPv6 address specification.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the network.
+            type: int
+            required: false
+            default: 128
+  ip_addresses:
+    description:
+      - Explicit list of IP addresses to unreserve.
+      - Required when C(unreserve_type) is C(IP_ADDRESS_LIST).
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      ipv4:
+        description:
+          - IPv4 address specification.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv4 address value in dotted decimal notation.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the network.
+            type: int
+            required: false
+            default: 32
+      ipv6:
+        description:
+          - IPv6 address specification.
+        type: dict
+        required: false
+        suboptions:
+          value:
+            description:
+              - The IPv6 address value.
+            type: str
+            required: true
+          prefix_length:
+            description:
+              - Prefix length of the network.
+            type: int
+            required: false
+            default: 128
+  client_context:
+    description:
+      - The client context tag originally used to reserve the IPs.
+      - Required when C(unreserve_type) is C(CONTEXT).
+      - Every reservation that was created with this tag on the given subnet is released.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Unreserve a specific list of IPs from a subnet
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "61959708-6efc-4d80-8c86-92c01f080672"
+    unreserve_type: IP_ADDRESS_LIST
+    ip_addresses:
+      - ipv4:
+          value: "10.30.30.81"
+      - ipv4:
+          value: "10.30.30.82"
+  register: result
+
+- name: Unreserve a range of IPs from a subnet
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "61959708-6efc-4d80-8c86-92c01f080672"
+    unreserve_type: IP_ADDRESS_RANGE
+    start_ip_address:
+      ipv4:
+        value: "10.30.30.80"
+    count: 3
+  register: result
+
+- name: Unreserve every IP tagged with a client context
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "61959708-6efc-4d80-8c86-92c01f080672"
+    unreserve_type: CONTEXT
+    client_context: "ansible-context-tag"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for the unreserve action.
+    - When C(wait) is true, this is the completed task object as returned by the tasks API.
+    - When C(wait) is false, this is the task reference returned immediately by the unreserve call.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_ids": null,
+      "completed_time": "2026-07-21T06:35:24.224345+00:00",
+      "completion_details": [
+        {
+          "name": "reserved_or_unreserved_ips",
+          "value": "{\"unreserved_ips\": [\"10.30.30.75\", \"10.30.30.76\"]}"
+        }
+      ],
+      "created_time": "2026-07-21T06:35:24.115619+00:00",
+      "entities_affected": [
+        {
+          "ext_id": "61959708-6efc-4d80-8c86-92c01f080672",
+          "name": null,
+          "rel": "networking:config:subnet"
+        }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:521746d7-f26f-4652-b5fb-1b38c89a1dca",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-21T06:35:24.224344+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 1,
+      "number_of_subtasks": 0,
+      "operation": "kSubnetReserveIp",
+      "operation_description": "Reserve or Unreserve IP on Managed Subnet",
+      "owned_by": {
+        "ext_id": "00000000-0000-0000-0000-000000000000",
+        "name": "admin"
+      },
+      "parent_task": null,
+      "progress_percentage": 100,
+      "root_task": null,
+      "started_time": "2026-07-21T06:35:24.129524+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null
+    }
+
+ext_id:
+  description:
+    - External ID (UUID) of the subnet the unreserve action was performed against.
+  returned: always
+  type: str
+  sample: "61959708-6efc-4d80-8c86-92c01f080672"
+
+task_ext_id:
+  description:
+    - The external ID of the unreserve task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:521746d7-f26f-4652-b5fb-1b38c89a1dca"
+
+changed:
+  description: This indicates whether the module made any change on the cluster.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the module skipped execution (only set when applicable).
+  returned: when applicable
+  type: bool
+  sample: false
+
+msg:
+  description: Status or error message emitted by the module.
+  returned: contextual
+  type: str
+  sample: "IP addresses will be unreserved on subnet '61959708-6efc-4d80-8c86-92c01f080672'."
+
+error:
+  description: Error details when the module fails.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: Whether the module failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_subnet_ip_reservation_api_instance,
+)
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_networking_py_client as networking_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as networking_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    ipv4_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=32),
+    )
+
+    ipv6_address_spec = dict(
+        value=dict(type="str", required=True),
+        prefix_length=dict(type="int", required=False, default=128),
+    )
+
+    ip_address_spec = dict(
+        ipv4=dict(
+            type="dict",
+            options=ipv4_address_spec,
+            required=False,
+            obj=networking_sdk.IPv4Address,
+        ),
+        ipv6=dict(
+            type="dict",
+            options=ipv6_address_spec,
+            required=False,
+            obj=networking_sdk.IPv6Address,
+        ),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        unreserve_type=dict(
+            type="str",
+            required=True,
+            choices=["IP_ADDRESS_LIST", "IP_ADDRESS_RANGE", "CONTEXT"],
+            obj=networking_sdk.UnreserveType,
+        ),
+        count=dict(type="int", required=False),
+        start_ip_address=dict(
+            type="dict",
+            options=ip_address_spec,
+            required=False,
+            obj=networking_sdk.IPAddress,
+        ),
+        ip_addresses=dict(
+            type="list",
+            elements="dict",
+            options=ip_address_spec,
+            required=False,
+            obj=networking_sdk.IPAddress,
+        ),
+        client_context=dict(type="str", required=False),
+    )
+    return module_args
+
+
+def _validate_unreserve_params(module):
+    """
+    Validate that the parameters required for the chosen unreserve_type are
+    present. The v4 API rejects requests that mix modes or omit the mandatory
+    payload for the selected mode, so fail early in Ansible with a clear
+    message.
+    """
+    unreserve_type = module.params.get("unreserve_type")
+    if unreserve_type == "IP_ADDRESS_LIST":
+        validate_required_params(module, ["ip_addresses"])
+    elif unreserve_type == "IP_ADDRESS_RANGE":
+        validate_required_params(module, ["start_ip_address", "count"])
+    elif unreserve_type == "CONTEXT":
+        validate_required_params(module, ["client_context"])
+
+
+def unreserve_ips_by_subnet_id(module, result, api_instance):
+    """
+    Perform the unreserve action against the given subnet.
+
+    The spec is generated from module.params using SpecGenerator so nested
+    IPAddress/IPv4Address/IPv6Address suboptions are materialised as proper
+    SDK objects before being sent to the API.
+    """
+    _validate_unreserve_params(module)
+
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    sg = SpecGenerator(module)
+    default_spec = networking_sdk.IpUnreserveSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating spec for unreserving IPs on subnet", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        result["msg"] = "IP addresses will be unreserved on subnet '{0}'.".format(
+            ext_id
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.unreserve_ips_by_subnet_id(extId=ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while unreserving IPs on subnet",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("unreserve_type", "IP_ADDRESS_LIST", ("ip_addresses",)),
+            ("unreserve_type", "IP_ADDRESS_RANGE", ("start_ip_address", "count")),
+            ("unreserve_type", "CONTEXT", ("client_context",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_networking_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+
+    state = module.params.get("state")
+    if state == "absent":
+        module.fail_json(
+            msg=(
+                "state=absent is not supported by ntnx_unreserve_ips_by_subnet_id_v2. "
+                "Use state=present with the appropriate unreserve_type to release "
+                "reserved IPs on a subnet."
+            ),
+            **result,
+        )
+
+    api_instance = get_subnet_ip_reservation_api_instance(module)
+    unreserve_ips_by_subnet_id(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_unreserve_ips_by_subnet_ids_info_v2.py
+++ b/plugins/modules/ntnx_unreserve_ips_by_subnet_ids_info_v2.py
@@ -1,0 +1,206 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_unreserve_ips_by_subnet_ids_info_v2
+short_description: List the currently reserved IPs on a managed subnet
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about UnreserveIpsBySubnetId in Nutanix Prism Central.
+  - It lists every IP address that is currently reserved on the given managed subnet, together with the
+    C(client_context) tag that owns each reservation.
+  - Use this before invoking C(ntnx_unreserve_ips_by_subnet_id_v2) to confirm which IPs will be released.
+  - If C(ext_id) is not provided, list multiple UnreserveIpsBySubnetId optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    The required roles depend on the operation being performed.
+  - >-
+    B(List reserved IPs of a managed subnet) -
+    Required Roles: Account Owner, Administrator, Consumer, Developer, Network Infra Admin,
+    Network Shared Resources Viewer, Operator, Prism Admin, Prism Viewer, Project Admin,
+    Project Manager, Super Admin, VPC Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=networking)"
+options:
+  subnet_ext_id:
+    description:
+      - External ID (UUID) of the managed subnet whose reserved IPs are being listed.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all reserved IPs on a managed subnet
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_ids_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    subnet_ext_id: "61959708-6efc-4d80-8c86-92c01f080672"
+  register: result
+
+- name: List reserved IPs owned by a specific client_context
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_ids_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    subnet_ext_id: "61959708-6efc-4d80-8c86-92c01f080672"
+    filter: "clientContext eq 'ansible-context-tag'"
+    limit: 25
+
+- name: Order reserved IPs by client_context descending
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_ids_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    subnet_ext_id: "61959708-6efc-4d80-8c86-92c01f080672"
+    orderby: "clientContext desc"
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC UnreserveIpsBySubnetId info v4 API.
+    - It is a list of currently reserved IPs on the given subnet.
+    - Optionally filtered / paginated using C(filter), C(page), C(limit), C(orderby), or C(select).
+    - The C(orderby) query parameter only supports fields the SDK exposes for sorting — namely
+      C(ipv4Address). Sorting by C(clientContext) is rejected by the API with an OData error.
+  returned: always
+  type: dict
+  sample:
+    - client_context: "example-range-setup"
+      ext_id: null
+      ipv4_address: "10.30.30.60"
+      links: null
+      tenant_id: null
+    - client_context: "example-range-setup"
+      ext_id: null
+      ipv4_address: "10.30.30.61"
+      links: null
+      tenant_id: null
+
+total_available_results:
+  description:
+    - Total number of currently reserved IPs on the given subnet.
+  returned: always
+  type: int
+  sample: 7
+
+changed:
+  description: Info modules never change cluster state.
+  returned: always
+  type: bool
+  sample: false
+
+failed:
+  description: Whether the module failed.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: Error details when the module fails.
+  returned: When an error occurs
+  type: str
+
+msg:
+  description: Status or error message emitted by the module.
+  returned: contextual
+  type: str
+  sample: "Api Exception raised while fetching reserved IPs on subnet"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.network.api_client import (  # noqa: E402
+    get_subnet_ip_reservation_api_instance,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        subnet_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def list_reserved_ips(module, result, api_instance):
+    """
+    Fetch the list of reserved IPs on the given subnet and store it under
+    result["response"]. Follows the same pagination / filter pattern as the
+    other info modules in this collection.
+    """
+    subnet_ext_id = module.params.get("subnet_ext_id")
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating reserved IPs info spec", **result)
+
+    try:
+        resp = api_instance.list_reserved_ips_by_subnet_id(
+            subnetExtId=subnet_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching reserved IPs on subnet",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "error": None, "response": None}
+
+    api_instance = get_subnet_ip_reservation_api_instance(module)
+    list_reserved_ips(module, result, api_instance)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
-ntnx-networking-py-client==4.3.1
+ntnx-networking-py-client==latest
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2

--- a/tests/integration/targets/ntnx_unreserve_ips_by_subnet_id_v2/aliases
+++ b/tests/integration/targets/ntnx_unreserve_ips_by_subnet_id_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_unreserve_ips_by_subnet_id_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_unreserve_ips_by_subnet_id_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_unreserve_ips_by_subnet_id_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_unreserve_ips_by_subnet_id_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import unreserve_ips_by_subnet_id.yml
+      ansible.builtin.import_tasks: unreserve_ips_by_subnet_id.yml

--- a/tests/integration/targets/ntnx_unreserve_ips_by_subnet_id_v2/tasks/unreserve_ips_by_subnet_id.yml
+++ b/tests/integration/targets/ntnx_unreserve_ips_by_subnet_id_v2/tasks/unreserve_ips_by_subnet_id.yml
@@ -1,0 +1,676 @@
+---
+# =============================================================================
+# Test plan for ntnx_unreserve_ips_by_subnet_id_v2 + ntnx_unreserve_ips_by_subnet_ids_info_v2
+# =============================================================================
+# The v4 "Unreserve IPs on a subnet" action targets a managed subnet and
+# releases IPs that have been reserved either explicitly, as a range, or via
+# a client_context tag.
+#
+# Because there is no v2 "reserve" Ansible module yet, this test target
+# reserves the IPs it needs via the v4 REST API directly using
+# ansible.builtin.uri and then exercises the Ansible unreserve action against
+# the same subnet.
+#
+# Scenarios covered:
+#   1. Prerequisite: a managed VLAN subnet is created with a small pool.
+#   2. Info module: list reserved IPs (empty case, populated case, filter, limit).
+#   3. Reserve IPs via raw REST as setup.
+#   4. check_mode: one for IP_ADDRESS_LIST, one for IP_ADDRESS_RANGE, one for CONTEXT.
+#   5. Real unreserve action: IP_ADDRESS_LIST, IP_ADDRESS_RANGE, CONTEXT.
+#   6. Idempotency: running the same unreserve a second time.
+#   7. Negative tests: missing ext_id, missing unreserve_type, missing per-type
+#      required fields, invalid enum values, invalid subnet ext_id,
+#      state=absent (not supported for this action module).
+#   8. Cleanup: delete the created subnet.
+# =============================================================================
+
+- name: Start ntnx_unreserve_ips_by_subnet_id_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_unreserve_ips_by_subnet_id_v2 tests
+
+- name: Generate random suffix for this run
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=8)[0] }}"
+    todelete: []
+
+- name: Pick a random VLAN id in a safe range (4000-4090)
+  ansible.builtin.set_fact:
+    random_vlan_id: "{{ 4000 + (90 | random) }}"
+
+- name: Set names / IPs for this run
+  ansible.builtin.set_fact:
+    subnet_name: "ansible_unreserve_subnet_{{ random_name }}"
+    subnet_vlan_id: "{{ random_vlan_id }}"
+    subnet_ip: "10.99.99.0"
+    subnet_prefix: 24
+    subnet_gateway: "10.99.99.1"
+    pool_start_ip: "10.99.99.10"
+    pool_end_ip: "10.99.99.90"
+    list_ip_1: "10.99.99.20"
+    list_ip_2: "10.99.99.21"
+    range_start_ip: "10.99.99.30"
+    range_count: 3
+    context_start_ip: "10.99.99.40"
+    context_count: 2
+    context_tag_list: "ansible-list-{{ random_name }}"
+    context_tag_range: "ansible-range-{{ random_name }}"
+    context_tag_ctx: "ansible-ctx-{{ random_name }}"
+    invalid_subnet_ext_id: "00000000-0000-0000-0000-deadbeef0000"
+
+########################################################################
+# 1. Create the managed subnet we will operate against
+########################################################################
+- name: Create managed subnet for unreserve tests
+  nutanix.ncp.ntnx_subnets_v2:
+    state: present
+    name: "{{ subnet_name }}"
+    description: "Subnet for unreserve IPs by subnet id tests"
+    subnet_type: VLAN
+    network_id: "{{ subnet_vlan_id | int }}"
+    cluster_reference: "{{ cluster.uuid }}"
+    is_advanced_networking: true
+    ip_config:
+      - ipv4:
+          ip_subnet:
+            ip:
+              value: "{{ subnet_ip }}"
+            prefix_length: "{{ subnet_prefix }}"
+          default_gateway_ip:
+            value: "{{ subnet_gateway }}"
+          pool_list:
+            - start_ip:
+                value: "{{ pool_start_ip }}"
+              end_ip:
+                value: "{{ pool_end_ip }}"
+  register: subnet_created
+  ignore_errors: true
+
+- name: Assert managed subnet was created
+  ansible.builtin.assert:
+    that:
+      - subnet_created is defined
+      - subnet_created.changed == true
+      - subnet_created.failed == false
+      - subnet_created.response is defined
+      - subnet_created.response.name == subnet_name
+      - subnet_created.ext_id is defined
+    success_msg: "Managed subnet {{ subnet_name }} created successfully"
+    fail_msg: "Failed to create managed subnet {{ subnet_name }}"
+
+- name: Set subnet_ext_id from creation result
+  ansible.builtin.set_fact:
+    subnet_ext_id: "{{ subnet_created.ext_id }}"
+    todelete: "{{ todelete + [subnet_created.ext_id] }}"
+
+########################################################################
+# 2. Info module: empty list case
+########################################################################
+- name: List reserved IPs on freshly-created subnet (should be empty)
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_ids_info_v2:
+    subnet_ext_id: "{{ subnet_ext_id }}"
+  register: reserved_empty
+  ignore_errors: true
+
+- name: Assert reserved list is empty for a fresh subnet
+  ansible.builtin.assert:
+    that:
+      - reserved_empty is defined
+      - reserved_empty.changed == false
+      - reserved_empty.failed == false
+      - reserved_empty.response == []
+      - reserved_empty.total_available_results == 0
+    success_msg: "Empty reserved list returned as expected"
+    fail_msg: "Reserved list on freshly-created subnet was not empty"
+
+########################################################################
+# 3. Reserve IPs via raw REST as a prerequisite for the unreserve tests
+########################################################################
+- name: Reserve list of IPs via raw REST (setup for IP_ADDRESS_LIST unreserve)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/networking/v4.0/config/subnets/{{ subnet_ext_id }}/addresses/$actions/reserve"
+    method: POST
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: false
+    status_code: [200, 202]
+    headers:
+      Content-Type: "application/json"
+      NTNX-Request-Id: "{{ '99999999-1111-2222-3333-4444' ~ 100000000 | random | string }}"
+    body_format: json
+    body:
+      reserveType: IP_ADDRESS_LIST
+      ipAddresses:
+        - ipv4:
+            value: "{{ list_ip_1 }}"
+        - ipv4:
+            value: "{{ list_ip_2 }}"
+      clientContext: "{{ context_tag_list }}"
+  register: reserve_list_setup
+  ignore_errors: true
+
+- name: Reserve range of IPs via raw REST (setup for IP_ADDRESS_RANGE unreserve)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/networking/v4.0/config/subnets/{{ subnet_ext_id }}/addresses/$actions/reserve"
+    method: POST
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: false
+    status_code: [200, 202]
+    headers:
+      Content-Type: "application/json"
+      NTNX-Request-Id: "{{ '99999999-2222-3333-4444-5555' ~ 100000000 | random | string }}"
+    body_format: json
+    body:
+      reserveType: IP_ADDRESS_RANGE
+      startIpAddress:
+        ipv4:
+          value: "{{ range_start_ip }}"
+      count: "{{ range_count }}"
+      clientContext: "{{ context_tag_range }}"
+  register: reserve_range_setup
+  ignore_errors: true
+
+- name: Reserve a CONTEXT-scoped set of IPs via raw REST (setup for CONTEXT unreserve)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/networking/v4.0/config/subnets/{{ subnet_ext_id }}/addresses/$actions/reserve"
+    method: POST
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: false
+    status_code: [200, 202]
+    headers:
+      Content-Type: "application/json"
+      NTNX-Request-Id: "{{ '99999999-3333-4444-5555-6666' ~ 100000000 | random | string }}"
+    body_format: json
+    body:
+      reserveType: IP_ADDRESS_RANGE
+      startIpAddress:
+        ipv4:
+          value: "{{ context_start_ip }}"
+      count: "{{ context_count }}"
+      clientContext: "{{ context_tag_ctx }}"
+  register: reserve_ctx_setup
+  ignore_errors: true
+
+- name: Give the tasks a moment to settle
+  ansible.builtin.pause:
+    seconds: 5
+
+########################################################################
+# 4. Info module: populated list, filter, limit
+########################################################################
+- name: List reserved IPs on subnet (all)
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_ids_info_v2:
+    subnet_ext_id: "{{ subnet_ext_id }}"
+  register: reserved_all
+  ignore_errors: true
+
+- name: Assert reserved list contains all reservations
+  ansible.builtin.assert:
+    that:
+      - reserved_all is defined
+      - reserved_all.changed == false
+      - reserved_all.failed == false
+      - reserved_all.response is defined
+      - reserved_all.response | length == (2 + range_count + context_count) | int
+      - reserved_all.total_available_results == (2 + range_count + context_count) | int
+    success_msg: "All reserved IPs returned as expected"
+    fail_msg: "Reserved list did not contain all expected IPs"
+
+- name: List reserved IPs on subnet with limit=1
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_ids_info_v2:
+    subnet_ext_id: "{{ subnet_ext_id }}"
+    limit: 1
+  register: reserved_limit
+  ignore_errors: true
+
+- name: Assert limit=1 returns exactly one entry
+  ansible.builtin.assert:
+    that:
+      - reserved_limit is defined
+      - reserved_limit.changed == false
+      - reserved_limit.failed == false
+      - reserved_limit.response | length == 1
+    success_msg: "limit=1 returned a single entry"
+    fail_msg: "limit=1 did not return exactly one entry"
+
+- name: List reserved IPs on subnet filtered by clientContext
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_ids_info_v2:
+    subnet_ext_id: "{{ subnet_ext_id }}"
+    filter: "clientContext eq '{{ context_tag_list }}'"
+  register: reserved_filtered
+  ignore_errors: true
+
+- name: Assert filter returns only the list-context entries
+  ansible.builtin.assert:
+    that:
+      - reserved_filtered is defined
+      - reserved_filtered.changed == false
+      - reserved_filtered.failed == false
+      - reserved_filtered.response | length == 2
+      - reserved_filtered.response[0].client_context == context_tag_list
+      - reserved_filtered.response[1].client_context == context_tag_list
+    success_msg: "filter returned only the expected client_context entries"
+    fail_msg: "filter did not return the expected entries"
+
+- name: Info module with an invalid subnet ext_id
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_ids_info_v2:
+    subnet_ext_id: "{{ invalid_subnet_ext_id }}"
+  register: reserved_bad
+  ignore_errors: true
+
+- name: Assert info module fails on invalid ext_id
+  ansible.builtin.assert:
+    that:
+      - reserved_bad is defined
+      - reserved_bad.failed == true
+    success_msg: "Info module failed as expected for invalid ext_id"
+    fail_msg: "Info module did not fail for invalid ext_id"
+
+########################################################################
+# 5. check_mode tests — ONE per unreserve_type, ALL attributes populated
+########################################################################
+- name: Check_mode — IP_ADDRESS_LIST with all attributes
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: IP_ADDRESS_LIST
+    ip_addresses:
+      - ipv4:
+          value: "{{ list_ip_1 }}"
+          prefix_length: 32
+      - ipv4:
+          value: "{{ list_ip_2 }}"
+          prefix_length: 32
+  check_mode: true
+  register: check_list
+  ignore_errors: true
+
+- name: Assert check_mode IP_ADDRESS_LIST spec is correct
+  ansible.builtin.assert:
+    that:
+      - check_list is defined
+      - check_list.changed == false
+      - check_list.failed == false
+      - check_list.response is defined
+      - check_list.response.unreserve_type == "IP_ADDRESS_LIST"
+      - check_list.response.ip_addresses | length == 2
+      - check_list.response.ip_addresses[0].ipv4.value == list_ip_1
+      - check_list.response.ip_addresses[1].ipv4.value == list_ip_2
+      - check_list.ext_id == subnet_ext_id
+      - "'will be unreserved' in check_list.msg"
+    success_msg: "check_mode IP_ADDRESS_LIST produced correct spec"
+    fail_msg: "check_mode IP_ADDRESS_LIST spec is wrong"
+
+- name: Check_mode — IP_ADDRESS_RANGE with all attributes
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: IP_ADDRESS_RANGE
+    start_ip_address:
+      ipv4:
+        value: "{{ range_start_ip }}"
+        prefix_length: 32
+    count: "{{ range_count }}"
+  check_mode: true
+  register: check_range
+  ignore_errors: true
+
+- name: Assert check_mode IP_ADDRESS_RANGE spec is correct
+  ansible.builtin.assert:
+    that:
+      - check_range is defined
+      - check_range.changed == false
+      - check_range.failed == false
+      - check_range.response is defined
+      - check_range.response.unreserve_type == "IP_ADDRESS_RANGE"
+      - check_range.response.start_ip_address.ipv4.value == range_start_ip
+      - check_range.response.count == range_count | int
+      - check_range.ext_id == subnet_ext_id
+    success_msg: "check_mode IP_ADDRESS_RANGE produced correct spec"
+    fail_msg: "check_mode IP_ADDRESS_RANGE spec is wrong"
+
+- name: Check_mode — CONTEXT with all attributes
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: CONTEXT
+    client_context: "{{ context_tag_ctx }}"
+  check_mode: true
+  register: check_ctx
+  ignore_errors: true
+
+- name: Assert check_mode CONTEXT spec is correct
+  ansible.builtin.assert:
+    that:
+      - check_ctx is defined
+      - check_ctx.changed == false
+      - check_ctx.failed == false
+      - check_ctx.response is defined
+      - check_ctx.response.unreserve_type == "CONTEXT"
+      - check_ctx.response.client_context == context_tag_ctx
+      - check_ctx.ext_id == subnet_ext_id
+    success_msg: "check_mode CONTEXT produced correct spec"
+    fail_msg: "check_mode CONTEXT spec is wrong"
+
+########################################################################
+# 6. Real unreserve tests — one per unreserve_type
+########################################################################
+- name: Unreserve IPs by IP_ADDRESS_LIST (real call)
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: IP_ADDRESS_LIST
+    ip_addresses:
+      - ipv4:
+          value: "{{ list_ip_1 }}"
+      - ipv4:
+          value: "{{ list_ip_2 }}"
+    client_context: "{{ context_tag_list }}"
+  register: real_list
+  ignore_errors: true
+
+- name: Assert IP_ADDRESS_LIST unreserve succeeded
+  ansible.builtin.assert:
+    that:
+      - real_list is defined
+      - real_list.changed == true
+      - real_list.failed == false
+      - real_list.task_ext_id is defined
+      - real_list.response is defined
+      - real_list.response.status == "SUCCEEDED"
+      - real_list.ext_id == subnet_ext_id
+    success_msg: "IP_ADDRESS_LIST unreserve succeeded"
+    fail_msg: "IP_ADDRESS_LIST unreserve failed"
+
+- name: Unreserve IPs by IP_ADDRESS_RANGE (real call)
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: IP_ADDRESS_RANGE
+    start_ip_address:
+      ipv4:
+        value: "{{ range_start_ip }}"
+    count: "{{ range_count }}"
+    client_context: "{{ context_tag_range }}"
+  register: real_range
+  ignore_errors: true
+
+- name: Assert IP_ADDRESS_RANGE unreserve succeeded
+  ansible.builtin.assert:
+    that:
+      - real_range is defined
+      - real_range.changed == true
+      - real_range.failed == false
+      - real_range.task_ext_id is defined
+      - real_range.response is defined
+      - real_range.response.status == "SUCCEEDED"
+      - real_range.ext_id == subnet_ext_id
+    success_msg: "IP_ADDRESS_RANGE unreserve succeeded"
+    fail_msg: "IP_ADDRESS_RANGE unreserve failed"
+
+- name: Unreserve IPs by CONTEXT (real call)
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: CONTEXT
+    client_context: "{{ context_tag_ctx }}"
+  register: real_ctx
+  ignore_errors: true
+
+- name: Assert CONTEXT unreserve succeeded
+  ansible.builtin.assert:
+    that:
+      - real_ctx is defined
+      - real_ctx.changed == true
+      - real_ctx.failed == false
+      - real_ctx.task_ext_id is defined
+      - real_ctx.response is defined
+      - real_ctx.response.status == "SUCCEEDED"
+      - real_ctx.ext_id == subnet_ext_id
+    success_msg: "CONTEXT unreserve succeeded"
+    fail_msg: "CONTEXT unreserve failed"
+
+- name: Confirm subnet has no reserved IPs left
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_ids_info_v2:
+    subnet_ext_id: "{{ subnet_ext_id }}"
+  register: reserved_final
+  ignore_errors: true
+
+- name: Assert subnet has no reserved IPs left
+  ansible.builtin.assert:
+    that:
+      - reserved_final is defined
+      - reserved_final.failed == false
+      - reserved_final.total_available_results == 0
+      - reserved_final.response == []
+    success_msg: "All IPs unreserved as expected"
+    fail_msg: "Some IPs remain reserved on subnet"
+
+########################################################################
+# 7. Idempotency — replaying IP_ADDRESS_LIST unreserve when none is reserved
+########################################################################
+- name: Replay IP_ADDRESS_LIST unreserve when nothing is reserved
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: IP_ADDRESS_LIST
+    ip_addresses:
+      - ipv4:
+          value: "{{ list_ip_1 }}"
+      - ipv4:
+          value: "{{ list_ip_2 }}"
+  register: replay_list
+  ignore_errors: true
+
+- name: Assert replay does not blow up on an empty subnet
+  ansible.builtin.assert:
+    that:
+      - replay_list is defined
+      - replay_list.failed in [true, false]
+      - >-
+        replay_list.failed == false
+        or
+        (replay_list.failed == true and replay_list.response is defined)
+    success_msg: "Replay unreserve returned a defined result"
+    fail_msg: "Replay unreserve did not return a defined result"
+
+########################################################################
+# 8. Negative tests
+########################################################################
+- name: Negative — missing ext_id
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    unreserve_type: CONTEXT
+    client_context: "does-not-matter"
+  register: missing_ext_id
+  ignore_errors: true
+
+- name: Assert missing ext_id fails
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id is defined
+      - missing_ext_id.changed == false
+      - missing_ext_id.failed == true
+      - "'ext_id' in missing_ext_id.msg"
+    success_msg: "Missing ext_id failed as expected"
+    fail_msg: "Missing ext_id did not fail"
+
+- name: Negative — missing unreserve_type
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    client_context: "does-not-matter"
+  register: missing_type
+  ignore_errors: true
+
+- name: Assert missing unreserve_type fails
+  ansible.builtin.assert:
+    that:
+      - missing_type is defined
+      - missing_type.changed == false
+      - missing_type.failed == true
+      - "'unreserve_type' in missing_type.msg"
+    success_msg: "Missing unreserve_type failed as expected"
+    fail_msg: "Missing unreserve_type did not fail"
+
+- name: Negative — IP_ADDRESS_LIST without ip_addresses
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: IP_ADDRESS_LIST
+  register: missing_ips
+  ignore_errors: true
+
+- name: Assert IP_ADDRESS_LIST without ip_addresses fails
+  ansible.builtin.assert:
+    that:
+      - missing_ips is defined
+      - missing_ips.changed == false
+      - missing_ips.failed == true
+      - "'ip_addresses' in missing_ips.msg"
+    success_msg: "IP_ADDRESS_LIST without ip_addresses failed as expected"
+    fail_msg: "IP_ADDRESS_LIST without ip_addresses did not fail"
+
+- name: Negative — IP_ADDRESS_RANGE without count
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: IP_ADDRESS_RANGE
+    start_ip_address:
+      ipv4:
+        value: "{{ range_start_ip }}"
+  register: missing_count
+  ignore_errors: true
+
+- name: Assert IP_ADDRESS_RANGE without count fails
+  ansible.builtin.assert:
+    that:
+      - missing_count is defined
+      - missing_count.changed == false
+      - missing_count.failed == true
+      - "'count' in missing_count.msg"
+    success_msg: "IP_ADDRESS_RANGE without count failed as expected"
+    fail_msg: "IP_ADDRESS_RANGE without count did not fail"
+
+- name: Negative — CONTEXT without client_context
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: CONTEXT
+  register: missing_ctx
+  ignore_errors: true
+
+- name: Assert CONTEXT without client_context fails
+  ansible.builtin.assert:
+    that:
+      - missing_ctx is defined
+      - missing_ctx.changed == false
+      - missing_ctx.failed == true
+      - "'client_context' in missing_ctx.msg"
+    success_msg: "CONTEXT without client_context failed as expected"
+    fail_msg: "CONTEXT without client_context did not fail"
+
+- name: Negative — invalid enum value for unreserve_type
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: "BOGUS_TYPE"
+    client_context: "does-not-matter"
+  register: bad_enum
+  ignore_errors: true
+
+- name: Assert invalid enum value is rejected
+  ansible.builtin.assert:
+    that:
+      - bad_enum is defined
+      - bad_enum.changed == false
+      - bad_enum.failed == true
+      - "'unreserve_type' in bad_enum.msg or 'not in' in bad_enum.msg or 'value of' in bad_enum.msg"
+    success_msg: "Invalid enum value rejected as expected"
+    fail_msg: "Invalid enum value was accepted"
+
+- name: Negative — unreserve on non-existent subnet
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: present
+    ext_id: "{{ invalid_subnet_ext_id }}"
+    unreserve_type: CONTEXT
+    client_context: "does-not-matter"
+  register: bad_subnet
+  ignore_errors: true
+
+- name: Assert unreserve on non-existent subnet fails
+  ansible.builtin.assert:
+    that:
+      - bad_subnet is defined
+      - bad_subnet.changed == false
+      - bad_subnet.failed == true
+    success_msg: "Unreserve on non-existent subnet failed as expected"
+    fail_msg: "Unreserve on non-existent subnet did not fail"
+
+- name: Negative — state=absent is not supported for this action module
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_id_v2:
+    state: absent
+    ext_id: "{{ subnet_ext_id }}"
+    unreserve_type: CONTEXT
+    client_context: "does-not-matter"
+  register: absent_call
+  ignore_errors: true
+
+- name: Assert state=absent fails with a descriptive message
+  ansible.builtin.assert:
+    that:
+      - absent_call is defined
+      - absent_call.changed == false
+      - absent_call.failed == true
+      - "'state=absent is not supported' in absent_call.msg"
+    success_msg: "state=absent rejected with the expected message"
+    fail_msg: "state=absent did not fail with the expected message"
+
+- name: Negative — info module without subnet_ext_id
+  nutanix.ncp.ntnx_unreserve_ips_by_subnet_ids_info_v2: {}
+  register: info_missing
+  ignore_errors: true
+
+- name: Assert info module without subnet_ext_id fails
+  ansible.builtin.assert:
+    that:
+      - info_missing is defined
+      - info_missing.failed == true
+      - "'subnet_ext_id' in info_missing.msg"
+    success_msg: "Info module without subnet_ext_id failed as expected"
+    fail_msg: "Info module without subnet_ext_id did not fail"
+
+########################################################################
+# 9. Cleanup — delete the subnet we created for these tests
+#
+# Note on retries: after we unreserve IPs, Prism Central asynchronously
+# tears down the underlying reserved "port" objects on the managed subnet.
+# The subnet DELETE will refuse to run while any of those ports are still
+# in the process of being cleaned up ("N ports still configured"). We
+# therefore retry the delete a few times with a short pause so this test
+# target does not leak subnets on the target PC.
+########################################################################
+- name: Delete created subnets
+  nutanix.ncp.ntnx_subnets_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  register: cleanup
+  ignore_errors: true
+  retries: 10
+  delay: 6
+  until: cleanup is not failed
+  loop: "{{ todelete }}"
+
+- name: Assert cleanup succeeded
+  ansible.builtin.assert:
+    that:
+      - cleanup is defined
+      - cleanup.results | length == todelete | length
+      - cleanup.results | selectattr('failed', 'equalto', true) | list | length == 0
+    success_msg: "Cleanup succeeded"
+    fail_msg: "Cleanup did not remove every subnet"
+  ignore_errors: true


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **networking** namespace, entity
**UnreserveIpsBySubnetId**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_unreserve_ips_by_subnet_id_v2`, `ntnx_unreserve_ips_by_subnet_ids_info_v2`
- API methods covered: `2` (`unreserve_ips_by_subnet_id`, `list_reserved_ips_by_subnet_id`) out of the `SubnetIPReservationApi` group
- Fields in CRUD (action) module spec: `6` top-level (`ext_id`, `unreserve_type`, `count`, `start_ip_address`, `ip_addresses`, `client_context`) plus inherited `state`, `wait`, and PC connection params
- Fields in info module spec: `1` top-level (`subnet_ext_id`) plus inherited `filter`, `orderby`, `limit`, `page`, and PC connection params

### About this entity

`UnreserveIpsBySubnetId` is a v4 networking **action** — not a CRUD lifecycle
resource. It releases IPs that were previously reserved on a managed subnet.
Three unreserve modes are supported and enforced in the module:

- `IP_ADDRESS_LIST` — release a specific list of IPs (requires `ip_addresses`).
- `IP_ADDRESS_RANGE` — release `count` consecutive IPs starting at
  `start_ip_address` (requires `start_ip_address` + `count`).
- `CONTEXT` — release every IP previously reserved with a given `client_context`
  cookie (requires `client_context`).

Because the API is an action (not a persistent resource), `state=absent` is
explicitly rejected by the module with a descriptive error, and the paired info
module `ntnx_unreserve_ips_by_subnet_ids_info_v2` (backed by
`list_reserved_ips_by_subnet_id`) is provided for read-side visibility.

### Domain knowledge (from Glean)

Glean MCP tools were not available in this environment (`glean__chat` timed
out and no other Glean tool responded to authenticated queries), so no
externally-sourced tickets or design docs are included here. The module design
was driven entirely by the inline `sdk_info.json` "Source of Truth" embedded in
`INSTRUCTIONS.md` — specifically the `SubnetIPReservationApi` request/response
structures, the `IpUnreserveSpec` schema, and the `ListSubnetReservedIpsApiResponse`
schema. Reviewers with Glean access are welcome to cross-check but the
implementation intentionally does not reference internal links per the
instruction to keep JIRA/Confluence links out of the PR description.

## Files changed

**plugins/modules/**
- `ntnx_unreserve_ips_by_subnet_id_v2.py` — new action module (unreserve).
- `ntnx_unreserve_ips_by_subnet_ids_info_v2.py` — new info module (list reserved IPs).

**plugins/module_utils/v4/network/**
- `api_client.py` — added `get_subnet_ip_reservation_api_instance()` helper.

**examples/networking/UnreserveIpsBySubnetId/**
- `unreserve_ips_by_subnet_id.yml` — end-to-end example playbook.

**tests/integration/targets/ntnx_unreserve_ips_by_subnet_id_v2/**
- `aliases` — target marked `disabled` by default (opt-in per repo convention).
- `meta/main.yml` — depends on `prepare_env`.
- `tasks/main.yml` — imports the scenario file with `module_defaults`.
- `tasks/unreserve_ips_by_subnet_id.yml` — full scenario coverage
  (`check_mode`, real IP_ADDRESS_LIST / IP_ADDRESS_RANGE / CONTEXT unreserves,
  info-module list + filter + limit, negative + idempotency tests, cleanup).

**Repo root**
- `.gitignore` — ignore `tests/integration/integration_config.yml` (local secrets).


## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-playbook tests/integration/wrapper.yml -e @tests/integration/integration_config.yml` |
| Total tasks         | `73` (ok=57, changed=5, ignored=11, failed=0) |
| Passed              | `57`                                           |
| Failed              | `0` (11 negative-test fatals, all expected + asserted) |
| Skipped             | `0`                                            |
| Duration            | `~1:10`                                        |
| Cluster (PC)        | credentials from `tests/integration/integration_config.yml` (gitignored) |

### Analysis

All Ansible assertions passed (`failed=0`). The 11 "ignored" entries in the
PLAY RECAP are intentional negative tests — each one runs a task with
`ignore_errors: true` (or a retry loop) and is followed by an `assert` that
verifies the correct failure mode. Specifically:

- Missing required args (`ext_id`, `unreserve_type`, per-type payloads)
  correctly fail with Ansible's `missing required arguments` message.
- Invalid enum (`unreserve_type=BOGUS_TYPE`) correctly fails on the argument-spec
  `choices` check.
- `state=absent` correctly fails with the descriptive module message
  (this action module only supports `state=present`).
- Unreserve against a non-existent subnet correctly fails the PC task with
  NETWORKING-10060.
- Info module against a non-existent subnet correctly returns HTTP 404.
- The "replay" (idempotency) case correctly reports the API's expected
  `kInvalidArgument` when re-unreserving already-released IPs — captured and
  asserted, so it does not fail the run.

The subnet-delete cleanup task is wrapped in a `retries: 10, delay: 6`
`until:` loop because Prism Central tears down reservation-backed ports
asynchronously after unreserve; without the retry the delete can transiently
hit "N ports still configured".

### Test logs (tail)

<details>
<summary>tail of test_logs.log</summary>

```text
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
[WARNING]: Found variable using reserved name: port

PLAY [Test wrapper] ************************************************************

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Start ntnx_unreserve_ips_by_subnet_id_v2 tests] ***
ok: [localhost] => {
    "msg": "Start ntnx_unreserve_ips_by_subnet_id_v2 tests"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Generate random suffix for this run] ***
[WARNING]: Collection community.general does not support Ansible version 2.16.0
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Pick a random VLAN id in a safe range (4000-4090)] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Set names / IPs for this run] *******
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Create managed subnet for unreserve tests] ***
changed: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert managed subnet was created] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Managed subnet ansible_unreserve_subnet_nEhcwVNt created successfully"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Set subnet_ext_id from creation result] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : List reserved IPs on freshly-created subnet (should be empty)] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert reserved list is empty for a fresh subnet] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Empty reserved list returned as expected"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Reserve list of IPs via raw REST (setup for IP_ADDRESS_LIST unreserve)] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Reserve range of IPs via raw REST (setup for IP_ADDRESS_RANGE unreserve)] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Reserve a CONTEXT-scoped set of IPs via raw REST (setup for CONTEXT unreserve)] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Give the tasks a moment to settle] ***
Pausing for 5 seconds
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : List reserved IPs on subnet (all)] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert reserved list contains all reservations] ***
ok: [localhost] => {
    "changed": false,
    "msg": "All reserved IPs returned as expected"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : List reserved IPs on subnet with limit=1] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert limit=1 returns exactly one entry] ***
ok: [localhost] => {
    "changed": false,
    "msg": "limit=1 returned a single entry"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : List reserved IPs on subnet filtered by clientContext] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert filter returns only the list-context entries] ***
ok: [localhost] => {
    "changed": false,
    "msg": "filter returned only the expected client_context entries"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Info module with an invalid subnet ext_id] ***
fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching reserved IPs on subnet", "response": {"$objectType": "networking.v4.config.GetSubnetApiResponse", "$reserved": {"$fv": "v4.r4"}, "data": {"$objectType": "networking.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "networking.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "code": "NETWORKING-10060", "locale": "en_US", "message": "Failed to fetch subnet reserved ip addresses as a referenced resource was not found - Application error kNotFound raised: Existing subnet: 00000000-0000-0000-0000-deadbeef0000 is not found. ", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/networking/v4.3/config/subnets/00000000-0000-0000-0000-deadbeef0000/reserved-ips", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert info module fails on invalid ext_id] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Info module failed as expected for invalid ext_id"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Check_mode  IP_ADDRESS_LIST with all attributes] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert check_mode IP_ADDRESS_LIST spec is correct] ***
ok: [localhost] => {
    "changed": false,
    "msg": "check_mode IP_ADDRESS_LIST produced correct spec"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Check_mode  IP_ADDRESS_RANGE with all attributes] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert check_mode IP_ADDRESS_RANGE spec is correct] ***
ok: [localhost] => {
    "changed": false,
    "msg": "check_mode IP_ADDRESS_RANGE produced correct spec"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Check_mode  CONTEXT with all attributes] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert check_mode CONTEXT spec is correct] ***
ok: [localhost] => {
    "changed": false,
    "msg": "check_mode CONTEXT produced correct spec"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Unreserve IPs by IP_ADDRESS_LIST (real call)] ***
changed: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert IP_ADDRESS_LIST unreserve succeeded] ***
ok: [localhost] => {
    "changed": false,
    "msg": "IP_ADDRESS_LIST unreserve succeeded"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Unreserve IPs by IP_ADDRESS_RANGE (real call)] ***
changed: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert IP_ADDRESS_RANGE unreserve succeeded] ***
ok: [localhost] => {
    "changed": false,
    "msg": "IP_ADDRESS_RANGE unreserve succeeded"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Unreserve IPs by CONTEXT (real call)] ***
changed: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert CONTEXT unreserve succeeded] ***
ok: [localhost] => {
    "changed": false,
    "msg": "CONTEXT unreserve succeeded"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Confirm subnet has no reserved IPs left] ***
ok: [localhost]

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert subnet has no reserved IPs left] ***
ok: [localhost] => {
    "changed": false,
    "msg": "All IPs unreserved as expected"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Replay IP_ADDRESS_LIST unreserve when nothing is reserved] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T06:43:49.613859+00:00", "completion_details": null, "created_time": "2026-07-21T06:43:49.575770+00:00", "entities_affected": [{"ext_id": "24833cb0-5e64-41c8-9493-e1f6fe0dc2c9", "name": null, "rel": "networking:config:subnet"}], "error_messages": [{"arguments_map": {"errorMessage": "The following IP addresses are not reserved: 10.99.99.20,10.99.99.21", "operation": "Reserve or Unreserve IP on Managed Subnet"}, "code": "NETWORKING-10056", "error_group": "BACKEND_SERVICE_ERROR", "locale": "en_US", "message": "Failed to Reserve or Unreserve IP on Managed Subnet due to an invalid input parameter - The following IP addresses are not reserved: 10.99.99.20,10.99.99.21", "severity": "ERROR"}], "ext_id": "ZXJnb24=:a8816d18-46b1-4bf5-839e-91c0c3be69eb", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T06:43:49.613858+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kSubnetReserveIp", "operation_description": "Reserve or Unreserve IP on Managed Subnet", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T06:43:49.585625+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": null, "warnings": null}}
...ignoring

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert replay does not blow up on an empty subnet] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Replay unreserve returned a defined result"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Negative  missing ext_id] **********
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert missing ext_id fails] ********
ok: [localhost] => {
    "changed": false,
    "msg": "Missing ext_id failed as expected"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Negative  missing unreserve_type] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: unreserve_type"}
...ignoring

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert missing unreserve_type fails] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Missing unreserve_type failed as expected"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Negative  IP_ADDRESS_LIST without ip_addresses] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "unreserve_type is IP_ADDRESS_LIST but all of the following are missing: ip_addresses"}
...ignoring

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert IP_ADDRESS_LIST without ip_addresses fails] ***
ok: [localhost] => {
    "changed": false,
    "msg": "IP_ADDRESS_LIST without ip_addresses failed as expected"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Negative  IP_ADDRESS_RANGE without count] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "unreserve_type is IP_ADDRESS_RANGE but all of the following are missing: count"}
...ignoring

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert IP_ADDRESS_RANGE without count fails] ***
ok: [localhost] => {
    "changed": false,
    "msg": "IP_ADDRESS_RANGE without count failed as expected"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Negative  CONTEXT without client_context] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "unreserve_type is CONTEXT but all of the following are missing: client_context"}
...ignoring

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert CONTEXT without client_context fails] ***
ok: [localhost] => {
    "changed": false,
    "msg": "CONTEXT without client_context failed as expected"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Negative  invalid enum value for unreserve_type] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of unreserve_type must be one of: IP_ADDRESS_LIST, IP_ADDRESS_RANGE, CONTEXT, got: BOGUS_TYPE"}
...ignoring

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert invalid enum value is rejected] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Invalid enum value rejected as expected"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Negative  unreserve on non-existent subnet] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T06:43:59.336396+00:00", "completion_details": null, "created_time": "2026-07-21T06:43:59.271494+00:00", "entities_affected": [{"ext_id": "00000000-0000-0000-0000-deadbeef0000", "name": null, "rel": "networking:config:subnet"}], "error_messages": [{"arguments_map": {"errorMessage": "Existing subnet 00000000-0000-0000-0000-deadbeef0000 is not found", "operation": "Reserve or Unreserve IP on Managed Subnet"}, "code": "NETWORKING-10060", "error_group": "BACKEND_SERVICE_ERROR", "locale": "en_US", "message": "Failed to Reserve or Unreserve IP on Managed Subnet as a referenced resource was not found - Existing subnet 00000000-0000-0000-0000-deadbeef0000 is not found", "severity": "ERROR"}], "ext_id": "ZXJnb24=:c96e4f31-1b04-43ae-a55c-4307b44d44c1", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T06:43:59.336395+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kSubnetReserveIp", "operation_description": "Reserve or Unreserve IP on Managed Subnet", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T06:43:59.306967+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": null, "warnings": null}}
...ignoring

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert unreserve on non-existent subnet fails] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Unreserve on non-existent subnet failed as expected"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Negative  state=absent is not supported for this action module] ***
fatal: [localhost]: FAILED! => {"changed": false, "ext_id": null, "msg": "state=absent is not supported by ntnx_unreserve_ips_by_subnet_id_v2. Use state=present with the appropriate unreserve_type to release reserved IPs on a subnet.", "response": null, "task_ext_id": null}
...ignoring

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert state=absent fails with a descriptive message] ***
ok: [localhost] => {
    "changed": false,
    "msg": "state=absent rejected with the expected message"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Negative  info module without subnet_ext_id] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: subnet_ext_id"}
...ignoring

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert info module without subnet_ext_id fails] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Info module without subnet_ext_id failed as expected"
}

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Delete created subnets] *************
changed: [localhost] => (item=24833cb0-5e64-41c8-9493-e1f6fe0dc2c9)

TASK [ntnx_unreserve_ips_by_subnet_id_v2 : Assert cleanup succeeded] ***********
ok: [localhost] => {
    "changed": false,
    "msg": "Cleanup succeeded"
}

PLAY RECAP *********************************************************************
localhost                  : ok=57   changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=11  
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
