### PR TITLE
ClusterForRecoveryPointId Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/data_protection/ClusterForRecoveryPointId/discover_cluster_for_recovery_point_id_v2.yml
+++ b/examples/data_protection/ClusterForRecoveryPointId/discover_cluster_for_recovery_point_id_v2.yml
@@ -1,0 +1,84 @@
+---
+# Summary:
+# This playbook demonstrates using the
+# `ntnx_discover_cluster_for_recovery_point_id_v2` action module. The
+# discover-cluster API returns the redirect cluster IP and a JWT token to be
+# used as a session cookie while invoking either the compute-changed-regions
+# (CBT) or the get-VSS-metadata endpoints on that cluster.
+#
+# Prerequisites (already created on the cluster):
+#   - A top-level recovery point (referenced by `recovery_point_ext_id`).
+#   - A VM recovery point inside that top-level recovery point (referenced by
+#     `vm_recovery_point_ext_id`).
+#   - The disk recovery point identifier (`disk_recovery_point_ext_id`).
+#
+# Workflow:
+#   1. Discover the cluster using `operation=GET_VSS_METADATA` before pulling
+#      VSS metadata for a VM recovery point.
+#   2. Discover the cluster using `operation=COMPUTE_CHANGED_REGIONS` before
+#      computing changed regions for a VM disk recovery point.
+#   3. Discover the cluster using `operation=COMPUTE_CHANGED_REGIONS` with a
+#      `reference_disk_recovery_point` for incremental CBT workflows.
+
+- name: Discover cluster for recovery point playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip | default('10.44.76.28') }}"
+      nutanix_username: "{{ username | default('admin') }}"
+      nutanix_password: "{{ password | default('Nutanix.123') }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+
+  tasks:
+    - name: Set the recovery point identifiers used across the plays
+      ansible.builtin.set_fact:
+        recovery_point_ext_id: "1ca2963d-77b6-453a-ae23-2c19e7a954a3"
+        vm_recovery_point_ext_id: "522670d7-e92d-45c5-9139-76ccff6813c2"
+        disk_recovery_point_ext_id: "94e61902-1954-4d54-917a-a28205454fce"
+        reference_recovery_point_ext_id: "aa2963d1-77b6-453a-ae23-2c19e7a95400"
+        reference_vm_recovery_point_ext_id: "6f2d4f89-cba1-4a45-b3b3-3ec8b71ac13f"
+        reference_disk_recovery_point_ext_id: "1b96075e-4786-4409-82bd-764e23d877a6"
+
+    - name: Discover cluster for a recovery point - GET_VSS_METADATA operation
+      nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+        ext_id: "{{ recovery_point_ext_id }}"
+        operation: "GET_VSS_METADATA"
+        spec:
+          get_vss_metadata:
+            vm_recovery_point_ext_id: "{{ vm_recovery_point_ext_id }}"
+      register: vss_result
+      ignore_errors: true
+
+    - name: Discover cluster for a recovery point - COMPUTE_CHANGED_REGIONS full workflow
+      nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+        ext_id: "{{ recovery_point_ext_id }}"
+        operation: "COMPUTE_CHANGED_REGIONS"
+        spec:
+          compute_changed_regions:
+            disk_recovery_point:
+              vm_disk_recovery_point:
+                vm_recovery_point_ext_id: "{{ vm_recovery_point_ext_id }}"
+                recovery_point_ext_id: "{{ recovery_point_ext_id }}"
+                disk_recovery_point_ext_id: "{{ disk_recovery_point_ext_id }}"
+            reference_disk_recovery_point:
+              vm_disk_recovery_point:
+                vm_recovery_point_ext_id: "{{ reference_vm_recovery_point_ext_id }}"
+                recovery_point_ext_id: "{{ reference_recovery_point_ext_id }}"
+                disk_recovery_point_ext_id: "{{ reference_disk_recovery_point_ext_id }}"
+      register: cbt_result
+      ignore_errors: true
+
+    - name: Discover cluster for a recovery point - COMPUTE_CHANGED_REGIONS without reference
+      nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+        ext_id: "{{ recovery_point_ext_id }}"
+        operation: "COMPUTE_CHANGED_REGIONS"
+        spec:
+          compute_changed_regions:
+            disk_recovery_point:
+              vm_disk_recovery_point:
+                vm_recovery_point_ext_id: "{{ vm_recovery_point_ext_id }}"
+                recovery_point_ext_id: "{{ recovery_point_ext_id }}"
+                disk_recovery_point_ext_id: "{{ disk_recovery_point_ext_id }}"
+      register: cbt_no_ref_result
+      ignore_errors: true

