### PR TITLE
EmailConfig Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/files/EmailConfig/email_config_v2.yml
+++ b/examples/files/EmailConfig/email_config_v2.yml
@@ -1,0 +1,48 @@
+---
+# Summary:
+# This playbook demonstrates the Nutanix Files EmailConfig v4 modules.
+#
+# The email configuration is a singleton per file server (identified by
+# file_server_ext_id) that defines the subject and content used by the quota
+# notification workflow. It only supports read (info) and update operations,
+# it cannot be created or deleted independently.
+#
+# This playbook will:
+# 1. Fetch the current email configuration of a file server.
+# 2. Update the email configuration of a file server (subject and content).
+# 3. Fetch the updated email configuration of the file server.
+
+- name: Nutanix Files EmailConfig playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "10.44.76.28"
+      nutanix_username: "admin"
+      nutanix_password: "Nutanix.123"
+      validate_certs: false
+  tasks:
+    - name: Set variables
+      ansible.builtin.set_fact:
+        file_server_ext_id: "1f4f80e2-2b1f-4f9a-8d3c-1a2b3c4d5e6f"
+
+    - name: Fetch the current email configuration of a file server
+      nutanix.ncp.ntnx_files_email_configs_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Update the email configuration of a file server
+      nutanix.ncp.ntnx_files_email_config_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        subject: "Quota notification for your file server share"
+        content: "You have exceeded the storage quota configured for your share. Please free up space."
+      register: result
+      ignore_errors: true
+
+    - name: Fetch the updated email configuration of the file server
+      nutanix.ncp.ntnx_files_email_configs_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+      register: result
+      ignore_errors: true

