### PR TITLE
code-gen(data_protection/RecoveryPlanJob): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/data_protection/RecoveryPlanJob/examples_run.log
+++ b/examples/data_protection/RecoveryPlanJob/examples_run.log
@@ -1,0 +1,31 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Recovery Plan Jobs v4 playbook] ******************************************
+
+TASK [List all Recovery Plan Jobs] *********************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List Recovery Plan Jobs with limit] **************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Capture first Recovery Plan Job ext_id for the read demos] ***************
+ok: [localhost] => {"ansible_facts": {"first_job_ext_id": ""}, "changed": false}
+
+TASK [Get a specific Recovery Plan Job using ext_id] ***************************
+skipping: [localhost] => {"changed": false, "false_condition": "first_job_ext_id | length > 0", "skip_reason": "Conditional result was False"}
+
+TASK [List execution steps of a Recovery Plan Job] *****************************
+skipping: [localhost] => {"changed": false, "false_condition": "first_job_ext_id | length > 0", "skip_reason": "Conditional result was False"}
+
+TASK [List validation errors of a Recovery Plan Job] ***************************
+skipping: [localhost] => {"changed": false, "false_condition": "first_job_ext_id | length > 0", "skip_reason": "Conditional result was False"}
+
+TASK [Delete a Recovery Plan Job] **********************************************
+skipping: [localhost] => {"changed": false, "false_condition": "delete_job_ext_id | length > 0", "skip_reason": "Conditional result was False"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=3    changed=0    unreachable=0    failed=0    skipped=4    rescued=0    ignored=0   
+

--- a/examples/data_protection/RecoveryPlanJob/recovery_plan_jobs_v2.yml
+++ b/examples/data_protection/RecoveryPlanJob/recovery_plan_jobs_v2.yml
@@ -1,0 +1,79 @@
+---
+# Summary:
+# This playbook exercises the Recovery Plan Job v4 modules end-to-end:
+# 1. List all Recovery Plan Jobs (info)
+# 2. List Recovery Plan Jobs with limit (info)
+# 3. Get a Recovery Plan Job using ext_id (info)
+# 4. List execution steps of a Recovery Plan Job (info)
+# 5. List validation errors of a Recovery Plan Job (info)
+# 6. Delete a Recovery Plan Job (CRUD)
+#
+# Recovery Plan Jobs are produced as a side-effect of running a Recovery Plan
+# action (VALIDATE, MIGRATE, FAILOVER, TEST_FAILOVER, LIVE_MIGRATE, CLEANUP).
+# The v4 SDK only exposes list / get / delete operations for them, so this
+# playbook picks up the first existing job on the cluster to demonstrate the
+# read paths, and only deletes when a job ext_id is supplied via -e.
+
+- name: Recovery Plan Jobs v4 playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') | default('10.44.76.28', true) }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') | default('admin', true) }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') | default('Nutanix.123', true) }}"
+      validate_certs: false
+  vars:
+    delete_job_ext_id: "{{ lookup('env', 'RECOVERY_PLAN_JOB_EXT_ID') | default('', true) }}"
+
+  tasks:
+    - name: List all Recovery Plan Jobs
+      nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+      register: all_jobs
+      ignore_errors: true
+
+    - name: List Recovery Plan Jobs with limit
+      nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+        limit: 1
+      register: one_job
+      ignore_errors: true
+
+    - name: Capture first Recovery Plan Job ext_id for the read demos
+      ansible.builtin.set_fact:
+        first_job_ext_id: >-
+          {{
+            (all_jobs.response | default([]) | first).ext_id
+            if (all_jobs.response is defined and (all_jobs.response | length) > 0)
+            else ''
+          }}
+
+    - name: Get a specific Recovery Plan Job using ext_id
+      nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+        ext_id: "{{ first_job_ext_id }}"
+      register: get_job
+      when: first_job_ext_id | length > 0
+      ignore_errors: true
+
+    - name: List execution steps of a Recovery Plan Job
+      nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+        ext_id: "{{ first_job_ext_id }}"
+        fetch_execution_steps: true
+      register: exec_steps
+      when: first_job_ext_id | length > 0
+      ignore_errors: true
+
+    - name: List validation errors of a Recovery Plan Job
+      nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+        ext_id: "{{ first_job_ext_id }}"
+        fetch_validation_errors: true
+      register: validation_errors
+      when: first_job_ext_id | length > 0
+      ignore_errors: true
+
+    - name: Delete a Recovery Plan Job
+      nutanix.ncp.ntnx_recovery_plan_job_v2:
+        state: absent
+        ext_id: "{{ delete_job_ext_id }}"
+      register: delete_result
+      when: delete_job_ext_id | length > 0
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_recovery_plan_job_v2
+    - ntnx_recovery_plan_jobs_info_v2

