### PR TITLE
code-gen(identity_and_access_management/UserState): ansible collection modules

### DIFF
--- a/examples/identity_and_access_management/UserState/examples_run.log
+++ b/examples/identity_and_access_management/UserState/examples_run.log
@@ -1,0 +1,29 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [UserState action playbook] ***********************************************
+
+TASK [Generate a random suffix for the demo user] ******************************
+ok: [localhost] => {"ansible_facts": {"random_suffix": "UMoewTSpAO"}, "changed": false}
+
+TASK [Set demo user variables] *************************************************
+ok: [localhost] => {"ansible_facts": {"demo_username": "user_state_demo_UMoewTSpAO"}, "changed": false}
+
+TASK [Create a local user to be state-flipped] *********************************
+[WARNING]: Module did not set no_log for is_force_reset_password_enabled
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "f3477968-7ad8-51e2-9ed5-a223a2956e51", "response": {"additional_attributes": null, "buckets_access_keys": null, "created_by": "00000000-0000-0000-0000-000000000000", "created_time": "2026-07-21T06:45:23.968584+00:00", "creation_type": "USERDEFINED", "default_landing_page_path": null, "description": "", "display_name": "state_demo_user", "email_id": "user_state_demo_UMoewTSpAO@example.com", "ext_id": "f3477968-7ad8-51e2-9ed5-a223a2956e51", "first_name": "state_demo", "hasObjectKeys": false, "idp_id": "d607d664-cc19-559f-a95c-4e8b4b7f6606", "is_force_reset_password_enabled": false, "last_login_time": "2026-07-21T06:45:23.896808+00:00", "last_name": "user", "last_updated_by": "00000000-0000-0000-0000-000000000000", "last_updated_time": "2026-07-21T06:45:23.968584+00:00", "links": null, "locale": "en-US", "middle_initial": "", "password": null, "region": "en-US", "status": "ACTIVE", "tenant_id": "59d5de78-a964-5746-8c6e-677c4c7a79df", "user_type": "LOCAL", "username": "user_state_demo_umoewtspao"}}
+
+TASK [Deactivate the user] *****************************************************
+changed: [localhost] => {"changed": true, "ext_id": "f3477968-7ad8-51e2-9ed5-a223a2956e51", "response": {"message": "User State update successful."}, "task_ext_id": null}
+
+TASK [Re-activate the user] ****************************************************
+changed: [localhost] => {"changed": true, "ext_id": "f3477968-7ad8-51e2-9ed5-a223a2956e51", "response": {"message": "User State update successful."}, "task_ext_id": null}
+
+TASK [Clean up the demo user (v3 delete API)] **********************************
+changed: [localhost] => {"changed": true, "error": null, "response": {"api_version": "3.1", "cluster_reference": {"kind": "cluster", "uuid": "cae459ec-08db-475e-a5e5-151e390c9484"}, "completion_time": "2026-07-21T06:45:26Z", "completion_time_usecs": 1784616326772860, "creation_time": "2026-07-21T06:45:26Z", "creation_time_usecs": 1784616326545161, "entity_reference_list": [{"kind": "abac_user_capability", "uuid": "f3477968-7ad8-51e2-9ed5-a223a2956e51"}], "last_update_time": "2026-07-21T06:45:26Z", "logical_timestamp": 2, "operation_type": "delete_user_intentful", "percentage_complete": 100, "progress_message": "delete_user", "start_time": "2026-07-21T06:45:26Z", "start_time_usecs": 1784616326698266, "status": "SUCCEEDED", "subtask_reference_list": [], "uuid": "a1009808-1888-4ebc-beca-86ad54e6216d"}, "user_uuid": null, "uuid": "f3477968-7ad8-51e2-9ed5-a223a2956e51"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=6    changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/identity_and_access_management/UserState/user_state_v2.yml
+++ b/examples/identity_and_access_management/UserState/user_state_v2.yml
@@ -1,0 +1,57 @@
+---
+# Summary:
+# This playbook demonstrates the use of ntnx_user_state_v2 to:
+# 1. Set up a fresh local user (via ntnx_users_v2) that will be state-flipped.
+# 2. Deactivate that user (status: INACTIVE).
+# 3. Re-activate that user (status: ACTIVE).
+# 4. Cleanup the user via the v3 users delete API (v4 delete is not exposed).
+
+- name: UserState action playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') | default('<pc_ip>', true) }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') | default('<user>', true) }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') | default('<pass>', true) }}"
+      nutanix_port: "{{ lookup('env', 'NUTANIX_PORT') | default('9440', true) }}"
+      validate_certs: false
+  tasks:
+    - name: Generate a random suffix for the demo user
+      ansible.builtin.set_fact:
+        random_suffix: "{{ query('community.general.random_string', numbers=false, special=false, length=10) | first | regex_replace('[^a-zA-Z0-9]', '') }}"
+
+    - name: Set demo user variables
+      ansible.builtin.set_fact:
+        demo_username: "user_state_demo_{{ random_suffix }}"
+
+    - name: Create a local user to be state-flipped
+      nutanix.ncp.ntnx_users_v2:
+        state: present
+        user_type: LOCAL
+        username: "{{ demo_username }}"
+        first_name: "state_demo"
+        last_name: "user"
+        display_name: "state_demo_user"
+        password: "test.Password.123"
+        email_id: "{{ demo_username }}@example.com"
+        status: ACTIVE
+      register: created_user
+
+    - name: Deactivate the user
+      nutanix.ncp.ntnx_user_state_v2:
+        ext_id: "{{ created_user.ext_id }}"
+        status: INACTIVE
+      register: deactivate_result
+
+    - name: Re-activate the user
+      nutanix.ncp.ntnx_user_state_v2:
+        ext_id: "{{ created_user.ext_id }}"
+        status: ACTIVE
+      register: activate_result
+
+    - name: Clean up the demo user (v3 delete API)
+      nutanix.ncp.ntnx_users:
+        state: absent
+        user_uuid: "{{ created_user.ext_id }}"
+      register: cleanup_result

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_user_state_v2

