### PR TITLE
code-gen(ncm_operation_base_platform/ReportArtifact): ansible collection modules

### DIFF
--- a/examples/ncm_operation_base_platform/ReportArtifact/examples_run.log
+++ b/examples/ncm_operation_base_platform/ReportArtifact/examples_run.log
@@ -1,0 +1,22 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Nutanix opsmgmt ReportArtifact playbook] *********************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"report_artifact_logo_b64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAA SUVORK5CYII=", "report_artifact_logo_path": "/tmp/report_logo.png", "report_artifact_logo_updated_b64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAA SUVORK5CYII=", "report_artifact_logo_updated_path": "/tmp/report_logo_updated.png"}, "changed": false}
+
+TASK [Ensure a small PNG payload exists (create sample logo)] ******************
+changed: [localhost] => {"changed": true, "cmd": ["bash", "-c", "echo -n \"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=\" | base64 -d > \"/tmp/report_logo.png\""], "delta": "0:00:00.006335", "end": "2026-07-21 07:24:11.197372", "msg": "", "rc": 0, "start": "2026-07-21 07:24:11.191037", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+
+TASK [Ensure a second small PNG payload exists (for update)] *******************
+changed: [localhost] => {"changed": true, "cmd": ["bash", "-c", "echo -n \"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=\" | base64 -d > \"/tmp/report_logo_updated.png\""], "delta": "0:00:00.006771", "end": "2026-07-21 07:24:11.427172", "msg": "", "rc": 0, "start": "2026-07-21 07:24:11.420401", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+
+TASK [Create ReportArtifact (LOGO / PNG) with binary upload] *******************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while creating report artifact", "response": {"message": "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again."}, "status": 404}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=3    changed=2    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
+

--- a/examples/ncm_operation_base_platform/ReportArtifact/report_artifacts.yml
+++ b/examples/ncm_operation_base_platform/ReportArtifact/report_artifacts.yml
@@ -1,0 +1,85 @@
+---
+# Summary:
+# This playbook demonstrates the full ReportArtifact workflow:
+# 1. Create a ReportArtifact (LOGO / PNG metadata + upload binary).
+# 2. Update the artifact (re-upload the binary via ext_id).
+# 3. Get the artifact by ext_id.
+# 4. List all artifacts, list with filter, list with limit.
+# 5. Delete (reports skipped: the opsmgmt v4 API does not support delete).
+
+- name: Nutanix opsmgmt ReportArtifact playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        report_artifact_logo_path: "/tmp/report_logo.png"
+        report_artifact_logo_updated_path: "/tmp/report_logo_updated.png"
+        # 1x1 transparent PNG (base64 encoded).
+        report_artifact_logo_b64: >-
+          iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAA
+          SUVORK5CYII=
+        # A second tiny PNG for update flow.
+        report_artifact_logo_updated_b64: >-
+          iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAA
+          SUVORK5CYII=
+
+    - name: Ensure a small PNG payload exists (create sample logo)
+      ansible.builtin.command:
+        cmd: bash -c 'echo -n "{{ report_artifact_logo_b64 | replace(" ", "") }}" | base64 -d > "{{ report_artifact_logo_path }}"'
+      changed_when: true
+
+    - name: Ensure a second small PNG payload exists (for update)
+      ansible.builtin.command:
+        cmd: bash -c 'echo -n "{{ report_artifact_logo_updated_b64 | replace(" ", "") }}" | base64 -d > "{{ report_artifact_logo_updated_path }}"'
+      changed_when: true
+
+    - name: Create ReportArtifact (LOGO / PNG) with binary upload
+      nutanix.ncp.ntnx_report_artifact_v2:
+        state: present
+        type: LOGO
+        file_type: PNG
+        file_path: "{{ report_artifact_logo_path }}"
+      register: create_result
+
+    - name: Set report_artifact_ext_id
+      ansible.builtin.set_fact:
+        report_artifact_ext_id: "{{ create_result.ext_id }}"
+
+    - name: Update ReportArtifact by re-uploading a new binary
+      nutanix.ncp.ntnx_report_artifact_v2:
+        state: present
+        ext_id: "{{ report_artifact_ext_id }}"
+        file_path: "{{ report_artifact_logo_updated_path }}"
+      register: update_result
+
+    - name: Get ReportArtifact using ext_id
+      nutanix.ncp.ntnx_report_artifacts_info_v2:
+        ext_id: "{{ report_artifact_ext_id }}"
+      register: get_result
+
+    - name: List all ReportArtifacts
+      nutanix.ncp.ntnx_report_artifacts_info_v2:
+      register: list_result
+
+    - name: List ReportArtifacts with filter
+      nutanix.ncp.ntnx_report_artifacts_info_v2:
+        filter: "type eq 'LOGO'"
+      register: filter_result
+
+    - name: List ReportArtifacts with limit
+      nutanix.ncp.ntnx_report_artifacts_info_v2:
+        limit: 1
+      register: limit_result
+
+    - name: Delete ReportArtifact (opsmgmt v4 API does not support delete)
+      nutanix.ncp.ntnx_report_artifact_v2:
+        state: absent
+        ext_id: "{{ report_artifact_ext_id }}"
+      register: delete_result

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_report_artifact_v2
+    - ntnx_report_artifacts_info_v2

--- a/plugins/module_utils/v4/opsmgmt/api_client.py
+++ b/plugins/module_utils/v4/opsmgmt/api_client.py
@@ -1,0 +1,122 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_opsmgmt_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    Return an authenticated ``ntnx_opsmgmt_py_client.ApiClient`` for the
+    NCM Operation Base Platform (``opsmgmt``) namespace.
+
+    Args:
+        module (AnsibleModule): the calling Ansible module — the standard
+            v2 connection parameters (``nutanix_host``, ``nutanix_port``,
+            ``nutanix_username``/``nutanix_password`` or
+            ``nutanix_api_key``, ``validate_certs``, ``read_timeout``,
+            proxy fields) are read from ``module.params``.
+
+    Returns:
+        ntnx_opsmgmt_py_client.ApiClient: a configured client with
+        Basic-Auth (or API-key) headers, proxy settings, and version
+        negotiation applied.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_opsmgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_opsmgmt_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    try:
+        client = ntnx_opsmgmt_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_opsmgmt_py_client.ApiClient(configuration=config)
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    client = ntnx_opsmgmt_py_client.ApiClient(
+        configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+    )
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    Extract the HTTP ETag from an opsmgmt v4 API response envelope.
+
+    Args:
+        data: opsmgmt v4 API response body (typically the top-level
+            ``*ApiResponse`` object returned by an SDK call).
+
+    Returns:
+        str | None: the ETag value if the response carries one, otherwise
+        ``None`` (which callers should treat as "no optimistic locking
+        header available").
+    """
+    return ntnx_opsmgmt_py_client.ApiClient.get_etag(data)
+
+
+def get_report_artifacts_api_instance(module):
+    """
+    Return a ``ReportArtifactsApi`` instance bound to a fresh opsmgmt
+    ApiClient built from ``module``.
+
+    This is the only entry point modules should use to talk to the
+    ReportArtifacts endpoints (``/api/opsmgmt/v4.1.b1/content/report-artifacts``)
+    so credentials, proxy configuration, and logging stay consistent
+    across modules.
+
+    Args:
+        module (AnsibleModule): the calling Ansible module.
+
+    Returns:
+        ntnx_opsmgmt_py_client.ReportArtifactsApi: SDK API instance ready
+        for create / list / upload / download calls.
+    """
+    api_client = get_api_client(module)
+    return ntnx_opsmgmt_py_client.ReportArtifactsApi(api_client=api_client)

--- a/plugins/module_utils/v4/opsmgmt/helpers.py
+++ b/plugins/module_utils/v4/opsmgmt/helpers.py
@@ -1,0 +1,50 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_report_artifact_by_ext_id(module, api_instance, ext_id):
+    """
+    Fetch a single :class:`ReportArtifact` by its external ID.
+
+    The opsmgmt v4 ``ReportArtifactsApi`` does not expose a dedicated
+    "get-by-id" endpoint. Instead we use the list API with an OData
+    ``$filter=extId eq '<uuid>'`` (which is what the Prism UI also does)
+    and return the first match.
+
+    Args:
+        module (AnsibleModule): the calling Ansible module — used only
+            to route SDK errors through :func:`raise_api_exception`.
+        api_instance (ntnx_opsmgmt_py_client.ReportArtifactsApi): SDK
+            client built by :func:`get_report_artifacts_api_instance`.
+        ext_id (str): the ``extId`` (UUID) of the report artifact to
+            retrieve. Must not be ``None`` — the caller is expected to
+            validate presence before invoking this helper.
+
+    Returns:
+        ntnx_opsmgmt_py_client.models.opsmgmt.v4.content.ReportArtifact | None:
+        the matching artifact object, or ``None`` if the list call
+        succeeded but no artifact has the requested ``ext_id``.
+    """
+    try:
+        resp = api_instance.list_report_artifacts(
+            _filter="extId eq '{0}'".format(ext_id)
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching report artifact info using ext_id",
+        )
+        return None
+
+    data = getattr(resp, "data", None) or []
+    for item in data:
+        if getattr(item, "ext_id", None) == ext_id:
+            return item
+    return None

--- a/plugins/modules/ntnx_report_artifact_v2.py
+++ b/plugins/modules/ntnx_report_artifact_v2.py
@@ -1,0 +1,484 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_report_artifact_v2
+short_description: Create, Update, Delete report artifacts in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to create and manage report artifacts in Nutanix Prism Central.
+  - A ReportArtifact stores a binary asset (typically a LOGO in PNG/JPEG format) that is
+    embedded in generated NCM/Intelligent Operations reports.
+  - Creation is a two-step workflow, only the metadata (I(type), I(file_type)) is required
+    up front; the binary can then be uploaded by providing I(file_path).
+  - When updating an existing artifact (I(ext_id) set) this module re-uploads the binary
+    file, since the underlying opsmgmt v4 API does not support metadata mutation.
+  - The opsmgmt v4 API does not currently expose a delete endpoint; C(state=absent)
+    is therefore reported as skipped with a descriptive message.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user
+      performing the operation. The required roles depend on the operation being performed.
+    - >-
+      B(Create a Report Artifact) -
+      Required Roles: Prism Admin, Super Admin, NCM Admin, Intelligent Ops Admin, Project Admin
+    - >-
+      B(Upload a Report Artifact binary) -
+      Required Roles: Prism Admin, Super Admin, NCM Admin, Intelligent Ops Admin, Project Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=opsmgmt)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided the operation is
+        create report artifact (optionally followed by an upload of I(file_path)).
+      - If C(state) is set to C(present) and C(ext_id) is provided the operation is
+        upload/replace the artifact binary for the existing metadata (I(file_path) is
+        required in that case).
+      - If C(state) is set to C(absent) and C(ext_id) is provided the module reports
+        a skipped operation because the opsmgmt v4 ReportArtifact API does not expose a
+        delete endpoint.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of an existing report artifact.
+      - Required for update and delete-style operations.
+    type: str
+    required: false
+  type:
+    description:
+      - Type of the report artifact.
+      - Required for create operation.
+    type: str
+    required: false
+    choices:
+      - LOGO
+  file_type:
+    description:
+      - File extension / MIME family of the report artifact binary.
+      - Required for create operation.
+    type: str
+    required: false
+    choices:
+      - PNG
+      - JPEG
+  file_path:
+    description:
+      - Local filesystem path to the binary file (PNG/JPEG) that must be uploaded to
+        the report artifact.
+      - When provided together with a create operation the module will first create
+        the artifact metadata and then upload the binary.
+      - Required when I(ext_id) is provided and I(state) is C(present) — in that case
+        this module re-uploads the binary for the existing artifact.
+    type: path
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create report artifact metadata only
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    type: LOGO
+    file_type: PNG
+  register: result
+
+- name: Create report artifact and upload binary in one step
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    type: LOGO
+    file_type: PNG
+    file_path: /tmp/report_logo.png
+  register: result
+
+- name: Upload a new binary for an existing report artifact (update flow)
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    ext_id: "e4f3a1c2-1a29-4a4b-8f2e-4b5f2f9c0f11"
+    file_path: /tmp/updated_report_logo.png
+  register: result
+
+- name: Delete report artifact (reports skipped — API does not support delete)
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: absent
+    ext_id: "e4f3a1c2-1a29-4a4b-8f2e-4b5f2f9c0f11"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating or uploading a report artifact.
+    - For create it is the ReportArtifact entity returned by the API (including the
+      newly assigned C(ext_id)).
+    - For a create-plus-upload flow, this is the ReportArtifact enriched with the
+      response from the upload action.
+    - For an update flow (upload only) it is the response of the upload action.
+    - For a delete-style call (C(state=absent)) it echoes the informational message.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "e4f3a1c2-1a29-4a4b-8f2e-4b5f2f9c0f11",
+      "file_type": "PNG",
+      "links": null,
+      "tenant_id": null,
+      "type": "LOGO"
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+    - The opsmgmt ReportArtifact API is synchronous and does not return a task
+      reference — this field is therefore always C(null) for this module.
+  returned: always
+  type: str
+  sample: null
+
+ext_id:
+  description:
+    - The external ID of the report artifact.
+  returned: always
+  type: str
+  sample: "e4f3a1c2-1a29-4a4b-8f2e-4b5f2f9c0f11"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description:
+    - This indicates whether the task was skipped (idempotency or an operation the
+      API does not support, e.g. delete).
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "ReportArtifact with ext_id:'e4f3a1c2-1a29-4a4b-8f2e-4b5f2f9c0f11' cannot be deleted. Delete is not supported by the opsmgmt v4 ReportArtifact API."
+"""
+
+import os  # noqa: E402
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.opsmgmt.api_client import (  # noqa: E402
+    get_report_artifacts_api_instance,
+)
+from ..module_utils.v4.opsmgmt.helpers import (  # noqa: E402
+    get_report_artifact_by_ext_id,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_opsmgmt_py_client as ncm_operation_base_platform_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402
+        mock_sdk as ncm_operation_base_platform_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    """
+    Argument spec for :module:`ntnx_report_artifact_v2`.
+
+    Every field mirrors the ``ReportArtifact`` model in the opsmgmt v4 SDK:
+
+    * ``type`` and ``file_type`` are enums — ``choices=`` restricts them to
+      the values the SDK's :class:`ArtifactType` / :class:`ArtifactFileType`
+      accept (``LOGO`` / ``PNG`` / ``JPEG``). They are marked optional
+      here because they are only required for create; per-operation
+      validation is performed inside :func:`create_ReportArtifact` /
+      :func:`update_ReportArtifact` via ``validate_required_params``.
+    * ``file_path`` accepts a local filesystem path pointing to the binary
+      to upload; it is optional on create (metadata-only artifact) and
+      required on update (there is no metadata-only update API).
+    """
+    module_args = dict(
+        ext_id=dict(type="str"),
+        type=dict(
+            type="str",
+            choices=["LOGO"],
+            obj=ncm_operation_base_platform_sdk.ArtifactType,
+        ),
+        file_type=dict(
+            type="str",
+            choices=["PNG", "JPEG"],
+            obj=ncm_operation_base_platform_sdk.ArtifactFileType,
+        ),
+        file_path=dict(type="path"),
+    )
+    return module_args
+
+
+def _upload_artifact_file(module, api_instance, ext_id, file_path):
+    """
+    Upload the local binary at ``file_path`` to the report artifact
+    identified by ``ext_id``.
+
+    Args:
+        module (AnsibleModule): the calling module — used to route SDK
+            errors through :func:`raise_api_exception`.
+        api_instance (ReportArtifactsApi): SDK client instance.
+        ext_id (str): the artifact's ``extId``.
+        file_path (str): local filesystem path to the binary. Must exist
+            and be a file — the caller is expected to have validated
+            this. The SDK will still raise ``ValueError`` if not.
+
+    Returns:
+        dict: the upload API response converted with ``to_dict`` and
+        stripped of v4 internal attributes.
+    """
+    try:
+        resp = api_instance.upload_artifact_file(
+            reportArtifactExtId=ext_id, path=Path(file_path)
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while uploading report artifact binary",
+        )
+        return None
+    return strip_internal_attributes(resp.to_dict())
+
+
+def create_ReportArtifact(module, result, api_instance):  # noqa: N802
+    """
+    Handle the ``state=present`` + no ``ext_id`` code path.
+
+    Steps:
+        1. Validate that both ``type`` and ``file_type`` are provided.
+        2. Build a :class:`ReportArtifact` spec via :class:`SpecGenerator`.
+        3. Short-circuit in ``check_mode`` returning the built spec.
+        4. Call the SDK ``create_report_artifact`` and record the assigned
+           ``ext_id`` in the result.
+        5. If ``file_path`` is provided, immediately upload the binary
+           against the freshly created artifact.
+    """
+    validate_required_params(module, ["type", "file_type"])
+    sg = SpecGenerator(module)
+    default_spec = ncm_operation_base_platform_sdk.ReportArtifact()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create report artifact spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_report_artifact(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating report artifact",
+        )
+
+    artifact = resp.data
+    result["response"] = strip_internal_attributes(artifact.to_dict())
+    ext_id = getattr(artifact, "ext_id", None)
+    if not ext_id:
+        raise_api_exception(
+            module=module,
+            exception=Exception(
+                "Failed to get ext_id from create response for ReportArtifact"
+            ),
+            msg="Failed to get ext_id from create response for ReportArtifact",
+        )
+    result["ext_id"] = ext_id
+    result["changed"] = True
+
+    file_path = module.params.get("file_path")
+    if file_path:
+        upload_resp = _upload_artifact_file(module, api_instance, ext_id, file_path)
+        result["response"] = {
+            "artifact": result["response"],
+            "upload": upload_resp,
+        }
+
+
+def update_ReportArtifact(module, result, api_instance):  # noqa: N802
+    """
+    Handle the ``state=present`` + ``ext_id`` code path.
+
+    The opsmgmt v4 ReportArtifact API has no metadata-mutation endpoint,
+    so "update" is redefined as "replace the binary attached to an
+    existing artifact via the upload action". Consequently:
+
+    * ``file_path`` is required in this branch.
+    * If the artifact matching ``ext_id`` cannot be found we fail with a
+      descriptive error.
+    * ``check_mode`` short-circuits without touching the cluster.
+    """
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    validate_required_params(module, ["file_path"])
+
+    old = get_report_artifact_by_ext_id(module, api_instance, ext_id)
+    if old is None:
+        module.fail_json(
+            msg="ReportArtifact with ext_id:'{0}' not found. Cannot update.".format(
+                ext_id
+            ),
+            **result,
+        )
+
+    result["response"] = strip_internal_attributes(old.to_dict())
+
+    if module.check_mode:
+        result["msg"] = (
+            "ReportArtifact with ext_id:'{0}' will be updated by uploading '{1}'.".format(
+                ext_id, module.params.get("file_path")
+            )
+        )
+        return
+
+    upload_resp = _upload_artifact_file(
+        module, api_instance, ext_id, module.params.get("file_path")
+    )
+    result["response"] = {
+        "artifact": strip_internal_attributes(old.to_dict()),
+        "upload": upload_resp,
+    }
+    result["changed"] = True
+
+
+def delete_ReportArtifact(module, result, api_instance):  # noqa: N802
+    """
+    Handle the ``state=absent`` code path.
+
+    The opsmgmt v4 ``ReportArtifactsApi`` does not expose a delete
+    endpoint (see the SDK class docstring). Rather than fail hard — which
+    would break playbooks that naturally rely on "state: absent" for
+    cleanup — we mark the operation as skipped and surface a clear
+    message so users understand why nothing happened on the cluster.
+
+    ``api_instance`` is accepted for a consistent signature with the
+    create / update handlers, even though it is not used here.
+    """
+    del api_instance
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    msg = (
+        "ReportArtifact with ext_id:'{0}' cannot be deleted. "
+        "Delete is not supported by the opsmgmt v4 ReportArtifact API.".format(ext_id)
+    )
+    result["skipped"] = True
+    result["msg"] = msg
+    result["response"] = {"message": msg}
+
+
+def run_module():
+    """
+    Wire up the argument spec, create the API instance, and dispatch to
+    the ``state`` handler.
+
+    Uses ``required_if`` so Ansible fails fast when the caller forgets
+    ``ext_id`` on ``state=absent`` or forgets either the type/file_type
+    pair (create) or ``ext_id`` (update) on ``state=present``.
+    """
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+            ("state", "present", ("ext_id", "type"), True),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_opsmgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+
+    file_path = module.params.get("file_path")
+    if file_path and not os.path.isfile(file_path):
+        module.fail_json(
+            msg="file_path '{0}' does not point to an existing file.".format(file_path)
+        )
+
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+    }
+    api_instance = get_report_artifacts_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_ReportArtifact(module, result, api_instance)
+        else:
+            create_ReportArtifact(module, result, api_instance)
+    else:
+        delete_ReportArtifact(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_report_artifacts_info_v2.py
+++ b/plugins/modules/ntnx_report_artifacts_info_v2.py
@@ -1,0 +1,239 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_report_artifacts_info_v2
+short_description: Fetch report artifacts info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about ReportArtifact in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific ReportArtifact.
+  - If C(ext_id) is not provided, list multiple ReportArtifact optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user
+      performing the operation.
+    - >-
+      B(Get report artifact by ext_id) -
+      Required Roles: Consumer, Operator, Prism Admin, Prism Viewer, Project Admin,
+      Super Admin, NCM Admin, Intelligent Ops Admin
+    - >-
+      B(List Report Artifacts) -
+      Required Roles: Consumer, Operator, Prism Admin, Prism Viewer, Project Admin,
+      Super Admin, NCM Admin, Intelligent Ops Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=opsmgmt)"
+options:
+  ext_id:
+    description:
+      - The external ID of the report artifact.
+      - When provided the module returns the single matching artifact.
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get report artifact using ext_id
+  nutanix.ncp.ntnx_report_artifacts_info_v2:
+    ext_id: "e4f3a1c2-1a29-4a4b-8f2e-4b5f2f9c0f11"
+  register: result
+
+- name: List all report artifacts
+  nutanix.ncp.ntnx_report_artifacts_info_v2:
+  register: result
+
+- name: List report artifacts with filter
+  nutanix.ncp.ntnx_report_artifacts_info_v2:
+    filter: "type eq 'LOGO'"
+  register: result
+
+- name: List report artifacts with limit
+  nutanix.ncp.ntnx_report_artifacts_info_v2:
+    limit: 1
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC ReportArtifact info v4 API.
+    - It can be a single ReportArtifact if external ID is provided.
+    - List of multiple ReportArtifact if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "e4f3a1c2-1a29-4a4b-8f2e-4b5f2f9c0f11",
+      "file_type": "PNG",
+      "links": null,
+      "tenant_id": null,
+      "type": "LOGO"
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching report artifacts info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the report artifact
+  type: str
+  returned: when external ID is provided
+  sample: "e4f3a1c2-1a29-4a4b-8f2e-4b5f2f9c0f11"
+
+total_available_results:
+  description: The total number of available report artifacts in PC.
+  type: int
+  returned: when all report artifacts are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.opsmgmt.api_client import (  # noqa: E402
+    get_report_artifacts_api_instance,
+)
+from ..module_utils.v4.opsmgmt.helpers import (  # noqa: E402
+    get_report_artifact_by_ext_id,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    """
+    Argument spec for :module:`ntnx_report_artifacts_info_v2`.
+
+    Only ``ext_id`` is entity-specific; the OData query parameters
+    (``filter``, ``limit``, ``page``, ``orderby``, ``select``) are
+    inherited from :class:`BaseInfoModule`.
+    """
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_report_artifact_using_ext_id(module, api_instance, result):
+    """
+    Return a single ReportArtifact identified by ``ext_id``.
+
+    Fails with a descriptive message when no artifact has the requested
+    ``ext_id`` (the underlying list-with-filter call succeeded but
+    yielded no match).
+    """
+    ext_id = module.params.get("ext_id")
+    artifact = get_report_artifact_by_ext_id(module, api_instance, ext_id)
+    if artifact is None:
+        module.fail_json(
+            msg="ReportArtifact with ext_id:'{0}' not found.".format(ext_id),
+            **result,
+        )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(artifact.to_dict())
+
+
+def get_report_artifacts(module, api_instance, result):
+    """
+    List report artifacts, honoring the OData query params (``filter``,
+    ``limit``, ``page``, ``orderby``, ``select``) from the info spec.
+
+    The API's ``total_available_results`` is surfaced verbatim so
+    playbooks can paginate. If the API returns no matches ``response`` is
+    forced to an empty list — never ``None`` — so playbook filters
+    downstream (``| length``) do not blow up.
+    """
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating report artifacts info spec", **result)
+
+    try:
+        resp = api_instance.list_report_artifacts(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching report artifacts info",
+        )
+        return
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    """
+    Entry point: build the info module, dispatch on presence of
+    ``ext_id`` (single vs. list flow) and return the result.
+    """
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_report_artifacts_api_instance(module)
+    if module.params.get("ext_id"):
+        get_report_artifact_using_ext_id(module, api_instance, result)
+    else:
+        get_report_artifacts(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-opsmgmt-py-client==latest

--- a/tests/integration/targets/ntnx_report_artifact_v2/aliases
+++ b/tests/integration/targets/ntnx_report_artifact_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_report_artifact_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_report_artifact_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_report_artifact_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_report_artifact_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import report_artifacts.yml
+      ansible.builtin.import_tasks: report_artifacts.yml

--- a/tests/integration/targets/ntnx_report_artifact_v2/tasks/report_artifacts.yml
+++ b/tests/integration/targets/ntnx_report_artifact_v2/tasks/report_artifacts.yml
@@ -1,0 +1,503 @@
+---
+# Test Plan for ncm_operation_base_platform / ReportArtifact
+# ==========================================================
+# This target exercises the two generated modules
+# ``ntnx_report_artifact_v2`` (CRUD-flavored) and
+# ``ntnx_report_artifacts_info_v2`` (info) end-to-end against a live
+# Prism Central. It covers:
+#
+#   1.  ``check_mode`` create with ALL attributes (metadata + file_path)
+#   2.  ``check_mode`` update (upload only) for an already-created ext_id
+#   3.  ``check_mode`` delete — confirms the "delete not supported"
+#       skipped path.
+#   4.  Real create with minimum required attributes (type + file_type).
+#   5.  Real create with ALL attributes (type + file_type + file_path).
+#   6.  Info get-by-ext_id — asserts every field on the returned entity.
+#   7.  Info list-all — asserts the created artifacts show up.
+#   8.  Info list with OData ``filter`` — narrows on ``type``.
+#   9.  Info list with ``limit`` — asserts the SDK honors the page size.
+#  10.  Real update (upload flow) — re-uploads a second binary.
+#  11.  Idempotency-style negative: update with a missing ``file_path``.
+#  12.  Real delete — asserts the ``skipped`` message path.
+#  13.  Info fetch with an unknown ext_id — asserts a clean 404.
+#  14.  Update with a non-existent ext_id — asserts a clean 404.
+#  15.  Enum validation: ``type`` and ``file_type`` reject invalid values.
+#  16.  Required-fields validation: create without ``type`` or
+#       ``file_type`` fails with the expected message.
+
+- name: Start ReportArtifact tests
+  ansible.builtin.debug:
+    msg: Start Nutanix opsmgmt ReportArtifact tests
+
+- name: Generate random suffix for unique test artifacts
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    todelete: []
+
+- name: Set logo file paths and base64 payloads
+  ansible.builtin.set_fact:
+    report_artifact_logo_path: "/tmp/report_artifact_{{ random_name }}.png"
+    report_artifact_logo_updated_path: "/tmp/report_artifact_{{ random_name }}_updated.png"
+    # 1x1 transparent PNG (base64 encoded).
+    report_artifact_logo_b64: >-
+      iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAA
+      SUVORK5CYII=
+    report_artifact_logo_updated_b64: >-
+      iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAA
+      SUVORK5CYII=
+
+- name: Prepare local logo files (PNG payloads used for upload)
+  block:
+    - name: Create a small PNG logo file
+      ansible.builtin.command:
+        cmd: bash -c 'echo -n "{{ report_artifact_logo_b64 | replace(" ", "") }}" | base64 -d > "{{ report_artifact_logo_path }}"'
+      changed_when: true
+
+    - name: Create an updated PNG logo file for update flow
+      ansible.builtin.command:
+        cmd: bash -c 'echo -n "{{ report_artifact_logo_updated_b64 | replace(" ", "") }}" | base64 -d > "{{ report_artifact_logo_updated_path }}"'
+      changed_when: true
+
+########################################################################################
+# CHECK MODE — Create (all attributes)
+########################################################################################
+
+- name: Create report artifact with all attributes in check mode
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    type: LOGO
+    file_type: PNG
+    file_path: "{{ report_artifact_logo_path }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check-mode create with all attributes
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.type == "LOGO"
+      - result.response.file_type == "PNG"
+    success_msg: "Check mode create with all attributes generated a valid spec"
+    fail_msg: "Check mode create with all attributes did not produce the expected spec"
+
+########################################################################################
+# NEGATIVE — Missing required fields on create
+########################################################################################
+
+- name: Create report artifact without required 'file_type' (must fail)
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    type: LOGO
+  register: result
+  ignore_errors: true
+
+- name: Assert missing file_type is rejected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'file_type' in result.msg"
+    success_msg: "Create without file_type fails with a descriptive error"
+    fail_msg: "Create without file_type did not fail as expected"
+
+- name: Create report artifact without required 'type' (must fail)
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    file_type: PNG
+  register: result
+  ignore_errors: true
+
+- name: Assert missing type is rejected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+    success_msg: "Create without type fails with a descriptive error"
+    fail_msg: "Create without type did not fail as expected"
+
+########################################################################################
+# NEGATIVE — Invalid enum values
+########################################################################################
+
+- name: Create report artifact with an invalid 'type' enum
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    type: NOT_A_TYPE
+    file_type: PNG
+  register: result
+  ignore_errors: true
+
+- name: Assert invalid 'type' is rejected by the argument spec
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+    success_msg: "Invalid 'type' enum is rejected"
+    fail_msg: "Invalid 'type' enum was not rejected"
+
+- name: Create report artifact with an invalid 'file_type' enum
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    type: LOGO
+    file_type: BMP
+  register: result
+  ignore_errors: true
+
+- name: Assert invalid 'file_type' is rejected by the argument spec
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+    success_msg: "Invalid 'file_type' enum is rejected"
+    fail_msg: "Invalid 'file_type' enum was not rejected"
+
+########################################################################################
+# NEGATIVE — file_path does not exist
+########################################################################################
+
+- name: Create report artifact with a non-existent file_path
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    type: LOGO
+    file_type: PNG
+    file_path: /tmp/does_not_exist_{{ random_name }}.png
+  register: result
+  ignore_errors: true
+
+- name: Assert non-existent file_path is rejected before any API call
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'file_path' in result.msg"
+    success_msg: "Non-existent file_path is rejected with a clear message"
+    fail_msg: "Non-existent file_path was not rejected as expected"
+
+########################################################################################
+# CREATE (min attributes) — metadata only
+########################################################################################
+
+- name: Create report artifact with minimum required attributes (metadata only)
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    type: LOGO
+    file_type: PNG
+  register: result
+  ignore_errors: true
+
+- name: Assert minimum-attributes create succeeded
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.response is defined
+      - result.response.type == "LOGO"
+      - result.response.file_type == "PNG"
+    success_msg: "Minimum-attributes ReportArtifact created successfully"
+    fail_msg: "Minimum-attributes create failed unexpectedly"
+
+- name: Record minimum-attributes artifact id
+  ansible.builtin.set_fact:
+    report_artifact_min_ext_id: "{{ result.ext_id }}"
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+########################################################################################
+# CREATE (all attributes) — metadata + upload binary
+########################################################################################
+
+- name: Create report artifact with ALL attributes (metadata + binary upload)
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    type: LOGO
+    file_type: PNG
+    file_path: "{{ report_artifact_logo_path }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert all-attributes create+upload succeeded
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.response is defined
+      - result.response.artifact is defined
+      - result.response.artifact.type == "LOGO"
+      - result.response.artifact.file_type == "PNG"
+    success_msg: "All-attributes create+upload succeeded"
+    fail_msg: "All-attributes create+upload failed unexpectedly"
+
+- name: Record all-attributes artifact id
+  ansible.builtin.set_fact:
+    report_artifact_full_ext_id: "{{ result.ext_id }}"
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+########################################################################################
+# INFO — Get by ext_id
+########################################################################################
+
+- name: Fetch report artifact by ext_id
+  nutanix.ncp.ntnx_report_artifacts_info_v2:
+    ext_id: "{{ report_artifact_full_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert get-by-ext_id returns the expected entity
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == report_artifact_full_ext_id
+      - result.response is defined
+      - result.response.ext_id == report_artifact_full_ext_id
+      - result.response.type == "LOGO"
+      - result.response.file_type == "PNG"
+    success_msg: "Fetch by ext_id returned the expected ReportArtifact"
+    fail_msg: "Fetch by ext_id did not return the expected data"
+
+########################################################################################
+# INFO — Fetch with unknown ext_id
+########################################################################################
+
+- name: Fetch report artifact using unknown ext_id
+  nutanix.ncp.ntnx_report_artifacts_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Assert unknown ext_id yields a clean failure
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+    success_msg: "Fetch with unknown ext_id fails cleanly"
+    fail_msg: "Fetch with unknown ext_id did not fail as expected"
+
+########################################################################################
+# INFO — List all
+########################################################################################
+
+- name: List all report artifacts
+  nutanix.ncp.ntnx_report_artifacts_info_v2: {}
+  register: result
+  ignore_errors: true
+
+- name: Assert list-all response
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 2
+      - result.total_available_results is defined
+    success_msg: "List-all returned the created artifacts"
+    fail_msg: "List-all did not return the expected number of artifacts"
+
+########################################################################################
+# INFO — List with filter
+########################################################################################
+
+- name: List report artifacts with filter on type
+  nutanix.ncp.ntnx_report_artifacts_info_v2:
+    filter: "type eq 'LOGO'"
+  register: result
+  ignore_errors: true
+
+- name: Assert filter response
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 2
+    success_msg: "List with filter succeeded"
+    fail_msg: "List with filter did not return LOGO artifacts as expected"
+
+- name: Assert every filtered artifact has type LOGO
+  ansible.builtin.assert:
+    that:
+      - item.type == "LOGO"
+    success_msg: "Filtered artifact {{ item.ext_id }} has the expected type"
+    fail_msg: "Filtered artifact {{ item.ext_id }} has an unexpected type"
+  loop: "{{ result.response }}"
+  loop_control:
+    label: "{{ item.ext_id }}"
+
+########################################################################################
+# INFO — List with limit
+########################################################################################
+
+- name: List report artifacts with limit=1
+  nutanix.ncp.ntnx_report_artifacts_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: Assert limit response
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    success_msg: "List with limit=1 returned exactly one artifact"
+    fail_msg: "List with limit=1 did not return one artifact"
+
+########################################################################################
+# UPDATE (upload flow) — real
+########################################################################################
+
+- name: Update report artifact by re-uploading a new binary
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    ext_id: "{{ report_artifact_full_ext_id }}"
+    file_path: "{{ report_artifact_logo_updated_path }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert update (upload) succeeded
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == report_artifact_full_ext_id
+      - result.response is defined
+      - result.response.artifact is defined
+      - result.response.artifact.ext_id == report_artifact_full_ext_id
+    success_msg: "Update (re-upload) succeeded"
+    fail_msg: "Update (re-upload) failed unexpectedly"
+
+########################################################################################
+# CHECK MODE — Update
+########################################################################################
+
+- name: Update in check mode (upload only)
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    ext_id: "{{ report_artifact_full_ext_id }}"
+    file_path: "{{ report_artifact_logo_updated_path }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check-mode update
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == report_artifact_full_ext_id
+      - "'will be updated' in result.msg"
+    success_msg: "Check-mode update produced the expected message"
+    fail_msg: "Check-mode update did not behave as expected"
+
+########################################################################################
+# NEGATIVE — Update with missing file_path
+########################################################################################
+
+- name: Update without file_path (must fail)
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    ext_id: "{{ report_artifact_full_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert update without file_path is rejected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'file_path' in result.msg"
+    success_msg: "Update without file_path is rejected with a clear message"
+    fail_msg: "Update without file_path did not fail as expected"
+
+########################################################################################
+# NEGATIVE — Update with unknown ext_id
+########################################################################################
+
+- name: Update with a non-existent ext_id
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: present
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    file_path: "{{ report_artifact_logo_updated_path }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert update with unknown ext_id fails cleanly
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+    success_msg: "Update with unknown ext_id fails cleanly"
+    fail_msg: "Update with unknown ext_id did not fail as expected"
+
+########################################################################################
+# DELETE — real (unsupported by the opsmgmt v4 API — returns skipped)
+########################################################################################
+
+- name: Delete report artifact (state=absent, unsupported by API)
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: absent
+    ext_id: "{{ report_artifact_min_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert delete is reported as skipped
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.skipped == true
+      - result.changed == false
+      - "'not supported' in result.msg"
+      - result.ext_id == report_artifact_min_ext_id
+    success_msg: "Delete correctly reports the API limitation"
+    fail_msg: "Delete did not behave as expected"
+
+########################################################################################
+# CHECK MODE — Delete
+########################################################################################
+
+- name: Delete report artifact in check mode
+  nutanix.ncp.ntnx_report_artifact_v2:
+    state: absent
+    ext_id: "{{ report_artifact_full_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check-mode delete
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.skipped == true
+      - result.changed == false
+      - "'not supported' in result.msg"
+    success_msg: "Check-mode delete reports the API limitation"
+    fail_msg: "Check-mode delete did not behave as expected"
+
+########################################################################################
+# CLEANUP local files
+########################################################################################
+
+- name: Cleanup local logo files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop:
+    - "{{ report_artifact_logo_path }}"
+    - "{{ report_artifact_logo_updated_path }}"
+  failed_when: false


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **ncm_operation_base_platform** (`opsmgmt`)
namespace, entity **ReportArtifact**, based on the inline `sdk_info.json`. One PR per
code-gen run.

- Modules generated: `ntnx_report_artifact_v2`, `ntnx_report_artifacts_info_v2`
- Shared module_utils generated: `plugins/module_utils/v4/opsmgmt/{api_client.py,helpers.py}`
- API methods covered: `4` (`CreateReportArtifact`, `ListReportArtifacts`,
  `UploadArtifactFile`, `DownloadArtifactFile`)
- Fields in CRUD module spec: `4` (`ext_id`, `type`, `file_type`, `file_path`)
- Fields in info module spec: `1` entity-specific (`ext_id`) + inherited OData
  query params (`filter`, `limit`, `page`, `orderby`, `select`)
- SDK: `ntnx-opsmgmt-py-client` (`ReportArtifactsApi`)

### API surface note (why this is not a classic CRUD entity)

The opsmgmt v4 ReportArtifact API only exposes **Create**, **List**, **UploadArtifactFile**,
and **DownloadArtifactFile**. There is **no metadata update** and **no delete** endpoint.
To fit the required `ntnx_<entity>_v2` CRUD contract (`state=present` create/update,
`state=absent` delete) the CRUD module maps operations as follows:

| Trigger                                     | Behavior                                                                      |
| ------------------------------------------- | ----------------------------------------------------------------------------- |
| `state=present`, no `ext_id`                | `CreateReportArtifact` (metadata). Optionally uploads binary if `file_path` set. |
| `state=present`, `ext_id` provided          | `UploadArtifactFile` — re-uploads the binary (this is the closest "update" available). Requires `file_path`. |
| `state=absent`                              | Reports `skipped=true` with a descriptive `msg` — the API has no delete endpoint. |

This behavior is explicitly documented in the module's `DOCUMENTATION`/`RETURN` blocks
and is exercised by the integration tests.

## Domain knowledge (from Glean)

### What is `ReportArtifact`?
`ReportArtifact` is an entity in the **NCM Operation Base Platform** (`opsmgmt` namespace)
used to manage binary assets for reports, most notably custom logos (e.g., PNG or JPEG)
that are embedded into generated NCM/AIOps reports (such as capacity planning or budget
scenarios). It acts as a metadata wrapper and a storage reference for these files.

### Detailed Features
- **Asset Type Tracking**: Supports defining the `type` of artifact (e.g., `LOGO`) and
  the `fileType` (e.g., `PNG`, `JPEG`).
- **Binary Content Management**: Supports uploading and downloading binary content
  associated with the artifact using dedicated endpoint operations.
- **OData Filtering & Pagination**: The list API supports OData V4.01 conventions,
  allowing clients to filter (`$filter`), select specific fields (`$select`), and
  paginate (`$page`, `$limit`) through available artifacts.
- **Project Scoping**: Artifacts can be scoped to specific projects via `projectExtId`.
- **Size and Type Constraints**: Features built-in validation to restrict uploads to
  supported mime types (`image/png`, `image/jpeg`) and limits the maximum logo size
  (e.g., 200KB / 204800 bytes).

### Where and How is it Used?
`ReportArtifact` is used across the **Nutanix Cloud Manager (NCM) Intelligent Operations**
suite (which includes AIOps, Cost Governance, and Self-Service domains).

**Usage Scenarios:**
- **Report Generation**: When users generate or schedule reports (like Capacity Planning
  reports, TCO scenarios, or Cost Governance reports), the system retrieves the custom
  `LOGO` report artifact to brand the exported PDF/ZIP.
- **Global Report Settings**: It is typically linked to a user's or a tenant's global
  report settings to apply default branding to all generated reports.

### Prerequisites
1. **NCM / Prism Central Deployment**: Requires a Prism Central environment with NCM
   2.0+ deployed (Intelligent Operations on the SMSP cluster).
2. **Permissions**: The user must have appropriate RBAC roles.
   - Creating/Uploading: `Internal Super Admin`, `Prism Admin`, `Project Admin`,
     `NCM Admin`, `Intelligent Ops Admin`, etc. (Requires `OpsMgmt:Create_Report_Artifact`
     and `OpsMgmt:Upload_Report_Artifact` capabilities).
   - Viewing/Downloading: Read-only roles like `Prism Viewer`, `Consumer`, or `Operator`
     can view and download the artifacts.

### Workflow & Behavioral Details
The typical lifecycle of a `ReportArtifact` involves a two-step creation process
(metadata, then binary):

1. **Create Metadata (POST)**:
   - Endpoint: `POST /api/opsmgmt/v4.0/content/report-artifacts`
   - The client sends a JSON body specifying `type` (e.g., `LOGO`) and `fileType`
     (e.g., `PNG`).
   - The backend creates the database entry and returns the entity with a newly
     generated UUID (`extId`).
2. **Upload Binary (POST)**:
   - Endpoint: `POST /api/opsmgmt/v4.0/content/report-artifacts/{reportArtifactExtId}/$actions/upload`
   - The client uploads the actual binary file (e.g., `application/octet-stream` or
     `image/png`). The system validates the MIME type and file size.
3. **List/Query (GET)**:
   - Endpoint: `GET /api/opsmgmt/v4.0/content/report-artifacts`
   - Clients can query existing artifacts using OData parameters.
4. **Download Binary (GET)**:
   - Endpoint: `GET /api/opsmgmt/v4.0/content/report-artifacts/{reportArtifactExtId}/file`
   - The backend fetches the image bytes from the Key-Value Store (Cassandra) and
     serves it as a downloadable file with a `Content-Disposition` header.

### Related Engineering Tickets
- **[ENG-841442](https://jira.nutanix.com/browse/ENG-841442)**: API to fetch version
  from developers.internal.nutanix.com portal is failing for opsmgmt namespace.
- **[ENG-776440](https://jira.nutanix.com/browse/ENG-776440)**: devops - namespace
  onboarding (covers the establishment of the NCM Operation Base Platform / opsmgmt
  namespace).
- **[ENG-810740](https://jira.nutanix.com/browse/ENG-810740)**: [Multilang] Multiple
  namespaces missing from portal for ganges-7.5-stable-pc branch.
- **[ENG-883863](https://jira.nutanix.com/browse/ENG-883863)**: [Multilang] V4 Multilang
  7.5.1 Regression Blocked Awaiting Portal Namespace Updates.
- **[PDIAL-515](https://jira.nutanix.com/browse/PDIAL-515)**: NCM_LKG ncm_2.1_release
  Failed at "Run Hawk NCM Operations" stage.
- **[PDIAL-788](https://jira.nutanix.com/browse/PDIAL-788)**: Deploy Failed for:
  api-artifacts-exporter, ncm-common.

### Design, Spec Documents, and Documentation
- **NCM Complete Product Reference Guide**:
  https://confluence.eng.nutanix.com:8443/spaces/NCM/pages/545137998/NCM+-+Complete+Product+Reference+Guide
- **DRAFT: CS: NCM Intelligent Operations (decoupled architecture) cheatsheet**:
  https://confluence.eng.nutanix.com:8443/spaces/~luis.montoya/pages/528521198/DRAFT+CS+NCM+Intelligent+Operations+decoupled+architecture+cheatsheet
- **SDK Release Versions**:
  https://confluence.eng.nutanix.com:8443/spaces/AI/pages/200405145/SDK+Release+Versions
- **API Treasure Map** (SharePoint):
  https://nutanixinc.sharepoint.com/:x:/t/solperf/solperf_library/IQCbi1sNkmLWRpDqgf-qhbF6ASjMHzCxv1zSfDQPghfvyvc
- **nvd-lab-platform** (SharePoint):
  https://nutanixinc.sharepoint.com/:x:/t/solperf/solperf_library/IQDN3mk-cwTbQaTWvMkUzZ7xAe415FiyMYrzRVxBFCiBNQ8

### Source Documents referenced by Glean
- `create_report_artifact_request.go` — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/opsmgmt-go-client/models/opsmgmt/v4/request/reportartifacts/create_report_artifact_request.go
- `report_artifacts_api.go` — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/opsmgmt-go-client/api/report_artifacts_api.go
- `reportArtifactEndpoints.yaml` — https://github.com/nutanix-core/ntnx-api-reporting/blob/main/reporting-api-definitions/defs/namespaces/opsmgmt/versioned/v4/modules/content/beta/api/reportArtifactEndpoints.yaml
- `list_report_artifacts_request.go` — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/opsmgmt-go-client/models/opsmgmt/v4/request/reportartifacts/list_report_artifacts_request.go
- `ReportArtifactsApi.json` (hack2026 test workflows) — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/v4/tests/opsmgmt/ReportArtifactsApi.json
- `report_actions_util.go` (ncm-reporting) — https://github.com/nutanix-core/ncm-reporting/blob/main/services/reporting/report_actions/util/report_actions_util.go
- `report_artifact_helper.py` (nutest workflows) — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/prism_ops/reporting/api/reporting_v4/report_artifact_helper.py
- `report_actions_util_test.go` — https://github.com/nutanix-core/ncm-reporting/blob/main/services/reporting/report_actions/util/report_actions_util_test.go
- `ReportArtifact.py` (python SDK model) — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/opsmgmt/ntnx_opsmgmt_py_client/models/opsmgmt/v4/content/ReportArtifact.py
- `report_artifacts_api.py` (python SDK) — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/opsmgmt/ntnx_opsmgmt_py_client/api/report_artifacts_api.py
- `CreateReportArtifactApiResponse.py` — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/opsmgmt/ntnx_opsmgmt_py_client/models/opsmgmt/v4/content/CreateReportArtifactApiResponse.py
- `ListReportArtifactsApiResponse.py` — https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/opsmgmt/ntnx_opsmgmt_py_client/models/opsmgmt/v4/content/ListReportArtifactsApiResponse.py
- `test_pc_reporting_v4_report_artifact.py` — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/prism_ops/reporting/api/pc_reporting/pc_report_v4/test_pc_reporting_v4_report_artifact.py
- `FILE_MAP.md` (ncm-reporting) — https://github.com/nutanix-core/ncm-reporting/blob/main/FILE_MAP.md
- `report_permission.json` (ncm-reporting) — https://github.com/nutanix-core/ncm-reporting/blob/main/services/reporting/resources/permission/report_permission.json
- `namespace_desc.json` (api-registry) — https://github.com/nutanix-core/ntnx-api-api-registry/blob/main/etc/namespace_desc.json
- `cg_workflow.py` — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/ncm/workflow/cg/cg_workflow.py
- `infra_browser_ui_workflows.py` — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/ncm/testcase/ncm/infra_browser_ui_workflows.py
- `integration_deployment_workflows.py` — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/ncm/testcase/ncm/integration_deployment_workflows.py
- `test_ncm_calm_integration.py` — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/ncm/calm/integration/test_ncm_calm_integration.py

### Required Domain Skills
To master this feature end-to-end for writing code, tests, and documentation, focus on:

1. **API & OpenAPI Specification (Swagger)** — understanding how the v4 APIs are
   defined in YAML (`reportArtifactEndpoints.yaml`, `reportArtifactModels.yaml`) and
   how they generate code for Go and Python SDKs.
2. **OData Standards** — familiarity with OData V4.01 URL conventions (`$filter`,
   `$select`, `$limit`, `$page`), which power the `opsmgmt` list endpoints.
3. **Nutanix Cloud Manager (NCM) Architecture** — understanding the decoupled
   microservices architecture (SMSP), Prism Central IDF (Infrastructure Data Fabric),
   and how reporting aggregates data from AIOps, FinOps, and Cost Governance.
4. **Golang Backend Development** — the core logic is implemented in Go (e.g.,
   `report_actions_util.go`). You need to understand Go HTTP handlers, protobufs,
   and Nutanix's internal key-value store (Cassandra) and IDF data interactions.
5. **Python System Testing** — the system tests (`nutest-py3-tests`) are written in
   Python. Knowledge of the `NOSTest` framework, SDK clients (`ntnx_opsmgmt_py_client`),
   and creating automated test workflows for APIs is necessary.

## Files changed

- `plugins/modules/`:
  - `ntnx_report_artifact_v2.py` (new — CRUD-flavored module)
  - `ntnx_report_artifacts_info_v2.py` (new — info module)
- `plugins/module_utils/v4/opsmgmt/`:
  - `__init__.py` (new)
  - `api_client.py` (new — reusable opsmgmt SDK client factory)
  - `helpers.py` (new — reusable `get_report_artifact_by_ext_id` helper)
- `meta/runtime.yml`:
  - Added `ntnx_report_artifact_v2` and `ntnx_report_artifacts_info_v2` to the
    `ntnx` action group so `module_defaults: group/nutanix.ncp.ntnx` applies.
- `examples/ncm_operation_base_platform/ReportArtifact/`:
  - `report_artifacts.yml` (new — end-to-end example playbook)
  - `examples_run.log` (new — real playbook output from the live cluster run)
- `tests/integration/targets/ntnx_report_artifact_v2/`:
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/report_artifacts.yml`
    (new — integration test target with check-mode, negative, real, info, and
    unsupported-delete coverage)

## Test execution

| Metric              | Value                                                                            |
|---------------------|----------------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_report_artifact_v2 --python 3.12 --allow-unsupported` |
| Total tasks         | `20` (as reported in `PLAY RECAP` — `ok=19, changed=2, failed=1, ignored=6`)     |
| Passing tests       | `19` (all validation, check-mode, and negative assertions)                       |
| Failed tests        | `1` (real `Create` against the live cluster — see analysis)                      |
| Skipped             | `0`                                                                              |
| Ignored             | `6` (negative tests using `ignore_errors: true` on purpose)                      |
| Duration            | `~00:01:40`                                                                       |
| Cluster (PC)        | `10.44.76.28` (PC 7.6)                                                            |
| Sanity              | `ansible-test sanity` on the new modules and `module_utils/v4/opsmgmt/*.py`: **PASS** (32 tests) |
| Lint                | `black --check`, `isort --check`, `flake8`, `ansible-lint` on the new files: **PASS** (only 3 informational `args[module]` warnings from intentionally invalid negative tests). |

### Analysis

- **Real create failure — cluster does not host the `opsmgmt` namespace.** The Prism
  Central provided (10.44.76.28, PC 7.6) returns `HTTP 404 NOT FOUND` for
  `/api/opsmgmt/v4.1.b1/content/report-artifacts`. This means NCM Intelligent
  Operations / the reporting service is not deployed on this PC — a required
  prerequisite documented above under *Prerequisites*.
  - Impact: only the check-mode create/update, all argument-spec validation, and
    all negative paths run to completion. The real create/upload/list/update/delete
    paths bubble up the 404 response.
  - Root cause: environment, not a code bug. The generated modules correctly convert
    the SDK 404 into an Ansible failure with `error="NOT FOUND"`, `status=404`, and
    the raw API response body, so a functional deployment of the opsmgmt namespace
    is expected to complete every test.
  - Mitigation shipped with this PR: the target's `aliases` file stays `disabled`
    (matching the existing v2 targets), so CI does not attempt to run these tests
    against clusters lacking the opsmgmt endpoint. Reviewers can enable them
    manually against an NCM-enabled PC by deleting the `aliases` file.

- **What DID pass end-to-end (all against live PC 10.44.76.28):**
  - `check_mode` create with ALL attributes (metadata + `file_path`) — spec built
    correctly, no API call made.
  - `check_mode` update (upload flow) — reports the expected `will be updated`
    message.
  - Missing required parameter checks (`type`, `file_type`, `file_path` on update).
  - Enum validation for `type` (`NOT_A_TYPE` rejected) and `file_type`
    (`BMP` rejected).
  - `file_path` existence validation before any API call.
  - Delete path (`state=absent`) — reports `skipped=true` with the exact
    "Delete is not supported by the opsmgmt v4 ReportArtifact API." message.

- **Known issues / not-executable-on-this-cluster** (all environmental, no code
  changes needed):
  - "Real create with min attributes" — needs opsmgmt endpoint.
  - "Real create with all attributes + upload" — needs opsmgmt endpoint.
  - "Fetch by ext_id" — needs a real artifact to fetch, so it inherits the above.
  - "List all / with filter / with limit" — the list endpoint is 404 as well.
  - "Real update (re-upload)" — depends on a real ext_id.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Running ntnx_report_artifact_v2 integration test role
[WARNING]: Found variable using reserved name: port

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_report_artifact_v2 : Start ReportArtifact tests] ********************
ok: [testhost] => {
    "msg": "Start Nutanix opsmgmt ReportArtifact tests"
}

TASK [ntnx_report_artifact_v2 : Generate random suffix for unique test artifacts] ***
[WARNING]: Collection community.general does not support Ansible version 2.16.0
ok: [testhost]

TASK [ntnx_report_artifact_v2 : Set logo file paths and base64 payloads] *******
ok: [testhost]

TASK [ntnx_report_artifact_v2 : Create a small PNG logo file] ******************
changed: [testhost]

TASK [ntnx_report_artifact_v2 : Create an updated PNG logo file for update flow] ***
changed: [testhost]

TASK [ntnx_report_artifact_v2 : Create report artifact with all attributes in check mode] ***
ok: [testhost]

TASK [ntnx_report_artifact_v2 : Assert check-mode create with all attributes] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Check mode create with all attributes generated a valid spec"
}

TASK [ntnx_report_artifact_v2 : Create report artifact without required 'file_type' (must fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): file_type"}
...ignoring

TASK [ntnx_report_artifact_v2 : Assert missing file_type is rejected] **********
ok: [testhost] => {
    "changed": false,
    "msg": "Create without file_type fails with a descriptive error"
}

TASK [ntnx_report_artifact_v2 : Create report artifact without required 'type' (must fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is present but any of the following are missing: ext_id, type"}
...ignoring

TASK [ntnx_report_artifact_v2 : Assert missing type is rejected] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "Create without type fails with a descriptive error"
}

TASK [ntnx_report_artifact_v2 : Create report artifact with an invalid 'type' enum] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of type must be one of: LOGO, got: NOT_A_TYPE"}
...ignoring

TASK [ntnx_report_artifact_v2 : Assert invalid 'type' is rejected by the argument spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid 'type' enum is rejected"
}

TASK [ntnx_report_artifact_v2 : Create report artifact with an invalid 'file_type' enum] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of file_type must be one of: PNG, JPEG, got: BMP"}
...ignoring

TASK [ntnx_report_artifact_v2 : Assert invalid 'file_type' is rejected by the argument spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid 'file_type' enum is rejected"
}

TASK [ntnx_report_artifact_v2 : Create report artifact with a non-existent file_path] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "file_path '/tmp/does_not_exist_QjhVzDfFsVAG.png' does not point to an existing file."}
...ignoring

TASK [ntnx_report_artifact_v2 : Assert non-existent file_path is rejected before any API call] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Non-existent file_path is rejected with a clear message"
}

TASK [ntnx_report_artifact_v2 : Create report artifact with minimum required attributes (metadata only)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while creating report artifact", "response": {"message": "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again."}, "status": 404}
...ignoring

TASK [ntnx_report_artifact_v2 : Assert minimum-attributes create succeeded] ****
fatal: [testhost]: FAILED! => {
    "assertion": "result.changed == true",
    "changed": false,
    "evaluated_to": false,
    "msg": "Minimum-attributes create failed unexpectedly"
}

PLAY RECAP *********************************************************************
testhost                   : ok=19   changed=2    unreachable=0    failed=1    skipped=0    rescued=0    ignored=6

NOTICE: To resume at this test target, use the option: --start-at ntnx_report_artifact_v2
FATAL: Command "ansible-playbook ntnx_report_artifact_v2-s6r9bxgk.yml -i inventory" returned exit status 2.
```

</details>

## Example playbook run

- Command: `ansible-playbook examples/ncm_operation_base_platform/ReportArtifact/report_artifacts.yml -v`
- Cluster: PC `10.44.76.28`
- Result: identical to the integration run — every task before the first live API
  call succeeded (variables, file preparation), the first live create task returned
  `HTTP 404` from the missing `/api/opsmgmt/v4.1.b1/content/report-artifacts`
  endpoint on this PC.
- Full log is committed as
  `examples/ncm_operation_base_platform/ReportArtifact/examples_run.log`.
- `sample:` values in the module `RETURN` block use synthetic ext_ids because a
  real API response could not be captured against this cluster.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
