### PR TITLE
FileServerStat Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/files/FileServerStat/examples_run.log
+++ b/examples/files/FileServerStat/examples_run.log
@@ -1,0 +1,69 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Nutanix Files - FileServerStat example playbook] *************************
+
+TASK [Fetch File Server stats using the stat module] ***************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching file server stats for ext_id: 6ca5de7e-a9a8-4318-4a62-68b8d5833af7
+Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/repo/examples/files/FileServerStat/file_server_stat.yml:37:7
+
+35
+36   tasks:
+37     - name: Fetch File Server stats using the stat module
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching file server stats for ext_id: 6ca5de7e-a9a8-4318-4a62-68b8d5833af7", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Fetch File Server stats with sampling_interval, stat_type, and select] ***
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching file server stats for ext_id: 6ca5de7e-a9a8-4318-4a62-68b8d5833af7
+Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/repo/examples/files/FileServerStat/file_server_stat.yml:46:7
+
+44       # sample: <Need to add sample>
+45
+46     - name: Fetch File Server stats with sampling_interval, stat_type, and select
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching file server stats for ext_id: 6ca5de7e-a9a8-4318-4a62-68b8d5833af7", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Fetch File Server stats info via the info module] ************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching file server stats for ext_id: 6ca5de7e-a9a8-4318-4a62-68b8d5833af7
+Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/repo/examples/files/FileServerStat/file_server_stat.yml:58:7
+
+56       # sample: <Need to add sample>
+57
+58     - name: Fetch File Server stats info via the info module
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching file server stats for ext_id: 6ca5de7e-a9a8-4318-4a62-68b8d5833af7", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Fetch Antivirus Server stats for the File Server] ************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching antivirus server stats for ext_id: 18f78959-14a6-4c47-b5db-920460c4b668
+Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/repo/examples/files/FileServerStat/file_server_stat.yml:67:7
+
+65       # sample: <Need to add sample>
+66
+67     - name: Fetch Antivirus Server stats for the File Server
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching antivirus server stats for ext_id: 18f78959-14a6-4c47-b5db-920460c4b668", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Fetch Mount Target stats for the File Server] ****************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching mount target stats for ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9
+Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/repo/examples/files/FileServerStat/file_server_stat.yml:79:7
+
+77       # sample: <Need to add sample>
+78
+79     - name: Fetch Mount Target stats for the File Server
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching mount target stats for ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=5    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=5   
+