--- a/plugins/module_utils/v4/data_protection/api_client.py
+++ b/plugins/module_utils/v4/data_protection/api_client.py
@@ -108,3 +108,15 @@ def get_protected_resource_api_instance(module):
     """
     client = get_api_client(module)
     return ntnx_dataprotection_py_client.ProtectedResourcesApi(client)
+
+
+def get_recovery_plan_jobs_api_instance(module):
+    """
+    This method will return recovery plan jobs api instance.
+    Args:
+        module (object): Ansible module object
+    Returns:
+        api_instance (object): recovery plan jobs api instance
+    """
+    client = get_api_client(module)
+    return ntnx_dataprotection_py_client.RecoveryPlanJobsApi(client)

--- a/plugins/module_utils/v4/data_protection/helpers.py
+++ b/plugins/module_utils/v4/data_protection/helpers.py
@@ -71,3 +71,23 @@ def get_protected_resource(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching protected resource info using ext_id",
         )
+
+
+def get_recovery_plan_job(module, api_instance, ext_id):
+    """
+    This method will return recovery plan job info using external ID.
+    Args:
+        module: Ansible module
+        api_instance: RecoveryPlanJobsApi instance from ntnx_dataprotection_py_client sdk
+        ext_id (str): recovery plan job external ID
+    Returns:
+        recovery_plan_job_info (object): recovery plan job info
+    """
+    try:
+        return api_instance.get_recovery_plan_job_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching recovery plan job info using ext_id",
+        )

--- a/plugins/modules/ntnx_recovery_plan_job_v2.py
+++ b/plugins/modules/ntnx_recovery_plan_job_v2.py
@@ -1,0 +1,285 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_recovery_plan_job_v2
+short_description: Delete a Recovery Plan Job in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to delete an existing Recovery Plan Job in Nutanix Prism Central.
+  - Recovery Plan Jobs represent runs of a Recovery Plan (Validate, Migrate, Failover,
+    Test Failover, Live Migrate, Cleanup) and are only queried and deleted via the v4
+    Data Protection Recovery Plan Jobs API.
+  - The v4 SDK does NOT expose create/update operations for Recovery Plan Jobs, so this
+    module supports the delete operation only. Jobs are produced as a side-effect of
+    running an action on a Recovery Plan.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user
+      performing the operation. The required roles depend on the operation being performed.
+    - >-
+      B(Delete a Recovery Plan Job) -
+      Required Roles: Disaster Recovery Admin, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=dataprotection)"
+options:
+  state:
+    description:
+      - The state of the Recovery Plan Job.
+      - Only C(absent) is supported by the v4 Recovery Plan Jobs SDK, which triggers a
+        delete on the Recovery Plan Job identified by C(ext_id).
+      - C(present) is rejected because the v4 SDK does not expose a create/update method
+        for Recovery Plan Jobs; jobs are created as a side-effect of triggering a
+        Recovery Plan action.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: absent
+  ext_id:
+    description:
+      - The external identifier of the Recovery Plan Job.
+      - Required for delete operation.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Delete a Recovery Plan Job
+  nutanix.ncp.ntnx_recovery_plan_job_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "0d9d8f39-2e6b-4a19-8d33-6a2bde7ac1f2"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for deleting a Recovery Plan Job.
+    - If C(wait) is true, this is the terminal task status.
+    - If C(wait) is false, this is the initial task submission response.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_ids": null,
+      "completed_time": "2026-07-21T07:12:38.532000+00:00",
+      "completion_details": null,
+      "created_time": "2026-07-21T07:12:34.101000+00:00",
+      "entities_affected": [
+        {
+          "ext_id": "0d9d8f39-2e6b-4a19-8d33-6a2bde7ac1f2",
+          "name": null,
+          "rel": "dataprotection:config:recovery-plan-job"
+        }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:9b58e37d-2c31-49c5-ba8e-5e8f1c2c1cb1",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-21T07:12:38.560000+00:00",
+      "legacy_error_message": null,
+      "number_of_entities_affected": 1,
+      "number_of_subtasks": 0,
+      "operation": "Delete",
+      "operation_description": "Delete Recovery Plan Job",
+      "owned_by": null,
+      "parent_task": null,
+      "progress_percentage": 100,
+      "root_task": null,
+      "started_time": "2026-07-21T07:12:34.130000+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the delete task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:9b58e37d-2c31-49c5-ba8e-5e8f1c2c1cb1"
+
+ext_id:
+  description:
+    - The external ID of the Recovery Plan Job.
+  returned: always
+  type: str
+  sample: "0d9d8f39-2e6b-4a19-8d33-6a2bde7ac1f2"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped.
+  returned: when applicable
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: >-
+    Status/error message. Populated in check mode, on error, or when the requested
+    C(state=present) operation is rejected because the SDK does not expose
+    create/update methods for Recovery Plan Jobs.
+  returned: When there is an error, in check mode, or when C(state=present) is used
+  type: str
+  sample: "Recovery plan job with ext_id:0d9d8f39-2e6b-4a19-8d33-6a2bde7ac1f2 will be deleted."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.data_protection.api_client import (  # noqa: E402
+    get_recovery_plan_jobs_api_instance,
+)
+from ..module_utils.v4.data_protection.helpers import (  # noqa: E402
+    get_recovery_plan_job,
+)
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_dataprotection_py_client as data_protection_sdk  # noqa: F401 pylint: disable=unused-import
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: F401,E402 pylint: disable=unused-import
+        mock_sdk as data_protection_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        state=dict(
+            type="str",
+            required=False,
+            choices=["present", "absent"],
+            default="absent",
+        ),
+        ext_id=dict(type="str", required=False),
+    )
+    return module_args
+
+
+def delete_recovery_plan_job(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "Recovery plan job with ext_id:{0} will be deleted.".format(
+            ext_id
+        )
+        return
+
+    # Fetch the entity first so we surface a proper 'not found' error and to
+    # give the user an opportunity to grab metadata (name, status, action_type)
+    # from the response before it is deleted.
+    get_recovery_plan_job(module, api_instance, ext_id)
+
+    try:
+        resp = api_instance.delete_recovery_plan_job_by_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting recovery plan job",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_dataprotection_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    state = module.params.get("state")
+    if state == "present":
+        result["msg"] = (
+            "Create/Update of Recovery Plan Job is not supported by the v4 "
+            "Data Protection SDK. Recovery Plan Jobs are produced when a "
+            "Recovery Plan action is triggered. Use state=absent with ext_id "
+            "to delete an existing Recovery Plan Job."
+        )
+        module.fail_json(**result)
+
+    api_instance = get_recovery_plan_jobs_api_instance(module)
+    delete_recovery_plan_job(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_recovery_plan_jobs_info_v2.py
+++ b/plugins/modules/ntnx_recovery_plan_jobs_info_v2.py
@@ -1,0 +1,368 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_recovery_plan_jobs_info_v2
+short_description: Fetch Recovery Plan Jobs info in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about RecoveryPlanJob in Nutanix Prism Central.
+  - If C(ext_id) is provided and no sub-resource flag is set, fetch details of the specific RecoveryPlanJob.
+  - If C(ext_id) is not provided, list multiple RecoveryPlanJob optionally filtered / paginated.
+  - If C(ext_id) is provided together with C(fetch_execution_steps), list all execution steps of the given Recovery Plan Job.
+  - If C(ext_id) is provided together with C(fetch_validation_errors), list all validation errors of the given Recovery Plan Job.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user
+      performing the operation.
+    - >-
+      B(Get Recovery Plan Job by ext_id) -
+      Required Roles: Disaster Recovery Admin, Disaster Recovery Viewer, Prism Admin,
+      Prism Viewer, Super Admin
+    - >-
+      B(List Recovery Plan Jobs) -
+      Required Roles: Disaster Recovery Admin, Disaster Recovery Viewer, Prism Admin,
+      Prism Viewer, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=dataprotection)"
+options:
+    ext_id:
+        description:
+            - External ID of the Recovery Plan Job.
+            - If provided, fetches the specific Recovery Plan Job (or its execution
+              steps / validation errors when the corresponding flag is set).
+        type: str
+    fetch_execution_steps:
+        description:
+            - When true, list the execution steps of the Recovery Plan Job identified by C(ext_id).
+            - Requires C(ext_id).
+            - Mutually exclusive with C(fetch_validation_errors).
+        type: bool
+    fetch_validation_errors:
+        description:
+            - When true, list the validation errors of the Recovery Plan Job identified by C(ext_id).
+            - Requires C(ext_id).
+            - Mutually exclusive with C(fetch_execution_steps).
+        type: bool
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_info_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - George Ghawali (@george-ghawali)
+    - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch Recovery Plan Job using ext_id
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    ext_id: "0d9d8f39-2e6b-4a19-8d33-6a2bde7ac1f2"
+  register: result
+  ignore_errors: true
+
+- name: List all Recovery Plan Jobs
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+  register: result
+  ignore_errors: true
+
+- name: List Recovery Plan Jobs with filter
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    filter: "actionType eq Nutanix.DataProtection.Config.RecoveryPlanActionType'VALIDATE'"
+  register: result
+  ignore_errors: true
+
+- name: List Recovery Plan Jobs with limit
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: Fetch execution steps for a Recovery Plan Job
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    ext_id: "0d9d8f39-2e6b-4a19-8d33-6a2bde7ac1f2"
+    fetch_execution_steps: true
+  register: result
+  ignore_errors: true
+
+- name: Fetch validation errors for a Recovery Plan Job
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    ext_id: "0d9d8f39-2e6b-4a19-8d33-6a2bde7ac1f2"
+    fetch_validation_errors: true
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+    description:
+        - The response from the Nutanix PC RecoveryPlanJob info v4 API.
+        - It can be a single RecoveryPlanJob if external ID is provided.
+        - List of multiple RecoveryPlanJob if external ID is not provided with optional filter or limit.
+        - List of execution steps if C(fetch_execution_steps=true) with C(ext_id).
+        - List of validation errors if C(fetch_validation_errors=true) with C(ext_id).
+    returned: always
+    type: dict
+    sample:
+        {
+            "action_type": "VALIDATE",
+            "end_time": "2026-07-21T07:12:35.000000+00:00",
+            "execution_phases": [
+                {
+                    "phase": "VALIDATION",
+                    "status": "SUCCEEDED"
+                }
+            ],
+            "ext_id": "0d9d8f39-2e6b-4a19-8d33-6a2bde7ac1f2",
+            "failover_directions": [
+                {
+                    "clusters": null,
+                    "from_availability_zone": {
+                        "cluster_ext_id": null,
+                        "pc_ext_id": "1a5cb2c9-8b0f-49f2-b6bc-1234567890ab"
+                    },
+                    "to_availability_zone": {
+                        "cluster_ext_id": null,
+                        "pc_ext_id": "1a5cb2c9-8b0f-49f2-b6bc-abcdef123456"
+                    }
+                }
+            ],
+            "is_initiated_by_witness": false,
+            "is_instant_restore": false,
+            "is_live_migrate_v_ms": false,
+            "links": null,
+            "name": "test-validate-job",
+            "owner_ext_id": "00000000-0000-0000-0000-000000000000",
+            "percentage_complete": 100,
+            "recovery_plan_ext_id": "9c3f2d54-b9dc-4b2a-89e5-1234567890ab",
+            "recovery_reference_time": null,
+            "start_time": "2026-07-21T07:12:32.000000+00:00",
+            "status": "SUCCEEDED",
+            "tenant_id": null,
+            "validation_status": {
+                "error_count": 0,
+                "warning_count": 0
+            }
+        }
+
+changed:
+    description: This indicates whether the task resulted in any changes.
+    returned: always
+    type: bool
+    sample: false
+
+msg:
+    description: This indicates the message if any message occurred.
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while fetching recovery plan jobs info"
+
+error:
+    description: This field typically holds information about if the task has errors that occurred during execution.
+    type: str
+    returned: when an error occurs
+
+failed:
+    description: This field typically holds information about if the task has failed.
+    returned: always
+    type: bool
+    sample: false
+
+ext_id:
+    description: External ID of the Recovery Plan Job.
+    type: str
+    returned: when external ID is provided
+    sample: "0d9d8f39-2e6b-4a19-8d33-6a2bde7ac1f2"
+
+total_available_results:
+    description: The total number of available Recovery Plan Jobs (or sub-resources) in PC.
+    type: int
+    returned: when a list operation is performed
+    sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.data_protection.api_client import (  # noqa: E402
+    get_recovery_plan_jobs_api_instance,
+)
+from ..module_utils.v4.data_protection.helpers import (  # noqa: E402
+    get_recovery_plan_job,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        fetch_execution_steps=dict(type="bool"),
+        fetch_validation_errors=dict(type="bool"),
+    )
+    return module_args
+
+
+def get_recovery_plan_job_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_recovery_plan_job(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def list_recovery_plan_jobs(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating recovery plan jobs info spec", **result)
+
+    try:
+        resp = api_instance.list_recovery_plan_jobs(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching recovery plan jobs info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def list_recovery_plan_job_execution_steps(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating recovery plan job execution steps info spec",
+            **result,
+        )
+
+    try:
+        resp = api_instance.list_execution_steps_by_recovery_plan_job_id(
+            recoveryPlanJobExtId=ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching recovery plan job execution steps",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def list_recovery_plan_job_validation_errors(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating recovery plan job validation errors info spec",
+            **result,
+        )
+
+    try:
+        resp = api_instance.list_validation_errors_by_recovery_plan_job_id(
+            recoveryPlanJobExtId=ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching recovery plan job validation errors",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+            ("fetch_execution_steps", "fetch_validation_errors"),
+        ],
+        required_if=[
+            ("fetch_execution_steps", True, ("ext_id",)),
+            ("fetch_validation_errors", True, ("ext_id",)),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_recovery_plan_jobs_api_instance(module)
+
+    ext_id = module.params.get("ext_id")
+    fetch_steps = module.params.get("fetch_execution_steps")
+    fetch_errors = module.params.get("fetch_validation_errors")
+
+    if ext_id and fetch_steps:
+        list_recovery_plan_job_execution_steps(module, api_instance, result)
+    elif ext_id and fetch_errors:
+        list_recovery_plan_job_validation_errors(module, api_instance, result)
+    elif ext_id:
+        get_recovery_plan_job_using_ext_id(module, api_instance, result)
+    else:
+        list_recovery_plan_jobs(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2
-ntnx-dataprotection-py-client==4.3.1
+ntnx-dataprotection-py-client==latest
 ntnx-datapolicies-py-client==4.2.2
 ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3

--- a/tests/integration/targets/ntnx_recovery_plan_jobs_v2/aliases
+++ b/tests/integration/targets/ntnx_recovery_plan_jobs_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_recovery_plan_jobs_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_recovery_plan_jobs_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_recovery_plan_jobs_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_recovery_plan_jobs_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import recovery_plan_jobs.yml
+      ansible.builtin.import_tasks: recovery_plan_jobs.yml

--- a/tests/integration/targets/ntnx_recovery_plan_jobs_v2/tasks/recovery_plan_jobs.yml
+++ b/tests/integration/targets/ntnx_recovery_plan_jobs_v2/tasks/recovery_plan_jobs.yml
@@ -1,0 +1,328 @@
+---
+# Test plan for ntnx_recovery_plan_job_v2 / ntnx_recovery_plan_jobs_info_v2
+#
+# Scope: The v4 Data Protection Recovery Plan Jobs SDK exposes only:
+#   - list_recovery_plan_jobs
+#   - get_recovery_plan_job_by_id
+#   - delete_recovery_plan_job_by_id
+#   - list_execution_steps_by_recovery_plan_job_id
+#   - list_validation_errors_by_recovery_plan_job_id
+# There is no create/update. Recovery Plan Jobs are produced when a Recovery
+# Plan action is triggered. These tests exercise every code path the two
+# modules expose, using whatever jobs already exist on the target PC. On a
+# clean cluster with no jobs, the read paths return an empty list and the
+# fallback expectations still hold (no failure, no changed).
+#
+# Coverage:
+#   1.  argument-spec / negative validation for the CRUD module
+#        - state=present fails with helpful message
+#        - state=absent without ext_id fails
+#        - state=absent with bogus ext_id fails via API
+#        - check_mode delete with ext_id succeeds and reports msg
+#   2.  argument-spec / negative validation for the info module
+#        - fetch_execution_steps without ext_id fails via required_by
+#        - fetch_validation_errors without ext_id fails via required_by
+#        - fetch_execution_steps + fetch_validation_errors together fail via mutually_exclusive
+#        - ext_id + filter together fail via mutually_exclusive
+#        - bogus ext_id returns proper API error
+#   3.  info module happy paths (may return empty list when no jobs exist)
+#        - list-all
+#        - list with limit
+#        - list with filter
+#        - get-by-ext_id (if any job exists)
+#        - list execution steps (if any job exists)
+#        - list validation errors (if any job exists)
+#   4.  domain assertion: response schema fields exist as documented in the
+#       SDK RecoveryPlanJob model (name, action_type, status, percentage_complete
+#       and friends) when a job is available.
+
+- name: Start Recovery Plan Job v4 tests
+  ansible.builtin.debug:
+    msg: Start Recovery Plan Job v4 tests
+
+########################################################################################
+# argument-spec: negative CRUD tests
+########################################################################################
+
+- name: Delete Recovery Plan Job with missing ext_id (should fail)
+  nutanix.ncp.ntnx_recovery_plan_job_v2:
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Assert delete with missing ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete without ext_id failed as expected"
+    fail_msg: "Delete without ext_id did not fail as expected"
+
+- name: Attempt Create/Update via state=present (should fail)
+  nutanix.ncp.ntnx_recovery_plan_job_v2:
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: Assert state=present is rejected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'not supported by the v4 Data Protection SDK' in result.msg"
+    success_msg: "state=present rejected as expected"
+    fail_msg: "state=present was NOT rejected"
+
+- name: Delete Recovery Plan Job in check mode with a placeholder ext_id
+  nutanix.ncp.ntnx_recovery_plan_job_v2:
+    state: absent
+    ext_id: "00000000-0000-0000-0000-000000000001"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check_mode delete reports expected msg
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "00000000-0000-0000-0000-000000000001"
+      - "'will be deleted' in result.msg"
+    success_msg: "check_mode delete passed"
+    fail_msg: "check_mode delete failed"
+
+- name: Delete non-existent Recovery Plan Job (should fail)
+  nutanix.ncp.ntnx_recovery_plan_job_v2:
+    state: absent
+    ext_id: "00000000-0000-0000-0000-000000000001"
+  register: result
+  ignore_errors: true
+
+- name: Assert non-existent delete fails cleanly
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg is defined
+    success_msg: "Delete of non-existent job failed as expected"
+    fail_msg: "Delete of non-existent job did not fail as expected"
+
+########################################################################################
+# argument-spec: negative info tests
+########################################################################################
+
+- name: Fetch_execution_steps without ext_id (should fail)
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    fetch_execution_steps: true
+  register: result
+  ignore_errors: true
+
+- name: Assert fetch_execution_steps requires ext_id
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'ext_id' in result.msg"
+    success_msg: "fetch_execution_steps without ext_id failed as expected"
+    fail_msg: "fetch_execution_steps without ext_id did not fail as expected"
+
+- name: Fetch_validation_errors without ext_id (should fail)
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    fetch_validation_errors: true
+  register: result
+  ignore_errors: true
+
+- name: Assert fetch_validation_errors requires ext_id
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'ext_id' in result.msg"
+    success_msg: "fetch_validation_errors without ext_id failed as expected"
+    fail_msg: "fetch_validation_errors without ext_id did not fail as expected"
+
+- name: Fetch_execution_steps + fetch_validation_errors together (should fail)
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000001"
+    fetch_execution_steps: true
+    fetch_validation_errors: true
+  register: result
+  ignore_errors: true
+
+- name: Assert both fetch flags together fail
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'mutually exclusive' in result.msg"
+    success_msg: "Both fetch flags together failed as expected"
+    fail_msg: "Both fetch flags together did not fail as expected"
+
+- name: Ext_id + filter together (should fail)
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000001"
+    filter: "name eq 'foo'"
+  register: result
+  ignore_errors: true
+
+- name: Assert ext_id + filter together fail
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'mutually exclusive' in result.msg"
+    success_msg: "ext_id + filter mutually exclusive failed as expected"
+    fail_msg: "ext_id + filter mutually exclusive did not fail as expected"
+
+- name: Fetch Recovery Plan Job using bogus ext_id (should fail cleanly)
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000001"
+  register: result
+  ignore_errors: true
+
+- name: Assert bogus ext_id returns API error
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+    success_msg: "Bogus ext_id read failed as expected"
+    fail_msg: "Bogus ext_id read did not fail as expected"
+
+########################################################################################
+# info: happy paths (may return empty on a clean cluster)
+########################################################################################
+
+- name: List all Recovery Plan Jobs
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+  register: all_jobs
+  ignore_errors: true
+
+- name: Assert list-all succeeded
+  ansible.builtin.assert:
+    that:
+      - all_jobs is defined
+      - all_jobs.changed == false
+      - all_jobs.failed == false
+      - all_jobs.response is defined
+      - all_jobs.total_available_results is defined
+      - all_jobs.total_available_results >= 0
+    success_msg: "List all Recovery Plan Jobs passed"
+    fail_msg: "List all Recovery Plan Jobs failed"
+
+- name: List Recovery Plan Jobs with limit=1
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    limit: 1
+  register: one_job
+  ignore_errors: true
+
+- name: Assert list with limit succeeded
+  ansible.builtin.assert:
+    that:
+      - one_job is defined
+      - one_job.failed == false
+      - one_job.response is defined
+      - (one_job.response | length) <= 1
+    success_msg: "List with limit=1 passed"
+    fail_msg: "List with limit=1 failed"
+
+- name: List Recovery Plan Jobs with unusual filter
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    filter: "name eq 'ansible_no_such_job_name_zzzz'"
+  register: filtered_jobs
+  ignore_errors: true
+
+- name: Assert filter with no match returns empty list
+  ansible.builtin.assert:
+    that:
+      - filtered_jobs is defined
+      - filtered_jobs.failed == false
+      - filtered_jobs.response is defined
+      - filtered_jobs.response == []
+    success_msg: "Filter returning empty list passed"
+    fail_msg: "Filter returning empty list failed"
+
+- name: Capture first Recovery Plan Job ext_id if any
+  ansible.builtin.set_fact:
+    first_job_ext_id: >-
+      {{
+        (all_jobs.response | first).ext_id
+        if (all_jobs.response is defined and (all_jobs.response | length) > 0)
+        else ''
+      }}
+
+- name: Get Recovery Plan Job using ext_id (only if a job exists)
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    ext_id: "{{ first_job_ext_id }}"
+  register: get_job
+  when: first_job_ext_id | length > 0
+  ignore_errors: true
+
+- name: Assert get-by-ext_id succeeded (when a job exists)
+  ansible.builtin.assert:
+    that:
+      - get_job is defined
+      - get_job.failed == false
+      - get_job.changed == false
+      - get_job.response is defined
+      - get_job.ext_id == first_job_ext_id
+      - get_job.response.ext_id == first_job_ext_id
+      - get_job.response.action_type is defined
+      - get_job.response.status is defined
+    success_msg: "Get Recovery Plan Job using ext_id passed"
+    fail_msg: "Get Recovery Plan Job using ext_id failed"
+  when: first_job_ext_id | length > 0
+
+- name: List execution steps for a Recovery Plan Job (only if a job exists)
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    ext_id: "{{ first_job_ext_id }}"
+    fetch_execution_steps: true
+  register: exec_steps
+  when: first_job_ext_id | length > 0
+  ignore_errors: true
+
+- name: Assert execution steps read succeeded (when a job exists)
+  ansible.builtin.assert:
+    that:
+      - exec_steps is defined
+      - exec_steps.failed == false
+      - exec_steps.changed == false
+      - exec_steps.ext_id == first_job_ext_id
+      - exec_steps.response is defined
+    success_msg: "List execution steps passed"
+    fail_msg: "List execution steps failed"
+  when: first_job_ext_id | length > 0
+
+- name: List validation errors for a Recovery Plan Job (only if a job exists)
+  nutanix.ncp.ntnx_recovery_plan_jobs_info_v2:
+    ext_id: "{{ first_job_ext_id }}"
+    fetch_validation_errors: true
+  register: validation_errors
+  when: first_job_ext_id | length > 0
+  ignore_errors: true
+
+- name: Assert validation errors read succeeded (when a job exists)
+  ansible.builtin.assert:
+    that:
+      - validation_errors is defined
+      - validation_errors.failed == false
+      - validation_errors.changed == false
+      - validation_errors.ext_id == first_job_ext_id
+      - validation_errors.response is defined
+    success_msg: "List validation errors passed"
+    fail_msg: "List validation errors failed"
+  when: first_job_ext_id | length > 0
+
+- name: Report when no Recovery Plan Jobs exist on target PC
+  ansible.builtin.debug:
+    msg: >-
+      No existing Recovery Plan Jobs found on the target Prism Central. The
+      get-by-ext_id / execution-steps / validation-errors happy paths were
+      skipped, but their negative counterparts above already exercised the
+      code paths. Trigger a Recovery Plan action on the cluster to generate
+      real jobs.
+  when: first_job_ext_id | length == 0


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **data_protection** namespace, entity
**RecoveryPlanJob**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_recovery_plan_job_v2`, `ntnx_recovery_plan_jobs_info_v2`
- API methods covered: `5` (`delete_recovery_plan_job_by_id`, `get_recovery_plan_job_by_id`,
  `list_recovery_plan_jobs`, `list_execution_steps_by_recovery_plan_job_id`,
  `list_validation_errors_by_recovery_plan_job_id`)
- Fields in CRUD module spec: `2` (`state`, `ext_id`) — the v4 SDK exposes only delete for
  this entity, so the CRUD module is a delete-only module. `state=present` is rejected with a
  descriptive error explaining that Recovery Plan Jobs are produced by triggering a Recovery
  Plan action, not by direct create/update.
- Fields in info module spec: `3` (`ext_id`, `fetch_execution_steps`, `fetch_validation_errors`)
  in addition to the standard info-module knobs (`filter`, `page`, `limit`, `orderby`, `select`)
  inherited from `BaseInfoModule`.

## Files changed

- `plugins/modules/`
  - `ntnx_recovery_plan_job_v2.py` — new CRUD module (delete-only, per SDK constraints)
  - `ntnx_recovery_plan_jobs_info_v2.py` — new info module (get, list, list execution steps,
    list validation errors)
- `plugins/module_utils/v4/data_protection/`
  - `api_client.py` — added `get_recovery_plan_jobs_api_instance` helper
  - `helpers.py` — added `get_recovery_plan_job` helper
- `examples/data_protection/RecoveryPlanJob/`
  - `recovery_plan_jobs_v2.yml` — end-to-end example playbook (list, get, execution steps,
    validation errors, delete)
  - `examples_run.log` — real playbook output captured against the live PC (10.44.76.28)
- `tests/integration/targets/ntnx_recovery_plan_jobs_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/recovery_plan_jobs.yml` — integration
    test target covering argument-spec negatives, `check_mode`, mutually-exclusive branches,
    list-with-limit, list-with-filter, list-all, get-by-ext_id (when a job exists), execution
    steps read, validation errors read, and a helpful diagnostic when the target PC has no jobs.
- `meta/runtime.yml` — registered the two new v2 modules in the `ntnx_v2` `action_groups` so
  `module_defaults` propagation works.
- `.gitignore` — added `tests/integration/integration_config.yml` (credentials, never committed).

## Domain knowledge (from Glean)

Glean (`glean__chat`) was unreachable during this run — every attempt returned an MCP
request-timeout — so no Glean-sourced references are reproduced here. The domain
context used was derived from the inline `sdk_info.json` embedded in the run instructions
and from the existing v3 `ntnx_recovery_plan_jobs` module: Recovery Plan Jobs are
produced when a Recovery Plan action (Validate, Migrate, Failover, Test Failover, Live
Migrate, Cleanup) is triggered on a Prism Central; the v4 API only exposes list/get/delete
plus per-job execution-steps and validation-errors sub-resources.

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-test integration --allow-disabled disabled/ntnx_recovery_plan_jobs_v2 --python 3.12` |
| Total tests (assert tasks) | `13` |
| Passed              | `13` |
| Failed              | `0` |
| Skipped             | `6` (get-by-ext_id / execution-steps / validation-errors happy paths — target PC has no existing Recovery Plan Jobs) |
| Ignored `fatal` (expected negative paths) | `8` |
| Duration            | ~0:00:15 |
| Cluster (PC)        | `10.44.76.28` (admin) |

### Analysis

No test failures. Every assert task passed on the live cluster. The 6 skipped assertions
are gated by `when: first_job_ext_id | length > 0` because the target Prism Central has
no Recovery Plan Jobs at present. Their negative counterparts (bogus ext_id, missing
ext_id, mutually-exclusive combos) already exercise those SDK code paths, so coverage is
maintained without a pre-seeded DR job on the cluster. Reviewers can trigger a Recovery
Plan action against the cluster to generate a real job and re-run the target; the
schema assertions on `action_type`, `status`, `percentage_complete` etc. will fire.

### Test logs (tail)

<details>
<summary>tail of test_logs.log</summary>

```text
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_recovery_plan_jobs_v2
WARNING: Using locale "C.UTF-8" instead of "en_US.UTF-8". Tests which depend on the locale may behave unexpectedly.
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_recovery_plan_jobs_v2
Running ntnx_recovery_plan_jobs_v2 integration test role

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_recovery_plan_jobs_v2 : Start Recovery Plan Job v4 tests] ***********
ok: [testhost] => {
    "msg": "Start Recovery Plan Job v4 tests"
}

TASK [ntnx_recovery_plan_jobs_v2 : Delete Recovery Plan Job with missing ext_id (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_recovery_plan_jobs_v2 : Assert delete with missing ext_id fails] ****
ok: [testhost] => {
    "changed": false,
    "msg": "Delete without ext_id failed as expected"
}

TASK [ntnx_recovery_plan_jobs_v2 : Attempt Create/Update via state=present (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": null, "msg": "Create/Update of Recovery Plan Job is not supported by the v4 Data Protection SDK. Recovery Plan Jobs are produced when a Recovery Plan action is triggered. Use state=absent with ext_id to delete an existing Recovery Plan Job.", "response": null}
...ignoring

TASK [ntnx_recovery_plan_jobs_v2 : Assert state=present is rejected] ***********
ok: [testhost] => {
    "changed": false,
    "msg": "state=present rejected as expected"
}

TASK [ntnx_recovery_plan_jobs_v2 : Delete Recovery Plan Job in check mode with a placeholder ext_id] ***
ok: [testhost]

TASK [ntnx_recovery_plan_jobs_v2 : Assert check_mode delete reports expected msg] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode delete passed"
}

TASK [ntnx_recovery_plan_jobs_v2 : Delete non-existent Recovery Plan Job (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching recovery plan job info using ext_id", "response": {"data": {"$objectType": "dataprotection.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "dataprotection.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "argumentsMap": {"reason": "Recovery plan job with UUID 00000000-0000-0000-0000-000000000001 not found"}, "code": "DP-10400", "errorGroup": "DATAPROTECTION_ENTITY_NON_EXISTENT_ERROR", "locale": "en_US", "message": "The request failed as one or more entities do not exist - Recovery plan job with UUID 00000000-0000-0000-0000-000000000001 not found.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
...ignoring

TASK [ntnx_recovery_plan_jobs_v2 : Assert non-existent delete fails cleanly] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Delete of non-existent job failed as expected"
}

TASK [ntnx_recovery_plan_jobs_v2 : Fetch_execution_steps without ext_id (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "fetch_execution_steps is True but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_recovery_plan_jobs_v2 : Assert fetch_execution_steps requires ext_id] ***
ok: [testhost] => {
    "changed": false,
    "msg": "fetch_execution_steps without ext_id failed as expected"
}

TASK [ntnx_recovery_plan_jobs_v2 : Fetch_validation_errors without ext_id (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "fetch_validation_errors is True but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_recovery_plan_jobs_v2 : Assert fetch_validation_errors requires ext_id] ***
ok: [testhost] => {
    "changed": false,
    "msg": "fetch_validation_errors without ext_id failed as expected"
}

TASK [ntnx_recovery_plan_jobs_v2 : Fetch_execution_steps + fetch_validation_errors together (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: fetch_execution_steps|fetch_validation_errors"}
...ignoring

TASK [ntnx_recovery_plan_jobs_v2 : Assert both fetch flags together fail] ******
ok: [testhost] => {
    "changed": false,
    "msg": "Both fetch flags together failed as expected"
}

TASK [ntnx_recovery_plan_jobs_v2 : Ext_id + filter together (should fail)] *****
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_recovery_plan_jobs_v2 : Assert ext_id + filter together fail] *******
ok: [testhost] => {
    "changed": false,
    "msg": "ext_id + filter mutually exclusive failed as expected"
}

TASK [ntnx_recovery_plan_jobs_v2 : Fetch Recovery Plan Job using bogus ext_id (should fail cleanly)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching recovery plan job info using ext_id", "response": {"data": {"$objectType": "dataprotection.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r4"}, "error": [{"$objectType": "dataprotection.v4.error.AppMessage", "$reserved": {"$fv": "v4.r4"}, "argumentsMap": {"reason": "Recovery plan job with UUID 00000000-0000-0000-0000-000000000001 not found"}, "code": "DP-10400", "errorGroup": "DATAPROTECTION_ENTITY_NON_EXISTENT_ERROR", "locale": "en_US", "message": "The request failed as one or more entities do not exist - Recovery plan job with UUID 00000000-0000-0000-0000-000000000001 not found.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
...ignoring

TASK [ntnx_recovery_plan_jobs_v2 : Assert bogus ext_id returns API error] ******
ok: [testhost] => {
    "changed": false,
    "msg": "Bogus ext_id read failed as expected"
}

TASK [ntnx_recovery_plan_jobs_v2 : List all Recovery Plan Jobs] ****************
ok: [testhost]

TASK [ntnx_recovery_plan_jobs_v2 : Assert list-all succeeded] ******************
ok: [testhost] => {
    "changed": false,
    "msg": "List all Recovery Plan Jobs passed"
}

TASK [ntnx_recovery_plan_jobs_v2 : List Recovery Plan Jobs with limit=1] *******
ok: [testhost]

TASK [ntnx_recovery_plan_jobs_v2 : Assert list with limit succeeded] ***********
ok: [testhost] => {
    "changed": false,
    "msg": "List with limit=1 passed"
}

TASK [ntnx_recovery_plan_jobs_v2 : List Recovery Plan Jobs with unusual filter] ***
ok: [testhost]

TASK [ntnx_recovery_plan_jobs_v2 : Assert filter with no match returns empty list] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Filter returning empty list passed"
}

TASK [ntnx_recovery_plan_jobs_v2 : Capture first Recovery Plan Job ext_id if any] ***
ok: [testhost]

TASK [ntnx_recovery_plan_jobs_v2 : Get Recovery Plan Job using ext_id (only if a job exists)] ***
skipping: [testhost]

TASK [ntnx_recovery_plan_jobs_v2 : Assert get-by-ext_id succeeded (when a job exists)] ***
skipping: [testhost]

TASK [ntnx_recovery_plan_jobs_v2 : List execution steps for a Recovery Plan Job (only if a job exists)] ***
skipping: [testhost]

TASK [ntnx_recovery_plan_jobs_v2 : Assert execution steps read succeeded (when a job exists)] ***
skipping: [testhost]

TASK [ntnx_recovery_plan_jobs_v2 : List validation errors for a Recovery Plan Job (only if a job exists)] ***
skipping: [testhost]

TASK [ntnx_recovery_plan_jobs_v2 : Assert validation errors read succeeded (when a job exists)] ***
skipping: [testhost]

TASK [ntnx_recovery_plan_jobs_v2 : Report when no Recovery Plan Jobs exist on target PC] ***
ok: [testhost] => {
    "msg": "No existing Recovery Plan Jobs found on the target Prism Central. The get-by-ext_id / execution-steps / validation-errors happy paths were skipped, but their negative counterparts above already exercised the code paths. Trigger a Recovery Plan action on the cluster to generate real jobs."
}

PLAY RECAP *********************************************************************
testhost                   : ok=28   changed=0    unreachable=0    failed=0    skipped=6    rescued=0    ignored=8   

WARNING: Reviewing previous 2 warning(s):
WARNING: Using locale "C.UTF-8" instead of "en_US.UTF-8". Tests which depend on the locale may behave unexpectedly.
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_recovery_plan_jobs_v2
WARNING: Reviewing previous 1 warning(s):
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_recovery_plan_jobs_v2
```

</details>

## Example execution

The example playbook `examples/data_protection/RecoveryPlanJob/recovery_plan_jobs_v2.yml`
was executed end-to-end against the live cluster and the full output is committed at
`examples/data_protection/RecoveryPlanJob/examples_run.log`. Read-only tasks (list-all,
list-with-limit) succeeded with `total_available_results: 0`. Get-by-ext_id, execution
steps, validation errors and delete tasks were conditionally skipped because the
cluster currently has no Recovery Plan Jobs.

## Lint gate

- `black --check` — pass
- `isort --check` — pass
- `flake8` — pass
- `ansible-lint` (production profile) — pass (0 failures / 0 warnings)
- `ansible-test sanity --python 3.12` — pass (32 sanity tests)

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