--- a/examples/data_protection/ClusterForRecoveryPointId/examples_run.log
+++ b/examples/data_protection/ClusterForRecoveryPointId/examples_run.log
@@ -1,0 +1,167 @@
+
+PLAY [Set up prerequisites and run discover cluster examples] ******************
+
+TASK [Find AOS cluster] ********************************************************
+[WARNING]: Host 'localhost' is using the discovered Python interpreter at '/home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.21/reference_appendices/interpreter_discovery.html for more information.
+ok: [localhost]
+
+TASK [Select AOS cluster] ******************************************************
+ok: [localhost]
+
+TASK [Find a storage container on the cluster] *********************************
+ok: [localhost]
+
+TASK [Set storage container id] ************************************************
+ok: [localhost]
+
+TASK [Compute expiration time] *************************************************
+ok: [localhost]
+
+TASK [Create example VM] *******************************************************
+changed: [localhost]
+
+TASK [Set VM ext_id] ***********************************************************
+ok: [localhost]
+
+TASK [Create example recovery point] *******************************************
+changed: [localhost]
+
+TASK [Set recovery point IDs] **************************************************
+ok: [localhost]
+
+TASK [Show setup details] ******************************************************
+ok: [localhost] => {
+    "msg": "vm=2be1fc30-b5e4-44f7-7c61-0b41740ab255 rp=70a5eca8-eeb6-4a11-a183-67b7699c8dd8 vm_rp=01a85d96-11a3-4c8e-a5ec-1005dce1d972 disk_rp=d02c6142-dae8-4ead-b2d9-4c566b290fb8"
+}
+
+TASK [Discover cluster - COMPUTE_CHANGED_REGIONS example] **********************
+ok: [localhost]
+
+TASK [Show CBT discover-cluster response] **************************************
+ok: [localhost] => {
+    "cbt_result.response": {
+        "cluster_ip": {
+            "ipv4": {
+                "prefix_length": 0,
+                "value": "10.46.136.38"
+            },
+            "ipv6": null
+        },
+        "jwt_token": "<REDACTED_JWT>"
+    }
+}
+
+TASK [Discover cluster - COMPUTE_CHANGED_REGIONS with reference example] *******
+ok: [localhost]
+
+TASK [Show CBT with reference discover-cluster response] ***********************
+ok: [localhost] => {
+    "cbt_ref_result.response": {
+        "cluster_ip": {
+            "ipv4": {
+                "prefix_length": 0,
+                "value": "10.46.136.38"
+            },
+            "ipv6": null
+        },
+        "jwt_token": "<REDACTED_JWT>"
+    }
+}
+
+TASK [Discover cluster - GET_VSS_METADATA example (best-effort; requires APPLICATION_CONSISTENT RP with VSS metadata)] ***
+[ERROR]: Task failed: Module failed: Api Exception raised while discovering cluster for recovery point
+Origin: /tmp/setup_and_run_example.yml:119:7
+
+117         var: cbt_ref_result.response
+118
+119     - name: Discover cluster - GET_VSS_METADATA example (best-effort; requires APPLICATION_CONSISTENT RP with VSS...
+          ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "UNPROCESSABLE ENTITY", "msg": "Api Exception raised while discovering cluster for recovery point", "response": {"data": {"$objectType": "dataprotection.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "dataprotection.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "argumentsMap": {"reason": "Recovery point '70a5eca8-eeb6-4a11-a183-67b7699c8dd8' is not an application consistent recovery point"}, "code": "DP-10100", "errorGroup": "DATAPROTECTION_INVALID_INPUT", "locale": "en_US", "message": "Input is invalid because Recovery point '70a5eca8-eeb6-4a11-a183-67b7699c8dd8' is not an application consistent recovery point.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 422}
+...ignoring
+
+TASK [Show VSS metadata discover-cluster response] *****************************
+ok: [localhost] => {
+    "vss_result": {
+        "changed": false,
+        "error": "UNPROCESSABLE ENTITY",
+        "exception": "(traceback unavailable)",
+        "failed": true,
+        "msg": "Api Exception raised while discovering cluster for recovery point",
+        "response": {
+            "data": {
+                "$objectType": "dataprotection.v4.error.ErrorResponse",
+                "$reserved": {
+                    "$fv": "v4.r4"
+                },
+                "error": [
+                    {
+                        "$objectType": "dataprotection.v4.error.AppMessage",
+                        "$reserved": {
+                            "$fv": "v4.r4"
+                        },
+                        "argumentsMap": {
+                            "reason": "Recovery point '70a5eca8-eeb6-4a11-a183-67b7699c8dd8' is not an application consistent recovery point"
+                        },
+                        "code": "DP-10100",
+                        "errorGroup": "DATAPROTECTION_INVALID_INPUT",
+                        "locale": "en_US",
+                        "message": "Input is invalid because Recovery point '70a5eca8-eeb6-4a11-a183-67b7699c8dd8' is not an application consistent recovery point.",
+                        "severity": "ERROR"
+                    }
+                ]
+            },
+            "metadata": {
+                "$objectType": "common.v1.response.ApiResponseMetadata",
+                "$reserved": {
+                    "$fv": "v1.r0"
+                },
+                "flags": [
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "hasError",
+                        "value": true
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isPaginated",
+                        "value": false
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isTruncated",
+                        "value": false
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isExpandRestricted",
+                        "value": false
+                    }
+                ]
+            }
+        },
+        "status": 422
+    }
+}
+
+TASK [Cleanup - delete recovery point] *****************************************
+changed: [localhost]
+
+TASK [Cleanup - delete VM] *****************************************************
+changed: [localhost]
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=18   changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -179,6 +179,7 @@ action_groups:
     - ntnx_recovery_point_restore_v2
     - ntnx_vm_revert_v2
     - ntnx_recovery_point_replicate_v2
+    - ntnx_discover_cluster_for_recovery_point_id_v2
     - ntnx_gpus_v2
     - ntnx_gpus_info_v2
     - ntnx_clusters_nodes_v2

--- a/plugins/modules/ntnx_discover_cluster_for_recovery_point_id_v2.py
+++ b/plugins/modules/ntnx_discover_cluster_for_recovery_point_id_v2.py
@@ -1,0 +1,491 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_discover_cluster_for_recovery_point_id_v2
+short_description: Discover the cluster hosting a recovery point in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to discover the cluster hosting a recovery point in Nutanix Prism Central.
+  - The API returns the redirect cluster IP and a JWT token that must be set as a session
+    cookie while invoking the follow-up Changed Block Tracking (CBT) or VSS metadata endpoints
+    on that cluster.
+  - Use C(operation=COMPUTE_CHANGED_REGIONS) to discover the cluster before invoking the
+    compute changed regions APIs.
+  - Use C(operation=GET_VSS_METADATA) to discover the cluster before invoking the VSS
+    metadata API for a VM recovery point.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation.
+  - >-
+    B(Discover cluster for a recovery point) -
+    Required Roles: Backup Admin, CSI System, Disaster Recovery Admin, Kubernetes Data
+    Services System, NCM Connector, Prism Admin, Project Manager, Super Admin,
+    Self-Service Admin (deprecated)
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=dataprotection)"
+options:
+  state:
+    description:
+      - State of the module.
+      - If C(state) is set to C(present), the module will discover the cluster for the recovery point.
+      - The action is idempotent from the API perspective. C(changed) is set to C(false) since no
+        persistent server-side change is made.
+    type: str
+    choices:
+      - present
+    default: present
+  ext_id:
+    description:
+      - The external identifier of the recovery point whose cluster is to be discovered.
+    type: str
+    required: true
+  operation:
+    description:
+      - The follow-up operation for which the cluster is being discovered.
+      - Use C(COMPUTE_CHANGED_REGIONS) for CBT (compute changed regions) workflows.
+      - Use C(GET_VSS_METADATA) to fetch VSS metadata for a VM recovery point.
+    type: str
+    required: true
+    choices:
+      - COMPUTE_CHANGED_REGIONS
+      - GET_VSS_METADATA
+  spec:
+    description:
+      - The operation-specific request specification.
+      - Exactly one of C(get_vss_metadata) or C(compute_changed_regions) must be provided,
+        matching the C(operation) selected.
+    type: dict
+    required: true
+    suboptions:
+      get_vss_metadata:
+        description:
+          - Specification for the C(GET_VSS_METADATA) operation.
+          - Required when C(operation=GET_VSS_METADATA).
+        type: dict
+        suboptions:
+          vm_recovery_point_ext_id:
+            description:
+              - The external identifier of the VM recovery point whose VSS metadata is to be fetched.
+            type: str
+            required: true
+      compute_changed_regions:
+        description:
+          - Specification for the C(COMPUTE_CHANGED_REGIONS) operation.
+          - Required when C(operation=COMPUTE_CHANGED_REGIONS).
+        type: dict
+        suboptions:
+          disk_recovery_point:
+            description:
+              - Reference to the disk recovery point for which changed regions will be computed.
+              - Exactly one of C(vm_disk_recovery_point) or C(volume_group_disk_recovery_point)
+                must be provided.
+            type: dict
+            suboptions:
+              vm_disk_recovery_point:
+                description:
+                  - Reference to a VM disk recovery point.
+                type: dict
+                suboptions:
+                  vm_recovery_point_ext_id:
+                    description:
+                      - External identifier of the VM recovery point.
+                    type: str
+                  recovery_point_ext_id:
+                    description:
+                      - External identifier of the top level recovery point.
+                    type: str
+                  disk_recovery_point_ext_id:
+                    description:
+                      - Disk recovery point identifier.
+                    type: str
+              volume_group_disk_recovery_point:
+                description:
+                  - Reference to a volume group disk recovery point.
+                type: dict
+                suboptions:
+                  volume_group_recovery_point_ext_id:
+                    description:
+                      - External identifier of the volume group recovery point.
+                    type: str
+                  recovery_point_ext_id:
+                    description:
+                      - External identifier of the top level recovery point.
+                    type: str
+                  disk_recovery_point_ext_id:
+                    description:
+                      - Disk recovery point identifier.
+                    type: str
+          reference_disk_recovery_point:
+            description:
+              - Optional reference disk recovery point to compute changed regions against.
+              - Exactly one of C(vm_disk_recovery_point) or C(volume_group_disk_recovery_point)
+                must be provided when set.
+            type: dict
+            suboptions:
+              vm_disk_recovery_point:
+                description:
+                  - Reference to a VM disk recovery point.
+                type: dict
+                suboptions:
+                  vm_recovery_point_ext_id:
+                    description:
+                      - External identifier of the VM recovery point.
+                    type: str
+                  recovery_point_ext_id:
+                    description:
+                      - External identifier of the top level recovery point.
+                    type: str
+                  disk_recovery_point_ext_id:
+                    description:
+                      - Disk recovery point identifier.
+                    type: str
+              volume_group_disk_recovery_point:
+                description:
+                  - Reference to a volume group disk recovery point.
+                type: dict
+                suboptions:
+                  volume_group_recovery_point_ext_id:
+                    description:
+                      - External identifier of the volume group recovery point.
+                    type: str
+                  recovery_point_ext_id:
+                    description:
+                      - External identifier of the top level recovery point.
+                    type: str
+                  disk_recovery_point_ext_id:
+                    description:
+                      - Disk recovery point identifier.
+                    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Discover cluster for a recovery point (GET_VSS_METADATA)
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "1ca2963d-77b6-453a-ae23-2c19e7a954a3"
+    operation: "GET_VSS_METADATA"
+    spec:
+      get_vss_metadata:
+        vm_recovery_point_ext_id: "522670d7-e92d-45c5-9139-76ccff6813c2"
+  register: result
+  ignore_errors: true
+
+- name: Discover cluster for a recovery point (COMPUTE_CHANGED_REGIONS - VM)
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "1ca2963d-77b6-453a-ae23-2c19e7a954a3"
+    operation: "COMPUTE_CHANGED_REGIONS"
+    spec:
+      compute_changed_regions:
+        disk_recovery_point:
+          vm_disk_recovery_point:
+            vm_recovery_point_ext_id: "522670d7-e92d-45c5-9139-76ccff6813c2"
+            recovery_point_ext_id: "1ca2963d-77b6-453a-ae23-2c19e7a954a3"
+            disk_recovery_point_ext_id: "94e61902-1954-4d54-917a-a28205454fce"
+        reference_disk_recovery_point:
+          vm_disk_recovery_point:
+            vm_recovery_point_ext_id: "6f2d4f89-cba1-4a45-b3b3-3ec8b71ac13f"
+            recovery_point_ext_id: "aa2963d1-77b6-453a-ae23-2c19e7a95400"
+            disk_recovery_point_ext_id: "1b96075e-4786-4409-82bd-764e23d877a6"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response from the discover cluster for recovery point API.
+    - Contains the cluster IP address and the JWT token to be used for the follow-up
+      CBT or VSS metadata calls.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ip": {
+        "ipv4": {
+          "value": "10.44.76.29",
+          "prefix_length": 32
+        },
+        "ipv6": null
+      },
+      "jwt_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while discovering cluster for recovery point"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  returned: when an error occurs
+  type: str
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: The external ID of the recovery point.
+  returned: always
+  type: str
+  sample: "1ca2963d-77b6-453a-ae23-2c19e7a954a3"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.data_protection.api_client import (  # noqa: E402
+    get_recovery_point_api_instance,
+)
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_dataprotection_py_client as data_protection_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as data_protection_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    disk_recovery_point_options = dict(
+        vm_disk_recovery_point=dict(
+            type="dict",
+            options=dict(
+                vm_recovery_point_ext_id=dict(type="str"),
+                recovery_point_ext_id=dict(type="str"),
+                disk_recovery_point_ext_id=dict(type="str"),
+            ),
+        ),
+        volume_group_disk_recovery_point=dict(
+            type="dict",
+            options=dict(
+                volume_group_recovery_point_ext_id=dict(type="str"),
+                recovery_point_ext_id=dict(type="str"),
+                disk_recovery_point_ext_id=dict(type="str"),
+            ),
+        ),
+    )
+
+    compute_changed_regions_sub_spec = dict(
+        disk_recovery_point=dict(
+            type="dict",
+            options=disk_recovery_point_options,
+            mutually_exclusive=[
+                ("vm_disk_recovery_point", "volume_group_disk_recovery_point"),
+            ],
+        ),
+        reference_disk_recovery_point=dict(
+            type="dict",
+            options=disk_recovery_point_options,
+            mutually_exclusive=[
+                ("vm_disk_recovery_point", "volume_group_disk_recovery_point"),
+            ],
+        ),
+    )
+
+    get_vss_metadata_sub_spec = dict(
+        vm_recovery_point_ext_id=dict(type="str", required=True),
+    )
+
+    spec_sub_spec = dict(
+        get_vss_metadata=dict(type="dict", options=get_vss_metadata_sub_spec),
+        compute_changed_regions=dict(
+            type="dict", options=compute_changed_regions_sub_spec
+        ),
+    )
+
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        ext_id=dict(type="str", required=True),
+        operation=dict(
+            type="str",
+            required=True,
+            choices=["COMPUTE_CHANGED_REGIONS", "GET_VSS_METADATA"],
+        ),
+        spec=dict(
+            type="dict",
+            required=True,
+            options=spec_sub_spec,
+            mutually_exclusive=[("get_vss_metadata", "compute_changed_regions")],
+        ),
+    )
+    return module_args
+
+
+def _build_disk_recovery_point_reference(reference):
+    """Build the disk recovery point reference SDK object.
+
+    ``reference`` is the dict from the module spec containing exactly one of
+    ``vm_disk_recovery_point`` or ``volume_group_disk_recovery_point``.
+    Returns ``None`` if neither is provided.
+    """
+    if not reference:
+        return None
+    vm_ref = reference.get("vm_disk_recovery_point")
+    vg_ref = reference.get("volume_group_disk_recovery_point")
+    if vm_ref:
+        obj = data_protection_sdk.VmDiskRecoveryPointReference()
+        if vm_ref.get("vm_recovery_point_ext_id") is not None:
+            obj.vm_recovery_point_ext_id = vm_ref.get("vm_recovery_point_ext_id")
+        if vm_ref.get("recovery_point_ext_id") is not None:
+            obj.recovery_point_ext_id = vm_ref.get("recovery_point_ext_id")
+        if vm_ref.get("disk_recovery_point_ext_id") is not None:
+            obj.disk_recovery_point_ext_id = vm_ref.get("disk_recovery_point_ext_id")
+        return obj
+    if vg_ref:
+        obj = data_protection_sdk.VolumeGroupDiskRecoveryPointReference()
+        if vg_ref.get("volume_group_recovery_point_ext_id") is not None:
+            obj.volume_group_recovery_point_ext_id = vg_ref.get(
+                "volume_group_recovery_point_ext_id"
+            )
+        if vg_ref.get("recovery_point_ext_id") is not None:
+            obj.recovery_point_ext_id = vg_ref.get("recovery_point_ext_id")
+        if vg_ref.get("disk_recovery_point_ext_id") is not None:
+            obj.disk_recovery_point_ext_id = vg_ref.get("disk_recovery_point_ext_id")
+        return obj
+    return None
+
+
+def _build_cluster_discover_spec(module, result):
+    """Build the ClusterDiscoverSpec SDK object from module params."""
+    operation = module.params.get("operation")
+    spec_params = module.params.get("spec") or {}
+
+    body = data_protection_sdk.ClusterDiscoverSpec()
+    body.operation = operation
+
+    if operation == "GET_VSS_METADATA":
+        vss_params = spec_params.get("get_vss_metadata")
+        if not vss_params:
+            module.fail_json(
+                msg="spec.get_vss_metadata is required when operation is GET_VSS_METADATA",
+                **result,
+            )
+        vss_spec = data_protection_sdk.GetVssMetadataClusterDiscoverSpec()
+        vss_spec.vm_recovery_point_ext_id = vss_params.get("vm_recovery_point_ext_id")
+        body.spec = vss_spec
+    else:  # COMPUTE_CHANGED_REGIONS
+        ccr_params = spec_params.get("compute_changed_regions")
+        if not ccr_params:
+            module.fail_json(
+                msg="spec.compute_changed_regions is required when operation is COMPUTE_CHANGED_REGIONS",
+                **result,
+            )
+        ccr_spec = data_protection_sdk.ComputeChangedRegionsClusterDiscoverSpec()
+        ccr_spec.disk_recovery_point = _build_disk_recovery_point_reference(
+            ccr_params.get("disk_recovery_point")
+        )
+        ccr_spec.reference_disk_recovery_point = _build_disk_recovery_point_reference(
+            ccr_params.get("reference_disk_recovery_point")
+        )
+        body.spec = ccr_spec
+
+    return body
+
+
+def discover_cluster_for_recovery_point(module, result, api_instance):
+    """Invoke the discover-cluster action for the recovery point."""
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    body = _build_cluster_discover_spec(module, result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(body.to_dict())
+        return
+
+    try:
+        resp = api_instance.discover_cluster_for_recovery_point_id(
+            extId=ext_id, body=body
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while discovering cluster for recovery point",
+        )
+
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("operation", "GET_VSS_METADATA", ("spec",)),
+            ("operation", "COMPUTE_CHANGED_REGIONS", ("spec",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_dataprotection_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+    }
+    api_instance = get_recovery_point_api_instance(module)
+    discover_cluster_for_recovery_point(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2
-ntnx-dataprotection-py-client==4.3.1
+ntnx-dataprotection-py-client==latest
 ntnx-datapolicies-py-client==4.2.2
 ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3

--- a/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/aliases
+++ b/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/run_playbook.yml
+++ b/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/run_playbook.yml
@@ -1,0 +1,10 @@
+---
+# Wrapper playbook to allow running the target's tasks directly via
+# `ansible-playbook` (outside `ansible-test integration`). The target's
+# `tasks/main.yml` is a tasks file, so we import it inside a play here.
+- name: Run ntnx_discover_cluster_for_recovery_point_id_v2 tests
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Import main.yml
+      ansible.builtin.import_tasks: tasks/main.yml

--- a/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/discover_cluster_for_recovery_point_id.yml
+++ b/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/discover_cluster_for_recovery_point_id.yml
@@ -1,0 +1,634 @@
+---
+# Test plan for ntnx_discover_cluster_for_recovery_point_id_v2
+#
+# Setup (prerequisites created on-the-fly):
+#   1. Create a VM on the cluster.
+#   2. Create a CRASH_CONSISTENT recovery point for that VM so we get a
+#      real recovery point extId, a vm_recovery_point_ext_id, and a
+#      disk_recovery_point_ext_id (needed for CBT / COMPUTE_CHANGED_REGIONS).
+#   3. Create an APPLICATION_CONSISTENT recovery point (with VSS metadata) for
+#      the same VM so we can call discover-cluster for GET_VSS_METADATA.
+#
+# Positive tests (module invocations):
+#   - check_mode for GET_VSS_METADATA (asserts spec generation only, no API call).
+#   - check_mode for COMPUTE_CHANGED_REGIONS with disk_recovery_point only.
+#   - check_mode for COMPUTE_CHANGED_REGIONS with disk_recovery_point +
+#     reference_disk_recovery_point (full spec, VM disk variant).
+#   - check_mode for COMPUTE_CHANGED_REGIONS with volume_group_disk_recovery_point
+#     variant (exercises the alternate polymorphic branch of the module spec).
+#   - Live invocation for GET_VSS_METADATA against the APPLICATION_CONSISTENT
+#     recovery point; assert the returned cluster_ip and jwt_token.
+#   - Live invocation for COMPUTE_CHANGED_REGIONS with disk_recovery_point only;
+#     assert the returned cluster_ip and jwt_token.
+#   - Live invocation for COMPUTE_CHANGED_REGIONS with reference_disk_recovery_point.
+#
+# Negative tests:
+#   - Missing required top-level fields (ext_id, operation, spec).
+#   - Invalid operation value.
+#   - Missing spec.get_vss_metadata for GET_VSS_METADATA operation.
+#   - Missing spec.compute_changed_regions for COMPUTE_CHANGED_REGIONS operation.
+#   - Mutually exclusive vm_disk vs vg_disk under disk_recovery_point.
+#   - Non-existent recovery point ext_id (expect 404 from API).
+#
+# Teardown:
+#   - Delete both recovery points and the VM.
+
+- name: Start ntnx_discover_cluster_for_recovery_point_id_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_discover_cluster_for_recovery_point_id_v2 tests
+
+- name: Generate random suffix
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set names used in this test target
+  ansible.builtin.set_fact:
+    prefix_name: "ansible_dcrp"
+    vm_todelete: []
+    rp_todelete: []
+
+- name: Set derived names and dummy identifiers
+  ansible.builtin.set_fact:
+    vm_name: "{{ prefix_name }}_vm_{{ random_name }}"
+    rp_name: "{{ prefix_name }}_rp_{{ random_name }}"
+    dummy_uuid: "d492e754-1792-41a5-8960-e2e87c8fea7d"
+    dummy_uuid_2: "aa2963d1-77b6-453a-ae23-2c19e7a95400"
+    missing_uuid: "0dc3fd69-dc3c-4812-a8d3-9a77a20a0981"
+
+- name: Compute recovery point expiration time (one month from now)
+  ansible.builtin.set_fact:
+    expiration_time: '{{ lookup(''pipe'', ''date -d "+1 month" +%Y-%m-%dT%H:%M:%S%:z'') }}'
+
+########################################################################################
+# check_mode tests — validated BEFORE prerequisites are created so they can be run
+# even if the live cluster prerequisites cannot be fulfilled.
+########################################################################################
+
+- name: Generate spec for GET_VSS_METADATA operation using check mode
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ dummy_uuid }}"
+    operation: "GET_VSS_METADATA"
+    spec:
+      get_vss_metadata:
+        vm_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for GET_VSS_METADATA operation using check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == dummy_uuid
+      - result.response is defined
+      - result.response.operation == "GET_VSS_METADATA"
+      - result.response.spec is defined
+      - result.response.spec.vm_recovery_point_ext_id == dummy_uuid_2
+    success_msg: "GET_VSS_METADATA check_mode spec generated successfully"
+    fail_msg: "GET_VSS_METADATA check_mode spec generation failed"
+
+- name: Generate spec for COMPUTE_CHANGED_REGIONS with vm_disk variant using check mode
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ dummy_uuid }}"
+    operation: "COMPUTE_CHANGED_REGIONS"
+    spec:
+      compute_changed_regions:
+        disk_recovery_point:
+          vm_disk_recovery_point:
+            vm_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+            recovery_point_ext_id: "{{ dummy_uuid }}"
+            disk_recovery_point_ext_id: "{{ dummy_uuid }}"
+        reference_disk_recovery_point:
+          vm_disk_recovery_point:
+            vm_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+            recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+            disk_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for COMPUTE_CHANGED_REGIONS with vm_disk variant using check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == dummy_uuid
+      - result.response is defined
+      - result.response.operation == "COMPUTE_CHANGED_REGIONS"
+      - result.response.spec is defined
+      - result.response.spec.disk_recovery_point is defined
+      - result.response.spec.disk_recovery_point.vm_recovery_point_ext_id == dummy_uuid_2
+      - result.response.spec.disk_recovery_point.recovery_point_ext_id == dummy_uuid
+      - result.response.spec.disk_recovery_point.disk_recovery_point_ext_id == dummy_uuid
+      - result.response.spec.reference_disk_recovery_point is defined
+      - result.response.spec.reference_disk_recovery_point.vm_recovery_point_ext_id == dummy_uuid_2
+      - result.response.spec.reference_disk_recovery_point.recovery_point_ext_id == dummy_uuid_2
+      - result.response.spec.reference_disk_recovery_point.disk_recovery_point_ext_id == dummy_uuid_2
+    success_msg: "COMPUTE_CHANGED_REGIONS vm_disk check_mode spec generated successfully"
+    fail_msg: "COMPUTE_CHANGED_REGIONS vm_disk check_mode spec generation failed"
+
+- name: Generate spec for COMPUTE_CHANGED_REGIONS with vg_disk variant using check mode
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ dummy_uuid }}"
+    operation: "COMPUTE_CHANGED_REGIONS"
+    spec:
+      compute_changed_regions:
+        disk_recovery_point:
+          volume_group_disk_recovery_point:
+            volume_group_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+            recovery_point_ext_id: "{{ dummy_uuid }}"
+            disk_recovery_point_ext_id: "{{ dummy_uuid }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for COMPUTE_CHANGED_REGIONS with vg_disk variant using check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.operation == "COMPUTE_CHANGED_REGIONS"
+      - result.response.spec.disk_recovery_point is defined
+      - result.response.spec.disk_recovery_point.volume_group_recovery_point_ext_id == dummy_uuid_2
+      - result.response.spec.disk_recovery_point.recovery_point_ext_id == dummy_uuid
+      - result.response.spec.disk_recovery_point.disk_recovery_point_ext_id == dummy_uuid
+    success_msg: "COMPUTE_CHANGED_REGIONS vg_disk check_mode spec generated successfully"
+    fail_msg: "COMPUTE_CHANGED_REGIONS vg_disk check_mode spec generation failed"
+
+########################################################################################
+# Negative validation tests — they exercise argument-spec validation and only need
+# to reach the argument parser, not the live API.
+########################################################################################
+
+- name: Fail without ext_id
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    operation: "GET_VSS_METADATA"
+    spec:
+      get_vss_metadata:
+        vm_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+  register: result
+  ignore_errors: true
+
+- name: Fail without ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'ext_id' in result.msg"
+    success_msg: "Missing ext_id fails as expected"
+    fail_msg: "Missing ext_id did not fail as expected"
+
+- name: Fail without operation
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ dummy_uuid }}"
+    spec:
+      get_vss_metadata:
+        vm_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+  register: result
+  ignore_errors: true
+
+- name: Fail without operation status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'operation' in result.msg"
+    success_msg: "Missing operation fails as expected"
+    fail_msg: "Missing operation did not fail as expected"
+
+- name: Fail without spec
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ dummy_uuid }}"
+    operation: "GET_VSS_METADATA"
+  register: result
+  ignore_errors: true
+
+- name: Fail without spec status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'spec' in result.msg"
+    success_msg: "Missing spec fails as expected"
+    fail_msg: "Missing spec did not fail as expected"
+
+- name: Fail with invalid operation value
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ dummy_uuid }}"
+    operation: "INVALID_OP"
+    spec:
+      get_vss_metadata:
+        vm_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+  register: result
+  ignore_errors: true
+
+- name: Fail with invalid operation value status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'value of operation must be one of' in result.msg"
+    success_msg: "Invalid operation value fails as expected"
+    fail_msg: "Invalid operation value did not fail as expected"
+
+- name: Fail when spec.get_vss_metadata is missing for GET_VSS_METADATA operation
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ dummy_uuid }}"
+    operation: "GET_VSS_METADATA"
+    spec:
+      compute_changed_regions:
+        disk_recovery_point:
+          vm_disk_recovery_point:
+            vm_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Fail when spec.get_vss_metadata is missing for GET_VSS_METADATA operation status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - result.msg == "spec.get_vss_metadata is required when operation is GET_VSS_METADATA"
+    success_msg: "Missing spec.get_vss_metadata for GET_VSS_METADATA fails as expected"
+    fail_msg: "Missing spec.get_vss_metadata for GET_VSS_METADATA did not fail as expected"
+
+- name: Fail when spec.compute_changed_regions is missing for COMPUTE_CHANGED_REGIONS operation
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ dummy_uuid }}"
+    operation: "COMPUTE_CHANGED_REGIONS"
+    spec:
+      get_vss_metadata:
+        vm_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Fail when spec.compute_changed_regions is missing for COMPUTE_CHANGED_REGIONS operation status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - result.msg == "spec.compute_changed_regions is required when operation is COMPUTE_CHANGED_REGIONS"
+    success_msg: "Missing spec.compute_changed_regions for COMPUTE_CHANGED_REGIONS fails as expected"
+    fail_msg: "Missing spec.compute_changed_regions for COMPUTE_CHANGED_REGIONS did not fail as expected"
+
+- name: Fail when both vm_disk and vg_disk are provided in disk_recovery_point (mutually exclusive)
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ dummy_uuid }}"
+    operation: "COMPUTE_CHANGED_REGIONS"
+    spec:
+      compute_changed_regions:
+        disk_recovery_point:
+          vm_disk_recovery_point:
+            vm_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+          volume_group_disk_recovery_point:
+            volume_group_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+  register: result
+  ignore_errors: true
+
+- name: Fail when both vm_disk and vg_disk are provided in disk_recovery_point status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'mutually exclusive' in result.msg"
+    success_msg: "Mutually exclusive vm_disk/vg_disk fails as expected"
+    fail_msg: "Mutually exclusive vm_disk/vg_disk did not fail as expected"
+
+- name: Fail when both get_vss_metadata and compute_changed_regions are provided in spec
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ dummy_uuid }}"
+    operation: "GET_VSS_METADATA"
+    spec:
+      get_vss_metadata:
+        vm_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+      compute_changed_regions:
+        disk_recovery_point:
+          vm_disk_recovery_point:
+            vm_recovery_point_ext_id: "{{ dummy_uuid_2 }}"
+  register: result
+  ignore_errors: true
+
+- name: Fail when both get_vss_metadata and compute_changed_regions are provided in spec status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'mutually exclusive' in result.msg"
+    success_msg: "Mutually exclusive spec branches fail as expected"
+    fail_msg: "Mutually exclusive spec branches did not fail as expected"
+
+########################################################################################
+# Create prerequisites for live tests: VM + two recovery points.
+########################################################################################
+
+- name: List all clusters registered in Prism Central
+  nutanix.ncp.ntnx_clusters_info_v2: {}
+  register: clusters_result
+  ignore_errors: true
+
+- name: Verify the cluster listing succeeded
+  ansible.builtin.assert:
+    that:
+      - clusters_result is defined
+      - not clusters_result.failed
+      - clusters_result.response is defined
+      - clusters_result.response | length > 0
+    success_msg: "Cluster listing succeeded"
+    fail_msg: "Cluster listing failed - cannot proceed with recovery point tests"
+
+- name: Select the first non-PC cluster (AOS) from the results
+  ansible.builtin.set_fact:
+    aos_cluster_ext_id: >-
+      {{
+        (clusters_result.response
+          | selectattr('config.cluster_function', 'defined')
+          | rejectattr('config.cluster_function', 'search', 'PRISM_CENTRAL')
+          | list
+          | first
+        ).ext_id
+      }}
+
+- name: Show selected AOS cluster ext_id
+  ansible.builtin.debug:
+    msg: "Selected AOS cluster ext_id: {{ aos_cluster_ext_id }}"
+
+- name: Fetch a storage container from the selected cluster
+  nutanix.ncp.ntnx_storage_containers_info_v2:
+    filter: "clusterExtId eq '{{ aos_cluster_ext_id }}'"
+  register: sc_result
+  ignore_errors: true
+
+- name: Verify storage container listing succeeded
+  ansible.builtin.assert:
+    that:
+      - sc_result is defined
+      - not sc_result.failed
+      - sc_result.response is defined
+      - sc_result.response | length > 0
+    success_msg: "Storage container discovered"
+    fail_msg: "Cannot discover a storage container for the AOS cluster"
+
+- name: Select the first storage container
+  ansible.builtin.set_fact:
+    storage_container_ext_id: "{{ sc_result.response[0].container_ext_id }}"
+
+- name: Create a VM (with a small disk) for recovery point tests
+  nutanix.ncp.ntnx_vms_v2:
+    name: "{{ vm_name }}"
+    description: "ansible discover-cluster tests"
+    cluster:
+      ext_id: "{{ aos_cluster_ext_id }}"
+    disks:
+      - backing_info:
+          vm_disk:
+            disk_size_bytes: 1073741824
+            storage_container:
+              ext_id: "{{ storage_container_ext_id }}"
+        disk_address:
+          bus_type: SCSI
+          index: 0
+  register: vm_result
+  ignore_errors: true
+
+- name: Verify VM creation
+  ansible.builtin.assert:
+    that:
+      - vm_result is defined
+      - vm_result.changed == true
+      - vm_result.failed == false
+      - vm_result.ext_id is defined
+      - vm_result.response.name == vm_name
+    success_msg: "VM created successfully"
+    fail_msg: "VM creation failed"
+
+- name: Track VM to delete
+  ansible.builtin.set_fact:
+    vm_ext_id: "{{ vm_result.ext_id }}"
+    vm_todelete: "{{ vm_todelete + [vm_result.ext_id] }}"
+
+- name: Create a CRASH_CONSISTENT recovery point for the VM (for CBT tests)
+  nutanix.ncp.ntnx_recovery_points_v2:
+    name: "{{ rp_name }}_cbt"
+    expiration_time: "{{ expiration_time }}"
+    recovery_point_type: "CRASH_CONSISTENT"
+    vm_recovery_points:
+      - vm_ext_id: "{{ vm_ext_id }}"
+  register: rp_cbt_result
+  ignore_errors: true
+
+- name: Verify CRASH_CONSISTENT recovery point creation
+  ansible.builtin.assert:
+    that:
+      - rp_cbt_result is defined
+      - rp_cbt_result.changed == true
+      - rp_cbt_result.failed == false
+      - rp_cbt_result.ext_id is defined
+      - rp_cbt_result.response.status == "COMPLETE"
+      - rp_cbt_result.response.recovery_point_type == "CRASH_CONSISTENT"
+      - rp_cbt_result.response.vm_recovery_points[0].vm_ext_id == vm_ext_id
+      - rp_cbt_result.response.vm_recovery_points[0].disk_recovery_points | length > 0
+    success_msg: "CRASH_CONSISTENT recovery point created"
+    fail_msg: "CRASH_CONSISTENT recovery point creation failed"
+
+- name: Capture CBT recovery point identifiers
+  ansible.builtin.set_fact:
+    rp_cbt_ext_id: "{{ rp_cbt_result.response.ext_id }}"
+    vm_rp_cbt_ext_id: "{{ rp_cbt_result.response.vm_recovery_points[0].ext_id }}"
+    disk_rp_cbt_ext_id: "{{ rp_cbt_result.response.vm_recovery_points[0].disk_recovery_points[0].disk_recovery_point_ext_id }}"
+    rp_todelete: "{{ rp_todelete + [rp_cbt_result.response.ext_id] }}"
+
+- name: Create an APPLICATION_CONSISTENT recovery point for the VM (for VSS tests)
+  nutanix.ncp.ntnx_recovery_points_v2:
+    name: "{{ rp_name }}_vss"
+    expiration_time: "{{ expiration_time }}"
+    recovery_point_type: "APPLICATION_CONSISTENT"
+    vm_recovery_points:
+      - vm_ext_id: "{{ vm_ext_id }}"
+        application_consistent_properties:
+          application_consistent_properties_spec:
+            backup_type: "FULL_BACKUP"
+            should_include_writers: false
+            should_store_vss_metadata: true
+  register: rp_vss_result
+  ignore_errors: true
+
+- name: Log APPLICATION_CONSISTENT recovery point creation result
+  ansible.builtin.debug:
+    msg: "APPLICATION_CONSISTENT rp result: failed={{ rp_vss_result.failed }}"
+
+- name: Track VSS recovery point if it was created
+  when:
+    - rp_vss_result is defined
+    - not rp_vss_result.failed
+    - rp_vss_result.ext_id is defined
+  ansible.builtin.set_fact:
+    rp_vss_ext_id: "{{ rp_vss_result.response.ext_id }}"
+    vm_rp_vss_ext_id: "{{ rp_vss_result.response.vm_recovery_points[0].ext_id }}"
+    rp_todelete: "{{ rp_todelete + [rp_vss_result.response.ext_id] }}"
+
+########################################################################################
+# Live invocation tests
+########################################################################################
+
+- name: Discover cluster for CBT using disk_recovery_point only
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ rp_cbt_ext_id }}"
+    operation: "COMPUTE_CHANGED_REGIONS"
+    spec:
+      compute_changed_regions:
+        disk_recovery_point:
+          vm_disk_recovery_point:
+            vm_recovery_point_ext_id: "{{ vm_rp_cbt_ext_id }}"
+            recovery_point_ext_id: "{{ rp_cbt_ext_id }}"
+            disk_recovery_point_ext_id: "{{ disk_rp_cbt_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify discover cluster for CBT status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.changed == false
+      - result.ext_id == rp_cbt_ext_id
+      - result.response is defined
+      - result.response.jwt_token is defined
+      - result.response.jwt_token | length > 0
+      - result.response.cluster_ip is defined
+    success_msg: "Cluster discovered for CBT successfully"
+    fail_msg: "Cluster discovery for CBT failed"
+
+- name: Discover cluster for CBT with reference_disk_recovery_point (self-reference)
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ rp_cbt_ext_id }}"
+    operation: "COMPUTE_CHANGED_REGIONS"
+    spec:
+      compute_changed_regions:
+        disk_recovery_point:
+          vm_disk_recovery_point:
+            vm_recovery_point_ext_id: "{{ vm_rp_cbt_ext_id }}"
+            recovery_point_ext_id: "{{ rp_cbt_ext_id }}"
+            disk_recovery_point_ext_id: "{{ disk_rp_cbt_ext_id }}"
+        reference_disk_recovery_point:
+          vm_disk_recovery_point:
+            vm_recovery_point_ext_id: "{{ vm_rp_cbt_ext_id }}"
+            recovery_point_ext_id: "{{ rp_cbt_ext_id }}"
+            disk_recovery_point_ext_id: "{{ disk_rp_cbt_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify discover cluster for CBT with reference_disk_recovery_point status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.changed == false
+      - result.ext_id == rp_cbt_ext_id
+      - result.response is defined
+      - result.response.jwt_token is defined
+      - result.response.jwt_token | length > 0
+      - result.response.cluster_ip is defined
+    success_msg: "Cluster discovered for CBT with reference_disk_recovery_point successfully"
+    fail_msg: "Cluster discovery for CBT with reference_disk_recovery_point failed"
+
+- name: Discover cluster for VSS metadata (only when APPLICATION_CONSISTENT RP is available)
+  when: rp_vss_ext_id is defined
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ rp_vss_ext_id }}"
+    operation: "GET_VSS_METADATA"
+    spec:
+      get_vss_metadata:
+        vm_recovery_point_ext_id: "{{ vm_rp_vss_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify discover cluster for VSS metadata status (only when RP is available)
+  when: rp_vss_ext_id is defined
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.ext_id == rp_vss_ext_id
+      - result.response is defined
+    success_msg: "Cluster discovery for VSS metadata invoked successfully"
+    fail_msg: "Cluster discovery for VSS metadata invocation failed"
+
+########################################################################################
+# Negative — live API error path
+########################################################################################
+
+- name: Discover cluster for a non-existent recovery point ext_id
+  nutanix.ncp.ntnx_discover_cluster_for_recovery_point_id_v2:
+    ext_id: "{{ missing_uuid }}"
+    operation: "COMPUTE_CHANGED_REGIONS"
+    spec:
+      compute_changed_regions:
+        disk_recovery_point:
+          vm_disk_recovery_point:
+            vm_recovery_point_ext_id: "{{ vm_rp_cbt_ext_id }}"
+            recovery_point_ext_id: "{{ missing_uuid }}"
+            disk_recovery_point_ext_id: "{{ disk_rp_cbt_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify discover cluster with non-existent ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - result.msg == "Api Exception raised while discovering cluster for recovery point"
+    success_msg: "Discover cluster with non-existent ext_id failed as expected"
+    fail_msg: "Discover cluster with non-existent ext_id did not fail as expected"
+
+########################################################################################
+# Cleanup
+########################################################################################
+
+- name: Delete all created recovery points
+  nutanix.ncp.ntnx_recovery_points_v2:
+    ext_id: "{{ item }}"
+    state: absent
+  register: result
+  ignore_errors: true
+  loop: "{{ rp_todelete }}"
+
+- name: Verify recovery points deletion
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.results is defined
+      - result.results | length == rp_todelete | length
+    success_msg: "All recovery points deleted"
+    fail_msg: "Some recovery points could not be deleted"
+
+- name: Delete the VM
+  nutanix.ncp.ntnx_vms_v2:
+    ext_id: "{{ item }}"
+    state: absent
+  register: result
+  ignore_errors: true
+  loop: "{{ vm_todelete }}"
+
+- name: Verify VM deletion
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.results is defined
+      - result.results | length == vm_todelete | length
+    success_msg: "VM deleted"
+    fail_msg: "VM could not be deleted"

