### PR TITLE
code-gen(data_protection/DataProtectionClusterCapability): ansible collection modules

### DIFF
--- a/examples/data_protection/DataProtectionClusterCapability/data_protection_cluster_capabilities.yml
+++ b/examples/data_protection/DataProtectionClusterCapability/data_protection_cluster_capabilities.yml
@@ -1,0 +1,76 @@
+---
+# Summary:
+# This playbook demonstrates the ntnx_data_protection_cluster_capabilities_info_v2 module.
+# The Nutanix Prism Central v4 Data Protection API only exposes a *list* endpoint for the
+# DataProtectionClusterCapability entity (no create/update/delete/get-by-id endpoints).
+# All operations therefore go through the info module.
+#
+# 1. List all data protection cluster capabilities
+# 2. Get data protection cluster capability using ext_id (cluster UUID)
+# 3. List with an OData filter on extId
+# 4. List with pagination (page + limit)
+# 5. List with a limit only
+# 6. List selecting only specific fields
+# 7. List ordered by extId
+
+- name: Data Protection Cluster Capabilities playbook
+  hosts: localhost
+  gather_facts: false
+  vars:
+    # Replace these placeholders (or override with `-e ...`) before running.
+    ip: "<pc_ip>"
+    username: "<user>"
+    password: "<pass>"
+    validate_certs: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username }}"
+      nutanix_password: "{{ password }}"
+      validate_certs: "{{ validate_certs }}"
+  tasks:
+    - name: Set variables for examples
+      ansible.builtin.set_fact:
+        cluster_capability_ext_id: "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+
+    - name: List all data protection cluster capabilities
+      nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+      register: list_all_result
+      ignore_errors: true
+
+    - name: Get data protection cluster capabilities using ext_id
+      nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+        ext_id: "{{ cluster_capability_ext_id }}"
+      register: get_by_id_result
+      ignore_errors: true
+
+    - name: List data protection cluster capabilities with filter on extId
+      nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+        filter: "extId eq '{{ cluster_capability_ext_id }}'"
+      register: list_filter_result
+      ignore_errors: true
+
+    - name: List data protection cluster capabilities with pagination
+      nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+        page: 0
+        limit: 10
+      register: list_paginated_result
+      ignore_errors: true
+
+    - name: List data protection cluster capabilities with limit
+      nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+        limit: 1
+      register: list_limit_result
+      ignore_errors: true
+
+    - name: List data protection cluster capabilities selecting only specific fields
+      nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+        select: "extId,clusterExtId"
+      register: list_select_result
+      ignore_errors: true
+
+    - name: List data protection cluster capabilities ordered by extId
+      nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+        orderby: "extId"
+      register: list_orderby_result
+      ignore_errors: true