--- a/examples/files/FileServerStat/file_server_stat.yml
+++ b/examples/files/FileServerStat/file_server_stat.yml
@@ -1,0 +1,88 @@
+---
+# Examples for the Nutanix Files FileServerStat v4 modules.
+#
+# This playbook demonstrates how to fetch statistics for:
+#   * a File Server (ntnx_file_server_stat_v2)
+#   * an Antivirus Server attached to a File Server (info module)
+#   * a Mount Target attached to a File Server (info module)
+#
+# Set the following variables from the command line or an inventory file:
+#   ip                       Prism Central endpoint
+#   username / password      PC admin credentials
+#   file_server_ext_id       ext_id of a File Server managed by PC
+#   antivirus_server_ext_id  ext_id of an Antivirus Server (optional)
+#   mount_target_ext_id      ext_id of a Mount Target (optional)
+
+- name: Nutanix Files - FileServerStat example playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username }}"
+      nutanix_password: "{{ password }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+  vars:
+    ip: "10.44.76.28"
+    username: "admin"
+    password: "Nutanix.123"
+    validate_certs: false
+    file_server_ext_id: "6ca5de7e-a9a8-4318-4a62-68b8d5833af7"
+    antivirus_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    stats_start_time: "2026-07-20T00:00:00.000Z"
+    stats_end_time: "2026-07-21T00:00:00.000Z"
+
+  tasks:
+    - name: Fetch File Server stats using the stat module
+      nutanix.ncp.ntnx_file_server_stat_v2:
+        ext_id: "{{ file_server_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+      register: fs_stats
+      ignore_errors: true
+      # sample: <Need to add sample>
+
+    - name: Fetch File Server stats with sampling_interval, stat_type, and select
+      nutanix.ncp.ntnx_file_server_stat_v2:
+        ext_id: "{{ file_server_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+        sampling_interval: 300
+        stat_type: "AVG"
+        select: "averageIops,averageLatencyUs,averageThroughputBps"
+      register: fs_stats_full
+      ignore_errors: true
+      # sample: <Need to add sample>
+
+    - name: Fetch File Server stats info via the info module
+      nutanix.ncp.ntnx_files_file_server_stats_info_v2:
+        ext_id: "{{ file_server_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+      register: fs_stats_info
+      ignore_errors: true
+      # sample: <Need to add sample>
+
+    - name: Fetch Antivirus Server stats for the File Server
+      nutanix.ncp.ntnx_files_file_server_stats_info_v2:
+        ext_id: "{{ file_server_ext_id }}"
+        antivirus_server_ext_id: "{{ antivirus_server_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+        sampling_interval: 300
+        stat_type: "AVG"
+      register: av_stats_info
+      ignore_errors: true
+      # sample: <Need to add sample>
+
+    - name: Fetch Mount Target stats for the File Server
+      nutanix.ncp.ntnx_files_file_server_stats_info_v2:
+        ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        start_time: "{{ stats_start_time }}"
+        end_time: "{{ stats_end_time }}"
+        select: "averageIops,averageLatencyUs,averageThroughputBps"
+      register: mt_stats_info
+      ignore_errors: true
+      # sample: <Need to add sample>

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_file_server_stat_v2
+    - ntnx_files_file_server_stats_info_v2

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,104 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    Build and return an SDK ApiClient for the Nutanix Files v4 SDK using
+    connection details supplied via module params (or env fallback).
+
+    Args:
+        module (AnsibleModule): the running Ansible module instance.
+
+    Returns:
+        ntnx_files_py_client.ApiClient: an authenticated API client.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    Fetch the etag header from a v4 SDK response object.
+
+    Args:
+        data: v4 SDK API response object.
+
+    Returns:
+        str: the etag string, or None if unavailable.
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_analytics_api_instance(module):
+    """
+    Return an AnalyticsApi instance for retrieving Nutanix Files stats.
+
+    Args:
+        module (AnsibleModule): the running Ansible module instance.
+
+    Returns:
+        ntnx_files_py_client.AnalyticsApi: analytics API instance.
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.AnalyticsApi(api_client=api_client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,96 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_file_server_stats(module, analytics_api, ext_id, **kwargs):
+    """
+    Retrieve statistics for a file server identified by ``ext_id``.
+
+    Args:
+        module (AnsibleModule): the running Ansible module instance.
+        analytics_api: AnalyticsApi instance from ntnx_files_py_client.
+        ext_id (str): file server external identifier.
+        **kwargs: additional query params passed through to the SDK call
+            (e.g. ``_startTime``, ``_endTime``, ``_samplingInterval``,
+            ``_statType``, ``_select``).
+
+    Returns:
+        SDK response object for the file server stats API.
+    """
+    try:
+        resp = analytics_api.get_file_server_stats(extId=ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching file server stats for ext_id: {0}".format(
+                ext_id
+            ),
+        )
+    return resp
+
+
+def get_antivirus_server_stats(
+    module, analytics_api, file_server_ext_id, ext_id, **kwargs
+):
+    """
+    Retrieve statistics for an antivirus server attached to a file server.
+
+    Args:
+        module (AnsibleModule): the running Ansible module instance.
+        analytics_api: AnalyticsApi instance from ntnx_files_py_client.
+        file_server_ext_id (str): external id of the parent file server.
+        ext_id (str): external id of the antivirus server.
+        **kwargs: additional query params passed through to the SDK call.
+
+    Returns:
+        SDK response object for the antivirus server stats API.
+    """
+    try:
+        resp = analytics_api.get_antivirus_server_stats(
+            fileServerExtId=file_server_ext_id, extId=ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching antivirus server stats for ext_id: {0}".format(
+                ext_id
+            ),
+        )
+    return resp
+
+
+def get_mount_target_stats(module, analytics_api, file_server_ext_id, ext_id, **kwargs):
+    """
+    Retrieve statistics for a mount target attached to a file server.
+
+    Args:
+        module (AnsibleModule): the running Ansible module instance.
+        analytics_api: AnalyticsApi instance from ntnx_files_py_client.
+        file_server_ext_id (str): external id of the parent file server.
+        ext_id (str): external id of the mount target.
+        **kwargs: additional query params passed through to the SDK call.
+
+    Returns:
+        SDK response object for the mount target stats API.
+    """
+    try:
+        resp = analytics_api.get_mount_target_stats(
+            fileServerExtId=file_server_ext_id, extId=ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching mount target stats for ext_id: {0}".format(
+                ext_id
+            ),
+        )
+    return resp

--- a/plugins/modules/ntnx_file_server_stat_v2.py
+++ b/plugins/modules/ntnx_file_server_stat_v2.py
@@ -1,0 +1,306 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_file_server_stat_v2
+short_description: Fetch statistics for a Nutanix File Server from Prism Central
+version_added: 2.7.0
+description:
+  - Fetch time-series performance and capacity statistics for a specific
+    Nutanix File Server managed by Prism Central.
+  - The Nutanix Files v4 stats APIs only expose read operations for File Server
+    statistics; there is no create, update, or delete API for this entity.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation.
+  - >-
+    B(Get File Server statistics) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin.
+options:
+  ext_id:
+    description:
+      - The external identifier of the File Server whose statistics are to be
+        fetched.
+    type: str
+    required: true
+  start_time:
+    description:
+      - The start time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format,
+        e.g. C(2024-07-31T12:41:56.955Z).
+    type: str
+    required: true
+  end_time:
+    description:
+      - The end time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format,
+        e.g. C(2025-07-31T12:41:56.955Z).
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - The sampling interval in seconds at which statistical data should be
+        collected. For example, provide C(30) to get data points every 30
+        seconds.
+    type: int
+    required: false
+  stat_type:
+    description:
+      - The down-sampling operator to apply when aggregating the raw stats
+        into the requested sampling interval.
+    type: str
+    required: false
+    choices:
+      - SUM
+      - AVG
+      - MIN
+      - MAX
+      - COUNT
+      - LAST
+  select:
+    description:
+      - Comma-separated list of specific stat properties to return.
+      - Follows the OData V4.01 C($select) query convention.
+      - >-
+        Valid property names include C(avCleanedFileCount), C(avLatencyMs),
+        C(avQuarantinedFileCount), C(avScannedFileCount), C(avThreatCount),
+        C(avThroughputBps), C(averageIops), C(averageLatencyUs),
+        C(averageThroughputBps), C(datasetSpaceUsedBytes),
+        C(icapDaemonQueueLength), C(metadataIops), C(metadataLatencyUs),
+        C(numberOfConnections), C(numberOfFiles), C(readIops),
+        C(readLatencyUs), C(readThroughputBps), C(snapshotUsedBytes),
+        C(totalTieredBytes), C(writeIops), C(writeLatencyUs),
+        C(writeThroughputBps). Use C(*) to return all properties.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch File Server stats for a given time window
+  nutanix.ncp.ntnx_file_server_stat_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "6ca5de7e-a9a8-4318-4a62-68b8d5833af7"
+    start_time: "2026-07-20T00:00:00.000Z"
+    end_time: "2026-07-21T00:00:00.000Z"
+  register: fs_stats
+
+- name: Fetch File Server stats with sampling interval and stat_type
+  nutanix.ncp.ntnx_file_server_stat_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "6ca5de7e-a9a8-4318-4a62-68b8d5833af7"
+    start_time: "2026-07-20T00:00:00.000Z"
+    end_time: "2026-07-21T00:00:00.000Z"
+    sampling_interval: 300
+    stat_type: "AVG"
+    select: "averageIops,averageLatencyUs,averageThroughputBps"
+  register: fs_stats
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The full API response for the File Server statistics query.
+    - Time-series stats are returned as lists of C({value, timestamp}) pairs.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "6ca5de7e-a9a8-4318-4a62-68b8d5833af7",
+      "links": null,
+      "tenant_id": null,
+      "average_iops": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 3}
+      ],
+      "average_latency_us": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 812}
+      ],
+      "average_throughput_bps": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 4096}
+      ],
+      "read_iops": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 2}
+      ],
+      "read_latency_us": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 750}
+      ],
+      "read_throughput_bps": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 3072}
+      ],
+      "write_iops": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 1}
+      ],
+      "write_latency_us": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 900}
+      ],
+      "write_throughput_bps": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 1024}
+      ],
+      "metadata_iops": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 0}
+      ],
+      "metadata_latency_us": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 0}
+      ],
+      "number_of_connections": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 1}
+      ],
+      "number_of_files": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 25}
+      ],
+      "snapshot_used_bytes": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 0}
+      ],
+      "dataset_space_used_bytes": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 10485760}
+      ],
+      "total_tiered_bytes": null,
+      "av_scanned_file_count": null,
+      "av_threat_count": null,
+      "av_cleaned_file_count": null,
+      "av_quarantined_file_count": null,
+      "av_latency_ms": null,
+      "av_throughput_bps": null,
+      "icap_daemon_queue_length": null
+    }
+ext_id:
+  description: External identifier of the File Server whose stats were fetched.
+  returned: always
+  type: str
+  sample: "6ca5de7e-a9a8-4318-4a62-68b8d5833af7"
+changed:
+  description: Whether the task resulted in any change. Always C(false).
+  returned: always
+  type: bool
+  sample: false
+failed:
+  description: Whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+msg:
+  description: Optional status/error message.
+  returned: When there is an error or nothing to return
+  type: str
+  sample: "Api Exception raised while fetching file server stats for ext_id: 6ca5de7e-a9a8-4318-4a62-68b8d5833af7"
+error:
+  description: The error message if an error occurs.
+  returned: When an error occurs
+  type: str
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import get_analytics_api_instance  # noqa: E402
+from ..module_utils.v4.files.helpers import (  # noqa: E402
+    get_file_server_stats as fetch_file_server_stats,
+)
+from ..module_utils.v4.utils import (  # noqa: E402
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int"),
+        stat_type=dict(
+            type="str",
+            choices=["SUM", "AVG", "MIN", "MAX", "COUNT", "LAST"],
+        ),
+        select=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_file_server_stat(module, api_instance, result):
+    """Populate ``result`` with the File Server stats response."""
+    validate_required_params(module, ["ext_id", "start_time", "end_time"])
+
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    kwargs = {
+        "_startTime": module.params.get("start_time"),
+        "_endTime": module.params.get("end_time"),
+    }
+    if module.params.get("sampling_interval") is not None:
+        kwargs["_samplingInterval"] = module.params.get("sampling_interval")
+    if module.params.get("stat_type") is not None:
+        kwargs["_statType"] = module.params.get("stat_type")
+    if module.params.get("select") is not None:
+        kwargs["_select"] = module.params.get("select")
+
+    resp = fetch_file_server_stats(module, api_instance, ext_id, **kwargs)
+
+    if getattr(resp, "data", None) is not None:
+        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    else:
+        module.fail_json(
+            msg="Failed to fetch file server stats for ext_id: {0}".format(ext_id),
+            **result,
+        )
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_analytics_api_instance(module)
+    get_file_server_stat(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_files_file_server_stats_info_v2.py
+++ b/plugins/modules/ntnx_files_file_server_stats_info_v2.py
@@ -1,0 +1,342 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_file_server_stats_info_v2
+short_description: Fetch File Server statistics info (File Server, Antivirus
+    Server, or Mount Target) from Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about FileServerStat in
+    Nutanix Prism Central.
+  - >-
+    When only C(ext_id) is provided, the module fetches statistics for the
+    File Server identified by C(ext_id).
+  - >-
+    When C(ext_id) is provided together with C(antivirus_server_ext_id), the
+    module fetches statistics for the given Antivirus Server attached to the
+    File Server.
+  - >-
+    When C(ext_id) is provided together with C(mount_target_ext_id), the
+    module fetches statistics for the given Mount Target attached to the
+    File Server.
+  - The Nutanix Files v4 stats APIs only expose read operations; there is no
+    list-all API for File Server stats — an entity ext_id is always required.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation.
+  - >-
+    B(Get statistics for File Server, Antivirus Server, or Mount Target) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin.
+options:
+  ext_id:
+    description:
+      - The external identifier of the File Server whose statistics are to be
+        fetched.
+      - Required for every operation.
+    type: str
+    required: true
+  antivirus_server_ext_id:
+    description:
+      - The external identifier of an Antivirus Server attached to the File
+        Server referenced by C(ext_id).
+      - When provided, the module fetches Antivirus Server statistics.
+      - Mutually exclusive with C(mount_target_ext_id).
+    type: str
+    required: false
+  mount_target_ext_id:
+    description:
+      - The external identifier of a Mount Target attached to the File Server
+        referenced by C(ext_id).
+      - When provided, the module fetches Mount Target statistics.
+      - Mutually exclusive with C(antivirus_server_ext_id).
+    type: str
+    required: false
+  start_time:
+    description:
+      - The start time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format,
+        e.g. C(2024-07-31T12:41:56.955Z).
+    type: str
+    required: true
+  end_time:
+    description:
+      - The end time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format,
+        e.g. C(2025-07-31T12:41:56.955Z).
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - The sampling interval in seconds at which statistical data should be
+        collected.
+    type: int
+    required: false
+  stat_type:
+    description:
+      - The down-sampling operator to apply when aggregating the raw stats
+        into the requested sampling interval.
+    type: str
+    required: false
+    choices:
+      - SUM
+      - AVG
+      - MIN
+      - MAX
+      - COUNT
+      - LAST
+  select:
+    description:
+      - Comma-separated list of specific stat properties to return.
+      - Follows the OData V4.01 C($select) query convention.
+      - Use C(*) to return all properties.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch File Server stats using ext_id
+  nutanix.ncp.ntnx_files_file_server_stats_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "6ca5de7e-a9a8-4318-4a62-68b8d5833af7"
+    start_time: "2026-07-20T00:00:00.000Z"
+    end_time: "2026-07-21T00:00:00.000Z"
+  register: fs_stats_info
+
+- name: Fetch Antivirus Server stats for a File Server
+  nutanix.ncp.ntnx_files_file_server_stats_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "6ca5de7e-a9a8-4318-4a62-68b8d5833af7"
+    antivirus_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    start_time: "2026-07-20T00:00:00.000Z"
+    end_time: "2026-07-21T00:00:00.000Z"
+    sampling_interval: 300
+    stat_type: "AVG"
+  register: av_stats_info
+
+- name: Fetch Mount Target stats for a File Server
+  nutanix.ncp.ntnx_files_file_server_stats_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "6ca5de7e-a9a8-4318-4a62-68b8d5833af7"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    start_time: "2026-07-20T00:00:00.000Z"
+    end_time: "2026-07-21T00:00:00.000Z"
+    select: "averageIops,averageLatencyUs"
+  register: mt_stats_info
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC FileServerStat info v4 API.
+    - >-
+      When C(antivirus_server_ext_id) is provided, the response is an
+      Antivirus Server stats object.
+    - >-
+      When C(mount_target_ext_id) is provided, the response is a Mount Target
+      stats object.
+    - Otherwise, the response is a File Server stats object.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "6ca5de7e-a9a8-4318-4a62-68b8d5833af7",
+      "links": null,
+      "tenant_id": null,
+      "average_iops": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 3}
+      ],
+      "average_latency_us": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 812}
+      ],
+      "average_throughput_bps": [
+          {"timestamp": "2026-07-20T00:00:00+00:00", "value": 4096}
+      ]
+    }
+ext_id:
+  description:
+    - The external identifier of the sub-entity queried (antivirus server or
+      mount target). When only File Server stats are queried, this is the
+      File Server C(ext_id).
+  returned: when a single entity is queried
+  type: str
+  sample: "6ca5de7e-a9a8-4318-4a62-68b8d5833af7"
+changed:
+  description: Whether the task resulted in any change. Always C(false).
+  returned: always
+  type: bool
+  sample: false
+failed:
+  description: Whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+msg:
+  description: Optional status/error message.
+  returned: When there is an error or nothing to return
+  type: str
+  sample: "Api Exception raised while fetching file server stats for ext_id: 6ca5de7e-a9a8-4318-4a62-68b8d5833af7"
+error:
+  description: The error message if an error occurs.
+  returned: When an error occurs
+  type: str
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import get_analytics_api_instance  # noqa: E402
+from ..module_utils.v4.files.helpers import (  # noqa: E402
+    get_antivirus_server_stats,
+    get_file_server_stats,
+    get_mount_target_stats,
+)
+from ..module_utils.v4.utils import (  # noqa: E402
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str", required=True),
+        antivirus_server_ext_id=dict(type="str"),
+        mount_target_ext_id=dict(type="str"),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int"),
+        stat_type=dict(
+            type="str",
+            choices=["SUM", "AVG", "MIN", "MAX", "COUNT", "LAST"],
+        ),
+        select=dict(type="str"),
+    )
+
+    return module_args
+
+
+def _build_common_kwargs(module):
+    kwargs = {
+        "_startTime": module.params.get("start_time"),
+        "_endTime": module.params.get("end_time"),
+    }
+    if module.params.get("sampling_interval") is not None:
+        kwargs["_samplingInterval"] = module.params.get("sampling_interval")
+    if module.params.get("stat_type") is not None:
+        kwargs["_statType"] = module.params.get("stat_type")
+    if module.params.get("select") is not None:
+        kwargs["_select"] = module.params.get("select")
+    return kwargs
+
+
+def get_stats(module, api_instance, result):
+    """Route to the correct stats endpoint based on the module params."""
+    validate_required_params(module, ["ext_id", "start_time", "end_time"])
+
+    file_server_ext_id = module.params.get("ext_id")
+    antivirus_ext_id = module.params.get("antivirus_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+
+    kwargs = _build_common_kwargs(module)
+
+    if antivirus_ext_id:
+        result["ext_id"] = antivirus_ext_id
+        resp = get_antivirus_server_stats(
+            module,
+            api_instance,
+            file_server_ext_id,
+            antivirus_ext_id,
+            **kwargs,
+        )
+        fail_msg = "Failed to fetch antivirus server stats for ext_id: {0}".format(
+            antivirus_ext_id
+        )
+    elif mount_target_ext_id:
+        result["ext_id"] = mount_target_ext_id
+        resp = get_mount_target_stats(
+            module,
+            api_instance,
+            file_server_ext_id,
+            mount_target_ext_id,
+            **kwargs,
+        )
+        fail_msg = "Failed to fetch mount target stats for ext_id: {0}".format(
+            mount_target_ext_id
+        )
+    else:
+        result["ext_id"] = file_server_ext_id
+        resp = get_file_server_stats(module, api_instance, file_server_ext_id, **kwargs)
+        fail_msg = "Failed to fetch file server stats for ext_id: {0}".format(
+            file_server_ext_id
+        )
+
+    if getattr(resp, "data", None) is not None:
+        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    else:
+        module.fail_json(msg=fail_msg, **result)
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+        mutually_exclusive=[
+            ("antivirus_server_ext_id", "mount_target_ext_id"),
+        ],
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_analytics_api_instance(module)
+    get_stats(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_file_server_stat_v2/aliases
+++ b/tests/integration/targets/ntnx_file_server_stat_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_file_server_stat_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_file_server_stat_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_file_server_stat_v2/tasks/file_server_stat.yml
+++ b/tests/integration/targets/ntnx_file_server_stat_v2/tasks/file_server_stat.yml
@@ -1,0 +1,306 @@
+---
+# =============================================================================
+# Integration tests for ntnx_file_server_stat_v2 and
+# ntnx_files_file_server_stats_info_v2.
+#
+# Test plan (Domain-Expert QA mindset):
+#
+# The Nutanix Files v4 stats APIs are read-only endpoints that require an
+# entity ext_id (File Server, Antivirus Server, or Mount Target). We therefore
+# cannot exercise a full create/update/delete lifecycle. Instead we cover:
+#
+#   1. Argument-spec validation for both modules
+#      - missing required params (ext_id / start_time / end_time)
+#      - invalid enum value for stat_type
+#      - mutually exclusive antivirus_server_ext_id vs mount_target_ext_id
+#
+#   2. Positive fetches (skipped if no File Server exists on the target PC):
+#      - fetch File Server stats with minimal params
+#      - fetch File Server stats with sampling_interval + stat_type + select
+#      - fetch same via the info module (default branch)
+#      - fetch antivirus server stats
+#      - fetch mount target stats
+#
+#   3. Negative fetches:
+#      - non-existent File Server ext_id returns an API error
+#      - non-existent Antivirus Server / Mount Target ext_id returns an error
+#
+# The playbook is idempotent: it only reads stats, it never mutates the
+# File Server, Antivirus Server, or Mount Target entities.
+# =============================================================================
+
+- name: Start ntnx_file_server_stat_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_file_server_stat_v2 tests
+
+- name: Compute time window for stats queries (last 1 hour)
+  ansible.builtin.set_fact:
+    fs_stat_end_time: "{{ ('%Y-%m-%dT%H:%M:%S.000Z' | strftime(ansible_date_time.epoch | int)) }}"
+    fs_stat_start_time: "{{ ('%Y-%m-%dT%H:%M:%S.000Z' | strftime((ansible_date_time.epoch | int) - 3600)) }}"
+
+- name: Show computed time window
+  ansible.builtin.debug:
+    msg: "Using window {{ fs_stat_start_time }} -> {{ fs_stat_end_time }}"
+
+# ---------------------------------------------------------------------------
+# 1. Argument-spec validation (does not require a live File Server)
+# ---------------------------------------------------------------------------
+
+- name: Negative - missing required ext_id for stat module
+  nutanix.ncp.ntnx_file_server_stat_v2:
+    start_time: "{{ fs_stat_start_time }}"
+    end_time: "{{ fs_stat_end_time }}"
+  register: missing_ext_id
+  ignore_errors: true
+
+- name: Assert missing ext_id is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id.failed == true
+      - missing_ext_id.changed == false
+      - "'ext_id' in missing_ext_id.msg"
+    fail_msg: "Expected missing ext_id to be rejected by the argument spec"
+    success_msg: "Missing ext_id correctly rejected"
+
+- name: Negative - missing start_time for stat module
+  nutanix.ncp.ntnx_file_server_stat_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    end_time: "{{ fs_stat_end_time }}"
+  register: missing_start
+  ignore_errors: true
+
+- name: Assert missing start_time is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_start.failed == true
+      - missing_start.changed == false
+      - "'start_time' in missing_start.msg"
+    fail_msg: "Expected missing start_time to be rejected by the argument spec"
+    success_msg: "Missing start_time correctly rejected"
+
+- name: Negative - missing end_time for stat module
+  nutanix.ncp.ntnx_file_server_stat_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    start_time: "{{ fs_stat_start_time }}"
+  register: missing_end
+  ignore_errors: true
+
+- name: Assert missing end_time is rejected
+  ansible.builtin.assert:
+    that:
+      - missing_end.failed == true
+      - missing_end.changed == false
+      - "'end_time' in missing_end.msg"
+    fail_msg: "Expected missing end_time to be rejected by the argument spec"
+    success_msg: "Missing end_time correctly rejected"
+
+- name: Negative - invalid enum value for stat_type
+  nutanix.ncp.ntnx_file_server_stat_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    start_time: "{{ fs_stat_start_time }}"
+    end_time: "{{ fs_stat_end_time }}"
+    stat_type: "NOT_A_REAL_OPERATOR"
+  register: bad_stat_type
+  ignore_errors: true
+
+- name: Assert invalid stat_type is rejected
+  ansible.builtin.assert:
+    that:
+      - bad_stat_type.failed == true
+      - bad_stat_type.changed == false
+      - "'value of stat_type must be one of' in bad_stat_type.msg or 'not a valid value' in bad_stat_type.msg"
+    fail_msg: "Expected invalid stat_type enum value to be rejected"
+    success_msg: "Invalid stat_type correctly rejected"
+
+- name: Negative - mutually exclusive antivirus_server_ext_id + mount_target_ext_id (info module)
+  nutanix.ncp.ntnx_files_file_server_stats_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    antivirus_server_ext_id: "18f78959-14a6-4c47-b5db-920460c4b668"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    start_time: "{{ fs_stat_start_time }}"
+    end_time: "{{ fs_stat_end_time }}"
+  register: mutex
+  ignore_errors: true
+
+- name: Assert mutually exclusive params are rejected
+  ansible.builtin.assert:
+    that:
+      - mutex.failed == true
+      - mutex.changed == false
+      - "'mutually exclusive' in mutex.msg"
+    fail_msg: "Expected mutually exclusive antivirus/mount-target ext_ids to be rejected"
+    success_msg: "Mutually exclusive params correctly rejected"
+
+# ---------------------------------------------------------------------------
+# 2. Negative API-level fetch with a bogus ext_id
+# ---------------------------------------------------------------------------
+
+- name: Negative - fetch stats for a non-existent File Server ext_id
+  nutanix.ncp.ntnx_file_server_stat_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    start_time: "{{ fs_stat_start_time }}"
+    end_time: "{{ fs_stat_end_time }}"
+  register: bogus_fs
+  ignore_errors: true
+
+- name: Assert bogus File Server ext_id returns an API error
+  ansible.builtin.assert:
+    that:
+      - bogus_fs.failed == true
+      - bogus_fs.changed == false
+    fail_msg: "Expected bogus File Server ext_id to return an API error"
+    success_msg: "Bogus File Server ext_id correctly failed at the API layer"
+
+- name: Negative - fetch antivirus stats for a non-existent File Server
+  nutanix.ncp.ntnx_files_file_server_stats_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    antivirus_server_ext_id: "00000000-0000-0000-0000-000000000001"
+    start_time: "{{ fs_stat_start_time }}"
+    end_time: "{{ fs_stat_end_time }}"
+  register: bogus_av
+  ignore_errors: true
+
+- name: Assert bogus antivirus stats fetch fails
+  ansible.builtin.assert:
+    that:
+      - bogus_av.failed == true
+      - bogus_av.changed == false
+    fail_msg: "Expected bogus antivirus stats fetch to fail"
+    success_msg: "Bogus antivirus stats fetch correctly failed"
+
+- name: Negative - fetch mount target stats for a non-existent File Server
+  nutanix.ncp.ntnx_files_file_server_stats_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    mount_target_ext_id: "00000000-0000-0000-0000-000000000002"
+    start_time: "{{ fs_stat_start_time }}"
+    end_time: "{{ fs_stat_end_time }}"
+  register: bogus_mt
+  ignore_errors: true
+
+- name: Assert bogus mount target stats fetch fails
+  ansible.builtin.assert:
+    that:
+      - bogus_mt.failed == true
+      - bogus_mt.changed == false
+    fail_msg: "Expected bogus mount target stats fetch to fail"
+    success_msg: "Bogus mount target stats fetch correctly failed"
+
+# ---------------------------------------------------------------------------
+# 3. Positive fetches — only run when a real File Server ext_id is supplied.
+#
+# The tester must set `file_server_ext_id` (and optionally
+# `antivirus_server_ext_id` and `mount_target_ext_id`) in
+# tests/integration/integration_config.yml to exercise these tasks.
+# If not set, positive tests are gracefully skipped.
+# ---------------------------------------------------------------------------
+
+- name: Positive branch - fetch File Server stats with minimal params
+  when: (file_server_ext_id | default('')) | length > 0
+  block:
+    - name: Fetch File Server stats using the stat module (minimal)
+      nutanix.ncp.ntnx_file_server_stat_v2:
+        ext_id: "{{ file_server_ext_id }}"
+        start_time: "{{ fs_stat_start_time }}"
+        end_time: "{{ fs_stat_end_time }}"
+      register: fs_stats_minimal
+
+    - name: Assert File Server stats minimal fetch succeeded
+      ansible.builtin.assert:
+        that:
+          - fs_stats_minimal.failed == false
+          - fs_stats_minimal.changed == false
+          - fs_stats_minimal.response is defined
+          - fs_stats_minimal.response is mapping
+          - fs_stats_minimal.ext_id == file_server_ext_id
+        fail_msg: "Failed to fetch File Server stats"
+        success_msg: "File Server stats fetched successfully"
+
+    - name: Fetch File Server stats with all optional params (full)
+      nutanix.ncp.ntnx_file_server_stat_v2:
+        ext_id: "{{ file_server_ext_id }}"
+        start_time: "{{ fs_stat_start_time }}"
+        end_time: "{{ fs_stat_end_time }}"
+        sampling_interval: 300
+        stat_type: "AVG"
+        select: "averageIops,averageLatencyUs,averageThroughputBps"
+      register: fs_stats_full
+
+    - name: Assert File Server stats full fetch succeeded
+      ansible.builtin.assert:
+        that:
+          - fs_stats_full.failed == false
+          - fs_stats_full.changed == false
+          - fs_stats_full.response is defined
+          - fs_stats_full.response is mapping
+          - fs_stats_full.ext_id == file_server_ext_id
+        fail_msg: "Failed to fetch File Server stats with all params"
+        success_msg: "File Server stats with all params fetched successfully"
+
+    - name: Fetch File Server stats via the info module (default branch)
+      nutanix.ncp.ntnx_files_file_server_stats_info_v2:
+        ext_id: "{{ file_server_ext_id }}"
+        start_time: "{{ fs_stat_start_time }}"
+        end_time: "{{ fs_stat_end_time }}"
+      register: fs_stats_info
+
+    - name: Assert File Server stats info fetch succeeded
+      ansible.builtin.assert:
+        that:
+          - fs_stats_info.failed == false
+          - fs_stats_info.changed == false
+          - fs_stats_info.response is defined
+          - fs_stats_info.response is mapping
+          - fs_stats_info.ext_id == file_server_ext_id
+        fail_msg: "Failed to fetch File Server stats via info module"
+        success_msg: "File Server stats via info module fetched successfully"
+
+- name: Positive branch - fetch Antivirus Server stats
+  when: >
+    (file_server_ext_id | default('')) | length > 0 and
+    (antivirus_server_ext_id | default('')) | length > 0
+  block:
+    - name: Fetch Antivirus Server stats
+      nutanix.ncp.ntnx_files_file_server_stats_info_v2:
+        ext_id: "{{ file_server_ext_id }}"
+        antivirus_server_ext_id: "{{ antivirus_server_ext_id }}"
+        start_time: "{{ fs_stat_start_time }}"
+        end_time: "{{ fs_stat_end_time }}"
+        sampling_interval: 300
+        stat_type: "AVG"
+      register: av_stats
+
+    - name: Assert Antivirus Server stats fetch succeeded
+      ansible.builtin.assert:
+        that:
+          - av_stats.failed == false
+          - av_stats.changed == false
+          - av_stats.response is defined
+          - av_stats.response is mapping
+          - av_stats.ext_id == antivirus_server_ext_id
+        fail_msg: "Failed to fetch Antivirus Server stats"
+        success_msg: "Antivirus Server stats fetched successfully"
+
+- name: Positive branch - fetch Mount Target stats
+  when: >
+    (file_server_ext_id | default('')) | length > 0 and
+    (mount_target_ext_id | default('')) | length > 0
+  block:
+    - name: Fetch Mount Target stats
+      nutanix.ncp.ntnx_files_file_server_stats_info_v2:
+        ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        start_time: "{{ fs_stat_start_time }}"
+        end_time: "{{ fs_stat_end_time }}"
+        select: "averageIops,averageLatencyUs,averageThroughputBps"
+      register: mt_stats
+
+    - name: Assert Mount Target stats fetch succeeded
+      ansible.builtin.assert:
+        that:
+          - mt_stats.failed == false
+          - mt_stats.changed == false
+          - mt_stats.response is defined
+          - mt_stats.response is mapping
+          - mt_stats.ext_id == mount_target_ext_id
+        fail_msg: "Failed to fetch Mount Target stats"
+        success_msg: "Mount Target stats fetched successfully"

--- a/tests/integration/targets/ntnx_file_server_stat_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_file_server_stat_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults for the FileServerStat v2 tests
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import FileServerStat tests
+      ansible.builtin.import_tasks: "file_server_stat.yml"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **files** namespace, entity
**FileServerStat**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_file_server_stat_v2`, `ntnx_files_file_server_stats_info_v2`
- API methods covered: 3 (`GetFileServerStats`, `GetAntivirusServerStats`, `GetMountTargetStats`)
- Fields in stat module spec: 6 (`ext_id`, `start_time`, `end_time`, `sampling_interval`, `stat_type`, `select`) + `read_timeout`
- Fields in info module spec: 8 (`ext_id`, `antivirus_server_ext_id`, `mount_target_ext_id`, `start_time`, `end_time`, `sampling_interval`, `stat_type`, `select`) + `read_timeout`

Both modules are stats-info modules because the SDK exposes read-only APIs for
FileServerStat (no create / update / delete). They mirror the pattern used by
`ntnx_storage_containers_stats_v2` and the info-module conventions of
`ntnx_virtual_switches_info_v2`.

## Domain knowledge (from Glean)

Enterprise-search results for FileServerStat (only public / product-level
titles retained per instructions - Confluence and Jira URLs intentionally
omitted):

- Files v4 API surface is separated from AOS APIs since Nutanix Files 4.0;
  early-release v4 APIs were introduced in Files 4.2.
- `AnalyticsApi.GetFileServerStats` on
  `/api/files/v4.0/stats/file-servers/{extId}` returns time-series
  performance and capacity stats (IOPS, latency, throughput, connection /
  file counts, dataset / snapshot / tiered bytes, AV counters).
- Sub-entity stats are read via
  `AnalyticsApi.GetAntivirusServerStats` and
  `AnalyticsApi.GetMountTargetStats`, which additionally require the parent
  `fileServerExtId`.
- All stats endpoints require `_startTime` / `_endTime` in extended ISO-8601
  form; optional `_samplingInterval` sets bucket granularity and `_statType`
  applies a down-sampling operator (`SUM`, `AVG`, `MIN`, `MAX`, `COUNT`,
  `LAST`). `_select` accepts an OData V4.01 `$select` expression to project
  a subset of stat properties.
- Required domain skills: Nutanix Files v4 API surface & rate limits,
  OData V4.01 `$select`/query semantics, ISO-8601 time windows, PC v4 IAM
  roles (Prism Admin / Prism Viewer / Super Admin), and general Ansible
  module design (`BaseInfoModule`, `strip_internal_attributes`,
  `raise_api_exception`).

## Files changed

- `plugins/modules/`
  - `ntnx_file_server_stat_v2.py` (new - stat fetch module)
  - `ntnx_files_file_server_stats_info_v2.py` (new - info module, routes to
    File Server / Antivirus Server / Mount Target stats endpoints)
- `plugins/module_utils/v4/files/` (new package)
  - `__init__.py`
  - `api_client.py` (Files SDK ApiClient + AnalyticsApi factory)
  - `helpers.py` (stat-fetch helpers with exception wrapping)
- `examples/files/FileServerStat/`
  - `file_server_stat.yml` (single example playbook covering all operations)
  - `examples_run.log` (real playbook output captured against the live PC)
- `tests/integration/targets/ntnx_file_server_stat_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/file_server_stat.yml`
- `meta/runtime.yml` - registered both new modules under the `ntnx`
  action group so `module_defaults` (`group/nutanix.ncp.ntnx`) applies.

## Test execution

| Metric              | Value                                                                 |
|---------------------|-----------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_file_server_stat_v2 --allow-unsupported --allow-disabled --python 3.11 -v` |
| Total tasks         | 30 (20 ok + 10 skipped)                                                |
| Passed (ok)         | 20                                                                     |
| Failed              | 0                                                                      |
| Skipped             | 10 (positive-path stats fetches - see analysis)                        |
| Ignored errors      | 8 (deliberate negative tests, module fails as expected)                |
| Duration            | ~4 min 47 sec                                                          |
| Cluster (PC)        | 10.44.76.28 (Prism Central endpoint from `pc_endpoint`)                |

### Analysis

- **Argument-spec validation** - every required field (`ext_id`, `start_time`,
  `end_time`), the `stat_type` enum, and the `antivirus_server_ext_id` /
  `mount_target_ext_id` mutually-exclusive rule are exercised. All argument
  validation tests pass.
- **Negative API-level fetches** - 3 tasks (bogus File Server, bogus
  Antivirus Server, bogus Mount Target ext_ids) intentionally hit the live
  PC. All return `503 SERVICE UNAVAILABLE` because the target Prism Central
  does not have the Nutanix Files service enabled on port 7509
  (`Http request to endpoint 0:127.0.0.1:7509 failed with error. Response
  status: 2`). The tests treat this as "API-layer failure = pass" so the
  negative branches still assert cleanly.
- **Positive-path stats fetches (skipped)** - the target PC has zero File
  Servers configured (verified via `POST /api/nutanix/v3/groups` with
  `entity_type=file_server_service` returning `total_entity_count=0`). The
  test playbook is written to gracefully skip these branches when
  `file_server_ext_id` / `antivirus_server_ext_id` / `mount_target_ext_id`
  are empty in `tests/integration/integration_config.yml`. Populate these
  vars on a cluster with a real File Server to exercise the happy paths.
- **Known cluster-prerequisite gap** - no Nutanix Files deployment on the
  supplied PC endpoint, so real response `sample:` values could not be
  captured for the example playbook. The example DOCUMENTATION `sample:`
  blocks retain representative shapes based on the SDK model attribute maps
  (`FileServerStats`, `AntivirusStats`, `MountTargetStats`,
  `TimeIntValuePair`).

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text
  ^ column 1

Using /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_file_server_stat_v2-t5jk_20p-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_file_server_stat_v2 : Start ntnx_file_server_stat_v2 tests] *********
ok: [testhost] => {
    "msg": "Start ntnx_file_server_stat_v2 tests"
}

TASK [ntnx_file_server_stat_v2 : Compute time window for stats queries (last 1 hour)] ***
ok: [testhost] => {"ansible_facts": {"fs_stat_end_time": "2026-07-21T07:12:07.000Z", "fs_stat_start_time": "2026-07-21T06:12:07.000Z"}, "changed": false}

TASK [ntnx_file_server_stat_v2 : Show computed time window] ********************
ok: [testhost] => {
    "msg": "Using window 2026-07-21T06:12:07.000Z -> 2026-07-21T07:12:07.000Z"
}

TASK [ntnx_file_server_stat_v2 : Negative - missing required ext_id for stat module] ***
[ERROR]: Task failed: Module failed: missing required arguments: ext_id
Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_file_server_stat_v2-t5jk_20p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_file_server_stat_v2/tasks/file_server_stat.yml:49:3

47 # ---------------------------------------------------------------------------
48
49 - name: Negative - missing required ext_id for stat module
     ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: ext_id"}
...ignoring

TASK [ntnx_file_server_stat_v2 : Assert missing ext_id is rejected] ************
ok: [testhost] => {
    "changed": false,
    "msg": "Missing ext_id correctly rejected"
}

TASK [ntnx_file_server_stat_v2 : Negative - missing start_time for stat module] ***
[ERROR]: Task failed: Module failed: missing required arguments: start_time
Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_file_server_stat_v2-t5jk_20p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_file_server_stat_v2/tasks/file_server_stat.yml:65:3

63     success_msg: "Missing ext_id correctly rejected"
64
65 - name: Negative - missing start_time for stat module
     ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: start_time"}
...ignoring

TASK [ntnx_file_server_stat_v2 : Assert missing start_time is rejected] ********
ok: [testhost] => {
    "changed": false,
    "msg": "Missing start_time correctly rejected"
}

TASK [ntnx_file_server_stat_v2 : Negative - missing end_time for stat module] ***
[ERROR]: Task failed: Module failed: missing required arguments: end_time
Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_file_server_stat_v2-t5jk_20p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_file_server_stat_v2/tasks/file_server_stat.yml:81:3

79     success_msg: "Missing start_time correctly rejected"
80
81 - name: Negative - missing end_time for stat module
     ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: end_time"}
...ignoring

TASK [ntnx_file_server_stat_v2 : Assert missing end_time is rejected] **********
ok: [testhost] => {
    "changed": false,
    "msg": "Missing end_time correctly rejected"
}

TASK [ntnx_file_server_stat_v2 : Negative - invalid enum value for stat_type] ***
[ERROR]: Task failed: Module failed: value of stat_type must be one of: SUM, AVG, MIN, MAX, COUNT, LAST, got: NOT_A_REAL_OPERATOR
Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_file_server_stat_v2-t5jk_20p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_file_server_stat_v2/tasks/file_server_stat.yml:97:3

95     success_msg: "Missing end_time correctly rejected"
96
97 - name: Negative - invalid enum value for stat_type
     ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of stat_type must be one of: SUM, AVG, MIN, MAX, COUNT, LAST, got: NOT_A_REAL_OPERATOR"}
...ignoring

TASK [ntnx_file_server_stat_v2 : Assert invalid stat_type is rejected] *********
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid stat_type correctly rejected"
}

TASK [ntnx_file_server_stat_v2 : Negative - mutually exclusive antivirus_server_ext_id + mount_target_ext_id (info module)] ***
[ERROR]: Task failed: Module failed: parameters are mutually exclusive: antivirus_server_ext_id|mount_target_ext_id
Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_file_server_stat_v2-t5jk_20p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_file_server_stat_v2/tasks/file_server_stat.yml:115:3

113     success_msg: "Invalid stat_type correctly rejected"
114
115 - name: Negative - mutually exclusive antivirus_server_ext_id + mount_target_ext_id (info module)
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: antivirus_server_ext_id|mount_target_ext_id"}
...ignoring

TASK [ntnx_file_server_stat_v2 : Assert mutually exclusive params are rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Mutually exclusive params correctly rejected"
}

TASK [ntnx_file_server_stat_v2 : Negative - fetch stats for a non-existent File Server ext_id] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching file server stats for ext_id: 00000000-0000-0000-0000-000000000000
Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_file_server_stat_v2-t5jk_20p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_file_server_stat_v2/tasks/file_server_stat.yml:138:3

136 # ---------------------------------------------------------------------------
137
138 - name: Negative - fetch stats for a non-existent File Server ext_id
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching file server stats for ext_id: 00000000-0000-0000-0000-000000000000", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_file_server_stat_v2 : Assert bogus File Server ext_id returns an API error] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Bogus File Server ext_id correctly failed at the API layer"
}

TASK [ntnx_file_server_stat_v2 : Negative - fetch antivirus stats for a non-existent File Server] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching antivirus server stats for ext_id: 00000000-0000-0000-0000-000000000001
Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_file_server_stat_v2-t5jk_20p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_file_server_stat_v2/tasks/file_server_stat.yml:154:3

152     success_msg: "Bogus File Server ext_id correctly failed at the API layer"
153
154 - name: Negative - fetch antivirus stats for a non-existent File Server
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching antivirus server stats for ext_id: 00000000-0000-0000-0000-000000000001", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_file_server_stat_v2 : Assert bogus antivirus stats fetch fails] *****
ok: [testhost] => {
    "changed": false,
    "msg": "Bogus antivirus stats fetch correctly failed"
}

TASK [ntnx_file_server_stat_v2 : Negative - fetch mount target stats for a non-existent File Server] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching mount target stats for ext_id: 00000000-0000-0000-0000-000000000002
Origin: /tmp/codegen/99ced00bfb594a0c9e7e360af47debec/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_file_server_stat_v2-t5jk_20p-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_file_server_stat_v2/tasks/file_server_stat.yml:171:3

169     success_msg: "Bogus antivirus stats fetch correctly failed"
170
171 - name: Negative - fetch mount target stats for a non-existent File Server
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching mount target stats for ext_id: 00000000-0000-0000-0000-000000000002", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_file_server_stat_v2 : Assert bogus mount target stats fetch fails] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Bogus mount target stats fetch correctly failed"
}

TASK [ntnx_file_server_stat_v2 : Fetch File Server stats using the stat module (minimal)] ***
skipping: [testhost] => {"changed": false, "false_condition": "(file_server_ext_id | default('')) | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_file_server_stat_v2 : Assert File Server stats minimal fetch succeeded] ***
skipping: [testhost] => {"changed": false, "false_condition": "(file_server_ext_id | default('')) | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_file_server_stat_v2 : Fetch File Server stats with all optional params (full)] ***
skipping: [testhost] => {"changed": false, "false_condition": "(file_server_ext_id | default('')) | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_file_server_stat_v2 : Assert File Server stats full fetch succeeded] ***
skipping: [testhost] => {"changed": false, "false_condition": "(file_server_ext_id | default('')) | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_file_server_stat_v2 : Fetch File Server stats via the info module (default branch)] ***
skipping: [testhost] => {"changed": false, "false_condition": "(file_server_ext_id | default('')) | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_file_server_stat_v2 : Assert File Server stats info fetch succeeded] ***
skipping: [testhost] => {"changed": false, "false_condition": "(file_server_ext_id | default('')) | length > 0", "skip_reason": "Conditional result was False"}

TASK [ntnx_file_server_stat_v2 : Fetch Antivirus Server stats] *****************
skipping: [testhost] => {"changed": false, "false_condition": "(file_server_ext_id | default('')) | length > 0 and (antivirus_server_ext_id | default('')) | length > 0\n", "skip_reason": "Conditional result was False"}

TASK [ntnx_file_server_stat_v2 : Assert Antivirus Server stats fetch succeeded] ***
skipping: [testhost] => {"changed": false, "false_condition": "(file_server_ext_id | default('')) | length > 0 and (antivirus_server_ext_id | default('')) | length > 0\n", "skip_reason": "Conditional result was False"}

TASK [ntnx_file_server_stat_v2 : Fetch Mount Target stats] *********************
skipping: [testhost] => {"changed": false, "false_condition": "(file_server_ext_id | default('')) | length > 0 and (mount_target_ext_id | default('')) | length > 0\n", "skip_reason": "Conditional result was False"}

TASK [ntnx_file_server_stat_v2 : Assert Mount Target stats fetch succeeded] ****
skipping: [testhost] => {"changed": false, "false_condition": "(file_server_ext_id | default('')) | length > 0 and (mount_target_ext_id | default('')) | length > 0\n", "skip_reason": "Conditional result was False"}

PLAY RECAP *********************************************************************
testhost                   : ok=20   changed=0    unreachable=0    failed=0    skipped=10   rescued=0    ignored=8   


```

</details>

### Example playbook execution

- Command: `ansible-playbook examples/files/FileServerStat/file_server_stat.yml -v`
- Cluster: `10.44.76.28`
- Result: `ok=5, failed=0, ignored=5` (every stats call returned 503 because
  the Files service is not deployed on this PC; each task uses
  `ignore_errors: true` so the playbook completes cleanly).
- Real playbook output is committed at
  `examples/files/FileServerStat/examples_run.log`.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Modules and tests follow the patterns from `ntnx_storage_containers_stats_v2`
  (stats fetch module) and `ntnx_virtual_switches_info_v2` (info module).
- Linting: `black`, `isort`, `flake8`, `ansible-lint`, and
  `ansible-test sanity --python 3.11` (all 24 sanity tests) all pass with 0
  failures on the newly added files.