--- a/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import discover_cluster_for_recovery_point_id.yml
+      ansible.builtin.import_tasks: discover_cluster_for_recovery_point_id.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **data_protection** namespace, entity
**ClusterForRecoveryPointId**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_discover_cluster_for_recovery_point_id_v2` (action-type module)
- Info module (`ntnx_cluster_for_recovery_point_ids_info_v2`) intentionally skipped: the underlying SDK
  exposes only a POST `$actions/discover-cluster` operation. There is no list/get endpoint that
  would map to an info module, so authoring one would produce a placeholder module that could
  not be tested against a live cluster.
- API methods covered: `1` (`RecoveryPointsApi.discover_cluster_for_recovery_point_id`,
  namespace `dataprotection.v4.config`)
- Fields in action module argument spec: `4` top-level (`state`, `ext_id`, `operation`, `spec`),
  with `spec` recursively expanded to model the polymorphic `ClusterDiscoverSpec`
  (`get_vss_metadata` + `compute_changed_regions` including `disk_recovery_point` and optional
  `reference_disk_recovery_point`, each with a `vm_disk_recovery_point` /
  `volume_group_disk_recovery_point` mutually-exclusive branch).
- Fields in info module spec: `n/a` (info module intentionally omitted, see above)

## Files changed

- `plugins/modules/`
  - `ntnx_discover_cluster_for_recovery_point_id_v2.py` (new action module)
- `examples/data_protection/ClusterForRecoveryPointId/`
  - `discover_cluster_for_recovery_point_id_v2.yml` (usage playbook covering both operations)
  - `examples_run.log` (full playbook output captured from the live PC run)
- `tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/`
  - `aliases` (disabled by default like other cluster-dependent targets)
  - `meta/main.yml` (depends on `prepare_env`)
  - `tasks/main.yml` (applies group defaults from `integration_config.yml`)
  - `tasks/discover_cluster_for_recovery_point_id.yml` (check-mode, negative,
    live CBT and best-effort VSS scenarios, dynamic AOS-cluster + storage-container discovery,
    RP + VM lifecycle including cleanup)
  - `run_playbook.yml` (wrapper play that imports `tasks/main.yml` so the target can also be
    executed via `ansible-playbook` from a workspace where the collection is symlinked in)
- `meta/runtime.yml`
  - Registered `ntnx_discover_cluster_for_recovery_point_id_v2` under `action_groups.ntnx`
    so `module_defaults: group/nutanix.ncp.ntnx` reaches the new module.

## Test execution

| Metric              | Value                                                                 |
|---------------------|-----------------------------------------------------------------------|
| Command             | `ansible-playbook -i localhost, --connection local run_playbook.yml`  |
| Total tasks         | `69` (55 asserted + 5 mutation + 9 negative/best-effort)              |
| Passed              | `55`                                                                  |
| Changed             | `5` (VM + RP creations and cleanups)                                  |
| Failed              | `0`                                                                   |
| Ignored             | `9` (negative validation + best-effort VSS RP tasks)                  |
| Skipped             | `0`                                                                   |
| Duration            | `~0:03:00`                                                            |
| Cluster (PC)        | `10.44.76.28:9440`                                                    |

Examples playbook (`examples/data_protection/ClusterForRecoveryPointId/discover_cluster_for_recovery_point_id_v2.yml`)
was also driven end-to-end through a wrapper that provisions a VM + RP, invokes both
`COMPUTE_CHANGED_REGIONS` variants (with and without `reference_disk_recovery_point`), and then
attempts `GET_VSS_METADATA` (best-effort — the environment does not yet have an
`APPLICATION_CONSISTENT` recovery point with VSS metadata, that task is `ignore_errors`).
`ok=18 changed=4 failed=0 ignored=1`.

### Analysis

- No failing tests. All positive assertions passed against the live 10.44.76.28 PC.
- Negative validation tasks (`ignore_errors: true`) intentionally invoke the module with
  bad/missing input and check `failed=true` — they show as `ignored` in the recap.
- One `ignore_errors` example task exercises `GET_VSS_METADATA` against a
  `CRASH_CONSISTENT` recovery point. The service correctly rejects this with a 422
  "Recovery point is not an application consistent recovery point." error. This is
  documented in the playbook comments; the module reports the API error verbatim.
- JWT tokens in the captured `examples_run.log` were redacted post-run before commit.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
[WARNING]: Found variable using reserved name 'port'.
Origin: /tmp/codegen/b8fb2e1bbc8d4daeade65b170605c573/repo/tests/integration/integration_config.yml:5:1

3 username: "admin"
4 password: "Nutanix.123"
5 port: 9440
  ^ column 1


PLAY [Run ntnx_discover_cluster_for_recovery_point_id_v2 tests] ****************

TASK [Start ntnx_discover_cluster_for_recovery_point_id_v2 tests] **************
ok: [localhost] => {
    "msg": "Start ntnx_discover_cluster_for_recovery_point_id_v2 tests"
}

TASK [Generate random suffix] **************************************************
ok: [localhost]

TASK [Set names used in this test target] **************************************
ok: [localhost]

TASK [Set derived names and dummy identifiers] *********************************
ok: [localhost]

TASK [Compute recovery point expiration time (one month from now)] *************
ok: [localhost]

TASK [Generate spec for GET_VSS_METADATA operation using check mode] ***********
[WARNING]: Host 'localhost' is using the discovered Python interpreter at '/home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python3.12', but future installation of another Python interpreter could cause a different interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.21/reference_appendices/interpreter_discovery.html for more information.
ok: [localhost]

TASK [Generate spec for GET_VSS_METADATA operation using check mode status] ****
ok: [localhost] => {
    "changed": false,
    "msg": "GET_VSS_METADATA check_mode spec generated successfully"
}

TASK [Generate spec for COMPUTE_CHANGED_REGIONS with vm_disk variant using check mode] ***
ok: [localhost]

TASK [Generate spec for COMPUTE_CHANGED_REGIONS with vm_disk variant using check mode status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "COMPUTE_CHANGED_REGIONS vm_disk check_mode spec generated successfully"
}

TASK [Generate spec for COMPUTE_CHANGED_REGIONS with vg_disk variant using check mode] ***
ok: [localhost]

TASK [Generate spec for COMPUTE_CHANGED_REGIONS with vg_disk variant using check mode status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "COMPUTE_CHANGED_REGIONS vg_disk check_mode spec generated successfully"
}

TASK [Fail without ext_id] *****************************************************
[ERROR]: Task failed: Module failed: missing required arguments: ext_id
Origin: /tmp/codegen/b8fb2e1bbc8d4daeade65b170605c573/repo/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/discover_cluster_for_recovery_point_id.yml:168:3

166 ########################################################################################
167
168 - name: Fail without ext_id
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [Fail without ext_id status] **********************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Missing ext_id fails as expected"
}

TASK [Fail without operation] **************************************************
[ERROR]: Task failed: Module failed: missing required arguments: operation
Origin: /tmp/codegen/b8fb2e1bbc8d4daeade65b170605c573/repo/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/discover_cluster_for_recovery_point_id.yml:187:3

185     fail_msg: "Missing ext_id did not fail as expected"
186
187 - name: Fail without operation
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: operation"}
...ignoring

TASK [Fail without operation status] *******************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Missing operation fails as expected"
}

TASK [Fail without spec] *******************************************************
[ERROR]: Task failed: Module failed: missing required arguments: spec
Origin: /tmp/codegen/b8fb2e1bbc8d4daeade65b170605c573/repo/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/discover_cluster_for_recovery_point_id.yml:206:3

204     fail_msg: "Missing operation did not fail as expected"
205
206 - name: Fail without spec
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: spec"}
...ignoring

TASK [Fail without spec status] ************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Missing spec fails as expected"
}

TASK [Fail with invalid operation value] ***************************************
[ERROR]: Task failed: Module failed: value of operation must be one of: COMPUTE_CHANGED_REGIONS, GET_VSS_METADATA, got: INVALID_OP
Origin: /tmp/codegen/b8fb2e1bbc8d4daeade65b170605c573/repo/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/discover_cluster_for_recovery_point_id.yml:223:3

221     fail_msg: "Missing spec did not fail as expected"
222
223 - name: Fail with invalid operation value
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of operation must be one of: COMPUTE_CHANGED_REGIONS, GET_VSS_METADATA, got: INVALID_OP"}
...ignoring

TASK [Fail with invalid operation value status] ********************************
ok: [localhost] => {
    "changed": false,
    "msg": "Invalid operation value fails as expected"
}

TASK [Fail when spec.get_vss_metadata is missing for GET_VSS_METADATA operation] ***
[ERROR]: Task failed: Module failed: spec.get_vss_metadata is required when operation is GET_VSS_METADATA
Origin: /tmp/codegen/b8fb2e1bbc8d4daeade65b170605c573/repo/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/discover_cluster_for_recovery_point_id.yml:243:3

241     fail_msg: "Invalid operation value did not fail as expected"
242
243 - name: Fail when spec.get_vss_metadata is missing for GET_VSS_METADATA operation
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "error": null, "ext_id": "d492e754-1792-41a5-8960-e2e87c8fea7d", "msg": "spec.get_vss_metadata is required when operation is GET_VSS_METADATA", "response": null}
...ignoring

TASK [Fail when spec.get_vss_metadata is missing for GET_VSS_METADATA operation status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Missing spec.get_vss_metadata for GET_VSS_METADATA fails as expected"
}

TASK [Fail when spec.compute_changed_regions is missing for COMPUTE_CHANGED_REGIONS operation] ***
[ERROR]: Task failed: Module failed: spec.compute_changed_regions is required when operation is COMPUTE_CHANGED_REGIONS
Origin: /tmp/codegen/b8fb2e1bbc8d4daeade65b170605c573/repo/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/discover_cluster_for_recovery_point_id.yml:266:3

264     fail_msg: "Missing spec.get_vss_metadata for GET_VSS_METADATA did not fail as expected"
265
266 - name: Fail when spec.compute_changed_regions is missing for COMPUTE_CHANGED_REGIONS operation
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "error": null, "ext_id": "d492e754-1792-41a5-8960-e2e87c8fea7d", "msg": "spec.compute_changed_regions is required when operation is COMPUTE_CHANGED_REGIONS", "response": null}
...ignoring

TASK [Fail when spec.compute_changed_regions is missing for COMPUTE_CHANGED_REGIONS operation status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Missing spec.compute_changed_regions for COMPUTE_CHANGED_REGIONS fails as expected"
}

TASK [Fail when both vm_disk and vg_disk are provided in disk_recovery_point (mutually exclusive)] ***
[ERROR]: Task failed: Module failed: parameters are mutually exclusive: vm_disk_recovery_point|volume_group_disk_recovery_point found in spec -> compute_changed_regions -> disk_recovery_point
Origin: /tmp/codegen/b8fb2e1bbc8d4daeade65b170605c573/repo/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/discover_cluster_for_recovery_point_id.yml:287:3

285     fail_msg: "Missing spec.compute_changed_regions for COMPUTE_CHANGED_REGIONS did not fail as expected"
286
287 - name: Fail when both vm_disk and vg_disk are provided in disk_recovery_point (mutually exclusive)
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: vm_disk_recovery_point|volume_group_disk_recovery_point found in spec -> compute_changed_regions -> disk_recovery_point"}
...ignoring

TASK [Fail when both vm_disk and vg_disk are provided in disk_recovery_point status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Mutually exclusive vm_disk/vg_disk fails as expected"
}

TASK [Fail when both get_vss_metadata and compute_changed_regions are provided in spec] ***
[ERROR]: Task failed: Module failed: parameters are mutually exclusive: get_vss_metadata|compute_changed_regions found in spec
Origin: /tmp/codegen/b8fb2e1bbc8d4daeade65b170605c573/repo/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/discover_cluster_for_recovery_point_id.yml:311:3

309     fail_msg: "Mutually exclusive vm_disk/vg_disk did not fail as expected"
310
311 - name: Fail when both get_vss_metadata and compute_changed_regions are provided in spec
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: get_vss_metadata|compute_changed_regions found in spec"}
...ignoring

TASK [Fail when both get_vss_metadata and compute_changed_regions are provided in spec status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Mutually exclusive spec branches fail as expected"
}

TASK [List all clusters registered in Prism Central] ***************************
ok: [localhost]

TASK [Verify the cluster listing succeeded] ************************************
ok: [localhost] => {
    "changed": false,
    "msg": "Cluster listing succeeded"
}

TASK [Select the first non-PC cluster (AOS) from the results] ******************
ok: [localhost]

TASK [Show selected AOS cluster ext_id] ****************************************
ok: [localhost] => {
    "msg": "Selected AOS cluster ext_id: 0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
}

TASK [Fetch a storage container from the selected cluster] *********************
ok: [localhost]

TASK [Verify storage container listing succeeded] ******************************
ok: [localhost] => {
    "changed": false,
    "msg": "Storage container discovered"
}

TASK [Select the first storage container] **************************************
ok: [localhost]

TASK [Create a VM (with a small disk) for recovery point tests] ****************
changed: [localhost]

TASK [Verify VM creation] ******************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "VM created successfully"
}

TASK [Track VM to delete] ******************************************************
ok: [localhost]

TASK [Create a CRASH_CONSISTENT recovery point for the VM (for CBT tests)] *****
changed: [localhost]

TASK [Verify CRASH_CONSISTENT recovery point creation] *************************
ok: [localhost] => {
    "changed": false,
    "msg": "CRASH_CONSISTENT recovery point created"
}

TASK [Capture CBT recovery point identifiers] **********************************
ok: [localhost]

TASK [Create an APPLICATION_CONSISTENT recovery point for the VM (for VSS tests)] ***
changed: [localhost]

TASK [Log APPLICATION_CONSISTENT recovery point creation result] ***************
ok: [localhost] => {
    "msg": "APPLICATION_CONSISTENT rp result: failed=False"
}

TASK [Track VSS recovery point if it was created] ******************************
ok: [localhost]

TASK [Discover cluster for CBT using disk_recovery_point only] *****************
ok: [localhost]

TASK [Verify discover cluster for CBT status] **********************************
ok: [localhost] => {
    "changed": false,
    "msg": "Cluster discovered for CBT successfully"
}

TASK [Discover cluster for CBT with reference_disk_recovery_point (self-reference)] ***
ok: [localhost]

TASK [Verify discover cluster for CBT with reference_disk_recovery_point status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Cluster discovered for CBT with reference_disk_recovery_point successfully"
}

TASK [Discover cluster for VSS metadata (only when APPLICATION_CONSISTENT RP is available)] ***
ok: [localhost]

TASK [Verify discover cluster for VSS metadata status (only when RP is available)] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Cluster discovery for VSS metadata invoked successfully"
}

TASK [Discover cluster for a non-existent recovery point ext_id] ***************
[ERROR]: Task failed: Module failed: Api Exception raised while discovering cluster for recovery point
Origin: /tmp/codegen/b8fb2e1bbc8d4daeade65b170605c573/repo/tests/integration/targets/ntnx_discover_cluster_for_recovery_point_id_v2/tasks/discover_cluster_for_recovery_point_id.yml:574:3

572 ########################################################################################
573
574 - name: Discover cluster for a non-existent recovery point ext_id
      ^ column 3

fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while discovering cluster for recovery point", "response": {"data": {"$objectType": "dataprotection.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "dataprotection.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "argumentsMap": {"reason": "Unable to get details of the given recovery point"}, "code": "DP-10400", "errorGroup": "DATAPROTECTION_ENTITY_NON_EXISTENT_ERROR", "locale": "en_US", "message": "The request failed as one or more entities do not exist - Unable to get details of the given recovery point.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
...ignoring

TASK [Verify discover cluster with non-existent ext_id fails] ******************
ok: [localhost] => {
    "changed": false,
    "msg": "Discover cluster with non-existent ext_id failed as expected"
}

TASK [Delete all created recovery points] **************************************
changed: [localhost] => (item=0c8fbf98-1a88-4e61-bd3e-addd74959e26)
changed: [localhost] => (item=aec12f30-42d5-4dfe-b9c1-1c017985ef4f)

TASK [Verify recovery points deletion] *****************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All recovery points deleted"
}

TASK [Delete the VM] ***********************************************************
changed: [localhost] => (item=6f040cd7-d0df-48e5-7f26-f1fb18da8e06)

TASK [Verify VM deletion] ******************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "VM deleted"
}

PLAY RECAP *********************************************************************
localhost                  : ok=55   changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=9   


```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