--- a/examples/files/EmailConfig/examples_run.log
+++ b/examples/files/EmailConfig/examples_run.log
@@ -1,0 +1,25 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Nutanix Files EmailConfig playbook] **************************************
+
+TASK [Set variables] ***********************************************************
+ok: [localhost] => {"ansible_facts": {"file_server_ext_id": "1f4f80e2-2b1f-4f9a-8d3c-1a2b3c4d5e6f"}, "changed": false}
+
+TASK [Fetch the current email configuration of a file server] ******************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching email configuration for file server", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Update the email configuration of a file server] *************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching email configuration for file server", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Fetch the updated email configuration of the file server] ****************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching email configuration for file server", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_files_email_config_v2
+    - ntnx_files_email_configs_info_v2

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,111 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details.
+    Args:
+        module (object): Ansible module object
+    return:
+        client (object): api client object
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    # The Nutanix Files SDK ApiClient does not support the
+    # allow_version_negotiation argument, so it is not passed here.
+    client = ntnx_files_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    # Setup API logging if debug is enabled
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    return:
+        etag (str): etag value
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_quota_policies_api_instance(module):
+    """
+    This method will return Nutanix Files QuotaPoliciesApi instance.
+
+    The QuotaPoliciesApi hosts the file server email configuration operations
+    (C(get_email_config) and C(update_email_config)) in addition to quota
+    policy operations.
+
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): v4 QuotaPoliciesApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.QuotaPoliciesApi(api_client=api_client)
+
+
+def get_file_servers_api_instance(module):
+    """
+    This method will return Nutanix Files FileServersApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): v4 FileServersApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.FileServersApi(api_client=api_client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,32 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_email_config(module, api_instance, file_server_ext_id):
+    """
+    This method will fetch the email configuration of a file server.
+
+    The email configuration is a singleton per file server, so it is fetched
+    using the external identifier of the file server (not its own external ID).
+
+    Args:
+        module (object): Ansible module object
+        api_instance (object): QuotaPoliciesApi instance from ntnx_files_py_client sdk
+        file_server_ext_id (str): External identifier of the file server
+    Returns:
+        email_config (object): EmailConfig info object
+    """
+    try:
+        return api_instance.get_email_config(fileServerExtId=file_server_ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching email configuration for file server",
+        )

--- a/plugins/modules/ntnx_files_email_config_v2.py
+++ b/plugins/modules/ntnx_files_email_config_v2.py
@@ -1,0 +1,259 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_email_config_v2
+short_description: Update the email configuration of a file server in Nutanix Files
+version_added: 2.7.0
+description:
+  - This module allows you to update the email configuration of a file server in Nutanix Files.
+  - The email configuration is a single (singleton) template per file server, identified by C(file_server_ext_id).
+  - It defines the subject and content used by the quota-notification workflow when emailing users and administrators about quota warnings and breaches.
+  - The email configuration cannot be created or deleted independently, it always exists for a file server and can only be updated.
+  - This module uses PC v4 APIs based SDKs.
+options:
+  state:
+    description:
+      - The state of the email configuration.
+      - If C(state) is set to C(present), the email configuration of the file server is updated.
+    type: str
+    choices:
+      - present
+    default: present
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server whose email configuration is updated.
+      - The external ID of the file server can be fetched from Nutanix Prism Central.
+    type: str
+    required: true
+  subject:
+    description:
+      - The email subject used by the quota-notification workflow.
+      - If not provided, the current subject of the email configuration is retained.
+    type: str
+    required: false
+  content:
+    description:
+      - The email content (body) used by the quota-notification workflow.
+      - If not provided, the current content of the email configuration is retained.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Update email configuration of a file server
+  nutanix.ncp.ntnx_files_email_config_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    file_server_ext_id: "1f4f80e2-2b1f-4f9a-8d3c-1a2b3c4d5e6f"
+    subject: "Quota notification for your file server share"
+    content: "You have exceeded the storage quota configured for your share. Please free up space."
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for updating the email configuration of the file server.
+    - It returns the updated email configuration details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "content": "You have exceeded the storage quota configured for your share. Please free up space.",
+      "ext_id": "1f4f80e2-2b1f-4f9a-8d3c-1a2b3c4d5e6f",
+      "links": null,
+      "subject": "Quota notification for your file server share",
+      "tenant_id": null
+    }
+
+ext_id:
+  description:
+    - The external ID of the email configuration.
+  returned: always
+  type: str
+  sample: "1f4f80e2-2b1f-4f9a-8d3c-1a2b3c4d5e6f"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped due to idempotency
+  returned: When the operation was skipped
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, the module is idempotent or in check mode
+  type: str
+  sample: "Nothing to change."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_etag,
+    get_quota_policies_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_email_config  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client as files_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as files_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        file_server_ext_id=dict(type="str", required=True),
+        subject=dict(type="str"),
+        content=dict(type="str"),
+    )
+    return module_args
+
+
+def check_email_config_idempotency(current_spec, update_spec):
+    return (
+        current_spec.subject == update_spec.subject
+        and current_spec.content == update_spec.content
+    )
+
+
+def update_email_config(module, result, api_instance):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+
+    current_spec = get_email_config(module, api_instance, file_server_ext_id)
+    result["ext_id"] = current_spec.ext_id
+
+    etag = get_etag(data=current_spec)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for updating email configuration", **result
+        )
+
+    # Build the update spec from the current configuration so that any attribute
+    # the user does not provide retains its current value. Only the writable
+    # attributes (subject and content) are carried into the request body, the
+    # read-only attributes (ext_id, links, tenant_id) are intentionally omitted.
+    default_spec = files_sdk.EmailConfig(
+        subject=current_spec.subject, content=current_spec.content
+    )
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating update email configuration spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_email_config_idempotency(current_spec, update_spec):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    resp = None
+    try:
+        resp = api_instance.update_email_config(
+            fileServerExtId=file_server_ext_id, body=update_spec, if_match=etag
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating email configuration",
+        )
+
+    # The update API is synchronous and does not return the updated entity in
+    # its response body, so re-fetch the email configuration to return it.
+    resp = get_email_config(module, api_instance, file_server_ext_id)
+    result["ext_id"] = resp.ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_quota_policies_api_instance(module)
+    update_email_config(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_files_email_configs_info_v2.py
+++ b/plugins/modules/ntnx_files_email_configs_info_v2.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_email_configs_info_v2
+short_description: Fetch the email configuration of a file server in Nutanix Files
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about the EmailConfig of a file server in Nutanix Prism Central.
+  - The email configuration is a single (singleton) template per file server, identified by C(file_server_ext_id).
+  - It fetches the email configuration used by the quota-notification workflow for the given file server.
+  - This module uses PC v4 APIs based SDKs.
+options:
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server whose email configuration is fetched.
+      - The external ID of the file server can be fetched from Nutanix Prism Central.
+    type: str
+    required: true
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch email configuration of a file server
+  nutanix.ncp.ntnx_files_email_configs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "1f4f80e2-2b1f-4f9a-8d3c-1a2b3c4d5e6f"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC EmailConfig info v4 API.
+    - It returns the email configuration of the file server identified by C(file_server_ext_id).
+  returned: always
+  type: dict
+  sample:
+    {
+      "content": "You have exceeded the storage quota configured for your share. Please free up space.",
+      "ext_id": "1f4f80e2-2b1f-4f9a-8d3c-1a2b3c4d5e6f",
+      "links": null,
+      "subject": "Quota notification for your file server share",
+      "tenant_id": null
+    }
+
+ext_id:
+  description: The external ID of the email configuration.
+  returned: when the email configuration is fetched
+  type: str
+  sample: "1f4f80e2-2b1f-4f9a-8d3c-1a2b3c4d5e6f"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching email configuration for file server"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: When an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_quota_policies_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_email_config  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        file_server_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_email_config_with_file_server_ext_id(module, api_instance, result):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    resp = get_email_config(module, api_instance, file_server_ext_id)
+    result["ext_id"] = resp.ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_quota_policies_api_instance(module)
+    get_email_config_with_file_server_ext_id(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_files_email_config_v2/aliases
+++ b/tests/integration/targets/ntnx_files_email_config_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_files_email_config_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_files_email_config_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_files_email_config_v2/tasks/email_config.yml
+++ b/tests/integration/targets/ntnx_files_email_config_v2/tasks/email_config.yml
@@ -1,0 +1,275 @@
+---
+# Test plan for the Nutanix Files EmailConfig v4 modules
+# (ntnx_files_email_config_v2 and ntnx_files_email_configs_info_v2).
+#
+# The email configuration is a singleton per file server, identified by
+# file_server_ext_id. It only supports read (info) and update operations, it
+# cannot be created or deleted independently. The tests below therefore focus
+# on the update and info workflows, idempotency, check mode, and negative
+# scenarios.
+#
+# 1. Argument-spec validation (no cluster needed):
+#    - Missing required file_server_ext_id -> module fails with a descriptive error.
+#    - Invalid state value -> rejected by choices.
+# 2. Info module:
+#    - Fetch the current email configuration of the file server.
+#    - Fetch using an invalid file_server_ext_id -> proper error.
+# 3. Update module:
+#    - check_mode update with all attributes -> spec is generated, no change made.
+#    - Update with all attributes (subject + content).
+#    - Update with only the subject (partial update).
+#    - Idempotency: repeat the same update -> changed false and "Nothing to change.".
+#    - Update using an invalid file_server_ext_id -> proper error.
+# 4. Restore the original email configuration at the end.
+
+- name: Start Nutanix Files EmailConfig tests
+  ansible.builtin.debug:
+    msg: Start Nutanix Files EmailConfig tests
+
+- name: Generate random suffix for test data
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set test data
+  ansible.builtin.set_fact:
+    test_subject: "Ansible quota notification {{ random_name }}"
+    test_content: "Your share {{ random_name }} has exceeded its configured storage quota. Please free up space."
+    updated_subject: "Ansible quota notification updated {{ random_name }}"
+    invalid_file_server_ext_id: "00000000-0000-0000-0000-000000000000"
+
+########################################################################################
+# Argument-spec validation tests (do not require a reachable Files service)
+########################################################################################
+
+- name: Update email configuration with missing file_server_ext_id
+  nutanix.ncp.ntnx_files_email_config_v2:
+    subject: "{{ test_subject }}"
+    content: "{{ test_content }}"
+  register: result
+  ignore_errors: true
+
+- name: Update email configuration with missing file_server_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: file_server_ext_id' in result.msg"
+    success_msg: "Update email configuration with missing file_server_ext_id failed as expected"
+    fail_msg: "Update email configuration with missing file_server_ext_id did not fail as expected"
+
+- name: Update email configuration with invalid state
+  nutanix.ncp.ntnx_files_email_config_v2:
+    state: absent
+    file_server_ext_id: "{{ email_config_file_server_ext_id }}"
+    subject: "{{ test_subject }}"
+  register: result
+  ignore_errors: true
+
+- name: Update email configuration with invalid state status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'value of state must be one of' in result.msg"
+    success_msg: "Update email configuration with invalid state failed as expected"
+    fail_msg: "Update email configuration with invalid state did not fail as expected"
+
+- name: Fetch email configuration with missing file_server_ext_id
+  nutanix.ncp.ntnx_files_email_configs_info_v2: {}
+  register: result
+  ignore_errors: true
+
+- name: Fetch email configuration with missing file_server_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: file_server_ext_id' in result.msg"
+    success_msg: "Fetch email configuration with missing file_server_ext_id failed as expected"
+    fail_msg: "Fetch email configuration with missing file_server_ext_id did not fail as expected"
+
+########################################################################################
+# Info module tests
+########################################################################################
+
+- name: Fetch the current email configuration of the file server
+  nutanix.ncp.ntnx_files_email_configs_info_v2:
+    file_server_ext_id: "{{ email_config_file_server_ext_id }}"
+  register: current_email_config
+  ignore_errors: true
+
+- name: Fetch the current email configuration of the file server status
+  ansible.builtin.assert:
+    that:
+      - current_email_config is defined
+      - current_email_config.changed == false
+      - current_email_config.failed == false
+      - current_email_config.response is defined
+      - current_email_config.ext_id is defined
+    success_msg: "Fetched the current email configuration of the file server successfully"
+    fail_msg: "Failed to fetch the current email configuration of the file server"
+
+- name: Save original email configuration for restore
+  ansible.builtin.set_fact:
+    original_subject: "{{ current_email_config.response.subject | default(omit) }}"
+    original_content: "{{ current_email_config.response.content | default(omit) }}"
+
+- name: Fetch email configuration using an invalid file_server_ext_id
+  nutanix.ncp.ntnx_files_email_configs_info_v2:
+    file_server_ext_id: "{{ invalid_file_server_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch email configuration using an invalid file_server_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Fetch email configuration using an invalid file_server_ext_id failed as expected"
+    fail_msg: "Fetch email configuration using an invalid file_server_ext_id did not fail as expected"
+
+########################################################################################
+# Update module tests
+########################################################################################
+
+- name: Generate spec for updating email configuration using check mode with all attributes
+  nutanix.ncp.ntnx_files_email_config_v2:
+    state: present
+    file_server_ext_id: "{{ email_config_file_server_ext_id }}"
+    subject: "{{ test_subject }}"
+    content: "{{ test_content }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for updating email configuration using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.subject == test_subject
+      - result.response.content == test_content
+    success_msg: "Spec for updating email configuration using check mode with all attributes generated successfully"
+    fail_msg: "Spec for updating email configuration using check mode with all attributes not generated successfully"
+
+- name: Update email configuration with all attributes
+  nutanix.ncp.ntnx_files_email_config_v2:
+    state: present
+    file_server_ext_id: "{{ email_config_file_server_ext_id }}"
+    subject: "{{ test_subject }}"
+    content: "{{ test_content }}"
+  register: result
+  ignore_errors: true
+
+- name: Update email configuration with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.response is defined
+      - result.response.subject == test_subject
+      - result.response.content == test_content
+    success_msg: "Update email configuration with all attributes passed"
+    fail_msg: "Update email configuration with all attributes failed"
+
+- name: Update email configuration with same values (idempotency test)
+  nutanix.ncp.ntnx_files_email_config_v2:
+    state: present
+    file_server_ext_id: "{{ email_config_file_server_ext_id }}"
+    subject: "{{ test_subject }}"
+    content: "{{ test_content }}"
+  register: result
+  ignore_errors: true
+
+- name: Update email configuration with same values status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.msg == "Nothing to change."
+    success_msg: "Update email configuration idempotency test passed"
+    fail_msg: "Update email configuration idempotency test failed"
+
+- name: Update email configuration with only the subject (partial update)
+  nutanix.ncp.ntnx_files_email_config_v2:
+    state: present
+    file_server_ext_id: "{{ email_config_file_server_ext_id }}"
+    subject: "{{ updated_subject }}"
+  register: result
+  ignore_errors: true
+
+- name: Update email configuration with only the subject status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.subject == updated_subject
+      - result.response.content == test_content
+    success_msg: "Update email configuration with only the subject passed"
+    fail_msg: "Update email configuration with only the subject failed"
+
+- name: Fetch the updated email configuration of the file server
+  nutanix.ncp.ntnx_files_email_configs_info_v2:
+    file_server_ext_id: "{{ email_config_file_server_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch the updated email configuration of the file server status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.subject == updated_subject
+      - result.response.content == test_content
+    success_msg: "Fetched the updated email configuration of the file server successfully"
+    fail_msg: "Failed to fetch the updated email configuration of the file server"
+
+- name: Update email configuration using an invalid file_server_ext_id
+  nutanix.ncp.ntnx_files_email_config_v2:
+    state: present
+    file_server_ext_id: "{{ invalid_file_server_ext_id }}"
+    subject: "{{ test_subject }}"
+    content: "{{ test_content }}"
+  register: result
+  ignore_errors: true
+
+- name: Update email configuration using an invalid file_server_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Update email configuration using an invalid file_server_ext_id failed as expected"
+    fail_msg: "Update email configuration using an invalid file_server_ext_id did not fail as expected"
+
+########################################################################################
+# Restore the original email configuration
+########################################################################################
+
+- name: Restore the original email configuration of the file server
+  nutanix.ncp.ntnx_files_email_config_v2:
+    state: present
+    file_server_ext_id: "{{ email_config_file_server_ext_id }}"
+    subject: "{{ original_subject | default(omit) }}"
+    content: "{{ original_content | default(omit) }}"
+  register: result
+  ignore_errors: true
+  when: original_subject is defined
+
+- name: End Nutanix Files EmailConfig tests
+  ansible.builtin.debug:
+    msg: End Nutanix Files EmailConfig tests

--- a/tests/integration/targets/ntnx_files_email_config_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_files_email_config_v2/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+      read_timeout: "{{ read_timeout | default(omit) }}"
+  block:
+    - name: Import email_config.yml
+      ansible.builtin.import_tasks: email_config.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **files** namespace, entity
**EmailConfig**, based on the inline `sdk_info.json`. One PR per code-gen run.

`EmailConfig` is the per-file-server email template (subject + content) used by the
Nutanix Files quota-notification workflow when emailing users and administrators about
quota warnings and breaches. It is a **singleton per file server** (keyed by
`file_server_ext_id`) and the API only exposes **read** (`GetEmailConfig`) and **update**
(`UpdateEmailConfig`) operations — there is no create or delete. The modules were modeled
on the existing update-only / singleton v4 modules (`ntnx_lcm_config_v2`) and the
`ntnx_virtual_switch_v2` / `ntnx_virtual_switches_info_v2` conventions.

- Modules generated: `ntnx_files_email_config_v2` (update), `ntnx_files_email_configs_info_v2` (info)
- API methods covered: `2` (`GetEmailConfig`, `UpdateEmailConfig`)
- Fields in CRUD module spec: `4` (`state`, `file_server_ext_id`, `subject`, `content`)
- Fields in info module spec: `1` core (`file_server_ext_id`) + `read_timeout`
- New helper package: `plugins/module_utils/v4/files/` (`api_client.py`, `helpers.py`)
- Registered both modules in the `nutanix.ncp.ntnx` action group (`meta/runtime.yml`)

### Design notes
- `UpdateEmailConfig` is **synchronous** (no async task) and returns no entity body on
  success, so the module re-fetches the configuration after the update to return it.
- `etag` from the current configuration is passed as `If-Match` on update.
- The Nutanix Files SDK `ApiClient` does not accept `allow_version_negotiation`
  (unlike the networking/lifecycle SDKs), so the files `api_client` omits it.
- Idempotency compares the writable attributes (`subject`, `content`); read-only
  attributes (`ext_id`, `links`, `tenant_id`) are never sent in the update body.

## Domain knowledge (from Glean)

Domain knowledge was gathered up front via the Glean MCP tools to inform the module
behaviour, tests, and examples. Per this repository's contribution policy, internal
engineering tickets, design/spec documents, and Confluence/SharePoint links are
intentionally **omitted** from this PR description. Summary of what was used:

- EmailConfig is a per-file-server email template (subject + content) consumed by the
  quota-notification code path when notifying users/admins about quota warnings and
  breaches.
- API surface: `GET /files/v4.0/config/file-servers/{fileServerExtId}/email-config`
  returns the single email configuration for the file server;
  `PUT .../email-config` updates it. A file server has a single email configuration.
- Prerequisite: an existing Nutanix Files file server (the email configuration always
  exists for it and cannot be created/deleted independently).

## Files changed

- `plugins/modules/`
  - `ntnx_files_email_config_v2.py` (new) — update the email configuration of a file server
  - `ntnx_files_email_configs_info_v2.py` (new) — fetch the email configuration of a file server
- `plugins/module_utils/v4/files/` (new)
  - `api_client.py` — Files SDK client + `QuotaPoliciesApi`/`FileServersApi` instances + `get_etag`
  - `helpers.py` — `get_email_config` helper
- `meta/runtime.yml` — added both modules to the `ntnx` action group
- `examples/files/EmailConfig/`
  - `email_config_v2.yml` (new) — get + update + get playbook
  - `examples_run.log` (new) — real output from running the example playbook against the PC
- `tests/integration/targets/ntnx_files_email_config_v2/` (new)
  - `tasks/email_config.yml`, `tasks/main.yml`, `meta/main.yml`, `aliases`

## Test execution

| Metric              | Value                                                                    |
|---------------------|--------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_files_email_config_v2 --local --allow-disabled -v` |
| Tasks executed      | 16 (play halted at the first live data-plane assertion)                  |
| Passed              | Argument-spec / error-handling assertions (missing `file_server_ext_id`, invalid `state`) |
| Failed              | 1 assertion — live "fetch current email configuration" (cluster returned HTTP 503) |
| Not executed        | Update / idempotency / partial-update / info happy-path (blocked by 503) |
| Duration            | ~0:01:38                                                                 |
| Cluster (PC)        | `10.44.76.28` (pc.7.6)                                                    |

Sanity: `ansible-test sanity --local` for the two modules and the `files` module_utils
passes with **0 failures** (all tests green; only Python 3.10/3.12 interpreters skipped
as not installed). `black`, `isort`, `flake8`, and `ansible-lint` all pass.

### Analysis

The **Nutanix Files (Minerva) backend service was unavailable on the provided Prism
Central** for the entire run. Every Files v4 API call (including a direct
`list_file_servers` probe and every module GET/PUT) returned:

```
HTTP 503 SERVICE UNAVAILABLE
{"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}
```

Because of this, no real file server exists to serve the email-configuration
read/update, so the data-plane tests (update, idempotency, partial update, info
get-by-file-server) could not complete and are recorded as **Known issues — blocked by
cluster (Files service 503)**. This is an environment limitation, not a defect in the
generated code:

- The modules connect, authenticate, build the Files SDK client, call the API, and
  **correctly surface the 503** via `raise_api_exception` (`failed: true`, `status: 503`,
  descriptive `msg`) — verified live.
- Argument-spec validation (required `file_server_ext_id`, `state` choices) and the
  info module's required-argument handling are **verified live and pass**.
- Idempotency, check-mode, and update flows are implemented following the
  `ntnx_lcm_config_v2` / `ntnx_virtual_switch_v2` reference patterns and pass
  `validate-modules` sanity.

The integration test also caught (and I fixed) a real bug during this run: the Files SDK
`ApiClient` does not accept `allow_version_negotiation`; the `files/api_client.py` was
updated accordingly.

RETURN/response `sample:` values reflect the exact `EmailConfig` SDK schema
(`subject`, `content`, `ext_id`, `links`, `tenant_id`); they could not be backfilled from
a live response because the Files service was down.

### Test logs (tail)

<details>
<summary>tail test_logs.log</summary>

```text
TASK [ntnx_files_email_config_v2 : Update email configuration with missing file_server_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: file_server_ext_id"}
...ignoring
TASK [... missing file_server_ext_id status] ***
ok: [testhost] => {"msg": "Update email configuration with missing file_server_ext_id failed as expected"}

TASK [ntnx_files_email_config_v2 : Update email configuration with invalid state] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of state must be one of: present, got: absent"}
...ignoring
TASK [... invalid state status] ***
ok: [testhost] => {"msg": "Update email configuration with invalid state failed as expected"}

TASK [ntnx_files_email_config_v2 : Fetch the current email configuration of the file server] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching email configuration for file server", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

PLAY RECAP *********************************************************************
testhost                   : ok=11   changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=4
```

</details>

The example playbook (`examples/files/EmailConfig/email_config_v2.yml`) was also executed
end-to-end against the same PC (`examples_run.log`); all three tasks returned the same
Files-service 503.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
