### PR TITLE
code-gen(identity_and_access_management/WelcomeBanner): ansible collection modules

### DIFF
--- a/examples/identity_and_access_management/WelcomeBanner/examples_run.log
+++ b/examples/identity_and_access_management/WelcomeBanner/examples_run.log
@@ -1,0 +1,105 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [IAM Welcome Banner example playbook] *************************************
+
+TASK [Fetch the current welcome banner configuration] **************************
+ok: [localhost] => {"changed": false, "error": null, "response": {"content": "Write HTML code here", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": false, "last_updated_time": "2026-07-21T06:50:15.095039+00:00"}}
+
+TASK [Show the current welcome banner] *****************************************
+ok: [localhost] => {
+    "welcome_banner_before.response": {
+        "content": "Write HTML code here",
+        "created_time": "2026-06-29T07:18:36.280134+00:00",
+        "is_enabled": false,
+        "last_updated_time": "2026-07-21T06:50:15.095039+00:00"
+    }
+}
+
+TASK [Update the welcome banner (create-equivalent for this singleton)] ********
+changed: [localhost] => {"changed": true, "ext_id": null, "response": {"content": "<p><b>Authorized access only.</b><br> All activity on this Nutanix Prism Central instance is logged and monitored. By clicking Accept you agree to the acceptable-use policy of your organization.</p>", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": true, "last_updated_time": "2026-07-21T06:50:36.855619+00:00"}, "task_ext_id": null}
+
+TASK [Show the updated welcome banner] *****************************************
+ok: [localhost] => {
+    "welcome_banner_updated": {
+        "changed": true,
+        "ext_id": null,
+        "failed": false,
+        "response": {
+            "content": "<p><b>Authorized access only.</b><br> All activity on this Nutanix Prism Central instance is logged and monitored. By clicking Accept you agree to the acceptable-use policy of your organization.</p>",
+            "created_time": "2026-06-29T07:18:36.280134+00:00",
+            "is_enabled": true,
+            "last_updated_time": "2026-07-21T06:50:36.855619+00:00"
+        },
+        "skipped": false,
+        "task_ext_id": null
+    }
+}
+
+TASK [Update the welcome banner content again (idempotency demo)] **************
+skipping: [localhost] => {"changed": false, "ext_id": null, "msg": "Welcome banner is already in the desired state. Skipping update.", "response": {"content": "<p><b>Authorized access only.</b><br> All activity on this Nutanix Prism Central instance is logged and monitored. By clicking Accept you agree to the acceptable-use policy of your organization.</p>", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": true, "last_updated_time": "2026-07-21T06:50:36.855653+00:00"}, "task_ext_id": null}
+
+TASK [Show the second update (should be skipped)] ******************************
+ok: [localhost] => {
+    "welcome_banner_second_update": {
+        "changed": false,
+        "ext_id": null,
+        "failed": false,
+        "msg": "Welcome banner is already in the desired state. Skipping update.",
+        "response": {
+            "content": "<p><b>Authorized access only.</b><br> All activity on this Nutanix Prism Central instance is logged and monitored. By clicking Accept you agree to the acceptable-use policy of your organization.</p>",
+            "created_time": "2026-06-29T07:18:36.280134+00:00",
+            "is_enabled": true,
+            "last_updated_time": "2026-07-21T06:50:36.855653+00:00"
+        },
+        "skipped": true,
+        "task_ext_id": null
+    }
+}
+
+TASK [Change only the enablement flag (real update)] ***************************
+changed: [localhost] => {"changed": true, "ext_id": null, "response": {"content": "<p><b>Authorized access only.</b><br> All activity on this Nutanix Prism Central instance is logged and monitored. By clicking Accept you agree to the acceptable-use policy of your organization.</p>", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": false, "last_updated_time": "2026-07-21T06:50:38.236156+00:00"}, "task_ext_id": null}
+
+TASK [Show the disabled welcome banner] ****************************************
+ok: [localhost] => {
+    "welcome_banner_disabled": {
+        "changed": true,
+        "ext_id": null,
+        "failed": false,
+        "response": {
+            "content": "<p><b>Authorized access only.</b><br> All activity on this Nutanix Prism Central instance is logged and monitored. By clicking Accept you agree to the acceptable-use policy of your organization.</p>",
+            "created_time": "2026-06-29T07:18:36.280134+00:00",
+            "is_enabled": false,
+            "last_updated_time": "2026-07-21T06:50:38.236156+00:00"
+        },
+        "skipped": false,
+        "task_ext_id": null
+    }
+}
+
+TASK [Reset the welcome banner to defaults (delete-equivalent)] ****************
+changed: [localhost] => {"changed": true, "ext_id": null, "msg": "Welcome banner has been reset to the default state.", "response": {"content": "Write HTML code here", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": false, "last_updated_time": "2026-07-21T06:50:38.920567+00:00"}, "task_ext_id": null}
+
+TASK [Show the reset welcome banner] *******************************************
+ok: [localhost] => {
+    "welcome_banner_reset": {
+        "changed": true,
+        "ext_id": null,
+        "failed": false,
+        "msg": "Welcome banner has been reset to the default state.",
+        "response": {
+            "content": "Write HTML code here",
+            "created_time": "2026-06-29T07:18:36.280134+00:00",
+            "is_enabled": false,
+            "last_updated_time": "2026-07-21T06:50:38.920567+00:00"
+        },
+        "skipped": false,
+        "task_ext_id": null
+    }
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=9    changed=3    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
+

--- a/examples/identity_and_access_management/WelcomeBanner/welcome_banner_v2.yml
+++ b/examples/identity_and_access_management/WelcomeBanner/welcome_banner_v2.yml
@@ -1,0 +1,87 @@
+---
+# Example playbook demonstrating how to manage the IAM Welcome Banner in
+# Nutanix Prism Central using the `ntnx_iam_welcome_banner_v2` and
+# `ntnx_iam_welcome_banner_info_v2` modules.
+#
+# The welcome banner is a singleton resource: it does not have an external ID
+# and cannot be created or truly deleted. The v4 API only supports GET and PUT.
+# For this reason the "update" flow always uses PUT (with optimistic
+# concurrency via the ETag/If-Match header) and the "delete" flow is
+# implemented as a reset back to the factory defaults (disabled + placeholder
+# content).
+#
+# Prerequisites:
+#   * Prism Central must be reachable at `nutanix_host`.
+#   * The account used to run this playbook must have `Super Admin` or
+#     `Prism Admin` roles to update the banner (`GET` is public).
+- name: IAM Welcome Banner example playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Fetch the current welcome banner configuration
+      nutanix.ncp.ntnx_iam_welcome_banner_info_v2:
+      register: welcome_banner_before
+
+    - name: Show the current welcome banner
+      ansible.builtin.debug:
+        var: welcome_banner_before.response
+
+    - name: Update the welcome banner (create-equivalent for this singleton)
+      nutanix.ncp.ntnx_iam_welcome_banner_v2:
+        state: present
+        content: >-
+          <p><b>Authorized access only.</b><br>
+          All activity on this Nutanix Prism Central instance is logged and
+          monitored. By clicking Accept you agree to the acceptable-use
+          policy of your organization.</p>
+        is_enabled: true
+      register: welcome_banner_updated
+
+    - name: Show the updated welcome banner
+      ansible.builtin.debug:
+        var: welcome_banner_updated
+
+    - name: Update the welcome banner content again (idempotency demo)
+      nutanix.ncp.ntnx_iam_welcome_banner_v2:
+        state: present
+        content: >-
+          <p><b>Authorized access only.</b><br>
+          All activity on this Nutanix Prism Central instance is logged and
+          monitored. By clicking Accept you agree to the acceptable-use
+          policy of your organization.</p>
+        is_enabled: true
+      register: welcome_banner_second_update
+
+    - name: Show the second update (should be skipped)
+      ansible.builtin.debug:
+        var: welcome_banner_second_update
+
+    - name: Change only the enablement flag (real update)
+      nutanix.ncp.ntnx_iam_welcome_banner_v2:
+        state: present
+        content: >-
+          <p><b>Authorized access only.</b><br>
+          All activity on this Nutanix Prism Central instance is logged and
+          monitored. By clicking Accept you agree to the acceptable-use
+          policy of your organization.</p>
+        is_enabled: false
+      register: welcome_banner_disabled
+
+    - name: Show the disabled welcome banner
+      ansible.builtin.debug:
+        var: welcome_banner_disabled
+
+    - name: Reset the welcome banner to defaults (delete-equivalent)
+      nutanix.ncp.ntnx_iam_welcome_banner_v2:
+        state: absent
+      register: welcome_banner_reset
+
+    - name: Show the reset welcome banner
+      ansible.builtin.debug:
+        var: welcome_banner_reset

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_iam_welcome_banner_v2
+    - ntnx_iam_welcome_banner_info_v2

--- a/plugins/module_utils/v4/iam/api_client.py
+++ b/plugins/module_utils/v4/iam/api_client.py
@@ -177,3 +177,15 @@ def get_entity_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_iam_py_client.EntitiesApi(api_client=api_client)
+
+
+def get_welcome_banner_api_instance(module):
+    """
+    This method will return welcome banner api instance.
+    Args:
+        module (object): Ansible module object
+    Returns:
+        api_instance (object): Welcome banner api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_iam_py_client.WelcomeBannerApi(api_client=api_client)

--- a/plugins/module_utils/v4/iam/helpers.py
+++ b/plugins/module_utils/v4/iam/helpers.py
@@ -187,3 +187,28 @@ def get_entity(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching entity info using ext_id",
         )
+
+
+def get_welcome_banner(module, api_instance):
+    """
+    This method will return the welcome banner configuration.
+
+    The welcome banner is a singleton resource in Prism Central (there is no
+    ext_id/id — the resource is accessed directly via a single URL), so this
+    helper takes no external identifier.
+
+    Args:
+        module (object): Ansible module object.
+        api_instance (object): Welcome banner api instance from
+            ``ntnx_iam_py_client``.
+    Returns:
+        welcome_banner (object): Welcome banner configuration object.
+    """
+    try:
+        return api_instance.get_welcome_banner().data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching welcome banner",
+        )

--- a/plugins/modules/ntnx_iam_welcome_banner_info_v2.py
+++ b/plugins/modules/ntnx_iam_welcome_banner_info_v2.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_iam_welcome_banner_info_v2
+short_description: Fetch the IAM Welcome Banner from Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about WelcomeBanner in Nutanix Prism Central.
+  - The welcome banner is a singleton resource in Prism Central; there is no
+    external ID and no list operation, so this module always returns the single
+    welcome banner configuration.
+  - The C(ext_id) option is accepted for consistency with the other v4 info
+    modules and is otherwise ignored.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation.
+  - >-
+    B(Get the Welcome Banner) - Required Roles: Super Admin, Prism Admin,
+    Prism Viewer. The banner GET endpoint is also invoked unauthenticated by
+    the Prism Central login page.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=iam)"
+options:
+  ext_id:
+    description:
+      - Placeholder external ID for the welcome banner.
+      - The welcome banner is a singleton resource in Prism Central and has no
+        real external ID; this option is accepted for consistency with the
+        other v4 info modules and is otherwise ignored.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch the welcome banner configuration
+  nutanix.ncp.ntnx_iam_welcome_banner_info_v2:
+  register: result
+
+- name: Fetch the welcome banner configuration (ext_id ignored - singleton)
+  nutanix.ncp.ntnx_iam_welcome_banner_info_v2:
+    ext_id: "welcome-banner"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC WelcomeBanner info v4 API.
+    - The welcome banner is a singleton resource, so this is always the single
+      welcome banner configuration as a dict. There is no list variant.
+  returned: always
+  type: dict
+  sample:
+    {
+      "content": "Authorized personnel only. All activity is monitored and recorded.",
+      "created_time": "2026-06-29T07:18:36.280134+00:00",
+      "is_enabled": true,
+      "last_updated_time": "2026-07-21T06:36:56.065999+00:00",
+      "links": null,
+      "tenant_id": null
+    }
+
+changed:
+  description: Always False for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Message if any error occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching welcome banner"
+
+error:
+  description:
+    - This field holds information about any error that occurred during task execution.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This field indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description:
+    - Placeholder external ID for the welcome banner.
+    - The welcome banner has no real external ID; this field is populated with
+      the C(ext_id) input value when supplied, otherwise C(null).
+  returned: when C(ext_id) is provided
+  type: str
+  sample: null
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.iam.api_client import (  # noqa: E402
+    get_welcome_banner_api_instance,
+)
+from ..module_utils.v4.iam.helpers import get_welcome_banner  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def fetch_welcome_banner(module, api_instance, result):
+    resp = get_welcome_banner(module, api_instance)
+    ext_id = module.params.get("ext_id")
+    if ext_id:
+        result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        # WelcomeBanner is a singleton — the standard info-module filter/limit/
+        # orderby/select/page options inherited from BaseInfoModule are accepted
+        # but the API ignores them; we do not pass them to the SDK.
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "error": None, "response": None}
+    api_instance = get_welcome_banner_api_instance(module)
+    fetch_welcome_banner(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_iam_welcome_banner_v2.py
+++ b/plugins/modules/ntnx_iam_welcome_banner_v2.py
@@ -1,0 +1,380 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_iam_welcome_banner_v2
+short_description: Manage the IAM Welcome Banner in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to update the IAM welcome banner in Nutanix Prism Central.
+  - The welcome banner is a singleton resource that is displayed on the Prism Central
+    login page before any authentication mechanism runs. It has no external ID.
+  - When C(state=present) the module updates the banner content and enablement flag
+    using the v4 PUT API (with C(If-Match) optimistic concurrency).
+  - When C(state=absent) the module resets the banner to its factory defaults
+    (disabled with the default content), which effectively hides the banner from
+    the login page.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation.
+  - >-
+    B(Update the Welcome Banner) - Required Roles: Super Admin, Prism Admin.
+  - >-
+    B(Reset the Welcome Banner) - Required Roles: Super Admin, Prism Admin.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=iam)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) the welcome banner will be updated with
+        the supplied C(content)/C(is_enabled) values.
+      - If C(state) is set to C(absent) the welcome banner will be reset to its
+        default state (C(is_enabled=false), default placeholder content).
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - Placeholder external ID for the welcome banner.
+      - The welcome banner is a singleton resource in Prism Central and does not
+        have a real external ID; this option is accepted for consistency with the
+        other CRUD-style v4 modules and is otherwise ignored.
+    type: str
+    required: false
+  content:
+    description:
+      - Content of the welcome banner. Supports plain text and a subset of HTML
+        (paragraphs, line breaks, custom coloring, and localized text).
+      - Required when C(state=present).
+    type: str
+    required: false
+  is_enabled:
+    description:
+      - Whether the welcome banner is displayed on the Prism Central login page.
+      - When C(true) the banner is shown before the login connectors (Local,
+        LDAP, SAML, CAC) and the user must click B(Accept) to proceed.
+    type: bool
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Update the welcome banner
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: present
+    content: "Authorized personnel only. All activity is monitored and recorded."
+    is_enabled: true
+  register: result
+
+- name: Disable the welcome banner but keep the content
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: present
+    content: "Authorized personnel only. All activity is monitored and recorded."
+    is_enabled: false
+  register: result
+
+- name: Reset the welcome banner to defaults (disabled + placeholder content)
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: absent
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for updating or resetting the welcome banner.
+    - Returns the full welcome banner details (content, is_enabled, created_time,
+      last_updated_time) after the operation completes.
+  returned: always
+  type: dict
+  sample:
+    {
+      "content": "Authorized personnel only. All activity is monitored and recorded.",
+      "created_time": "2026-06-29T07:18:36.280134+00:00",
+      "is_enabled": true,
+      "last_updated_time": "2026-07-21T06:36:56.065999+00:00",
+      "links": null,
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+    - The welcome banner PUT API is synchronous and does not return a task, so this
+      field is always C(null) for this module. It is kept for API consistency with
+      other v4 CRUD modules.
+  returned: always
+  type: str
+  sample: null
+
+ext_id:
+  description:
+    - The external ID of the welcome banner.
+    - The welcome banner is a singleton resource and has no real external ID; this
+      field is always C(null).
+  returned: always
+  type: str
+  sample: null
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped (idempotent no-op).
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, the module is idempotent, or check mode is used.
+  type: str
+  sample: "Welcome banner is already in the desired state. Skipping update."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.iam.api_client import (  # noqa: E402
+    get_etag,
+    get_welcome_banner_api_instance,
+)
+from ..module_utils.v4.iam.helpers import get_welcome_banner  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_iam_py_client as identity_and_access_management_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402
+        mock_sdk as identity_and_access_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+DEFAULT_BANNER_CONTENT = "Write HTML code here"
+READ_ONLY_FIELDS = ("created_time", "last_updated_time")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        content=dict(type="str"),
+        is_enabled=dict(type="bool"),
+    )
+    return module_args
+
+
+def _fetch_current_banner(module, api_instance):
+    """Fetch the current welcome banner and its etag from Prism Central."""
+    current = get_welcome_banner(module, api_instance)
+    etag = get_etag(data=current)
+    return current, etag
+
+
+def _is_no_op(current_dict, desired_dict):
+    """Return True when the desired banner already matches the current banner."""
+    current_dict = strip_internal_attributes(deepcopy(current_dict))
+    desired_dict = strip_internal_attributes(deepcopy(desired_dict))
+    for field in READ_ONLY_FIELDS:
+        current_dict.pop(field, None)
+        desired_dict.pop(field, None)
+    return current_dict == desired_dict
+
+
+def create_welcome_banner(module, result, api_instance):
+    """
+    The welcome banner is a singleton resource — it is always present in Prism
+    Central. "Create" for this entity is therefore the same operation as
+    "update": push the desired content/is_enabled via PUT.
+    """
+    update_welcome_banner(module, result, api_instance)
+
+
+def update_welcome_banner(module, result, api_instance):
+    validate_required_params(module, ["content"])
+
+    current, etag = _fetch_current_banner(module, api_instance)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for updating the welcome banner", **result
+        )
+
+    sg = SpecGenerator(module)
+    default_spec = identity_and_access_management_sdk.WelcomeBanner()
+    update_spec, err = sg.generate_spec(obj=deepcopy(default_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating welcome banner update spec", **result)
+
+    # `created_time` and `last_updated_time` are server-managed; a fresh spec
+    # created via the SDK model does not carry them, so no explicit stripping
+    # is required (the SDK property has no deleter).
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if _is_no_op(current.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        result["response"] = strip_internal_attributes(current.to_dict())
+        result["msg"] = (
+            "Welcome banner is already in the desired state. Skipping update."
+        )
+        return
+
+    try:
+        resp = api_instance.update_welcome_banner(body=update_spec, if_match=etag)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating the welcome banner",
+        )
+
+    if resp.data:
+        result["response"] = strip_internal_attributes(resp.data.to_dict())
+    else:
+        fresh = get_welcome_banner(module, api_instance)
+        result["response"] = strip_internal_attributes(fresh.to_dict())
+    result["changed"] = True
+
+
+def delete_welcome_banner(module, result, api_instance):
+    """
+    A welcome banner cannot be removed from Prism Central (it is a singleton).
+    "Delete" for this module is therefore implemented as a reset: push a PUT
+    that disables the banner and restores the factory default placeholder
+    content. This is the closest analogue to a DELETE for an update-only
+    singleton resource.
+    """
+    current, etag = _fetch_current_banner(module, api_instance)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for resetting the welcome banner", **result
+        )
+
+    reset_spec = identity_and_access_management_sdk.WelcomeBanner()
+    reset_spec.content = DEFAULT_BANNER_CONTENT
+    reset_spec.is_enabled = False
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(reset_spec.to_dict())
+        result["msg"] = "Welcome banner will be reset to default state."
+        return
+
+    if _is_no_op(current.to_dict(), reset_spec.to_dict()):
+        result["skipped"] = True
+        result["response"] = strip_internal_attributes(current.to_dict())
+        result["msg"] = (
+            "Welcome banner is already in the default state. Skipping reset."
+        )
+        return
+
+    try:
+        resp = api_instance.update_welcome_banner(body=reset_spec, if_match=etag)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while resetting the welcome banner",
+        )
+
+    if resp.data:
+        result["response"] = strip_internal_attributes(resp.data.to_dict())
+    else:
+        fresh = get_welcome_banner(module, api_instance)
+        result["response"] = strip_internal_attributes(fresh.to_dict())
+    result["changed"] = True
+    result["msg"] = "Welcome banner has been reset to the default state."
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "present", ("content",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_iam_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+    }
+
+    api_instance = get_welcome_banner_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_welcome_banner(module, result, api_instance)
+        else:
+            create_welcome_banner(module, result, api_instance)
+    else:
+        delete_welcome_banner(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pip>=23.0
 setuptools>=65.0
 requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
-ntnx-iam-py-client==4.1.2b2
+ntnx-iam-py-client==latest
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1

--- a/tests/integration/targets/ntnx_iam_welcome_banner_v2/aliases
+++ b/tests/integration/targets/ntnx_iam_welcome_banner_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_iam_welcome_banner_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_iam_welcome_banner_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_iam_welcome_banner_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_iam_welcome_banner_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults for the IAM Welcome Banner tests
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import welcome_banner.yml
+      ansible.builtin.import_tasks: welcome_banner.yml

--- a/tests/integration/targets/ntnx_iam_welcome_banner_v2/tasks/welcome_banner.yml
+++ b/tests/integration/targets/ntnx_iam_welcome_banner_v2/tasks/welcome_banner.yml
@@ -1,0 +1,375 @@
+---
+###########################################################################
+# Test plan for ntnx_iam_welcome_banner_v2 / ntnx_iam_welcome_banner_info_v2
+#
+# The Welcome Banner is a singleton IAM resource in Prism Central: no ext_id,
+# only GET and PUT. This test file covers every scenario a QA engineer would
+# expect for a singleton entity plus the domain-level behavior a real user
+# cares about (login-page HTML content, enabled/disabled toggling, ETag-based
+# optimistic concurrency, idempotency, factory reset, and negative paths).
+#
+# 1. Baseline fetch via info module (assert schema is populated)
+# 2. Check-mode update covering ALL attributes (content + is_enabled)
+# 3. Real update with ALL attributes (content + is_enabled=true) — assert changed
+# 4. Info module fetches the updated banner (round-trip via GET)
+# 5. Idempotency: re-run same update, assert skipped=true & msg
+# 6. Meaningful transition: flip only is_enabled to false, assert changed
+# 7. HTML content workflow (login-page style HTML), assert content persisted
+# 8. Check-mode delete (reset), assert unchanged on the server
+# 9. Real delete (reset) — assert changed, content=default, is_enabled=false
+# 10. Idempotency of delete: re-run reset on default state, assert skipped
+# 11. Negative: state=present without content, assert module fails (required_if)
+# 12. Restore the banner to the ORIGINAL configuration captured in step 1
+###########################################################################
+
+- name: Start ntnx_iam_welcome_banner_v2 tests
+  ansible.builtin.debug:
+    msg: start ntnx_iam_welcome_banner_v2 tests
+
+###########################################################################
+# Dynamic test data — random suffix so parallel test runs never collide.
+###########################################################################
+
+- name: Generate random suffix for the welcome banner content
+  ansible.builtin.set_fact:
+    banner_suffix: "{{ 999999 | random | to_uuid }}"
+
+- name: Build banner content strings (plain + HTML)
+  ansible.builtin.set_fact:
+    banner_plain_content: "Ansible IAM WelcomeBanner test - {{ banner_suffix }}"
+    banner_html_content: >-
+      <p><b>Ansible IAM WelcomeBanner HTML test - {{ banner_suffix }}</b><br>
+      All access to this system is logged and monitored.</p>
+    banner_default_content: "Write HTML code here"
+
+###########################################################################
+# 1. Baseline fetch (info module) — capture original state for restore
+###########################################################################
+
+- name: Fetch the welcome banner using the info module (baseline)
+  nutanix.ncp.ntnx_iam_welcome_banner_info_v2:
+  register: baseline
+  ignore_errors: true
+
+- name: Assert baseline info fetch succeeded and returned a WelcomeBanner
+  ansible.builtin.assert:
+    that:
+      - baseline.changed == false
+      - baseline.failed == false
+      - baseline.response is defined
+      - baseline.response.content is defined
+      - baseline.response.is_enabled is defined
+      - baseline.response.created_time is defined
+      - baseline.response.last_updated_time is defined
+    fail_msg: Baseline welcome banner fetch failed
+    success_msg: Baseline welcome banner fetch passed
+
+- name: Store original welcome banner state for later restoration
+  ansible.builtin.set_fact:
+    original_banner_content: "{{ baseline.response.content }}"
+    original_banner_is_enabled: "{{ baseline.response.is_enabled }}"
+
+###########################################################################
+# 2. Check-mode update covering ALL attributes (no server change)
+###########################################################################
+
+- name: Update the welcome banner in check_mode with ALL attributes
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: present
+    content: "{{ banner_plain_content }}"
+    is_enabled: true
+  register: cm_update
+  check_mode: true
+  ignore_errors: true
+
+- name: Assert check_mode update returns the desired spec without changing state
+  ansible.builtin.assert:
+    that:
+      - cm_update.changed == false
+      - cm_update.failed == false
+      - cm_update.response is defined
+      - cm_update.response.content == banner_plain_content
+      - cm_update.response.is_enabled == true
+    fail_msg: check_mode update did not return the expected desired spec
+    success_msg: check_mode update returned the expected desired spec
+
+- name: Fetch banner after check_mode update to confirm no server-side change
+  nutanix.ncp.ntnx_iam_welcome_banner_info_v2:
+  register: after_check_mode
+  ignore_errors: true
+
+- name: Assert the server-side banner is unchanged by check_mode
+  ansible.builtin.assert:
+    that:
+      - after_check_mode.changed == false
+      - after_check_mode.failed == false
+      - after_check_mode.response.content == original_banner_content
+      - after_check_mode.response.is_enabled == (original_banner_is_enabled | bool)
+    fail_msg: check_mode unexpectedly mutated the welcome banner on the server
+    success_msg: check_mode did not mutate the welcome banner on the server
+
+###########################################################################
+# 3. Real update with ALL attributes (plain content + is_enabled=true)
+###########################################################################
+
+- name: Update the welcome banner with plain content and enable it
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: present
+    content: "{{ banner_plain_content }}"
+    is_enabled: true
+  register: full_update
+  ignore_errors: true
+
+- name: Assert full welcome banner update succeeded
+  ansible.builtin.assert:
+    that:
+      - full_update.changed == true
+      - full_update.failed == false
+      - full_update.skipped == false
+      - full_update.response is defined
+      - full_update.response.content == banner_plain_content
+      - full_update.response.is_enabled == true
+      - full_update.response.last_updated_time is defined
+      - full_update.ext_id is none
+      - full_update.task_ext_id is none
+    fail_msg: Full welcome banner update failed
+    success_msg: Full welcome banner update passed
+
+###########################################################################
+# 4. Info module round-trip fetch of the updated banner
+###########################################################################
+
+- name: Fetch the welcome banner after the update
+  nutanix.ncp.ntnx_iam_welcome_banner_info_v2:
+  register: after_full_update
+  ignore_errors: true
+
+- name: Assert the info module round-trips the update we just made
+  ansible.builtin.assert:
+    that:
+      - after_full_update.changed == false
+      - after_full_update.failed == false
+      - after_full_update.response is defined
+      - after_full_update.response.content == banner_plain_content
+      - after_full_update.response.is_enabled == true
+    fail_msg: Info module did not return the updated welcome banner
+    success_msg: Info module returned the updated welcome banner
+
+###########################################################################
+# 4a. Info module invoked with an ext_id (accepted for consistency, ignored)
+###########################################################################
+
+- name: Fetch the welcome banner passing a placeholder ext_id
+  nutanix.ncp.ntnx_iam_welcome_banner_info_v2:
+    ext_id: "welcome-banner"
+  register: info_with_extid
+  ignore_errors: true
+
+- name: Assert info module accepted ext_id and returned the singleton banner
+  ansible.builtin.assert:
+    that:
+      - info_with_extid.changed == false
+      - info_with_extid.failed == false
+      - info_with_extid.response is defined
+      - info_with_extid.response.content == banner_plain_content
+      - info_with_extid.response.is_enabled == true
+      - info_with_extid.ext_id == "welcome-banner"
+    fail_msg: Info module with ext_id did not return the welcome banner
+    success_msg: Info module with ext_id returned the welcome banner
+
+###########################################################################
+# 5. Idempotency: re-run the same update, assert skipped
+###########################################################################
+
+- name: Re-run the same welcome banner update (idempotency)
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: present
+    content: "{{ banner_plain_content }}"
+    is_enabled: true
+  register: idempotent_update
+  ignore_errors: true
+
+- name: Assert idempotent update is a no-op
+  ansible.builtin.assert:
+    that:
+      - idempotent_update.changed == false
+      - idempotent_update.failed == false
+      - idempotent_update.skipped == true
+      - idempotent_update.response.content == banner_plain_content
+      - idempotent_update.response.is_enabled == true
+      - idempotent_update.msg == "Welcome banner is already in the desired state. Skipping update."
+    fail_msg: Idempotent update was not detected as a no-op
+    success_msg: Idempotent update correctly detected as a no-op
+
+###########################################################################
+# 6. Meaningful state transition: flip only is_enabled to false
+###########################################################################
+
+- name: Flip is_enabled to false, keep the same content
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: present
+    content: "{{ banner_plain_content }}"
+    is_enabled: false
+  register: disable_only
+  ignore_errors: true
+
+- name: Assert only is_enabled changed
+  ansible.builtin.assert:
+    that:
+      - disable_only.changed == true
+      - disable_only.failed == false
+      - disable_only.skipped == false
+      - disable_only.response.content == banner_plain_content
+      - disable_only.response.is_enabled == false
+    fail_msg: Disable-only update failed
+    success_msg: Disable-only update succeeded
+
+###########################################################################
+# 7. Update with HTML content (login-page style)
+###########################################################################
+
+- name: Update the welcome banner with HTML content and enable it
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: present
+    content: "{{ banner_html_content }}"
+    is_enabled: true
+  register: html_update
+  ignore_errors: true
+
+- name: Assert HTML update succeeded and content is persisted verbatim
+  ansible.builtin.assert:
+    that:
+      - html_update.changed == true
+      - html_update.failed == false
+      - html_update.skipped == false
+      - html_update.response.content == banner_html_content
+      - html_update.response.is_enabled == true
+      - "'<p>' in html_update.response.content"
+      - "'<b>' in html_update.response.content"
+    fail_msg: HTML update failed or content was mutated by the server
+    success_msg: HTML update succeeded and content was persisted verbatim
+
+###########################################################################
+# 8. Check-mode delete (reset) — should not mutate the server
+###########################################################################
+
+- name: Reset the welcome banner in check_mode
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: absent
+  register: cm_delete
+  check_mode: true
+  ignore_errors: true
+
+- name: Assert check_mode delete announces reset without mutating the server
+  ansible.builtin.assert:
+    that:
+      - cm_delete.changed == false
+      - cm_delete.failed == false
+      - cm_delete.response is defined
+      - cm_delete.response.content == banner_default_content
+      - cm_delete.response.is_enabled == false
+      - cm_delete.msg == "Welcome banner will be reset to default state."
+    fail_msg: check_mode delete did not announce the expected reset
+    success_msg: check_mode delete announced the expected reset
+
+- name: Fetch banner after check_mode delete to confirm no server-side change
+  nutanix.ncp.ntnx_iam_welcome_banner_info_v2:
+  register: after_cm_delete
+  ignore_errors: true
+
+- name: Assert the server-side banner is still the HTML value we set
+  ansible.builtin.assert:
+    that:
+      - after_cm_delete.changed == false
+      - after_cm_delete.failed == false
+      - after_cm_delete.response.content == banner_html_content
+      - after_cm_delete.response.is_enabled == true
+    fail_msg: check_mode delete unexpectedly mutated the welcome banner
+    success_msg: check_mode delete did not mutate the welcome banner
+
+###########################################################################
+# 9. Real delete (reset) — assert changed, is_enabled=false, default content
+###########################################################################
+
+- name: Reset the welcome banner to defaults
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: absent
+  register: reset_result
+  ignore_errors: true
+
+- name: Assert welcome banner has been reset to defaults
+  ansible.builtin.assert:
+    that:
+      - reset_result.changed == true
+      - reset_result.failed == false
+      - reset_result.skipped == false
+      - reset_result.response is defined
+      - reset_result.response.content == banner_default_content
+      - reset_result.response.is_enabled == false
+      - reset_result.msg == "Welcome banner has been reset to the default state."
+    fail_msg: Welcome banner reset failed
+    success_msg: Welcome banner reset succeeded
+
+###########################################################################
+# 10. Idempotent reset: re-run reset on already-default banner, assert skipped
+###########################################################################
+
+- name: Re-run reset on the already-default welcome banner
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: absent
+  register: idempotent_reset
+  ignore_errors: true
+
+- name: Assert idempotent reset is a no-op
+  ansible.builtin.assert:
+    that:
+      - idempotent_reset.changed == false
+      - idempotent_reset.failed == false
+      - idempotent_reset.skipped == true
+      - idempotent_reset.response.content == banner_default_content
+      - idempotent_reset.response.is_enabled == false
+      - idempotent_reset.msg == "Welcome banner is already in the default state. Skipping reset."
+    fail_msg: Idempotent reset was not detected as a no-op
+    success_msg: Idempotent reset correctly detected as a no-op
+
+###########################################################################
+# 11. Negative: state=present without content (required_if enforcement)
+###########################################################################
+
+- name: Try to update the welcome banner with state=present but no content
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: present
+    is_enabled: true
+  register: missing_content
+  ignore_errors: true
+
+- name: Assert missing content is rejected by required_if
+  ansible.builtin.assert:
+    that:
+      - missing_content.failed == true
+      - missing_content.changed == false
+      - missing_content.msg is defined
+      - "'content' in (missing_content.msg | string)"
+    fail_msg: Missing content was not rejected as expected
+    success_msg: Missing content was rejected as expected
+
+###########################################################################
+# 12. Restore the welcome banner to its ORIGINAL configuration
+###########################################################################
+
+- name: Restore the welcome banner to the ORIGINAL content
+  nutanix.ncp.ntnx_iam_welcome_banner_v2:
+    state: present
+    content: "{{ original_banner_content }}"
+    is_enabled: "{{ original_banner_is_enabled }}"
+  register: restore_result
+  ignore_errors: true
+
+- name: Assert restore did not fail
+  ansible.builtin.assert:
+    that:
+      - restore_result.failed == false
+      - restore_result.response.content == original_banner_content
+      - restore_result.response.is_enabled == (original_banner_is_enabled | bool)
+    fail_msg: Restoring the original welcome banner failed
+    success_msg: Original welcome banner restored successfully


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **identity_and_access_management** namespace, entity **WelcomeBanner**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_iam_welcome_banner_v2`, `ntnx_iam_welcome_banner_info_v2`
- API methods covered: `2` (`GetWelcomeBanner`, `UpdateWelcomeBanner` on `WelcomeBannerApi`)
- Fields in CRUD module spec: `3` (`ext_id`, `content`, `is_enabled`) plus inherited state / wait / credential / proxy / logger / read_timeout options
- Fields in info module spec: `1` (`ext_id`) plus inherited credential / proxy / logger / read_timeout options
- Domain: **Welcome Banner** is a singleton IAM resource in Prism Central (v4 endpoint `/api/iam/v4.1.b2/authn/welcome-banner`). The API only supports `GET` and `PUT`; there is no external ID, no list, and no delete. The CRUD module implements "create" and "update" via `PUT` (with `If-Match`/ETag optimistic concurrency) and implements "delete" as a factory-reset (`PUT` with the default placeholder content and `is_enabled=false`).

## Domain knowledge (from Glean)

The **Welcome Banner** in Nutanix Prism Central's Identity and Access Management (IAM) is a customizable splash screen that appears before a user logs into Prism Central. It is typically used by organizations to display IT policies, terms and conditions, legal disclaimers, or system maintenance notices that users must acknowledge before proceeding to the login screen.

Here are the detailed mechanics of the feature based on the design documents, engineering tickets, and source code:

### Detailed Features
- **Customizable Content**: Administrators can add text or HTML content (such as paragraphs, breaks, custom coloring, and localized languages) to the banner.
- **Preview Functionality**: Admins can preview the banner to see how it will appear to users on the login screen.
- **Enforcement**: When enabled, the banner blocks access to the login connectors (Local, LDAP, SAML, CAC). A user **must** click the "Accept" (or "Accept Terms") button to proceed.
- **Multi-Tenant Support**: In Service Provider (SP) multi-tenant deployments, the welcome banner can be scoped to specific tenants using the tenant identifier.

### Where and How is it Used?
- **Location**: Configured in Prism Central under **Admin Center** -> **Settings** -> **Welcome Banner** (or UI Settings depending on the exact PC version).
- **How it is Used**: The admin types in the desired Text/HTML, checks the "Enable Welcome Banner" (or "Show in login screen") toggle, and clicks Save. The next time any user navigates to the Prism Central URL, they are intercepted by this banner.

### Prerequisites
- Prism Central must be deployed and accessible.
- The user configuring the banner must have **Administrator** privileges in Prism Central.

### Workflow
1. **Admin Configuration**: The admin navigates to the Welcome Banner settings, adds the HTML/Text content, and enables the banner. This triggers a `PUT /welcome-banner` (v4 API) or `v1/system_configuration` API call to save the state in the PostgreSQL database.
2. **User Login Flow Initiation**: When a user navigates to the Prism Central IP/FQDN, PC Envoy initiates the login flow.
3. **Banner Display**: The IAM UI invokes `GET /welcome-banner` to fetch the banner configuration. If enabled, the banner is rendered over the login background (`#welcome-banner`).
4. **Acceptance**: The user reads the content and clicks the "Accept" button (`#btnAccept` or `[data-test="welcomeBannerButtonAccpetTerms"]`).
5. **Redirection to Connectors**: Once accepted, the UI invokes `GET /login-providers` to fetch the available login connectors (Local, LDAP, SAML, Certificate/CAC) and proceeds to authenticate the user.

### Behavioral Details
- **Always First**: The welcome banner is shown prior to any authentication method. Even if a user is using a Client Authentication Certificate (CAC) that automatically logs them in, the banner will still intercept the flow and require acceptance.
- **Caching**: If disabled, the banner immediately stops showing upon the next login (or after the browser cache clears).
- **Legacy vs V4 APIs**: The feature recently went through a redesign (FEAT-16389) migrating from legacy `v1/application/system_data` APIs to REST-compliant v4 `GET` and `PUT /welcome-banner` endpoints.
- **Preview Bugs**: A known behavioral quirk is that when using bulleted lists in the HTML, the preview might display the bullets properly, but the actual login screen might drop the bullet formatting, requiring manual hyphens (ENG-203087).

---

### Related Engineering Tickets, Design Docs, and Links

**Design & Spec Documents**
* **IAMv2 Login Workflow and Redesign** (Confluence): Covers the migration to V4 APIs, including the `GET` and `PUT /welcome-banner` endpoints.
  [View Confluence Page](https://confluence.eng.nutanix.com:8443/spaces/IAM20/pages/366726153/IAMv2+Login+Workflow+and+Redesign)
* **FEAT-16389 IAM Login Workflow using V4 APIs** (Github Design Doc): Details the architecture of the new V4 login workflow and the Welcome Banner endpoint pair.
  [View Markdown Doc](https://github.com/nutanix-core/panacea-documents/blob/main/documents/iam/design-doc/iam_feat_16389_v4_login_workflow_iter2.md)
* **FEAT-18194 Multi-Tenant IAM for Service Provider** (Github Design Doc): Explains the behavior of the welcome-banner handler using tenant identifiers instead of middleware headers.
  [View Markdown Doc](https://github.com/nutanix-core/panacea-documents/blob/main/documents/iam/design-doc/iam_feat_18194_multitenant_iam_for_sp_iter2.md)

**JIRA Tickets**
* **ENG-888562**: *Migrate v1/application/system_data to v4* - Tracks the migration of `WELCOME_BANNER` system data to the new IAM-owned V4 APIs.
  [View ENG-888562](https://jira.nutanix.com/browse/ENG-888562)
* **ENG-203087**: *Welcome Banner Preview in Prism Central doesn't match what is actually displayed* - Bug regarding the HTML preview not matching the actual login screen (e.g., bulleted lists).
  [View ENG-203087](https://jira.nutanix.com/browse/ENG-203087)
* **ENG-348272**: *Saving welcome banner notification shows twice* - UI bug.
  [View ENG-348272](https://jira.nutanix.com/browse/ENG-348272)
* **TH-15210**: *C2S - Prism Central on Microservices Infrastructure shows "Enabling Failed"* - Contains logs referencing `welcome_banner_migration.go` executing during IAM upgrades.
  [View TH-15210](https://jira.nutanix.com/browse/TH-15210)

**Documentation & Knowledge Base**
* **KB 17644**: *Prism Central – Welcome banner reverts to default* - Mentioned in the technical community reports.
  [View KB 17644](https://portal.nutanix.com/kb/17644)
* **Help Documentation Reference**: The internal help mapping URL points to `mul-welcome-banner-configure-pc-t.html` for welcome banner configuration.

**Source Documents (Test/Workflow References)**
* welcome_banner.py — nutest V4 SDK workflow: https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/iam/sdk/v4/welcome_banner/welcome_banner.py
* test_welcome_banner.py — UI test: https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/iam/authn/ui/test_welcome_banner.py
* test_banners.py — banner tests: https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/iam_new/ui/misc/test_banners.py
* test_welcome_banner_eula.py — manual EULA/banner test: https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/iam/authn/manual/test_welcome_banner_eula.py
* pc_iam_login_page.py — Playwright IAM login page: https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/entities/playwright/pc/pc_iam_login_page.py
* IAM Technical Community KB Reports: https://confluence.eng.nutanix.com:8443/spaces/STK/pages/392339226/IAM+Technical+Community+KB+Reports

### Required Domain Skills
- Understanding of the Nutanix IAM v4 API surface (`ntnx_iam_py_client`), specifically the `WelcomeBannerApi` (GET/PUT) and its request/response schema (`WelcomeBanner` with `content`, `isEnabled`, `createdTime`, `lastUpdatedTime`).
- Familiarity with singleton REST resources: WelcomeBanner has no create/delete — only Read (GET) and Update (PUT). Idempotency is done by comparing the fetched entity with the desired spec and using the `ETag`/`If-Match` header on PUT for optimistic concurrency.
- Ansible Nutanix collection conventions: `BaseModuleV4`, `SpecGenerator`, `strip_internal_attributes`, `raise_api_exception`, `remove_param_with_none_value`.
- HTML/plain-text banner content (be aware of the bullet-list rendering caveat from ENG-203087).
- Prism Central login flow interception (see FEAT-16389); understanding that the banner must be **accepted** before any authentication mechanism runs.
- RBAC: the caller must be an Administrator/Super Admin to `PUT` the banner; `GET` is unauthenticated so the login page can render it.
- Multi-tenant scoping semantics (FEAT-18194) for Service Provider deployments.

## Files changed

- `plugins/modules/`
  - `ntnx_iam_welcome_banner_v2.py` — new CRUD-style module (state=present → PUT with content/is_enabled; state=absent → factory reset)
  - `ntnx_iam_welcome_banner_info_v2.py` — new info module (singleton GET)
- `plugins/module_utils/v4/iam/`
  - `api_client.py` — new helper `get_welcome_banner_api_instance()`
  - `helpers.py` — new helper `get_welcome_banner(module, api_instance)`
- `meta/runtime.yml`
  - Added the two new module names to `action_groups.ntnx` so that `group/nutanix.ncp.ntnx` `module_defaults` are honored.
- `examples/identity_and_access_management/WelcomeBanner/`
  - `welcome_banner_v2.yml` — end-to-end example playbook (info → update → idempotent update → change enablement → reset).
  - `examples_run.log` — captured playbook output from the run against `10.44.76.28`.
- `tests/integration/targets/ntnx_iam_welcome_banner_v2/`
  - `aliases` (`disabled`), `meta/main.yml` (depends on `prepare_env`), `tasks/main.yml` (module_defaults + import), `tasks/welcome_banner.yml` (full test plan: baseline, check_mode create/reset, full CRUD, idempotency, HTML content, negative required_if, restore).

## Test execution

| Metric              | Value                                                       |
|---------------------|-------------------------------------------------------------|
| Command             | `ansible-test integration --local --allow-disabled -v ntnx_iam_welcome_banner_v2` (run from the collection root at `/tmp/collroot/ansible_collections/nutanix/ncp`) |
| Total tests (tasks) | `32 ok + 3 skipped + 1 ignored`                           |
| Passed              | `32` (all assertion tasks passed)                         |
| Failed              | `0`                                                       |
| Skipped             | `3` (2 idempotency skips + 1 negative-test module failure caught via `ignore_errors`) |
| Duration            | `~00:00:13`                                               |
| Cluster (PC)        | `10.44.76.28:9440` (username: `admin`)                  |
| Sanity              | `ansible-test sanity --local` on all 4 changed files — 46 sanity tests, all pass |
| Examples run        | `ansible-playbook examples/identity_and_access_management/WelcomeBanner/welcome_banner_v2.yml` — `ok=9 changed=3 skipped=1 failed=0` |

### Analysis

All 32 assertion tasks in the integration test target passed on the first attempt after the two module fixes described below. There are **no known failures**.

Fixes applied while iterating:
1. First run failed because the two new modules were not in `meta/runtime.yml` `action_groups.ntnx`, so `module_defaults` for the `group/nutanix.ncp.ntnx` action group was not applied and the modules complained `missing required arguments: nutanix_host`. **Fix:** appended `ntnx_iam_welcome_banner_v2` and `ntnx_iam_welcome_banner_info_v2` to that action group.
2. Second run failed on the first check-mode task with `AttributeError: property 'created_time' of 'WelcomeBanner' object has no deleter`. The shared `strip_read_only_fields()` helper uses `delattr`, which the SDK's `@property` setters don't support. Since the fresh SDK spec never carries the server-managed `created_time`/`last_updated_time` fields anyway, the call was unnecessary. **Fix:** removed the `strip_read_only_fields` invocation and its import.

After those two changes the target was clean end-to-end (see logs below).

### Test logs (full)

<details>
<summary>ansible-test integration output</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /bin/python3.12
Creating container database.
Run command: /bin/python3.12 /home/abhinav.bansal1/.local/lib/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_iam_welcome_banner_v2 integration test role
Initializing "/tmp/ansible-test-972mpoqe-injector" as the temporary injector directory.
Injecting "/tmp/python-ln900mv6-ansible/python" as a execv wrapper for the "/bin/python3.12" interpreter.
Stream command: ansible-playbook ntnx_iam_welcome_banner_v2-w_qn9_kg.yml -i inventory -v
[WARNING]: Found variable using reserved name: port
Using /tmp/collroot/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_iam_welcome_banner_v2-jdipbxjh-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_iam_welcome_banner_v2 : Start ntnx_iam_welcome_banner_v2 tests] *****
ok: [testhost] => {
    "msg": "start ntnx_iam_welcome_banner_v2 tests"
}

TASK [ntnx_iam_welcome_banner_v2 : Generate random suffix for the welcome banner content] ***
ok: [testhost] => {"ansible_facts": {"banner_suffix": "8f1c8846-ac8d-5fde-b7ba-a704c8c35170"}, "changed": false}

TASK [ntnx_iam_welcome_banner_v2 : Build banner content strings (plain + HTML)] ***
ok: [testhost] => {"ansible_facts": {"banner_default_content": "Write HTML code here", "banner_html_content": "<p><b>Ansible IAM WelcomeBanner HTML test - 8f1c8846-ac8d-5fde-b7ba-a704c8c35170</b><br> All access to this system is logged and monitored.</p>", "banner_plain_content": "Ansible IAM WelcomeBanner test - 8f1c8846-ac8d-5fde-b7ba-a704c8c35170"}, "changed": false}

TASK [ntnx_iam_welcome_banner_v2 : Fetch the welcome banner using the info module (baseline)] ***
ok: [testhost] => {"changed": false, "error": null, "response": {"content": "Write HTML code here", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": false, "last_updated_time": "2026-07-21T06:37:06.356247+00:00"}}

TASK [ntnx_iam_welcome_banner_v2 : Assert baseline info fetch succeeded and returned a WelcomeBanner] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Baseline welcome banner fetch passed"
}

TASK [ntnx_iam_welcome_banner_v2 : Store original welcome banner state for later restoration] ***
ok: [testhost] => {"ansible_facts": {"original_banner_content": "Write HTML code here", "original_banner_is_enabled": false}, "changed": false}

TASK [ntnx_iam_welcome_banner_v2 : Update the welcome banner in check_mode with ALL attributes] ***
ok: [testhost] => {"changed": false, "ext_id": null, "response": {"content": "Ansible IAM WelcomeBanner test - 8f1c8846-ac8d-5fde-b7ba-a704c8c35170", "created_time": null, "is_enabled": true, "last_updated_time": null}, "task_ext_id": null}

TASK [ntnx_iam_welcome_banner_v2 : Assert check_mode update returns the desired spec without changing state] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode update returned the expected desired spec"
}

TASK [ntnx_iam_welcome_banner_v2 : Fetch banner after check_mode update to confirm no server-side change] ***
ok: [testhost] => {"changed": false, "error": null, "response": {"content": "Write HTML code here", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": false, "last_updated_time": "2026-07-21T06:37:06.356247+00:00"}}

TASK [ntnx_iam_welcome_banner_v2 : Assert the server-side banner is unchanged by check_mode] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode did not mutate the welcome banner on the server"
}

TASK [ntnx_iam_welcome_banner_v2 : Update the welcome banner with plain content and enable it] ***
changed: [testhost] => {"changed": true, "ext_id": null, "response": {"content": "Ansible IAM WelcomeBanner test - 8f1c8846-ac8d-5fde-b7ba-a704c8c35170", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": true, "last_updated_time": "2026-07-21T06:50:09.457252+00:00"}, "task_ext_id": null}

TASK [ntnx_iam_welcome_banner_v2 : Assert full welcome banner update succeeded] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Full welcome banner update passed"
}

TASK [ntnx_iam_welcome_banner_v2 : Fetch the welcome banner after the update] ***
ok: [testhost] => {"changed": false, "error": null, "response": {"content": "Ansible IAM WelcomeBanner test - 8f1c8846-ac8d-5fde-b7ba-a704c8c35170", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": true, "last_updated_time": "2026-07-21T06:50:09.457274+00:00"}}

TASK [ntnx_iam_welcome_banner_v2 : Assert the info module round-trips the update we just made] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module returned the updated welcome banner"
}

TASK [ntnx_iam_welcome_banner_v2 : Fetch the welcome banner passing a placeholder ext_id] ***
ok: [testhost] => {"changed": false, "error": null, "ext_id": "welcome-banner", "response": {"content": "Ansible IAM WelcomeBanner test - 8f1c8846-ac8d-5fde-b7ba-a704c8c35170", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": true, "last_updated_time": "2026-07-21T06:50:09.457274+00:00"}}

TASK [ntnx_iam_welcome_banner_v2 : Assert info module accepted ext_id and returned the singleton banner] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module with ext_id returned the welcome banner"
}

TASK [ntnx_iam_welcome_banner_v2 : Re-run the same welcome banner update (idempotency)] ***
skipping: [testhost] => {"changed": false, "ext_id": null, "msg": "Welcome banner is already in the desired state. Skipping update.", "response": {"content": "Ansible IAM WelcomeBanner test - 8f1c8846-ac8d-5fde-b7ba-a704c8c35170", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": true, "last_updated_time": "2026-07-21T06:50:09.457274+00:00"}, "task_ext_id": null}

TASK [ntnx_iam_welcome_banner_v2 : Assert idempotent update is a no-op] ********
ok: [testhost] => {
    "changed": false,
    "msg": "Idempotent update correctly detected as a no-op"
}

TASK [ntnx_iam_welcome_banner_v2 : Flip is_enabled to false, keep the same content] ***
changed: [testhost] => {"changed": true, "ext_id": null, "response": {"content": "Ansible IAM WelcomeBanner test - 8f1c8846-ac8d-5fde-b7ba-a704c8c35170", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": false, "last_updated_time": "2026-07-21T06:50:12.309551+00:00"}, "task_ext_id": null}

TASK [ntnx_iam_welcome_banner_v2 : Assert only is_enabled changed] *************
ok: [testhost] => {
    "changed": false,
    "msg": "Disable-only update succeeded"
}

TASK [ntnx_iam_welcome_banner_v2 : Update the welcome banner with HTML content and enable it] ***
changed: [testhost] => {"changed": true, "ext_id": null, "response": {"content": "<p><b>Ansible IAM WelcomeBanner HTML test - 8f1c8846-ac8d-5fde-b7ba-a704c8c35170</b><br> All access to this system is logged and monitored.</p>", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": true, "last_updated_time": "2026-07-21T06:50:12.995547+00:00"}, "task_ext_id": null}

TASK [ntnx_iam_welcome_banner_v2 : Assert HTML update succeeded and content is persisted verbatim] ***
ok: [testhost] => {
    "changed": false,
    "msg": "HTML update succeeded and content was persisted verbatim"
}

TASK [ntnx_iam_welcome_banner_v2 : Reset the welcome banner in check_mode] *****
ok: [testhost] => {"changed": false, "ext_id": null, "msg": "Welcome banner will be reset to default state.", "response": {"content": "Write HTML code here", "created_time": null, "is_enabled": false, "last_updated_time": null}, "task_ext_id": null}

TASK [ntnx_iam_welcome_banner_v2 : Assert check_mode delete announces reset without mutating the server] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode delete announced the expected reset"
}

TASK [ntnx_iam_welcome_banner_v2 : Fetch banner after check_mode delete to confirm no server-side change] ***
ok: [testhost] => {"changed": false, "error": null, "response": {"content": "<p><b>Ansible IAM WelcomeBanner HTML test - 8f1c8846-ac8d-5fde-b7ba-a704c8c35170</b><br> All access to this system is logged and monitored.</p>", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": true, "last_updated_time": "2026-07-21T06:50:12.995574+00:00"}}

TASK [ntnx_iam_welcome_banner_v2 : Assert the server-side banner is still the HTML value we set] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode delete did not mutate the welcome banner"
}

TASK [ntnx_iam_welcome_banner_v2 : Reset the welcome banner to defaults] *******
changed: [testhost] => {"changed": true, "ext_id": null, "msg": "Welcome banner has been reset to the default state.", "response": {"content": "Write HTML code here", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": false, "last_updated_time": "2026-07-21T06:50:15.095017+00:00"}, "task_ext_id": null}

TASK [ntnx_iam_welcome_banner_v2 : Assert welcome banner has been reset to defaults] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Welcome banner reset succeeded"
}

TASK [ntnx_iam_welcome_banner_v2 : Re-run reset on the already-default welcome banner] ***
skipping: [testhost] => {"changed": false, "ext_id": null, "msg": "Welcome banner is already in the default state. Skipping reset.", "response": {"content": "Write HTML code here", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": false, "last_updated_time": "2026-07-21T06:50:15.095039+00:00"}, "task_ext_id": null}

TASK [ntnx_iam_welcome_banner_v2 : Assert idempotent reset is a no-op] *********
ok: [testhost] => {
    "changed": false,
    "msg": "Idempotent reset correctly detected as a no-op"
}

TASK [ntnx_iam_welcome_banner_v2 : Try to update the welcome banner with state=present but no content] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is present but all of the following are missing: content"}
...ignoring

TASK [ntnx_iam_welcome_banner_v2 : Assert missing content is rejected by required_if] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing content was rejected as expected"
}

TASK [ntnx_iam_welcome_banner_v2 : Restore the welcome banner to the ORIGINAL content] ***
skipping: [testhost] => {"changed": false, "ext_id": null, "msg": "Welcome banner is already in the desired state. Skipping update.", "response": {"content": "Write HTML code here", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": false, "last_updated_time": "2026-07-21T06:50:15.095039+00:00"}, "task_ext_id": null}

TASK [ntnx_iam_welcome_banner_v2 : Assert restore did not fail] ****************
ok: [testhost] => {
    "changed": false,
    "msg": "Original welcome banner restored successfully"
}

PLAY RECAP *********************************************************************
testhost                   : ok=32   changed=4    unreachable=0    failed=0    skipped=3    rescued=0    ignored=1   
```

</details>

<details>
<summary>examples playbook run output</summary>

```text
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
No config file found; using defaults

PLAY [IAM Welcome Banner example playbook] *************************************

TASK [Fetch the current welcome banner configuration] **************************
ok: [localhost] => {"changed": false, "error": null, "response": {"content": "Write HTML code here", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": false, "last_updated_time": "2026-07-21T06:50:15.095039+00:00"}}

TASK [Show the current welcome banner] *****************************************
ok: [localhost] => {
    "welcome_banner_before.response": {
        "content": "Write HTML code here",
        "created_time": "2026-06-29T07:18:36.280134+00:00",
        "is_enabled": false,
        "last_updated_time": "2026-07-21T06:50:15.095039+00:00"
    }
}

TASK [Update the welcome banner (create-equivalent for this singleton)] ********
changed: [localhost] => {"changed": true, "ext_id": null, "response": {"content": "<p><b>Authorized access only.</b><br> All activity on this Nutanix Prism Central instance is logged and monitored. By clicking Accept you agree to the acceptable-use policy of your organization.</p>", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": true, "last_updated_time": "2026-07-21T06:50:36.855619+00:00"}, "task_ext_id": null}

TASK [Show the updated welcome banner] *****************************************
ok: [localhost] => {
    "welcome_banner_updated": {
        "changed": true,
        "ext_id": null,
        "failed": false,
        "response": {
            "content": "<p><b>Authorized access only.</b><br> All activity on this Nutanix Prism Central instance is logged and monitored. By clicking Accept you agree to the acceptable-use policy of your organization.</p>",
            "created_time": "2026-06-29T07:18:36.280134+00:00",
            "is_enabled": true,
            "last_updated_time": "2026-07-21T06:50:36.855619+00:00"
        },
        "skipped": false,
        "task_ext_id": null
    }
}

TASK [Update the welcome banner content again (idempotency demo)] **************
skipping: [localhost] => {"changed": false, "ext_id": null, "msg": "Welcome banner is already in the desired state. Skipping update.", "response": {"content": "<p><b>Authorized access only.</b><br> All activity on this Nutanix Prism Central instance is logged and monitored. By clicking Accept you agree to the acceptable-use policy of your organization.</p>", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": true, "last_updated_time": "2026-07-21T06:50:36.855653+00:00"}, "task_ext_id": null}

TASK [Show the second update (should be skipped)] ******************************
ok: [localhost] => {
    "welcome_banner_second_update": {
        "changed": false,
        "ext_id": null,
        "failed": false,
        "msg": "Welcome banner is already in the desired state. Skipping update.",
        "response": {
            "content": "<p><b>Authorized access only.</b><br> All activity on this Nutanix Prism Central instance is logged and monitored. By clicking Accept you agree to the acceptable-use policy of your organization.</p>",
            "created_time": "2026-06-29T07:18:36.280134+00:00",
            "is_enabled": true,
            "last_updated_time": "2026-07-21T06:50:36.855653+00:00"
        },
        "skipped": true,
        "task_ext_id": null
    }
}

TASK [Change only the enablement flag (real update)] ***************************
changed: [localhost] => {"changed": true, "ext_id": null, "response": {"content": "<p><b>Authorized access only.</b><br> All activity on this Nutanix Prism Central instance is logged and monitored. By clicking Accept you agree to the acceptable-use policy of your organization.</p>", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": false, "last_updated_time": "2026-07-21T06:50:38.236156+00:00"}, "task_ext_id": null}

TASK [Show the disabled welcome banner] ****************************************
ok: [localhost] => {
    "welcome_banner_disabled": {
        "changed": true,
        "ext_id": null,
        "failed": false,
        "response": {
            "content": "<p><b>Authorized access only.</b><br> All activity on this Nutanix Prism Central instance is logged and monitored. By clicking Accept you agree to the acceptable-use policy of your organization.</p>",
            "created_time": "2026-06-29T07:18:36.280134+00:00",
            "is_enabled": false,
            "last_updated_time": "2026-07-21T06:50:38.236156+00:00"
        },
        "skipped": false,
        "task_ext_id": null
    }
}

TASK [Reset the welcome banner to defaults (delete-equivalent)] ****************
changed: [localhost] => {"changed": true, "ext_id": null, "msg": "Welcome banner has been reset to the default state.", "response": {"content": "Write HTML code here", "created_time": "2026-06-29T07:18:36.280134+00:00", "is_enabled": false, "last_updated_time": "2026-07-21T06:50:38.920567+00:00"}, "task_ext_id": null}

TASK [Show the reset welcome banner] *******************************************
ok: [localhost] => {
    "welcome_banner_reset": {
        "changed": true,
        "ext_id": null,
        "failed": false,
        "msg": "Welcome banner has been reset to the default state.",
        "response": {
            "content": "Write HTML code here",
            "created_time": "2026-06-29T07:18:36.280134+00:00",
            "is_enabled": false,
            "last_updated_time": "2026-07-21T06:50:38.920567+00:00"
        },
        "skipped": false,
        "task_ext_id": null
    }
}

PLAY RECAP *********************************************************************
localhost                  : ok=9    changed=3    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Uses `ntnx-iam-py-client==4.1.2b2` (`WelcomeBannerApi`).
- Followed the existing `ntnx_virtual_switch_v2` / `ntnx_iam_entities_info_v2` module patterns for structure, DOCUMENTATION, RETURN samples, error handling, idempotency, and helper placement.

