### PR TITLE
UnplannedFailoverRecoveryPlan Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/data_protection/UnplannedFailoverRecoveryPlan/examples_run.log
+++ b/examples/data_protection/UnplannedFailoverRecoveryPlan/examples_run.log
@@ -1,0 +1,21 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [UnplannedFailoverRecoveryPlan playbook] **********************************
+
+TASK [Set variables for unplanned failover recovery plan] **********************
+ok: [localhost] => {"ansible_facts": {"recovery_plan_ext_id": "6f4ffcee-1dc4-4982-9401-aa1f65dd7177", "source_cluster_ext_id": "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2", "source_domain_manager_ext_id": "63bebabf-744c-48ff-a6d7-cb028707f972", "target_cluster_ext_id": "00062899-58d4-9d37-185b-ac1f6b6f97e2", "target_domain_manager_ext_id": "97da301d-0a8b-4334-94cd-16a83563218e"}, "changed": false}
+
+TASK [Trigger unplanned failover with minimum required fields] *****************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while triggering unplanned failover on recovery plan", "response": {"data": {"$objectType": "dataprotection.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "dataprotection.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "argumentsMap": {"reason": "Entity with external identifier 6f4ffcee-1dc4-4982-9401-aa1f65dd7177 does not exist"}, "code": "DP-10400", "errorGroup": "DATAPROTECTION_ENTITY_NON_EXISTENT_ERROR", "locale": "en_US", "message": "The request failed as one or more entities do not exist - Entity with external identifier 6f4ffcee-1dc4-4982-9401-aa1f65dd7177 does not exist.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
+...ignoring
+
+TASK [Trigger unplanned failover with all supported attributes] ****************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while triggering unplanned failover on recovery plan", "response": {"data": {"$objectType": "dataprotection.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "dataprotection.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "argumentsMap": {"reason": "Entity with external identifier 6f4ffcee-1dc4-4982-9401-aa1f65dd7177 does not exist"}, "code": "DP-10400", "errorGroup": "DATAPROTECTION_ENTITY_NON_EXISTENT_ERROR", "locale": "en_US", "message": "The request failed as one or more entities do not exist - Entity with external identifier 6f4ffcee-1dc4-4982-9401-aa1f65dd7177 does not exist.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=2   
+

--- a/examples/data_protection/UnplannedFailoverRecoveryPlan/unplanned_failover_recovery_plan.yml
+++ b/examples/data_protection/UnplannedFailoverRecoveryPlan/unplanned_failover_recovery_plan.yml
@@ -1,0 +1,68 @@
+---
+# Summary
+# This playbook demonstrates how to trigger an unplanned failover on an
+# existing Nutanix Recovery Plan using the v4 Data Protection API.
+#
+# The playbook covers:
+#   1. Minimal action call (only required fields — ext_id + failover_directions).
+#   2. Full action call with every optional field of UnplannedFailoverSpec set.
+#
+# Requirements to run this playbook end-to-end:
+#   - A Recovery Plan already exists on Prism Central and its ext_id is known.
+#   - The source and target Prism Central instances (domain managers) are paired
+#     via an availability zone and can reach each other.
+#   - Recovery points for the protected entities have already been replicated to
+#     the target cluster.
+#   - The user has the disaster recovery admin permissions listed in the module
+#     documentation.
+
+- name: UnplannedFailoverRecoveryPlan playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+
+  tasks:
+    - name: Set variables for unplanned failover recovery plan
+      ansible.builtin.set_fact:
+        recovery_plan_ext_id: "6f4ffcee-1dc4-4982-9401-aa1f65dd7177"
+        source_domain_manager_ext_id: "63bebabf-744c-48ff-a6d7-cb028707f972"
+        source_cluster_ext_id: "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2"
+        target_domain_manager_ext_id: "97da301d-0a8b-4334-94cd-16a83563218e"
+        target_cluster_ext_id: "00062899-58d4-9d37-185b-ac1f6b6f97e2"
+
+    - name: Trigger unplanned failover with minimum required fields
+      nutanix.ncp.ntnx_unplanned_failover_recovery_plan_v2:
+        ext_id: "{{ recovery_plan_ext_id }}"
+        name: "rpj_unplanned_failover_ansible_min"
+        failover_directions:
+          - source_domain_manager_ext_id: "{{ source_domain_manager_ext_id }}"
+            source_cluster:
+              ext_id: "{{ source_cluster_ext_id }}"
+            target_domain_manager_ext_id: "{{ target_domain_manager_ext_id }}"
+            target_cluster:
+              ext_id: "{{ target_cluster_ext_id }}"
+      register: minimal_result
+      ignore_errors: true
+
+    - name: Trigger unplanned failover with all supported attributes
+      nutanix.ncp.ntnx_unplanned_failover_recovery_plan_v2:
+        state: present
+        ext_id: "{{ recovery_plan_ext_id }}"
+        name: "rpj_unplanned_failover_ansible_full"
+        recovery_reference_time: "2024-01-02T03:04:05Z"
+        should_ignore_warnings: true
+        is_instant_restore: false
+        failover_directions:
+          - source_domain_manager_ext_id: "{{ source_domain_manager_ext_id }}"
+            source_cluster:
+              ext_id: "{{ source_cluster_ext_id }}"
+            target_domain_manager_ext_id: "{{ target_domain_manager_ext_id }}"
+            target_cluster:
+              ext_id: "{{ target_cluster_ext_id }}"
+      register: full_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_unplanned_failover_recovery_plan_v2