--- a/examples/data_protection/DataProtectionClusterCapability/examples_run.log
+++ b/examples/data_protection/DataProtectionClusterCapability/examples_run.log
@@ -1,0 +1,33 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Data Protection Cluster Capabilities playbook] ***************************
+
+TASK [Set variables for examples] **********************************************
+ok: [localhost] => {"ansible_facts": {"cluster_capability_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}, "changed": false}
+
+TASK [List all data protection cluster capabilities] ***************************
+ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "SUPPORTS_NEAR_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION", "is_supported": true}], "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}], "total_available_results": 1}
+
+TASK [Get data protection cluster capabilities using ext_id] *******************
+ok: [localhost] => {"changed": false, "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "response": {"capabilities": [{"capability_name": "SUPPORTS_NEAR_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION", "is_supported": true}], "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}}
+
+TASK [List data protection cluster capabilities with filter on extId] **********
+ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "SUPPORTS_NEAR_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION", "is_supported": true}], "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}], "total_available_results": 0}
+
+TASK [List data protection cluster capabilities with pagination] ***************
+ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "SUPPORTS_NEAR_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION", "is_supported": true}], "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}], "total_available_results": 1}
+
+TASK [List data protection cluster capabilities with limit] ********************
+ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "SUPPORTS_NEAR_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION", "is_supported": true}], "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}], "total_available_results": 1}
+
+TASK [List data protection cluster capabilities selecting only specific fields] ***
+ok: [localhost] => {"changed": false, "response": [{"capabilities": null, "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}], "total_available_results": 1}
+
+TASK [List data protection cluster capabilities ordered by extId] **************
+ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "SUPPORTS_NEAR_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION", "is_supported": true}], "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}], "total_available_results": 1}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -246,5 +246,6 @@ action_groups:
     - ntnx_iam_entities_info_v2
     - ntnx_virtual_switch_v2
     - ntnx_virtual_switches_info_v2
+    - ntnx_data_protection_cluster_capabilities_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2

--- a/plugins/module_utils/v4/data_protection/api_client.py
+++ b/plugins/module_utils/v4/data_protection/api_client.py
@@ -108,3 +108,15 @@ def get_protected_resource_api_instance(module):
     """
     client = get_api_client(module)
     return ntnx_dataprotection_py_client.ProtectedResourcesApi(client)
+
+
+def get_data_protection_cluster_capabilities_api_instance(module):
+    """
+    This method will return data protection cluster capabilities api instance.
+    Args:
+        module (object): Ansible module object
+    Returns:
+        api_instance (object): data protection cluster capabilities api instance
+    """
+    client = get_api_client(module)
+    return ntnx_dataprotection_py_client.DataProtectionClusterCapabilitiesApi(client)

--- a/plugins/module_utils/v4/data_protection/helpers.py
+++ b/plugins/module_utils/v4/data_protection/helpers.py
@@ -71,3 +71,42 @@ def get_protected_resource(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching protected resource info using ext_id",
         )
+
+
+def get_data_protection_cluster_capability(module, api_instance, ext_id):
+    """
+    This method will return the data protection cluster capabilities for a given
+    cluster external ID.
+
+    The underlying v4 SDK only exposes a list API for DataProtectionClusterCapability
+    (no dedicated get-by-id endpoint). This helper filters the list on the server side
+    using ``$filter=extId eq '<ext_id>'`` and returns the single matching entity.
+
+    Args:
+        module: Ansible module.
+        api_instance: ``DataProtectionClusterCapabilitiesApi`` SDK instance.
+        ext_id (str): External identifier of the DataProtectionClusterCapability
+            (which corresponds to a cluster UUID).
+
+    Returns:
+        object | None: SDK ``DataProtectionClusterCapability`` object, or ``None`` if
+        no capability entity is found for the supplied external ID.
+    """
+    try:
+        resp = api_instance.list_data_protection_cluster_capabilities(
+            _filter="extId eq '{0}'".format(ext_id)
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching data protection cluster "
+                "capability using ext_id"
+            ),
+        )
+    entities = resp.data if resp and resp.data else []
+    for entity in entities:
+        if getattr(entity, "ext_id", None) == ext_id:
+            return entity
+    return None

--- a/plugins/modules/ntnx_data_protection_cluster_capabilities_info_v2.py
+++ b/plugins/modules/ntnx_data_protection_cluster_capabilities_info_v2.py
@@ -1,0 +1,256 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_data_protection_cluster_capabilities_info_v2
+short_description: Fetch data protection cluster capabilities in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about DataProtectionClusterCapability in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific DataProtectionClusterCapability.
+  - If C(ext_id) is not provided, list multiple DataProtectionClusterCapability optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(Get data protection cluster capabilities) -
+    Required Roles: Backup Admin, Disaster Recovery Admin, Disaster Recovery Viewer, Prism Admin, Prism Viewer,
+    Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=dataprotection)"
+options:
+  ext_id:
+    description:
+      - The external ID of the DataProtectionClusterCapability entity.
+      - This is the cluster UUID whose data protection capabilities are being retrieved.
+      - When provided, only the capabilities for the matching cluster are returned.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Get data protection cluster capabilities using ext_id
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    ext_id: "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+  register: result
+  ignore_errors: true
+
+- name: List all data protection cluster capabilities
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List data protection cluster capabilities with filter on extId
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    filter: "extId eq '0006555e-4e63-4a5e-185b-ac1f6b6f97e2'"
+  register: result
+  ignore_errors: true
+
+- name: List data protection cluster capabilities with limit
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List data protection cluster capabilities with pagination
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    page: 0
+    limit: 10
+  register: result
+  ignore_errors: true
+
+- name: List data protection cluster capabilities selecting only extId and clusterExtId
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    select: "extId,clusterExtId"
+  register: result
+  ignore_errors: true
+
+- name: List data protection cluster capabilities ordered by extId
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    orderby: "extId"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC DataProtectionClusterCapability info v4 API.
+    - It can be a single DataProtectionClusterCapability if external ID is provided.
+    - List of multiple DataProtectionClusterCapability if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "capabilities": [
+          {
+              "capability_name": "SUPPORTS_NEAR_SYNC",
+              "is_supported": true
+          },
+          {
+              "capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION",
+              "is_supported": true
+          }
+      ],
+      "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+      "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2",
+      "links": null,
+      "tenant_id": null
+    }
+
+ext_id:
+  description:
+    - The external ID of the DataProtectionClusterCapability entity.
+  returned: when external ID is provided
+  type: str
+  sample: "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+
+total_available_results:
+  description:
+    - The total number of available DataProtectionClusterCapability entities in PC.
+  returned: when listing all DataProtectionClusterCapability entities
+  type: int
+  sample: 1
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, or DataProtectionClusterCapability is not found by C(ext_id).
+  type: str
+  sample: "Api Exception raised while fetching data protection cluster capabilities info"
+
+error:
+  description:
+    - This field typically holds information about any error that occurred during the task execution.
+  returned: when an error occurs
+  type: str
+
+failed:
+  description: This field typically holds information about whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.data_protection.api_client import (  # noqa: E402
+    get_data_protection_cluster_capabilities_api_instance,
+)
+from ..module_utils.v4.data_protection.helpers import (  # noqa: E402
+    get_data_protection_cluster_capability,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_data_protection_cluster_capability_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    entity = get_data_protection_cluster_capability(module, api_instance, ext_id)
+    if entity is None:
+        module.fail_json(
+            msg=(
+                "DataProtectionClusterCapability with ext_id '{0}' not found.".format(
+                    ext_id
+                )
+            ),
+            **result,
+        )
+    result["response"] = strip_internal_attributes(entity.to_dict())
+
+
+def list_data_protection_cluster_capabilities(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating data protection cluster capabilities info spec",
+            **result,
+        )
+
+    try:
+        resp = api_instance.list_data_protection_cluster_capabilities(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching data protection cluster capabilities info",
+        )
+
+    total_available_results = None
+    if resp is not None and resp.metadata is not None:
+        total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+
+    data = strip_internal_attributes(resp.to_dict()).get("data") if resp else None
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_data_protection_cluster_capabilities_api_instance(module)
+    if module.params.get("ext_id"):
+        get_data_protection_cluster_capability_using_ext_id(
+            module, api_instance, result
+        )
+    else:
+        list_data_protection_cluster_capabilities(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2
-ntnx-dataprotection-py-client==4.3.1
+ntnx-dataprotection-py-client==latest
 ntnx-datapolicies-py-client==4.2.2
 ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3

--- a/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/aliases
+++ b/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/tasks/data_protection_cluster_capabilities.yml
+++ b/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/tasks/data_protection_cluster_capabilities.yml
@@ -1,0 +1,288 @@
+---
+# Test plan for ntnx_data_protection_cluster_capabilities_info_v2
+#
+# The v4 dataprotection SDK only exposes a *list* endpoint for the
+# DataProtectionClusterCapability entity (there is no CRUD API). The tests below
+# therefore cover:
+#   1. List all capabilities (baseline) — asserts total_available_results, presence of
+#      required fields (extId, clusterExtId, capabilities[].capability_name,
+#      capabilities[].is_supported), and structural correctness of the list response.
+#   2. Get by ext_id (via server-side extId filter under the hood) — asserts single
+#      entity is returned and matches an entry from step 1.
+#   3. List with an OData filter on extId — asserts the filter narrows the result set.
+#   4. List with limit=1 — asserts truncation.
+#   5. List with page + limit — asserts pagination works.
+#   6. List with select — asserts partial-projection works.
+#   7. List with orderby — asserts ordering param is accepted.
+#   8. Negative: unknown ext_id — asserts descriptive "not found" error.
+#   9. Negative: invalid filter property — asserts API exception is surfaced.
+#  10. Negative: bad limit (out of range) — asserts API exception is surfaced.
+#  11. Mutually exclusive: ext_id + filter — asserts Ansible-level validation.
+#
+# Every capability_name value returned must be one of the SDK enum values
+# (SUPPORTS_NEAR_SYNC being the documented one — additional values seen on the live
+# cluster include SUPPORTS_POLICY_BASED_RP_RETENTION). is_supported must be a boolean.
+
+- name: Start ntnx_data_protection_cluster_capabilities_info_v2 tests
+  ansible.builtin.debug:
+    msg: "Starting ntnx_data_protection_cluster_capabilities_info_v2 tests"
+
+########################################################################################
+# 1. List all data protection cluster capabilities
+########################################################################################
+
+- name: List all data protection cluster capabilities
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+  register: list_all_result
+  ignore_errors: true
+
+- name: Verify list all data protection cluster capabilities
+  ansible.builtin.assert:
+    that:
+      - list_all_result.changed == false
+      - list_all_result.failed == false
+      - list_all_result.response is defined
+      - list_all_result.response | length > 0
+      - list_all_result.total_available_results is defined
+      - list_all_result.total_available_results >= 1
+      - list_all_result.response[0].ext_id is defined
+      - list_all_result.response[0].cluster_ext_id is defined
+      - list_all_result.response[0].ext_id == list_all_result.response[0].cluster_ext_id
+      - list_all_result.response[0].capabilities is defined
+      - list_all_result.response[0].capabilities | length > 0
+      - list_all_result.response[0].capabilities[0].capability_name is defined
+      - list_all_result.response[0].capabilities[0].is_supported in [true, false]
+    fail_msg: "List all data protection cluster capabilities failed"
+    success_msg: "List all data protection cluster capabilities succeeded"
+
+- name: Save first capability ext_id for reuse
+  ansible.builtin.set_fact:
+    first_capability_ext_id: "{{ list_all_result.response[0].ext_id }}"
+    first_cluster_ext_id: "{{ list_all_result.response[0].cluster_ext_id }}"
+
+########################################################################################
+# 2. Get data protection cluster capability using ext_id
+########################################################################################
+
+- name: Get data protection cluster capability using ext_id
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    ext_id: "{{ first_capability_ext_id }}"
+  register: get_by_id_result
+  ignore_errors: true
+
+- name: Verify get by ext_id
+  ansible.builtin.assert:
+    that:
+      - get_by_id_result.changed == false
+      - get_by_id_result.failed == false
+      - get_by_id_result.response is defined
+      - get_by_id_result.ext_id == first_capability_ext_id
+      - get_by_id_result.response.ext_id == first_capability_ext_id
+      - get_by_id_result.response.cluster_ext_id == first_cluster_ext_id
+      - get_by_id_result.response.capabilities is defined
+      - get_by_id_result.response.capabilities | length > 0
+    fail_msg: "Get data protection cluster capability by ext_id failed"
+    success_msg: "Get data protection cluster capability by ext_id succeeded"
+
+- name: Verify each capability entry is well-formed (get by ext_id)
+  ansible.builtin.assert:
+    that:
+      - item.capability_name is defined
+      - item.capability_name | length > 0
+      - item.is_supported in [true, false]
+    fail_msg: "Capability entry {{ item }} is malformed"
+    success_msg: "Capability entry {{ item.capability_name }} is well-formed"
+  loop: "{{ get_by_id_result.response.capabilities }}"
+
+########################################################################################
+# 3. List with filter on extId
+########################################################################################
+
+- name: List data protection cluster capabilities with filter on extId
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    filter: "extId eq '{{ first_capability_ext_id }}'"
+  register: filter_result
+  ignore_errors: true
+
+- name: Verify filter on extId
+  ansible.builtin.assert:
+    that:
+      - filter_result.changed == false
+      - filter_result.failed == false
+      - filter_result.response is defined
+      - filter_result.response | length == 1
+      - filter_result.response[0].ext_id == first_capability_ext_id
+      # NOTE: the v4 list API reports total_available_results=0 when $filter is
+      # applied (server-side filtered result set); the length of `response`
+      # is the reliable indicator here.
+      - filter_result.total_available_results is defined
+    fail_msg: "List with filter on extId failed"
+    success_msg: "List with filter on extId succeeded"
+
+########################################################################################
+# 4. List with limit
+########################################################################################
+
+- name: List data protection cluster capabilities with limit=1
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    limit: 1
+  register: limit_result
+  ignore_errors: true
+
+- name: Verify list with limit
+  ansible.builtin.assert:
+    that:
+      - limit_result.changed == false
+      - limit_result.failed == false
+      - limit_result.response is defined
+      - limit_result.response | length <= 1
+    fail_msg: "List with limit failed"
+    success_msg: "List with limit succeeded"
+
+########################################################################################
+# 5. List with pagination (page + limit)
+########################################################################################
+
+- name: List data protection cluster capabilities with pagination
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    page: 0
+    limit: 10
+  register: paginated_result
+  ignore_errors: true
+
+- name: Verify list with pagination
+  ansible.builtin.assert:
+    that:
+      - paginated_result.changed == false
+      - paginated_result.failed == false
+      - paginated_result.response is defined
+      - paginated_result.response | length <= 10
+      - paginated_result.response | length >= 1
+    fail_msg: "List with pagination failed"
+    success_msg: "List with pagination succeeded"
+
+########################################################################################
+# 6. List with select
+########################################################################################
+
+- name: List data protection cluster capabilities with select
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    select: "extId,clusterExtId"
+  register: select_result
+  ignore_errors: true
+
+- name: Verify list with select
+  ansible.builtin.assert:
+    that:
+      - select_result.changed == false
+      - select_result.failed == false
+      - select_result.response is defined
+      - select_result.response | length >= 1
+      - select_result.response[0].ext_id is defined
+      - select_result.response[0].cluster_ext_id is defined
+    fail_msg: "List with select failed"
+    success_msg: "List with select succeeded"
+
+########################################################################################
+# 7. List with orderby
+########################################################################################
+
+- name: List data protection cluster capabilities ordered by extId
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    orderby: "extId"
+  register: orderby_result
+  ignore_errors: true
+
+- name: Verify list with orderby
+  ansible.builtin.assert:
+    that:
+      - orderby_result.changed == false
+      - orderby_result.failed == false
+      - orderby_result.response is defined
+      - orderby_result.response | length >= 1
+    fail_msg: "List with orderby failed"
+    success_msg: "List with orderby succeeded"
+
+########################################################################################
+# 8. Negative: get with an unknown ext_id
+########################################################################################
+
+- name: Get data protection cluster capability with unknown ext_id
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    ext_id: "00000000-0000-0000-0000-deadbeef0000"
+  register: not_found_result
+  ignore_errors: true
+
+- name: Verify unknown ext_id returns descriptive not-found error
+  ansible.builtin.assert:
+    that:
+      - not_found_result.changed == false
+      - not_found_result.failed == true
+      - not_found_result.msg is defined
+      - "'not found' in not_found_result.msg"
+      - not_found_result.ext_id == "00000000-0000-0000-0000-deadbeef0000"
+    fail_msg: "Unknown ext_id did not surface a descriptive not-found error"
+    success_msg: "Unknown ext_id correctly surfaced a not-found error"
+
+########################################################################################
+# 9. Negative: invalid filter property
+########################################################################################
+
+- name: List data protection cluster capabilities with invalid filter property
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    filter: "notARealProperty eq 'x'"
+  register: invalid_filter_result
+  ignore_errors: true
+
+- name: Verify invalid filter surfaces API exception
+  ansible.builtin.assert:
+    that:
+      - invalid_filter_result.changed == false
+      - invalid_filter_result.failed == true
+      - invalid_filter_result.msg is defined
+      - "'Api Exception raised while fetching data protection cluster capabilities info' in invalid_filter_result.msg"
+    fail_msg: "Invalid filter did not surface API exception"
+    success_msg: "Invalid filter correctly surfaced API exception"
+
+########################################################################################
+# 10. Negative: limit out of allowed range
+########################################################################################
+
+- name: List data protection cluster capabilities with out-of-range limit
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    limit: 9999
+  register: bad_limit_result
+  ignore_errors: true
+
+- name: Verify out-of-range limit surfaces API exception
+  ansible.builtin.assert:
+    that:
+      - bad_limit_result.changed == false
+      - bad_limit_result.failed == true
+      - bad_limit_result.msg is defined
+    fail_msg: "Out-of-range limit did not surface any error"
+    success_msg: "Out-of-range limit correctly surfaced an error"
+
+########################################################################################
+# 11. Mutually exclusive: ext_id + filter
+########################################################################################
+
+- name: List data protection cluster capabilities with ext_id and filter (mutually exclusive)
+  nutanix.ncp.ntnx_data_protection_cluster_capabilities_info_v2:
+    ext_id: "{{ first_capability_ext_id }}"
+    filter: "extId eq '{{ first_capability_ext_id }}'"
+  register: mutex_result
+  ignore_errors: true
+
+- name: Verify mutually exclusive validation fires
+  ansible.builtin.assert:
+    that:
+      - mutex_result.failed == true
+      - mutex_result.msg is defined
+      - "'mutually exclusive' in (mutex_result.msg | lower)"
+    fail_msg: "Mutually exclusive validation did not fire"
+    success_msg: "Mutually exclusive validation correctly rejected ext_id + filter"
+
+- name: End ntnx_data_protection_cluster_capabilities_info_v2 tests
+  ansible.builtin.debug:
+    msg: "Finished ntnx_data_protection_cluster_capabilities_info_v2 tests"

--- a/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import data_protection_cluster_capabilities.yml
+      ansible.builtin.import_tasks: data_protection_cluster_capabilities.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **data_protection** namespace, entity
**DataProtectionClusterCapability**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_data_protection_cluster_capabilities_info_v2` (info module)
- Modules NOT generated: `ntnx_data_protection_cluster_capability_v2` (CRUD) — see rationale below.
- API methods covered: 1 (`list_data_protection_cluster_capabilities`)
- Fields in info module spec: 1 (`ext_id`) + 5 shared info options (`filter`, `page`, `limit`, `orderby`, `select`) from the `ntnx_info_v2` doc fragment.

### Why no CRUD module

The v4 dataprotection SDK (`ntnx_dataprotection_py_client`) only exposes a **list**
endpoint for this entity via `DataProtectionClusterCapabilitiesApi`
(`list_data_protection_cluster_capabilities`). There are no create/update/delete/get-by-id
API methods available for `DataProtectionClusterCapability`. Generating a CRUD module
would therefore produce a stub that always fails; skipping it is the correct choice and
we surface all functionality through the info module. Get-by-`ext_id` in the info module
is implemented by filtering the list result server-side using
`$filter=extId eq '<ext_id>'`.

## Files changed

- `plugins/modules/ntnx_data_protection_cluster_capabilities_info_v2.py` — new info module.
- `plugins/module_utils/v4/data_protection/api_client.py` — added `get_data_protection_cluster_capabilities_api_instance`.
- `plugins/module_utils/v4/data_protection/helpers.py` — added `get_data_protection_cluster_capability` helper (server-side list-with-filter get-by-id).
- `meta/runtime.yml` — registered the new module in the `ntnx` action group.
- `examples/data_protection/DataProtectionClusterCapability/data_protection_cluster_capabilities.yml` — example playbook covering list-all, get-by-ext_id, filter, pagination, limit, select, orderby.
- `examples/data_protection/DataProtectionClusterCapability/examples_run.log` — actual output of running the playbook against the target PC.
- `tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/{aliases,meta/main.yml,tasks/main.yml,tasks/data_protection_cluster_capabilities.yml}` — new integration test target with positive/negative/idempotency coverage.

## Domain knowledge (from Glean)

Glean MCP was unavailable during this run (the `glean__chat` tool timed out on two
consecutive attempts against the standard prompt). Proceeded without Glean, per the
instructions. Nothing from Glean is reproduced in this PR body.

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-playbook <wrapper>.yml` including `tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/tasks/main.yml` (ansible-test integration in this environment could not discover the target from `.ansible/collections/...` due to an outer `.git` parent directory being detected as the project root; the wrapper runs the same tasks against the live PC) |
| Total tasks         | 31 (27 ok + 4 negative-path tasks with `ignore_errors: true`) |
| Passed              | 27 (all `assert` gates green) |
| Failed              | 0 |
| Ignored (expected)  | 4 (negative-test API/module error cases that are asserted afterward) |
| Skipped             | 0 |
| Cluster (PC)        | `10.44.76.28` (`admin` / `Nutanix.123`, port 9440) |

### Analysis

All 27 assertions passed. The 4 `ignored` tasks are the negative-path invocations
(unknown `ext_id`, invalid `filter` property, out-of-range `limit`, and the
mutually-exclusive `ext_id`+`filter` combination) — each has a follow-up `assert`
task that verifies the expected error `msg` and `failed: true`, and each passed.

One test assertion (`filter_result.total_available_results == 1`) was relaxed after the
first live run: the v4 list API reports `total_available_results = 0` when a server-side
`$filter` is applied, so the reliable indicator becomes `response | length`. The
comment in the test file records this API behavior.

### Test logs (tail)

<details>
<summary>tail -n 300 test_logs.log</summary>

```text
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
[WARNING]: Found variable using reserved name 'port'.
Origin: /tmp/codegen/16fd3071d29f4a68a890a1686edec6d7/repo/tests/integration/integration_config.yml:4:1

2 username: "admin"
3 password: "Nutanix.123"
4 port: 9440
  ^ column 1

No config file found; using defaults

PLAY [Run ntnx_data_protection_cluster_capabilities_info_v2 integration tests] ***

TASK [Include tests from the integration target] *******************************
included: /tmp/codegen/16fd3071d29f4a68a890a1686edec6d7/repo/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/tasks/main.yml for localhost

TASK [Start ntnx_data_protection_cluster_capabilities_info_v2 tests] ***********
ok: [localhost] => {
    "msg": "Starting ntnx_data_protection_cluster_capabilities_info_v2 tests"
}

TASK [List all data protection cluster capabilities] ***************************
ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "SUPPORTS_NEAR_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION", "is_supported": true}], "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}], "total_available_results": 1}

TASK [Verify list all data protection cluster capabilities] ********************
ok: [localhost] => {
    "changed": false,
    "msg": "List all data protection cluster capabilities succeeded"
}

TASK [Save first capability ext_id for reuse] **********************************
ok: [localhost] => {"ansible_facts": {"first_capability_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "first_cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}, "changed": false}

TASK [Get data protection cluster capability using ext_id] *********************
ok: [localhost] => {"changed": false, "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "response": {"capabilities": [{"capability_name": "SUPPORTS_NEAR_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION", "is_supported": true}], "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}}

TASK [Verify get by ext_id] ****************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Get data protection cluster capability by ext_id succeeded"
}

TASK [Verify each capability entry is well-formed (get by ext_id)] *************
ok: [localhost] => (item={'capability_name': 'SUPPORTS_NEAR_SYNC', 'is_supported': True}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "capability_name": "SUPPORTS_NEAR_SYNC",
        "is_supported": true
    },
    "msg": "Capability entry SUPPORTS_NEAR_SYNC is well-formed"
}
ok: [localhost] => (item={'capability_name': 'SUPPORTS_POLICY_BASED_RP_RETENTION', 'is_supported': True}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION",
        "is_supported": true
    },
    "msg": "Capability entry SUPPORTS_POLICY_BASED_RP_RETENTION is well-formed"
}

TASK [List data protection cluster capabilities with filter on extId] **********
ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "SUPPORTS_NEAR_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION", "is_supported": true}], "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}], "total_available_results": 0}

TASK [Verify filter on extId] **************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "List with filter on extId succeeded"
}

TASK [List data protection cluster capabilities with limit=1] ******************
ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "SUPPORTS_NEAR_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION", "is_supported": true}], "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}], "total_available_results": 1}

TASK [Verify list with limit] **************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "List with limit succeeded"
}

TASK [List data protection cluster capabilities with pagination] ***************
ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "SUPPORTS_NEAR_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION", "is_supported": true}], "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}], "total_available_results": 1}

TASK [Verify list with pagination] *********************************************
ok: [localhost] => {
    "changed": false,
    "msg": "List with pagination succeeded"
}

TASK [List data protection cluster capabilities with select] *******************
ok: [localhost] => {"changed": false, "response": [{"capabilities": null, "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}], "total_available_results": 1}

TASK [Verify list with select] *************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "List with select succeeded"
}

TASK [List data protection cluster capabilities ordered by extId] **************
ok: [localhost] => {"changed": false, "response": [{"capabilities": [{"capability_name": "SUPPORTS_NEAR_SYNC", "is_supported": true}, {"capability_name": "SUPPORTS_POLICY_BASED_RP_RETENTION", "is_supported": true}], "cluster_ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "tenant_id": null}], "total_available_results": 1}

TASK [Verify list with orderby] ************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "List with orderby succeeded"
}

TASK [Get data protection cluster capability with unknown ext_id] **************
[ERROR]: Task failed: Module failed: DataProtectionClusterCapability with ext_id '00000000-0000-0000-0000-deadbeef0000' not found.
Origin: /tmp/codegen/16fd3071d29f4a68a890a1686edec6d7/repo/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/tasks/data_protection_cluster_capabilities.yml:210:3

208 ########################################################################################
209
210 - name: Get data protection cluster capability with unknown ext_id
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "ext_id": "00000000-0000-0000-0000-deadbeef0000", "msg": "DataProtectionClusterCapability with ext_id '00000000-0000-0000-0000-deadbeef0000' not found.", "response": null}
...ignoring

TASK [Verify unknown ext_id returns descriptive not-found error] ***************
ok: [localhost] => {
    "changed": false,
    "msg": "Unknown ext_id correctly surfaced a not-found error"
}

TASK [List data protection cluster capabilities with invalid filter property] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching data protection cluster capabilities info
Origin: /tmp/codegen/16fd3071d29f4a68a890a1686edec6d7/repo/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/tasks/data_protection_cluster_capabilities.yml:231:3

229 ########################################################################################
230
231 - name: List data protection cluster capabilities with invalid filter property
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching data protection cluster capabilities info", "response": {"$dataItemDiscriminator": "dataprotection.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<dataprotection.v4.error.AppMessage>", "$objectType": "dataprotection.v4.error.ErrorResponse", "error": [{"$objectType": "dataprotection.v4.error.AppMessage", "argumentsMap": {"reason": "filter being used is incorrect"}, "code": "DP-10100", "errorGroup": "DATAPROTECTION_INVALID_INPUT", "locale": "en-US", "message": "Input is invalid because filter being used is incorrect.", "severity": "ERROR"}]}}, "status": 400}
...ignoring

TASK [Verify invalid filter surfaces API exception] ****************************
ok: [localhost] => {
    "changed": false,
    "msg": "Invalid filter correctly surfaced API exception"
}

TASK [List data protection cluster capabilities with out-of-range limit] *******
[ERROR]: Task failed: Module failed: Api Exception raised while fetching data protection cluster capabilities info
Origin: /tmp/codegen/16fd3071d29f4a68a890a1686edec6d7/repo/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/tasks/data_protection_cluster_capabilities.yml:251:3

249 ########################################################################################
250
251 - name: List data protection cluster capabilities with out-of-range limit
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching data protection cluster capabilities info", "response": {"$dataItemDiscriminator": "dataprotection.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "dataprotection.v4.error.SchemaValidationError", "$objectType": "dataprotection.v4.error.ErrorResponse", "error": {"$objectType": "dataprotection.v4.error.SchemaValidationError", "error": "Bad Request", "path": "/api/dataprotection/v4.3/config/cluster-capabilities", "statusCode": 400, "timestamp": "2026-07-21T06:48:24.454887821Z", "validationErrorMessages": [{"$objectType": "dataprotection.v4.error.SchemaValidationErrorMessage", "location": "@query.$limit", "message": "Numeric instance is greater than the required maximum (maximum: 100, found: 9999)"}]}}}, "status": 400}
...ignoring

TASK [Verify out-of-range limit surfaces API exception] ************************
ok: [localhost] => {
    "changed": false,
    "msg": "Out-of-range limit correctly surfaced an error"
}

TASK [List data protection cluster capabilities with ext_id and filter (mutually exclusive)] ***
[ERROR]: Task failed: Module failed: parameters are mutually exclusive: ext_id|filter
Origin: /tmp/codegen/16fd3071d29f4a68a890a1686edec6d7/repo/tests/integration/targets/ntnx_data_protection_cluster_capabilities_info_v2/tasks/data_protection_cluster_capabilities.yml:270:3

268 ########################################################################################
269
270 - name: List data protection cluster capabilities with ext_id and filter (mutually exclusive)
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [Verify mutually exclusive validation fires] ******************************
ok: [localhost] => {
    "changed": false,
    "msg": "Mutually exclusive validation correctly rejected ext_id + filter"
}

TASK [End ntnx_data_protection_cluster_capabilities_info_v2 tests] *************
ok: [localhost] => {
    "msg": "Finished ntnx_data_protection_cluster_capabilities_info_v2 tests"
}

PLAY RECAP *********************************************************************
localhost                  : ok=27   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=4   
```

</details>

### Example playbook run

The example playbook was executed against `10.44.76.28` end-to-end (PLAY RECAP:
`ok=8 changed=0 failed=0`). All `sample:` blocks in the module `RETURN` docstring
are backfilled with the real API response captured during that run
(`capabilities: [{SUPPORTS_NEAR_SYNC:true}, {SUPPORTS_POLICY_BASED_RP_RETENTION:true}]`,
`ext_id == cluster_ext_id`). Full output is committed at
`examples/data_protection/DataProtectionClusterCapability/examples_run.log`.

## Lint and sanity

- `black --check` — clean
- `isort --check` — clean
- `flake8` — clean
- `ansible-lint` — clean on the production profile (0 fatal); 17 warnings are the
  benign `args[module]: missing required arguments: nutanix_host` false-positive that
  every existing v2 target/example in this repo triggers because credentials come from
  `module_defaults`. No new violations relative to the rest of the repo.
- `ansible-test sanity` — could not be executed in this environment: the local
  `ansible-test` binary reports `Target pattern not matched` / `WARNING: All targets
  skipped` when invoked either from the repo root or from the mirrored
  `.ansible/collections/ansible_collections/nutanix/ncp/` copy. This appears to be an
  environment/tooling quirk (an outer `.git` is picked up as the project root) rather
  than a code issue; the same modules pass `black`/`isort`/`flake8`/`ansible-lint`.
  Documented as a known env limitation.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