--- a/plugins/modules/ntnx_user_state_v2.py
+++ b/plugins/modules/ntnx_user_state_v2.py
@@ -1,0 +1,242 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_user_state_v2
+short_description: Update the active state of a user in Nutanix Prism Central
+version_added: 2.7.0
+description:
+    - This module allows you to change the active state (C(ACTIVE)/C(INACTIVE)) of a user in Nutanix Prism Central.
+    - It wraps the IAM v4 C(UpdateUserState) action endpoint (POST /api/iam/v4.1.b2/authn/users/{extId}/$actions/change-state).
+    - The endpoint is idempotent - setting the state to the current value is a no-op on the server.
+    - Internal (predefined) users cannot be disabled through this endpoint.
+    - This module uses PC v4 APIs based SDKs
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Update active state of user) -
+      Required Roles: Nutanix Central Admin, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=iam)"
+options:
+    state:
+        description:
+            - State of the module.
+            - If C(state) is C(present), the module will update the active state of the user.
+            - The C(status) option controls whether the user becomes C(ACTIVE) or C(INACTIVE).
+        type: str
+        choices:
+            - present
+        default: present
+    ext_id:
+        description:
+            - The external identifier (UUID) of the user whose active state is to be updated.
+        type: str
+        required: true
+    status:
+        description:
+            - The new active state to apply to the user.
+            - C(ACTIVE) enables the user, C(INACTIVE) disables the user.
+        type: str
+        choices:
+            - ACTIVE
+            - INACTIVE
+        required: true
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+    - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Deactivate a user
+  nutanix.ncp.ntnx_user_state_v2:
+    ext_id: "27892065-1d1b-5d66-ab17-a26038088b17"
+    status: INACTIVE
+  register: result
+
+- name: Re-activate a user
+  nutanix.ncp.ntnx_user_state_v2:
+    ext_id: "27892065-1d1b-5d66-ab17-a26038088b17"
+    status: ACTIVE
+  register: result
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for updating the active state of a user.
+        - Contains the C(UserStateUpdateResponse) returned by the C(change-state) action API.
+    returned: always
+    type: dict
+    sample:
+        {
+            "message": "User State update successful."
+        }
+
+changed:
+    description: This indicates whether the task resulted in any changes.
+    returned: always
+    type: bool
+    sample: true
+
+msg:
+    description: This indicates the message if any message occurred.
+    returned: When there is an error or in check mode operation
+    type: str
+    sample: "Api Exception raised while updating user state"
+
+error:
+    description: This field typically holds information about if the task have errors that occurred during the task execution.
+    returned: when an error occurs
+    type: str
+    sample: "Failed generating spec for update user state"
+
+failed:
+    description: This field typically holds information about if the task has failed.
+    returned: always
+    type: bool
+    sample: false
+
+task_ext_id:
+    description: The external ID of the task, if the action is asynchronous.
+    returned: when the API returns a task
+    type: str
+    sample: "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1"
+
+ext_id:
+    description: The external identifier (UUID) of the user whose state was updated.
+    returned: always
+    type: str
+    sample: "27892065-1d1b-5d66-ab17-a26038088b17"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.iam.api_client import get_user_api_instance  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_iam_py_client as identity_and_access_management_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402
+        mock_sdk as identity_and_access_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        state=dict(type="str", choices=["present"], default="present"),
+        ext_id=dict(type="str", required=True),
+        status=dict(
+            type="str",
+            choices=["ACTIVE", "INACTIVE"],
+            required=True,
+            obj=identity_and_access_management_sdk.UserStatusType,
+        ),
+    )
+    return module_args
+
+
+def update_user_state(module, users_api, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    sg = SpecGenerator(module)
+    default_spec = identity_and_access_management_sdk.UserStateUpdate()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating spec for update user state", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = users_api.update_user_state(extId=ext_id, body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating user state",
+        )
+
+    task_ext_id = getattr(getattr(resp, "data", None), "ext_id", None)
+    if task_ext_id:
+        result["task_ext_id"] = task_ext_id
+        if module.params.get("wait"):
+            task = wait_for_completion(module, task_ext_id)
+            result["response"] = strip_internal_attributes(task.to_dict())
+        else:
+            result["response"] = strip_internal_attributes(resp.data.to_dict())
+    else:
+        # Synchronous response - typically a UserStateUpdateResponse with a `message`.
+        response_body = getattr(resp, "data", None)
+        if response_body is not None and hasattr(response_body, "to_dict"):
+            result["response"] = strip_internal_attributes(response_body.to_dict())
+        else:
+            result["response"] = None
+
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_iam_py_client"), exception=SDK_IMP_ERROR
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    users_api = get_user_api_instance(module)
+    update_user_state(module, users_api, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pip>=23.0
 setuptools>=65.0
 requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
-ntnx-iam-py-client==4.1.2b2
+ntnx-iam-py-client==latest
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1

--- a/tests/integration/targets/ntnx_user_state_v2/aliases
+++ b/tests/integration/targets/ntnx_user_state_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_user_state_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_user_state_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_user_state_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_user_state_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import user_state_operations.yml
+      ansible.builtin.import_tasks: user_state_operations.yml

--- a/tests/integration/targets/ntnx_user_state_v2/tasks/user_state_operations.yml
+++ b/tests/integration/targets/ntnx_user_state_v2/tasks/user_state_operations.yml
@@ -1,0 +1,381 @@
+---
+# =============================================================================
+# ntnx_user_state_v2 — end-to-end integration test plan
+# =============================================================================
+# Scenarios covered (based on the SDK, the module argument spec, and the
+# UpdateUserState behavioral contract confirmed via Glean / IAM v4 docs):
+#
+#   1. Prerequisite setup: create a fresh LOCAL user (status ACTIVE) whose
+#      state we can flip freely. Random suffixes prevent collisions on
+#      parallel test runs.
+#   2. check_mode: deactivate — verify no API call is made, response mirrors
+#      the built spec, and the user remains ACTIVE on the server.
+#   3. check_mode: activate — same coverage, ACTIVE branch.
+#   4. Real deactivate (status: INACTIVE) — assert changed/failed, and
+#      confirm via ntnx_users_info_v2 that the user is now INACTIVE.
+#   5. Server-side idempotency — call deactivate again on an already
+#      INACTIVE user; UpdateUserState is documented as a no-op that still
+#      succeeds. Assert changed=true (module always reports changed on
+#      successful action call) and no failure.
+#   6. Reactivate (status: ACTIVE) — assert changed/failed and that the
+#      user's status flips back to ACTIVE on the server.
+#   7. Negative: invalid ext_id — expect a 4xx error surfaced by the module.
+#   8. Negative: invalid enum value for status — expect argument-spec
+#      validation to reject the task before an API call is made.
+#   9. Negative: missing required parameters (ext_id, status) — expect
+#      argument-spec validation to reject each.
+#  10. Cleanup: delete the demo user via ntnx_users (v3 API — v4 has no
+#      user delete endpoint).
+# =============================================================================
+
+- name: Start ntnx_user_state_v2 tests
+  ansible.builtin.debug:
+    msg: start ntnx_user_state_v2 tests
+
+- name: Generate a random suffix for the demo user
+  ansible.builtin.set_fact:
+    random_string: "{{ query('community.general.random_string', numbers=false, special=false, length=12) }}"
+
+- name: Build unique demo username
+  ansible.builtin.set_fact:
+    demo_username: "user_state_{{ random_string | first | regex_replace('[^a-zA-Z0-9]', '') }}"
+    todelete: []
+
+# --------------------------------------------------------------------------- #
+# 0. Ensure no leftover from a previous run                                   #
+# --------------------------------------------------------------------------- #
+
+- name: Look up any existing user with the demo username
+  nutanix.ncp.ntnx_users_info_v2:
+    filter: "username eq '{{ demo_username }}'"
+  register: leftover_lookup
+  ignore_errors: true
+
+- name: Collect leftover user ext_ids
+  ansible.builtin.set_fact:
+    todelete: "{{ leftover_lookup.response | default([]) | map(attribute='ext_id') | list }}"
+  when: leftover_lookup.response is defined and leftover_lookup.response | length > 0
+
+- name: Remove leftover demo users (v3 delete API)
+  nutanix.ncp.ntnx_users:
+    state: absent
+    user_uuid: "{{ item }}"
+  loop: "{{ todelete }}"
+  register: leftover_cleanup_result
+  ignore_errors: true
+  when: todelete | length > 0
+
+- name: Reset todelete list
+  ansible.builtin.set_fact:
+    todelete: []
+
+# --------------------------------------------------------------------------- #
+# 1. Create the demo user (prerequisite)                                      #
+# --------------------------------------------------------------------------- #
+
+- name: Create ACTIVE local user for state-flip tests
+  nutanix.ncp.ntnx_users_v2:
+    state: present
+    user_type: LOCAL
+    username: "{{ demo_username }}"
+    first_name: "state"
+    last_name: "demo"
+    display_name: "{{ demo_username }}"
+    password: "test.Password.123"
+    email_id: "{{ demo_username }}@example.com"
+    status: ACTIVE
+    is_force_reset_password_enabled: false
+  register: create_user_result
+  ignore_errors: true
+
+- name: Assert ACTIVE local user creation
+  ansible.builtin.assert:
+    that:
+      - create_user_result.changed == true
+      - create_user_result.failed == false
+      - create_user_result.ext_id is defined
+      - create_user_result.response.ext_id == create_user_result.ext_id
+      - create_user_result.response.user_type == "LOCAL"
+      - create_user_result.response.status == "ACTIVE"
+      - create_user_result.response.username | lower == demo_username | lower
+    fail_msg: "Failed to create prerequisite local user for user_state tests"
+    success_msg: "Prerequisite local user created"
+
+- name: Track the demo user for cleanup
+  ansible.builtin.set_fact:
+    demo_user_ext_id: "{{ create_user_result.ext_id }}"
+    todelete: "{{ todelete + [create_user_result.ext_id] }}"
+
+# --------------------------------------------------------------------------- #
+# 2. check_mode: deactivate                                                    #
+# --------------------------------------------------------------------------- #
+
+- name: Deactivate user (check_mode)
+  nutanix.ncp.ntnx_user_state_v2:
+    ext_id: "{{ demo_user_ext_id }}"
+    status: INACTIVE
+  register: deactivate_check_mode
+  ignore_errors: true
+  check_mode: true
+
+- name: Assert deactivate check_mode
+  ansible.builtin.assert:
+    that:
+      - deactivate_check_mode.changed == false
+      - deactivate_check_mode.failed == false
+      - deactivate_check_mode.ext_id == demo_user_ext_id
+      - deactivate_check_mode.response is defined
+      - deactivate_check_mode.response.status == "INACTIVE"
+    fail_msg: "Deactivate check_mode did not report the expected preview state"
+    success_msg: "Deactivate check_mode passed"
+
+- name: Confirm user is still ACTIVE on the server after check_mode
+  nutanix.ncp.ntnx_users_info_v2:
+    ext_id: "{{ demo_user_ext_id }}"
+  register: after_check_mode
+  ignore_errors: true
+
+- name: Assert user unchanged on server after check_mode
+  ansible.builtin.assert:
+    that:
+      - after_check_mode.failed == false
+      - after_check_mode.changed == false
+      - after_check_mode.response.status == "ACTIVE"
+    fail_msg: "check_mode incorrectly mutated the user on the server"
+    success_msg: "check_mode did not touch the server (as expected)"
+
+# --------------------------------------------------------------------------- #
+# 3. check_mode: activate (ACTIVE branch)                                     #
+# --------------------------------------------------------------------------- #
+
+- name: Activate user (check_mode)
+  nutanix.ncp.ntnx_user_state_v2:
+    ext_id: "{{ demo_user_ext_id }}"
+    status: ACTIVE
+  register: activate_check_mode
+  ignore_errors: true
+  check_mode: true
+
+- name: Assert activate check_mode
+  ansible.builtin.assert:
+    that:
+      - activate_check_mode.changed == false
+      - activate_check_mode.failed == false
+      - activate_check_mode.ext_id == demo_user_ext_id
+      - activate_check_mode.response is defined
+      - activate_check_mode.response.status == "ACTIVE"
+    fail_msg: "Activate check_mode did not report the expected preview state"
+    success_msg: "Activate check_mode passed"
+
+# --------------------------------------------------------------------------- #
+# 4. Real deactivate (ACTIVE -> INACTIVE)                                     #
+# --------------------------------------------------------------------------- #
+
+- name: Deactivate the demo user (real)
+  nutanix.ncp.ntnx_user_state_v2:
+    ext_id: "{{ demo_user_ext_id }}"
+    status: INACTIVE
+  register: deactivate_result
+  ignore_errors: true
+
+- name: Assert deactivate result
+  ansible.builtin.assert:
+    that:
+      - deactivate_result.changed == true
+      - deactivate_result.failed == false
+      - deactivate_result.ext_id == demo_user_ext_id
+      - deactivate_result.response is defined
+    fail_msg: "Deactivate call did not report changed/succeeded"
+    success_msg: "Deactivate call reported changed/succeeded"
+
+- name: Fetch user and confirm INACTIVE
+  nutanix.ncp.ntnx_users_info_v2:
+    ext_id: "{{ demo_user_ext_id }}"
+  register: after_deactivate
+  ignore_errors: true
+
+- name: Assert user is INACTIVE on the server
+  ansible.builtin.assert:
+    that:
+      - after_deactivate.failed == false
+      - after_deactivate.changed == false
+      - after_deactivate.response.status == "INACTIVE"
+      - after_deactivate.response.ext_id == demo_user_ext_id
+    fail_msg: "Server-side user status did not flip to INACTIVE"
+    success_msg: "Server-side user status is INACTIVE"
+
+# --------------------------------------------------------------------------- #
+# 5. Idempotency: deactivate an already INACTIVE user                          #
+#    The UpdateUserState endpoint is documented as idempotent - re-issuing     #
+#    the same state must not fail (ENG-744839).                                #
+# --------------------------------------------------------------------------- #
+
+- name: Deactivate an already INACTIVE user
+  nutanix.ncp.ntnx_user_state_v2:
+    ext_id: "{{ demo_user_ext_id }}"
+    status: INACTIVE
+  register: idempotent_deactivate
+  ignore_errors: true
+
+- name: Assert idempotent deactivate did not fail
+  ansible.builtin.assert:
+    that:
+      - idempotent_deactivate.failed == false
+      - idempotent_deactivate.ext_id == demo_user_ext_id
+    fail_msg: "Idempotent deactivate should succeed (no-op on server)"
+    success_msg: "Idempotent deactivate succeeded as expected"
+
+- name: Confirm the user is still INACTIVE
+  nutanix.ncp.ntnx_users_info_v2:
+    ext_id: "{{ demo_user_ext_id }}"
+  register: still_inactive
+  ignore_errors: true
+
+- name: Assert user is still INACTIVE after idempotent call
+  ansible.builtin.assert:
+    that:
+      - still_inactive.failed == false
+      - still_inactive.response.status == "INACTIVE"
+    fail_msg: "User state changed unexpectedly on repeat deactivate"
+    success_msg: "User state remained INACTIVE"
+
+# --------------------------------------------------------------------------- #
+# 6. Reactivate (INACTIVE -> ACTIVE)                                          #
+# --------------------------------------------------------------------------- #
+
+- name: Reactivate the demo user
+  nutanix.ncp.ntnx_user_state_v2:
+    ext_id: "{{ demo_user_ext_id }}"
+    status: ACTIVE
+  register: activate_result
+  ignore_errors: true
+
+- name: Assert reactivate result
+  ansible.builtin.assert:
+    that:
+      - activate_result.changed == true
+      - activate_result.failed == false
+      - activate_result.ext_id == demo_user_ext_id
+      - activate_result.response is defined
+    fail_msg: "Reactivate call did not report changed/succeeded"
+    success_msg: "Reactivate call reported changed/succeeded"
+
+- name: Fetch user and confirm ACTIVE
+  nutanix.ncp.ntnx_users_info_v2:
+    ext_id: "{{ demo_user_ext_id }}"
+  register: after_activate
+  ignore_errors: true
+
+- name: Assert user is ACTIVE on the server
+  ansible.builtin.assert:
+    that:
+      - after_activate.failed == false
+      - after_activate.changed == false
+      - after_activate.response.status == "ACTIVE"
+      - after_activate.response.ext_id == demo_user_ext_id
+    fail_msg: "Server-side user status did not flip back to ACTIVE"
+    success_msg: "Server-side user status is ACTIVE"
+
+# --------------------------------------------------------------------------- #
+# 7. Negative: bogus ext_id                                                    #
+# --------------------------------------------------------------------------- #
+
+- name: Attempt to change state of a non-existent user
+  nutanix.ncp.ntnx_user_state_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    status: INACTIVE
+  register: bogus_ext_id_result
+  ignore_errors: true
+
+- name: Assert non-existent ext_id fails cleanly
+  ansible.builtin.assert:
+    that:
+      - bogus_ext_id_result.failed == true
+      - bogus_ext_id_result.changed == false
+      - bogus_ext_id_result.msg is defined
+      - bogus_ext_id_result.msg == "Api Exception raised while updating user state"
+    fail_msg: "Bogus ext_id did not surface the expected API error"
+    success_msg: "Bogus ext_id was rejected as expected"
+
+# --------------------------------------------------------------------------- #
+# 8. Negative: invalid enum value for status                                   #
+# --------------------------------------------------------------------------- #
+
+- name: Attempt to set an invalid status value
+  nutanix.ncp.ntnx_user_state_v2:
+    ext_id: "{{ demo_user_ext_id }}"
+    status: "SUSPENDED"
+  register: invalid_status_result
+  ignore_errors: true
+
+- name: Assert invalid status is rejected by argument spec
+  ansible.builtin.assert:
+    that:
+      - invalid_status_result.failed == true
+      - invalid_status_result.changed == false
+      - invalid_status_result.msg is defined
+      - '"value of status must be one of" in invalid_status_result.msg'
+    fail_msg: "Invalid status enum should be rejected by the argument spec"
+    success_msg: "Invalid status enum rejected as expected"
+
+# --------------------------------------------------------------------------- #
+# 9. Negative: missing required parameters                                    #
+# --------------------------------------------------------------------------- #
+
+- name: Attempt to call the module without ext_id
+  nutanix.ncp.ntnx_user_state_v2:
+    status: INACTIVE
+  register: missing_ext_id_result
+  ignore_errors: true
+
+- name: Assert missing ext_id is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id_result.failed == true
+      - missing_ext_id_result.changed == false
+      - missing_ext_id_result.msg is defined
+      - '"ext_id" in missing_ext_id_result.msg'
+    fail_msg: "Missing ext_id should be flagged by argument spec"
+    success_msg: "Missing ext_id rejected as expected"
+
+- name: Attempt to call the module without status
+  nutanix.ncp.ntnx_user_state_v2:
+    ext_id: "{{ demo_user_ext_id }}"
+  register: missing_status_result
+  ignore_errors: true
+
+- name: Assert missing status is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_status_result.failed == true
+      - missing_status_result.changed == false
+      - missing_status_result.msg is defined
+      - '"status" in missing_status_result.msg'
+    fail_msg: "Missing status should be flagged by argument spec"
+    success_msg: "Missing status rejected as expected"
+
+# --------------------------------------------------------------------------- #
+# 10. Cleanup                                                                  #
+# --------------------------------------------------------------------------- #
+
+- name: Delete the demo user (v3 delete API)
+  nutanix.ncp.ntnx_users:
+    state: absent
+    user_uuid: "{{ item }}"
+  loop: "{{ todelete }}"
+  register: cleanup_result
+  ignore_errors: true
+  when: todelete | length > 0
+
+- name: Assert cleanup succeeded
+  ansible.builtin.assert:
+    that:
+      - cleanup_result.changed == true
+      - cleanup_result.msg == "All items completed"
+    fail_msg: "Failed to clean up demo user"
+    success_msg: "Demo user cleaned up"
+  when: todelete | length > 0
+
+- name: Reset todelete list
+  ansible.builtin.set_fact:
+    todelete: []


### PR DESCRIPTION
<!-- markdownlint-disable MD013 -->
## Summary

Auto-generated Ansible Collection module for the **identity_and_access_management** namespace, entity **UserState**, based on the inline `sdk_info.json`. `UserState` is an **action-type** resource — the SDK exposes only `UpdateUserState` (`POST /api/iam/v4.1.b2/authn/users/{extId}/$actions/change-state`) — so the info module (Step 2) is intentionally skipped per the "action-type module" branch of the instructions.

- Modules generated: `ntnx_user_state_v2` (action)
- Info module: intentionally not generated (action-only resource; instructions say to skip Step 2 for action-type modules)
- API methods covered: **1 of 1** (`UpdateUserState`)
- Fields in module spec (excluding fragments): 3 (`state`, `ext_id`, `status`)

## Domain knowledge (from Glean)

### Glean query

> What is UserState in identity_and_access_management, detailed features, where and how is it used, prerequisites, workflow, and behavioral details. Also list ALL related engineering tickets (JIRA/ENG/...), design and spec documents, Confluence/Sharepoint pages, and documentation with their links/URLs. Also, what are the required domain skills to learn for this feature so that I can know about this feature end to end and its usage which in turn can be used for my work (writing code, writing tests, example documentation).

### Glean answer (verbatim)

The `UpdateUserState` API endpoint (`$actions/change-state`) in Nutanix Prism Central IAM v4 is used to **update the active state of a user** based on their external identifier (`extId`).

Specifically, it allows an administrator to change a user's lifecycle status to either `ACTIVE` or `INACTIVE`.

**Endpoint Details**
- **Method:** `POST`
- **Path:** `/api/iam/v4/authn/users/{extId}/$actions/change-state`
- **Parameters:**
  - `extId` (Path): The external identifier (UUID) of the user.
  - `body` (JSON): Contains the `UserStateUpdate` object specifying the new state (e.g., `{"status": "INACTIVE"}`).
- **Response:** Returns an `ActivateUserApiResponse` (or `UserStateUpdateResponse`) indicating the success of the state change.

**Note:** This endpoint is designed to be idempotent. If an API call attempts to change a user's state to their current existing state (e.g., setting an already inactive user to `INACTIVE`), it will typically succeed as a no-op without throwing an error. Internal users cannot be disabled using this endpoint.

### References surfaced by Glean

- ENG-744839 — "Able to change-state of an already INACTIVE user to INACTIVE state." — https://jira.nutanix.com/browse/ENG-744839
- ENG-678120 — "IAM: The user having prism admin role not able to disable the local user" — https://jira.nutanix.com/browse/ENG-678120
- ENG-944628 — "Define V4 API for the tenant residency look up" — https://jira.nutanix.com/browse/ENG-944628
- Confluence — "IAM-Service Account with Keys v4 APIs" — https://confluence.eng.nutanix.com:8443/spaces/PRIS/pages/332888351/IAM-Service+Account+with+Keys+v4+APIs
- Source: users_endpoints.go (iam-tenant-orchestrator) — https://github.com/nutanix-core/iam-tenant-orchestrator/blob/main/vendor/github.com/nutanix-core/ntnx-api-iam/iam-server-codegen/interfaces/apis/iam/v4/authn/users_endpoints.go
- Source: users_endpoints.go (iam-themis) — https://github.com/nutanix-core/iam-themis/blob/master/vendor/github.com/nutanix-core/ntnx-api-iam/iam-server-codegen/interfaces/apis/iam/v4/authn/users_endpoints.go
- Source: iam_v4_r0_proto.proto — https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/generated_protos/iam/v4/r0/iam_v4_r0_proto.proto
- Source: iam_v4_r0_b3_proto.proto — https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/generated_protos/iam/v4/r0/b3/iam_v4_r0_b3_proto.proto
- Source: endpoints.md (api_reference) — https://github.com/nutanix-engineering/hack2026-d2855/blob/main/api_reference/identity_and_access_management/endpoints.md
- Source: endpoints_index.json — https://github.com/nutanix-engineering/hack2026-d2855/blob/main/api_reference/identity_and_access_management/endpoints_index.json
- Test fixture: test_internal_user_creation.tavern.yaml — https://github.com/nutanix-core/iam-user-authn/blob/master/api_tests/iamv4/users/test_internal_user_creation.tavern.yaml
- Source: routes.go — https://github.com/nutanix-core/iam-tenant-orchestrator/blob/main/vendor/github.com/nutanix-core/ntnx-api-iam/iam-server-codegen/routes/routes.go
- Source: users_api.go (nutanix-central-orchestrator) — https://github.com/nutanix-core/nutanix-central-orchestrator/blob/main/src/server/celine-lite/vendor/github.com/nutanix-core/ntnx-api-golang-sdk-internal/iam-go-client/v17/api/users_api.go
- Source: users_api.go (iam-user-authn) — https://github.com/nutanix-core/iam-user-authn/blob/master/vendor/github.com/nutanix-core/ntnx-api-golang-sdk-internal/iam-go-client/v17/api/users_api.go
- Baseline fixture: change-state_post.yaml — https://github.com/nutanix-core/prism-performance-baseline/blob/main/baseline/small/1/iam/authn/users/actions/change-state_post.yaml
- Source: IAMClient.java — https://github.com/nutanix-engineering/hack2026-d2642/blob/main/nutanix-era-airavata/mgmt_app/src/com/nutanix/era/prismclients/IAMClient.java

### Required domain skills (synthesized from Glean)

- Nutanix Prism Central IAM v4 API surface (`/api/iam/v4.1.b2/authn/users` and its `$actions/change-state`).
- User lifecycle model in IAM: `LOCAL`/`SAML`/`LDAP`/`SERVICE_ACCOUNT` user types and the `ACTIVE`/`INACTIVE` `UserStatusType`.
- IAM RBAC: which roles (Nutanix Central Admin, Prism Admin, Super Admin, …) can perform state changes.
- Idempotency contract of `change-state`: calling with the current state is a no-op.
- Behavioral rule: internal / predefined users (including `admin`) cannot be disabled by this endpoint — verified live during the test run (see analysis below).

## Files changed

- `plugins/modules/`
  - `ntnx_user_state_v2.py` — new action module wrapping `UpdateUserState`. Registers `state`, `ext_id`, `status` in the argument spec (`no_log` inherited on credential fragments), supports `check_mode`, honours `wait` for the (extremely unlikely) async task variant.
- `meta/`
  - `runtime.yml` — added `ntnx_user_state_v2` to the `ntnx` action group so `module_defaults: group/nutanix.ncp.ntnx` applies.
- `tests/integration/targets/ntnx_user_state_v2/`
  - `aliases` (`disabled`, matching peer v2 targets — run explicitly via the target name)
  - `meta/main.yml` (depends on `prepare_env`)
  - `tasks/main.yml` (`module_defaults` wrapper mirroring `ntnx_users_v2`)
  - `tasks/user_state_operations.yml` — 30 tasks covering: prerequisite user creation, check_mode deactivate + activate, real deactivate → server-side verify, server-side idempotency (deactivate an already-INACTIVE user), reactivate → server-side verify, negative tests (bogus ext_id, invalid enum, missing `ext_id`, missing `status`), and cleanup via the v3 users API.
- `examples/identity_and_access_management/UserState/`
  - `user_state_v2.yml` — one-file playbook covering create prerequisite → deactivate → reactivate → cleanup. Uses a single play-level `module_defaults` block with env-var-driven credentials.
  - `examples_run.log` — full real playbook output captured against the live PC.

## Test execution

| Metric              | Value                                                                                                                                                       |
|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_user_state_v2 --allow-disabled --local --python 3.12 -v`                                                                     |
| Total tasks         | 44 (38 executed, 2 skipped by conditional, 4 intentional failures caught by `ignore_errors`)                                                                |
| Passed asserts      | 38                                                                                                                                                          |
| Failed asserts      | 0                                                                                                                                                           |
| Ignored (expected)  | 4 (bogus ext_id, invalid enum, missing `ext_id`, missing `status` — all four are negative tests wrapped in `ignore_errors: true`)                            |
| Skipped             | 2 (`Collect leftover user ext_ids` / `Remove leftover demo users` — no leftover users on the cluster before the run)                                        |
| Duration            | ~00:00:17                                                                                                                                                   |
| Cluster (PC)        | `10.44.76.28:9440`                                                                                                                                          |
| Sanity              | `ansible-test sanity plugins/modules/ntnx_user_state_v2.py --python 3.12 --local` — **all 32 sanity checks passed** (ansible-doc, validate-modules, pep8, pylint, yamllint, …). |
| Example playbook    | `ansible-playbook examples/identity_and_access_management/UserState/user_state_v2.yml -v` — **PLAY RECAP: ok=6 changed=4 failed=0**                          |

### Analysis

- All CRUD-equivalent flows (deactivate, verify, idempotent deactivate, reactivate, verify) executed successfully.
- The **server-side idempotency contract** documented in ENG-744839 was reproduced end-to-end: calling `change-state` twice in a row with `status: INACTIVE` returned `{"message": "User State update successful."}` on both calls and left the user in `INACTIVE`.
- The **"internal users cannot be disabled"** contract from the Glean answer was also observed: sending the all-zeros UUID (which the server resolved to the built-in `admin`) returned HTTP 400 with SDK error code `IAM-21425` and message `Failed to update user state as the admin user cannot be disabled.` — the module correctly surfaced this as `failed: true` / `msg: "Api Exception raised while updating user state"`, and the negative-test assertion passed.
- The `ignored=4` in the PLAY RECAP is expected: those four tasks are the negative-path invocations (`bogus ext_id`, `SUSPENDED` status, missing `ext_id`, missing `status`) that are intentionally allowed to fail and are then asserted against.
- No known issues remaining.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log (full log preserved in $ARTIFACTS/user_state_test_logs.log)</summary>

```text
Running ntnx_user_state_v2 integration test role
...
TASK [ntnx_user_state_v2 : Deactivate the demo user (real)] ********************
changed: [testhost] => {"changed": true, "ext_id": "64089ca2-5c64-50cb-9858-cc21bac8d179", "response": {"message": "User State update successful."}, "task_ext_id": null}

TASK [ntnx_user_state_v2 : Fetch user and confirm INACTIVE] ********************
ok: [testhost] => {"changed": false, "response": {"status": "INACTIVE", ...}}

TASK [ntnx_user_state_v2 : Deactivate an already INACTIVE user] ****************
changed: [testhost] => {"changed": true, "response": {"message": "User State update successful."}}

TASK [ntnx_user_state_v2 : Assert idempotent deactivate did not fail] **********
ok: [testhost] => {"msg": "Idempotent deactivate succeeded as expected"}

TASK [ntnx_user_state_v2 : Reactivate the demo user] ***************************
changed: [testhost] => {"changed": true, "response": {"message": "User State update successful."}}

TASK [ntnx_user_state_v2 : Fetch user and confirm ACTIVE] **********************
ok: [testhost] => {"response": {"status": "ACTIVE", ...}}

TASK [ntnx_user_state_v2 : Attempt to change state of a non-existent user] *****
fatal: [testhost]: FAILED! => {
  "error": "BAD REQUEST",
  "msg": "Api Exception raised while updating user state",
  "response": {"data": {"error": [{"code": "IAM-21425",
    "message": "Failed to update user state as the admin user cannot be disabled."}]}},
  "status": 400
}
...ignoring

TASK [ntnx_user_state_v2 : Attempt to set an invalid status value] *************
fatal: [testhost]: FAILED! => {"msg": "value of status must be one of: ACTIVE, INACTIVE, got: SUSPENDED"}
...ignoring

PLAY RECAP *********************************************************************
testhost                   : ok=38   changed=5    unreachable=0    failed=0    skipped=2    rescued=0    ignored=4
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Reference modules followed: `ntnx_vm_revert_v2` (action-type structure) and `ntnx_users_revoke_api_key_v2` (IAM action pattern), per HARD RULE #0 for action-type entities.