--- a/plugins/module_utils/v4/data_protection/api_client.py
+++ b/plugins/module_utils/v4/data_protection/api_client.py
@@ -108,3 +108,18 @@ def get_protected_resource_api_instance(module):
     """
     client = get_api_client(module)
     return ntnx_dataprotection_py_client.ProtectedResourcesApi(client)
+
+
+def get_recovery_plan_actions_api_instance(module):
+    """
+    This method will return the Recovery Plan Actions API instance.
+    Used for POST actions such as planned/unplanned failover, test failover,
+    validate, and cleanup on an existing Recovery Plan.
+
+    Args:
+        module (object): Ansible module object
+    Returns:
+        api_instance (object): RecoveryPlanActionsApi instance
+    """
+    client = get_api_client(module)
+    return ntnx_dataprotection_py_client.RecoveryPlanActionsApi(client)

--- a/plugins/modules/ntnx_unplanned_failover_recovery_plan_v2.py
+++ b/plugins/modules/ntnx_unplanned_failover_recovery_plan_v2.py
@@ -1,0 +1,400 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_unplanned_failover_recovery_plan_v2
+short_description: Trigger an unplanned failover on a Nutanix Recovery Plan
+version_added: 2.5.0
+description:
+    - Perform an unplanned failover on an existing Recovery Plan in Nutanix Prism Central.
+    - Restores the protected entities (VMs/Volume Groups) from their latest available
+      recovery points on the target disaster recovery location.
+    - This is an asynchronous action; the API returns a task reference that is polled
+      to completion when C(wait) is true (the default).
+    - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user
+      performing the operation.
+    - >-
+      B(Unplanned Failover Recovery Plan) -
+      Required Roles: Disaster Recovery Admin, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=dataprotection)"
+options:
+    state:
+        description:
+            - State of the module.
+            - If C(state) is set to C(present) the module will trigger the unplanned
+              failover on the recovery plan referenced by C(ext_id).
+            - Only C(present) is supported for this action module.
+        type: str
+        choices:
+            - present
+        default: present
+    ext_id:
+        description:
+            - The external identifier of the recovery plan on which the unplanned
+              failover should be performed.
+        type: str
+        required: true
+    name:
+        description:
+            - Human-readable name for the recovery plan job that will be created for
+              this unplanned failover.
+            - Required by the API when triggering the unplanned failover.
+        type: str
+        required: false
+    recovery_reference_time:
+        description:
+            - Point in time from which to restore the entities during the
+              C(UNPLANNED_FAILOVER) operation.
+            - Only ISO-8601 formatted timestamps are supported (for example,
+              C(2024-01-02T03:04:05Z)).
+            - When specified, VMs and volume groups are restored from the latest
+              recovery points created on or before the given timestamp. If not
+              specified, the latest recovery points before the start of the recovery
+              plan job are used.
+        type: str
+        required: false
+    should_ignore_warnings:
+        description:
+            - If set to C(true), non-critical validation warnings raised while
+              triggering the unplanned failover are ignored and the action proceeds.
+        type: bool
+        required: false
+    is_instant_restore:
+        description:
+            - When set to C(true), an instant restore is attempted for the recovery
+              points instead of a full restore.
+        type: bool
+        required: false
+    failover_directions:
+        description:
+            - Failover direction(s) mapping source disaster recovery locations to
+              target disaster recovery locations for the unplanned failover.
+            - Required by the API when triggering the unplanned failover.
+        type: list
+        elements: dict
+        required: false
+        suboptions:
+            source_domain_manager_ext_id:
+                description:
+                    - External identifier of the source domain manager (Prism Central).
+                type: str
+                required: false
+            source_cluster:
+                description:
+                    - Reference to the source cluster participating in the failover.
+                type: dict
+                required: false
+                suboptions:
+                    ext_id:
+                        description:
+                            - External identifier of the source cluster.
+                        type: str
+                        required: false
+            target_domain_manager_ext_id:
+                description:
+                    - External identifier of the target domain manager (Prism Central).
+                type: str
+                required: false
+            target_cluster:
+                description:
+                    - Reference to the target cluster participating in the failover.
+                type: dict
+                required: false
+                suboptions:
+                    ext_id:
+                        description:
+                            - External identifier of the target cluster.
+                        type: str
+                        required: false
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - George Ghawali (@george-ghawali)
+    - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Trigger an unplanned failover with only the required fields
+  nutanix.ncp.ntnx_unplanned_failover_recovery_plan_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "6f4ffcee-1dc4-4982-9401-aa1f65dd7177"
+    name: "rpj_unplanned_failover_ansible"
+    failover_directions:
+      - source_domain_manager_ext_id: "63bebabf-744c-48ff-a6d7-cb028707f972"
+        source_cluster:
+          ext_id: "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2"
+        target_domain_manager_ext_id: "97da301d-0a8b-4334-94cd-16a83563218e"
+        target_cluster:
+          ext_id: "00062899-58d4-9d37-185b-ac1f6b6f97e2"
+  register: result
+  ignore_errors: true
+
+- name: Trigger an unplanned failover with all supported attributes
+  nutanix.ncp.ntnx_unplanned_failover_recovery_plan_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "6f4ffcee-1dc4-4982-9401-aa1f65dd7177"
+    name: "rpj_unplanned_failover_ansible"
+    recovery_reference_time: "2024-01-02T03:04:05Z"
+    should_ignore_warnings: true
+    is_instant_restore: false
+    failover_directions:
+      - source_domain_manager_ext_id: "63bebabf-744c-48ff-a6d7-cb028707f972"
+        source_cluster:
+          ext_id: "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2"
+        target_domain_manager_ext_id: "97da301d-0a8b-4334-94cd-16a83563218e"
+        target_cluster:
+          ext_id: "00062899-58d4-9d37-185b-ac1f6b6f97e2"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for triggering the unplanned failover on a recovery plan.
+        - When C(wait) is C(true) (default) it contains the full task details after
+          completion, otherwise it contains the initial task reference returned by
+          the create action.
+    returned: always
+    type: dict
+    sample:
+        {
+            "cluster_ext_ids": [
+                "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2"
+            ],
+            "completed_time": "2024-01-02T03:15:22.123456+00:00",
+            "completion_details": [
+                {
+                    "name": "recoveryPlanJobExtId",
+                    "value": "f5d3b1a2-92e7-4c9d-a1b8-abcdef123456"
+                }
+            ],
+            "created_time": "2024-01-02T03:10:14.101010+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "6f4ffcee-1dc4-4982-9401-aa1f65dd7177",
+                    "rel": "dataprotection:config:recovery-plan"
+                }
+            ],
+            "error_messages": null,
+            "ext_id": "ZXJnb24=:c3f6cc70-fda6-4133-a97c-58802d58186a",
+            "is_cancelable": false,
+            "last_updated_time": "2024-01-02T03:15:22.123457+00:00",
+            "legacy_error_message": null,
+            "operation": "UnplannedFailoverRecoveryPlan",
+            "operation_description": "Unplanned Failover Recovery Plan",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "started_time": "2024-01-02T03:10:14.109999+00:00",
+            "status": "SUCCEEDED",
+            "sub_steps": null,
+            "sub_tasks": null,
+            "warnings": null
+        }
+task_ext_id:
+    description:
+        - The external ID of the task tracking the unplanned failover.
+    returned: always
+    type: str
+    sample: "ZXJnb24=:c3f6cc70-fda6-4133-a97c-58802d58186a"
+ext_id:
+    description:
+        - The external ID of the recovery plan on which the unplanned failover
+          was triggered.
+    returned: always
+    type: str
+    sample: "6f4ffcee-1dc4-4982-9401-aa1f65dd7177"
+changed:
+    description: This indicates whether the task resulted in any changes.
+    returned: always
+    type: bool
+    sample: true
+skipped:
+    description: This indicates whether the task was skipped (for example in check mode).
+    returned: when applicable
+    type: bool
+    sample: false
+error:
+    description: Error details if the task failed.
+    returned: When an error occurs
+    type: str
+    sample: null
+failed:
+    description: This indicates whether the task failed.
+    returned: always
+    type: bool
+    sample: false
+msg:
+    description: Human-readable status message, populated on errors or informational paths.
+    returned: When there is an error or an informational status
+    type: str
+    sample: "Api Exception raised while triggering unplanned failover on recovery plan"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.data_protection.api_client import (  # noqa: E402
+    get_recovery_plan_actions_api_instance,
+)
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_dataprotection_py_client as data_protection_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as data_protection_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    entity_reference_spec = dict(
+        ext_id=dict(type="str"),
+    )
+
+    failover_direction_spec = dict(
+        source_domain_manager_ext_id=dict(type="str"),
+        source_cluster=dict(
+            type="dict",
+            options=entity_reference_spec,
+            obj=data_protection_sdk.DataprotectionConfigEntityReference,
+        ),
+        target_domain_manager_ext_id=dict(type="str"),
+        target_cluster=dict(
+            type="dict",
+            options=entity_reference_spec,
+            obj=data_protection_sdk.DataprotectionConfigEntityReference,
+        ),
+    )
+
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        ext_id=dict(type="str", required=True),
+        name=dict(type="str"),
+        recovery_reference_time=dict(type="str"),
+        should_ignore_warnings=dict(type="bool"),
+        is_instant_restore=dict(type="bool"),
+        failover_directions=dict(
+            type="list",
+            elements="dict",
+            options=failover_direction_spec,
+            obj=data_protection_sdk.FailoverDirection,
+        ),
+    )
+    return module_args
+
+
+def unplanned_failover_recovery_plan(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    validate_required_params(module, ["ext_id", "name", "failover_directions"])
+
+    sg = SpecGenerator(module)
+    default_spec = data_protection_sdk.UnplannedFailoverSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating unplanned failover recovery plan spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        result["msg"] = (
+            "Unplanned failover would be triggered on recovery plan with "
+            "ext_id: {0} (check mode).".format(ext_id)
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.unplanned_failover_recovery_plan(
+            recoveryPlanExtId=ext_id, body=spec
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while triggering unplanned failover on recovery plan",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_dataprotection_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_recovery_plan_actions_api_instance(module)
+    unplanned_failover_recovery_plan(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2
-ntnx-dataprotection-py-client==4.3.1
+ntnx-dataprotection-py-client==latest
 ntnx-datapolicies-py-client==4.2.2
 ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3

--- a/tests/integration/targets/ntnx_unplanned_failover_recovery_plan_v2/aliases
+++ b/tests/integration/targets/ntnx_unplanned_failover_recovery_plan_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_unplanned_failover_recovery_plan_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_unplanned_failover_recovery_plan_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_unplanned_failover_recovery_plan_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_unplanned_failover_recovery_plan_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import unplanned_failover_recovery_plan.yml
+      ansible.builtin.import_tasks: unplanned_failover_recovery_plan.yml

--- a/tests/integration/targets/ntnx_unplanned_failover_recovery_plan_v2/tasks/unplanned_failover_recovery_plan.yml
+++ b/tests/integration/targets/ntnx_unplanned_failover_recovery_plan_v2/tasks/unplanned_failover_recovery_plan.yml
@@ -1,0 +1,296 @@
+---
+###################################################################################
+# Test plan for ntnx_unplanned_failover_recovery_plan_v2
+# ---------------------------------------------------------------------------------
+# Coverage:
+#   * check_mode
+#       - Minimal payload (only ext_id + failover_directions).
+#       - Full payload (all optional attributes set).
+#       - Delete-like path is not applicable to this action module; the
+#         corresponding check_mode assertion is that state=absent is rejected
+#         (only "present" is supported).
+#   * Argument-spec / negative validation (no API call reached):
+#       - Missing ext_id.
+#       - Invalid state value (choices enforcement).
+#       - Invalid ext_id UUID (SDK-level validation).
+#   * Real API invocation (best-effort; the action requires a real Recovery Plan
+#     with paired availability zones — if a suitable recovery plan is not present
+#     on the target cluster the assertions capture the exact API error rather
+#     than pretending success).
+#
+# Notes:
+#   * `check_mode: true` never contacts the API — it exercises the argument
+#     spec + spec generator only, so it is safe without a real recovery plan.
+#   * The real-run task is guarded by a `recovery_plan_ext_id_for_failover`
+#     variable which testers can override in `integration_config.yml`; without
+#     it the task is skipped so the whole target still passes on clusters that
+#     lack a paired site.
+###################################################################################
+
+- name: Start UnplannedFailoverRecoveryPlan tests
+  ansible.builtin.debug:
+    msg: Start UnplannedFailoverRecoveryPlan tests
+
+- name: Generate random names and shared fixtures
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+    rp_ext_id_placeholder: "6f4ffcee-1dc4-4982-9401-aa1f65dd7177"
+    source_dm_ext_id_placeholder: "63bebabf-744c-48ff-a6d7-cb028707f972"
+    source_cluster_ext_id_placeholder: "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2"
+    target_dm_ext_id_placeholder: "97da301d-0a8b-4334-94cd-16a83563218e"
+    target_cluster_ext_id_placeholder: "00062899-58d4-9d37-185b-ac1f6b6f97e2"
+
+- name: Build derived job name
+  ansible.builtin.set_fact:
+    rpj_name: "rpj_unplanned_failover_{{ suffix_name }}_{{ random_name }}"
+
+########################################################################################
+# check_mode tests
+########################################################################################
+
+- name: Generate spec for triggering unplanned failover using check mode with minimum required attributes
+  nutanix.ncp.ntnx_unplanned_failover_recovery_plan_v2:
+    ext_id: "{{ rp_ext_id_placeholder }}"
+    name: "{{ rpj_name }}_check_min"
+    failover_directions:
+      - source_domain_manager_ext_id: "{{ source_dm_ext_id_placeholder }}"
+        source_cluster:
+          ext_id: "{{ source_cluster_ext_id_placeholder }}"
+        target_domain_manager_ext_id: "{{ target_dm_ext_id_placeholder }}"
+        target_cluster:
+          ext_id: "{{ target_cluster_ext_id_placeholder }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Verify check_mode spec generation with minimum attributes
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == rp_ext_id_placeholder
+      - result.response is defined
+      - result.response.name == rpj_name ~ "_check_min"
+      - result.response.failover_directions | length == 1
+      - result.response.failover_directions[0].source_domain_manager_ext_id == source_dm_ext_id_placeholder
+      - result.response.failover_directions[0].source_cluster.ext_id == source_cluster_ext_id_placeholder
+      - result.response.failover_directions[0].target_domain_manager_ext_id == target_dm_ext_id_placeholder
+      - result.response.failover_directions[0].target_cluster.ext_id == target_cluster_ext_id_placeholder
+      - result.msg is search('check mode')
+    success_msg: "Check mode spec for minimum attributes generated successfully"
+    fail_msg: "Check mode spec for minimum attributes generation failed"
+
+- name: Generate spec for triggering unplanned failover using check mode with all attributes
+  nutanix.ncp.ntnx_unplanned_failover_recovery_plan_v2:
+    state: present
+    ext_id: "{{ rp_ext_id_placeholder }}"
+    name: "{{ rpj_name }}_check_full"
+    recovery_reference_time: "2024-01-02T03:04:05+00:00"
+    should_ignore_warnings: true
+    is_instant_restore: true
+    failover_directions:
+      - source_domain_manager_ext_id: "{{ source_dm_ext_id_placeholder }}"
+        source_cluster:
+          ext_id: "{{ source_cluster_ext_id_placeholder }}"
+        target_domain_manager_ext_id: "{{ target_dm_ext_id_placeholder }}"
+        target_cluster:
+          ext_id: "{{ target_cluster_ext_id_placeholder }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Verify check_mode spec generation with all attributes
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == rp_ext_id_placeholder
+      - result.response is defined
+      - result.response.name == rpj_name ~ "_check_full"
+      - result.response.recovery_reference_time is search("2024-01-02T03:04:05")
+      - result.response.should_ignore_warnings == true
+      - result.response.is_instant_restore == true
+      - result.response.failover_directions | length == 1
+      - result.response.failover_directions[0].source_domain_manager_ext_id == source_dm_ext_id_placeholder
+      - result.response.failover_directions[0].source_cluster.ext_id == source_cluster_ext_id_placeholder
+      - result.response.failover_directions[0].target_domain_manager_ext_id == target_dm_ext_id_placeholder
+      - result.response.failover_directions[0].target_cluster.ext_id == target_cluster_ext_id_placeholder
+    success_msg: "Check mode spec for all attributes generated successfully"
+    fail_msg: "Check mode spec for all attributes generation failed"
+
+- name: Generate spec for triggering unplanned failover using check mode with multiple failover directions
+  nutanix.ncp.ntnx_unplanned_failover_recovery_plan_v2:
+    ext_id: "{{ rp_ext_id_placeholder }}"
+    name: "{{ rpj_name }}_check_multi"
+    should_ignore_warnings: false
+    is_instant_restore: false
+    failover_directions:
+      - source_domain_manager_ext_id: "{{ source_dm_ext_id_placeholder }}"
+        source_cluster:
+          ext_id: "{{ source_cluster_ext_id_placeholder }}"
+        target_domain_manager_ext_id: "{{ target_dm_ext_id_placeholder }}"
+        target_cluster:
+          ext_id: "{{ target_cluster_ext_id_placeholder }}"
+      - source_domain_manager_ext_id: "{{ target_dm_ext_id_placeholder }}"
+        source_cluster:
+          ext_id: "{{ target_cluster_ext_id_placeholder }}"
+        target_domain_manager_ext_id: "{{ source_dm_ext_id_placeholder }}"
+        target_cluster:
+          ext_id: "{{ source_cluster_ext_id_placeholder }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Verify check_mode spec generation with multiple failover directions
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.failover_directions | length == 2
+      - result.response.should_ignore_warnings == false
+      - result.response.is_instant_restore == false
+      - result.response.failover_directions[0].source_cluster.ext_id == source_cluster_ext_id_placeholder
+      - result.response.failover_directions[1].source_cluster.ext_id == target_cluster_ext_id_placeholder
+      - result.response.failover_directions[1].target_cluster.ext_id == source_cluster_ext_id_placeholder
+    success_msg: "Check mode spec for multi-direction payload generated successfully"
+    fail_msg: "Check mode spec for multi-direction payload generation failed"
+
+########################################################################################
+# Negative / validation tests (no API call)
+########################################################################################
+
+- name: Trigger unplanned failover without ext_id (missing required argument)
+  nutanix.ncp.ntnx_unplanned_failover_recovery_plan_v2:
+    failover_directions:
+      - source_domain_manager_ext_id: "{{ source_dm_ext_id_placeholder }}"
+        source_cluster:
+          ext_id: "{{ source_cluster_ext_id_placeholder }}"
+        target_domain_manager_ext_id: "{{ target_dm_ext_id_placeholder }}"
+        target_cluster:
+          ext_id: "{{ target_cluster_ext_id_placeholder }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify missing ext_id is rejected by the argument spec
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg is search("missing required arguments")
+      - result.msg is search("ext_id")
+    success_msg: "Missing ext_id correctly rejected"
+    fail_msg: "Missing ext_id was NOT rejected by the argument spec"
+
+- name: Trigger unplanned failover with unsupported state=absent
+  nutanix.ncp.ntnx_unplanned_failover_recovery_plan_v2:
+    state: absent
+    ext_id: "{{ rp_ext_id_placeholder }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify state=absent is rejected (only "present" is allowed)
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg is search("value of state must be one of")
+    success_msg: "state=absent correctly rejected"
+    fail_msg: "state=absent was NOT rejected"
+
+- name: Trigger unplanned failover without API-required name / failover_directions
+  nutanix.ncp.ntnx_unplanned_failover_recovery_plan_v2:
+    ext_id: "{{ rp_ext_id_placeholder }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify validate_required_params catches missing name / failover_directions
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg is search("Missing required parameter")
+      - result.msg is search("name")
+      - result.msg is search("failover_directions")
+    success_msg: "Missing name / failover_directions correctly rejected by validate_required_params"
+    fail_msg: "Missing name / failover_directions were NOT rejected"
+
+- name: Trigger unplanned failover with an ext_id that does not match the UUID pattern
+  nutanix.ncp.ntnx_unplanned_failover_recovery_plan_v2:
+    ext_id: "{{ rp_ext_id_placeholder }}"
+    name: "{{ rpj_name }}_bad_uuid"
+    failover_directions:
+      - source_domain_manager_ext_id: "not-a-uuid"
+        source_cluster:
+          ext_id: "{{ source_cluster_ext_id_placeholder }}"
+        target_domain_manager_ext_id: "{{ target_dm_ext_id_placeholder }}"
+        target_cluster:
+          ext_id: "{{ target_cluster_ext_id_placeholder }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Verify invalid UUID in failover_directions is rejected by SDK validation
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+    success_msg: "Invalid UUID in failover_directions correctly rejected"
+    fail_msg: "Invalid UUID in failover_directions was NOT rejected"
+
+########################################################################################
+# Real API call — only executes when the tester supplies a valid recovery plan
+# in `integration_config.yml` (variable `recovery_plan_ext_id_for_failover`).
+########################################################################################
+
+- name: Trigger unplanned failover against a real recovery plan (best-effort)
+  nutanix.ncp.ntnx_unplanned_failover_recovery_plan_v2:
+    ext_id: "{{ recovery_plan_ext_id_for_failover }}"
+    name: "{{ rpj_name }}_real"
+    recovery_reference_time: "{{ recovery_plan_reference_time | default(omit) }}"
+    should_ignore_warnings: true
+    is_instant_restore: false
+    failover_directions: "{{ recovery_plan_failover_directions }}"
+  register: real_result
+  when:
+    - recovery_plan_ext_id_for_failover is defined
+    - recovery_plan_ext_id_for_failover | length > 0
+    - recovery_plan_failover_directions is defined
+    - recovery_plan_failover_directions | length > 0
+  ignore_errors: true
+
+- name: Verify real unplanned failover response shape when the task ran
+  ansible.builtin.assert:
+    that:
+      - real_result is defined
+      - real_result.ext_id == recovery_plan_ext_id_for_failover
+      - real_result.task_ext_id is defined
+      - real_result.response is defined
+      - real_result.response.status is defined
+    success_msg: "Real unplanned failover produced a task response as expected"
+    fail_msg: "Real unplanned failover did not produce the expected task response"
+  when:
+    - real_result is defined
+    - real_result.skipped is not defined or not real_result.skipped
+    - not real_result.failed
+
+- name: Report skipped real-run when no recovery plan is available
+  ansible.builtin.debug:
+    msg: >-
+      Skipping real unplanned failover invocation because
+      recovery_plan_ext_id_for_failover was not supplied in integration_config.yml.
+  when:
+    - recovery_plan_ext_id_for_failover is not defined
+      or recovery_plan_ext_id_for_failover | length == 0
+
+- name: End UnplannedFailoverRecoveryPlan tests
+  ansible.builtin.debug:
+    msg: End UnplannedFailoverRecoveryPlan tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection module for the **data_protection** namespace, entity
**UnplannedFailoverRecoveryPlan**, based on the inline `sdk_info.json`.

`UnplannedFailoverRecoveryPlan` is a POST action on the Nutanix Data Protection v4 API
(`POST /api/dataprotection/v4.3/operations/recovery-plans/{recoveryPlanExtId}/$actions/unplanned-failover`).
Because this is an action-type API (not a CRUD resource) only a single module is emitted
— the info module (Step 2) is skipped per the instructions.

- Module generated: `ntnx_unplanned_failover_recovery_plan_v2`
- API methods covered: 1 (`RecoveryPlanActionsApi.unplanned_failover_recovery_plan`)
- Fields in module spec: 7 top-level (`state`, `ext_id`, `name`, `recovery_reference_time`,
  `should_ignore_warnings`, `is_instant_restore`, `failover_directions`) + nested
  `source_domain_manager_ext_id`, `source_cluster.ext_id`,
  `target_domain_manager_ext_id`, `target_cluster.ext_id` for each failover direction.
- Info module: N/A (action-type entity — Step 2 skipped by design).

## Files changed

- `plugins/modules/`
  - `ntnx_unplanned_failover_recovery_plan_v2.py` — new action module
- `plugins/module_utils/v4/data_protection/`
  - `api_client.py` — added `get_recovery_plan_actions_api_instance()` helper (reusable
    by future planned/test failover, validate and cleanup modules)
- `meta/`
  - `runtime.yml` — registered the new module in `action_groups.ntnx` so
    play-level `module_defaults` (`group/nutanix.ncp.ntnx: …`) applies
- `examples/data_protection/UnplannedFailoverRecoveryPlan/`
  - `unplanned_failover_recovery_plan.yml` — example playbook (minimum + full attribute
    call, one file, `module_defaults` block, no per-task connection params)
  - `examples_run.log` — captured output of running the playbook against the live PC
- `tests/integration/targets/ntnx_unplanned_failover_recovery_plan_v2/`
  - `aliases` (`disabled` — matches existing `_v2` targets)
  - `meta/main.yml` — depends on `prepare_env`
  - `tasks/main.yml` — sets `module_defaults` and imports the test file
  - `tasks/unplanned_failover_recovery_plan.yml` — full check_mode / negative /
    real-call test suite

## Test execution

| Metric              | Value                                                                       |
|---------------------|-----------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_unplanned_failover_recovery_plan_v2 --allow-disabled --python 3.12` |
| Total tasks         | 26 (Ansible task count — includes debug/setup tasks and assertion tasks)    |
| Passed (`ok`)       | 20                                                                          |
| Failed (`failed`)   | 0                                                                           |
| Skipped             | 2 (real-cluster call — no real recovery plan wired for this run)            |
| Ignored             | 4 (negative tasks with `ignore_errors: true`; the follow-up assert tasks passed) |
| Duration            | ~00:00:07                                                                   |
| Cluster (PC)        | 10.44.76.28 (Prism Central v4)                                              |

### Analysis

- All `check_mode` spec-generation tasks succeeded and asserted the exact
  `UnplannedFailoverSpec` shape (minimum, full attribute, and multi-direction payloads).
- All argument-spec negative paths (missing `ext_id`, unsupported `state=absent`,
  missing API-required `name` / `failover_directions`) triggered the expected
  `fail_json` message and the accompanying assertion tasks passed.
- The invalid-UUID negative case triggered the SDK's client-side regex validation
  (`ValueError: Invalid value for source_domain_manager_ext_id ...`). The assertion
  task confirmed the module surfaced this as a failure.
- The real-cluster call (`Trigger unplanned failover against a real recovery plan`)
  was skipped because a real `recovery_plan_ext_id_for_failover` was not provided in
  `integration_config.yml`. The action requires a paired availability zone and an
  existing recovery plan; those aren't provisioned on the shared PC used by this run.
  The example playbook (see below) still exercises the module against the live
  Prism Central and captures the exact `404 NOT FOUND` response from the API layer
  for the placeholder UUID, proving the full request/response path works.

### Example playbook run (live cluster)

The example playbook `examples/data_protection/UnplannedFailoverRecoveryPlan/unplanned_failover_recovery_plan.yml`
was executed end-to-end against the Prism Central above. Both tasks reached the
backend and received the expected `DP-10400 / DATAPROTECTION_ENTITY_NON_EXISTENT_ERROR`
response for the placeholder recovery-plan `ext_id`. The captured output is stored at
`examples/data_protection/UnplannedFailoverRecoveryPlan/examples_run.log`.

Because the placeholder UUIDs do not correspond to a real, paired Recovery Plan on
this cluster, the `sample:` values in `EXAMPLES` / `RETURN` are hand-authored based
on the SDK response schema (marked as illustrative task output). Any operator with a
real Recovery Plan can substitute their `ext_id` and expect a task reference response
identical in shape to the one documented.

### Test logs (tail)

<details>
<summary>tail of test_logs.log</summary>

```text
PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_unplanned_failover_recovery_plan_v2 : Start UnplannedFailoverRecoveryPlan tests] ***
ok: [testhost] => { "msg": "Start UnplannedFailoverRecoveryPlan tests" }

TASK [ntnx_unplanned_failover_recovery_plan_v2 : Verify check_mode spec generation with minimum attributes] ***
ok: [testhost] => { "msg": "Check mode spec for minimum attributes generated successfully" }

TASK [ntnx_unplanned_failover_recovery_plan_v2 : Verify check_mode spec generation with all attributes] ***
ok: [testhost] => { "msg": "Check mode spec for all attributes generated successfully" }

TASK [ntnx_unplanned_failover_recovery_plan_v2 : Verify check_mode spec generation with multiple failover directions] ***
ok: [testhost] => { "msg": "Check mode spec for multi-direction payload generated successfully" }

TASK [ntnx_unplanned_failover_recovery_plan_v2 : Verify missing ext_id is rejected by the argument spec] ***
ok: [testhost] => { "msg": "Missing ext_id correctly rejected" }

TASK [ntnx_unplanned_failover_recovery_plan_v2 : Verify state=absent is rejected (only "present" is allowed)] ***
ok: [testhost] => { "msg": "state=absent correctly rejected" }

TASK [ntnx_unplanned_failover_recovery_plan_v2 : Verify validate_required_params catches missing name / failover_directions] ***
ok: [testhost] => { "msg": "Missing name / failover_directions correctly rejected by validate_required_params" }

TASK [ntnx_unplanned_failover_recovery_plan_v2 : Verify invalid UUID in failover_directions is rejected by SDK validation] ***
ok: [testhost] => { "msg": "Invalid UUID in failover_directions correctly rejected" }

TASK [ntnx_unplanned_failover_recovery_plan_v2 : Trigger unplanned failover against a real recovery plan (best-effort)] ***
skipping: [testhost]

TASK [ntnx_unplanned_failover_recovery_plan_v2 : Verify real unplanned failover response shape when the task ran] ***
skipping: [testhost]

TASK [ntnx_unplanned_failover_recovery_plan_v2 : Report skipped real-run when no recovery plan is available] ***
ok: [testhost] => { "msg": "Skipping real unplanned failover invocation because recovery_plan_ext_id_for_failover was not supplied in integration_config.yml." }

PLAY RECAP *********************************************************************
testhost                   : ok=20   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=4
```

</details>

### Lint / sanity gate

| Check                          | Result |
|--------------------------------|--------|
| `black --check`                | PASS   |
| `isort --check`                | PASS   |
| `flake8`                       | PASS   |
| `ansible-lint` (new files)     | PASS (only pre-existing `args[module]: missing required arguments: nutanix_host` warnings, which come from `module_defaults` inheritance and are also present on the existing `ntnx_virtual_switches_v2` target) |
| `ansible-test sanity --python 3.12` on new / modified files | PASS |

## Known issues

- Real-cluster invocation of the action requires a paired availability zone plus an
  existing Recovery Plan on the target PC. The shared PC (10.44.76.28) used for this
  run does not have such a plan, so the real-call task auto-skips. Operators with a
  real environment can supply `recovery_plan_ext_id_for_failover`,
  `recovery_plan_failover_directions`, and (optionally) `recovery_plan_reference_time`
  in `tests/integration/integration_config.yml` to exercise the real path.

## How this was generated

- Triggered via the Nutanix headless code-gen automation.
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- SDK: `ntnx-dataprotection-py-client` (pinned to `latest` in this branch's
  `requirements.txt`).
