### PR TITLE
code-gen(ncm_operation_base_platform/GlobalReportSetting): ansible collection modules

### DIFF
--- a/examples/ncm_operation_base_platform/GlobalReportSetting/examples_run.log
+++ b/examples/ncm_operation_base_platform/GlobalReportSetting/examples_run.log
@@ -1,0 +1,20 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+[WARNING]: Found variable using reserved name: port
+Using /tmp/ansible.cfg as config file
+
+PLAY [GlobalReportSetting playbook] ********************************************
+
+TASK [Discover the admin user's ext_id] ****************************************
+ok: [localhost] => {"changed": false, "error": null, "response": [{"additional_attributes": null, "buckets_access_keys": null, "created_by": "00000000-0000-0000-0000-000000000000", "created_time": "2026-06-29T07:01:40.666580+00:00", "creation_type": null, "default_landing_page_path": null, "description": "", "display_name": "admin", "email_id": "", "ext_id": "00000000-0000-0000-0000-000000000000", "first_name": "admin", "hasObjectKeys": false, "idp_id": "d607d664-cc19-559f-a95c-4e8b4b7f6606", "is_force_reset_password_enabled": false, "last_login_time": "2026-07-21T07:39:25.068329+00:00", "last_name": "", "last_updated_by": "00000000-0000-0000-0000-000000000000", "last_updated_time": "2026-06-29T07:27:11.035361+00:00", "links": null, "locale": "en-US", "middle_initial": "", "password": null, "region": "en-US", "status": "ACTIVE", "tenant_id": "59d5de78-a964-5746-8c6e-677c4c7a79df", "user_type": "LOCAL", "username": "admin"}], "total_available_results": 1}
+
+TASK [Set the user_ext_id used by GlobalReportSetting] *************************
+ok: [localhost] => {"ansible_facts": {"admin_user_ext_id": "00000000-0000-0000-0000-000000000000"}, "changed": false}
+
+TASK [Get the current global report setting for the admin user] ****************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching global report setting for user ext_id", "response": {"message": "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again."}, "status": 404}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=2    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
+

--- a/examples/ncm_operation_base_platform/GlobalReportSetting/global_report_setting_v2.yml
+++ b/examples/ncm_operation_base_platform/GlobalReportSetting/global_report_setting_v2.yml
@@ -1,0 +1,72 @@
+---
+# Summary:
+# This playbook demonstrates the ncm_operation_base_platform GlobalReportSetting v4 modules:
+# 1. Discover the calling user's ext_id (used as the userExtId path parameter).
+# 2. Fetch the current GlobalReportSetting for that user.
+# 3. Update the GlobalReportSetting with retention, notification, and customization fields.
+# 4. Fetch the updated GlobalReportSetting to verify changes.
+# 5. Update the GlobalReportSetting to a minimal configuration.
+#
+# Notes:
+#  - GlobalReportSetting is a per-user singleton. There is no create / delete API — only
+#    Get and Update (PUT) are available. The module supports state=present only.
+
+- name: GlobalReportSetting playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username }}"
+      nutanix_password: "{{ password }}"
+      validate_certs: false
+  tasks:
+    - name: Discover the admin user's ext_id
+      nutanix.ncp.ntnx_users_info_v2:
+        filter: "username eq 'admin'"
+      register: users_result
+
+    - name: Set the user_ext_id used by GlobalReportSetting
+      ansible.builtin.set_fact:
+        admin_user_ext_id: "{{ users_result.response[0].ext_id }}"
+
+    - name: Get the current global report setting for the admin user
+      nutanix.ncp.ntnx_global_report_settings_info_v2:
+        user_ext_id: "{{ admin_user_ext_id }}"
+      register: current_setting
+
+    - name: Update the global report setting with full configuration
+      nutanix.ncp.ntnx_global_report_setting_v2:
+        state: present
+        user_ext_id: "{{ admin_user_ext_id }}"
+        name: "global_report_setting_ansible"
+        retention_config:
+          retention_count: 5
+        notification_policy:
+          recipients:
+            - email_address: "reports@example.com"
+              recipient_name: "Reports Owner"
+          recipient_formats:
+            - PDF
+            - CSV
+          email_subject: "Your Nutanix reports"
+          email_body: "Please find the attached reports."
+        report_customization:
+          header_html: "<h1>Nutanix reports</h1>"
+          footer_html: "<p>Copyright Nutanix</p>"
+          css_style_sheet: "body { font-family: Arial; }"
+      register: full_update
+
+    - name: Fetch the updated global report setting
+      nutanix.ncp.ntnx_global_report_settings_info_v2:
+        user_ext_id: "{{ admin_user_ext_id }}"
+      register: after_full_update
+
+    - name: Update the global report setting to a minimal configuration
+      nutanix.ncp.ntnx_global_report_setting_v2:
+        state: present
+        user_ext_id: "{{ admin_user_ext_id }}"
+        name: "global_report_setting_min"
+        retention_config:
+          retention_period_seconds: 604800
+      register: min_update

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_global_report_setting_v2
+    - ntnx_global_report_settings_info_v2

--- a/plugins/module_utils/v4/opsmgmt/api_client.py
+++ b/plugins/module_utils/v4/opsmgmt/api_client.py
@@ -1,0 +1,120 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_opsmgmt_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    Build an :class:`ntnx_opsmgmt_py_client.ApiClient` from the module's
+    connection parameters. Follows the same pattern used by the networking /
+    vmm helpers in this collection.
+
+    Args:
+        module (AnsibleModule): The module instance whose params contain the
+            connection details (host, port, credentials, proxy, TLS options).
+
+    Returns:
+        ntnx_opsmgmt_py_client.ApiClient: A ready-to-use API client with
+        authentication, TLS verification, proxy handling, and request logging
+        wired up.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_opsmgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_opsmgmt_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    try:
+        client = ntnx_opsmgmt_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_opsmgmt_py_client.ApiClient(configuration=config)
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    client = ntnx_opsmgmt_py_client.ApiClient(
+        configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+    )
+
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    Extract the ETag value from a v4 API response object.
+
+    The v4 SDK stores the ETag in the response's ``_reserved`` metadata; this
+    helper delegates to :meth:`ApiClient.get_etag` which already knows how to
+    read it. Consumers pass the resulting string to update / delete calls via
+    the ``if_match`` keyword argument.
+
+    Args:
+        data: A v4 response object (typically the ``.data`` attribute of an
+            API response).
+
+    Returns:
+        str | None: The ETag string, or ``None`` if the response does not
+        carry one.
+    """
+    return ntnx_opsmgmt_py_client.ApiClient.get_etag(data)
+
+
+def get_global_report_setting_api_instance(module):
+    """
+    Build and return a :class:`GlobalReportSettingApi` client.
+
+    Args:
+        module (AnsibleModule): The module whose connection parameters are
+            used to construct the underlying API client.
+
+    Returns:
+        ntnx_opsmgmt_py_client.GlobalReportSettingApi: An API instance ready
+        to invoke Get / Update on the per-user global report setting.
+    """
+    api_client = get_api_client(module)
+    return ntnx_opsmgmt_py_client.GlobalReportSettingApi(api_client=api_client)

--- a/plugins/module_utils/v4/opsmgmt/helpers.py
+++ b/plugins/module_utils/v4/opsmgmt/helpers.py
@@ -1,0 +1,44 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_global_report_setting(module, api_instance, user_ext_id):
+    """
+    Fetch the GlobalReportSetting for the specified user.
+
+    ``GlobalReportSetting`` is a per-user singleton — the reporting service
+    always returns the setting associated with ``user_ext_id``. On failure
+    this helper delegates to :func:`raise_api_exception` which calls
+    ``module.fail_json`` with a descriptive message and the underlying SDK
+    error body.
+
+    Args:
+        module (AnsibleModule): The Ansible module (used for error reporting).
+        api_instance: A ``GlobalReportSettingApi`` instance built via
+            :func:`get_global_report_setting_api_instance`.
+        user_ext_id (str): External ID of the user whose global report setting
+            should be fetched. Passed as the ``userExtId`` path parameter.
+
+    Returns:
+        The raw :class:`GetGlobalReportSettingApiResponse` object returned by
+        the SDK. Callers typically read ``resp.data`` for the entity itself
+        and use ``get_etag(resp.data)`` to pick up the concurrency token for
+        subsequent updates.
+    """
+    try:
+        return api_instance.get_global_report_setting(userExtId=user_ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching global report setting "
+                "for user ext_id"
+            ),
+        )

--- a/plugins/modules/ntnx_global_report_setting_v2.py
+++ b/plugins/modules/ntnx_global_report_setting_v2.py
@@ -1,0 +1,564 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_global_report_setting_v2
+short_description: Update the global report setting for a user in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to update the global report setting for a user in Nutanix Prism Central.
+  - C(GlobalReportSetting) is a per-user singleton that is always present for a given user.
+  - The Nutanix v4 API only exposes Get and Update (PUT) for this resource, so this module supports
+    C(state=present) only and always issues an idempotent update against the setting owned by the
+    supplied C(user_ext_id).
+  - This module uses PC v4 APIs based SDKs
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Update the Global Report Setting) -
+      Required Roles: NCM Admin, Operations Management Admin, Prism Admin, Project Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=opsmgmt)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) the module will update the global report setting
+        owned by C(user_ext_id) using the supplied fields.
+      - C(state=absent) is not supported for this resource because the underlying v4 API does
+        not expose a delete operation for the per-user global report setting.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the global report setting itself.
+      - Optional; when supplied the module will confirm the fetched setting matches and use it
+        for logging in the response.
+      - The v4 API does not use this value to route the request — the setting is identified by
+        C(user_ext_id).
+    type: str
+    required: false
+  user_ext_id:
+    description:
+      - External ID (UUID) of the user whose global report setting is being updated.
+      - This maps to the C(userExtId) path parameter on the underlying v4 API.
+      - Required for all operations.
+    type: str
+    required: true
+  name:
+    description:
+      - Name of the global report setting.
+      - Must be between 1 and 64 characters.
+      - Required for update operation.
+    type: str
+    required: false
+  retention_config:
+    description:
+      - Defines how long generated reports should be retained.
+      - Only one of C(retention_period_seconds) and C(retention_count) should be specified.
+    type: dict
+    required: false
+    suboptions:
+      retention_period_seconds:
+        description:
+          - Retention period in seconds for the generated reports.
+        type: int
+        required: false
+      retention_count:
+        description:
+          - Number of most-recent reports to retain per report configuration.
+        type: int
+        required: false
+  notification_policy:
+    description:
+      - Notification policy applied when generated reports are emailed to recipients.
+    type: dict
+    required: false
+    suboptions:
+      recipients:
+        description:
+          - List of recipients that should receive the report email.
+          - Required inside C(notification_policy) whenever it is supplied.
+        type: list
+        elements: dict
+        required: false
+        suboptions:
+          email_address:
+            description:
+              - Email address of the recipient.
+            type: str
+            required: true
+          recipient_name:
+            description:
+              - Display name for the recipient. Maximum 64 characters.
+            type: str
+            required: false
+      recipient_formats:
+        description:
+          - Formats in which the report is attached to the notification email.
+        type: list
+        elements: str
+        required: false
+        choices:
+          - PDF
+          - CSV
+      email_subject:
+        description:
+          - Subject of the notification email. Maximum 100 characters.
+        type: str
+        required: false
+      email_body:
+        description:
+          - Body of the notification email. Maximum 1000 characters.
+        type: str
+        required: false
+  report_customization:
+    description:
+      - Report-level customizations (branding, styling, logo).
+    type: dict
+    required: false
+    suboptions:
+      header_html:
+        description:
+          - Custom header HTML applied to the report.
+        type: str
+        required: false
+      footer_html:
+        description:
+          - Custom footer HTML applied to the report.
+        type: str
+        required: false
+      css_style_sheet:
+        description:
+          - Global cascading style sheet applied to the report.
+        type: str
+        required: false
+      logo_image_ext_id:
+        description:
+          - External ID of an uploaded C(ReportArtifact) that should be used as the report logo.
+        type: str
+        required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Update global report setting for a user
+  nutanix.ncp.ntnx_global_report_setting_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    user_ext_id: "00000000-0000-0000-0000-000000000000"
+    name: "global_report_setting_ansible"
+    retention_config:
+      retention_count: 5
+    notification_policy:
+      recipients:
+        - email_address: "reports@example.com"
+          recipient_name: "Reports Owner"
+      recipient_formats:
+        - PDF
+        - CSV
+      email_subject: "Your Nutanix reports"
+      email_body: "Please find the attached reports."
+    report_customization:
+      header_html: "<h1>Nutanix reports</h1>"
+      footer_html: "<p>Copyright Nutanix</p>"
+      css_style_sheet: "body { font-family: Arial; }"
+  register: result
+  ignore_errors: true
+
+- name: Reset the global report setting to a minimal configuration
+  nutanix.ncp.ntnx_global_report_setting_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    user_ext_id: "00000000-0000-0000-0000-000000000000"
+    name: "global_report_setting_reset"
+    retention_config:
+      retention_period_seconds: 604800
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for updating the global report setting.
+    - If the operation is update and C(wait) is true, the module will re-fetch and return the
+      updated global report setting details.
+    - If C(wait) is false, the module will return the task response captured immediately after
+      the update was submitted.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "b1b5b0c4-c8a2-4b58-9f22-2a4b7e8b9a10",
+      "links": null,
+      "name": "global_report_setting_ansible",
+      "notification_policy": {
+          "email_body": "Please find the attached reports.",
+          "email_subject": "Your Nutanix reports",
+          "recipient_formats": ["PDF", "CSV"],
+          "recipients": [
+              {
+                  "email_address": "reports@example.com",
+                  "recipient_name": "Reports Owner"
+              }
+          ]
+      },
+      "report_customization": {
+          "css_style_sheet": "body { font-family: Arial; }",
+          "footer_html": "<p>Copyright Nutanix</p>",
+          "header_html": "<h1>Nutanix reports</h1>",
+          "logo_image_ext_id": null
+      },
+      "retention_config": {
+          "retention_count": 5,
+          "retention_period_seconds": null
+      },
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+    - The Update API for GlobalReportSetting is synchronous, so this field is typically null.
+  returned: always
+  type: str
+  sample: null
+
+ext_id:
+  description:
+    - The external ID of the global report setting.
+  returned: always
+  type: str
+  sample: "b1b5b0c4-c8a2-4b58-9f22-2a4b7e8b9a10"
+
+user_ext_id:
+  description:
+    - External ID of the user whose global report setting was updated.
+  returned: always
+  type: str
+  sample: "00000000-0000-0000-0000-000000000000"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped due to idempotency.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description:
+    - Human-readable status message.
+    - Populated when the module is idempotent, when C(state=absent) is requested (which is
+      unsupported), or when an error occurs.
+  returned: When there is an error, module is idempotent, or an unsupported state is requested
+  type: str
+  sample: "GlobalReportSetting with name 'global_report_setting_ansible' already matches the desired state. Skipping update."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.opsmgmt.api_client import (  # noqa: E402
+    get_etag,
+    get_global_report_setting_api_instance,
+)
+from ..module_utils.v4.opsmgmt.helpers import get_global_report_setting  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_opsmgmt_py_client as ncm_operation_base_platform_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402
+        mock_sdk as ncm_operation_base_platform_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+# Attributes populated by the platform that must not be included in the update body.
+_READ_ONLY_FIELDS = ("links", "tenant_id")
+
+
+def get_module_spec():
+    """
+    Build and return the Ansible argument spec for the CRUD module.
+
+    Field mapping and validation constraints mirror the v4 SDK model
+    :class:`ntnx_opsmgmt_py_client.GlobalReportSetting` and its nested models
+    (``RetentionConfig``, ``NotificationPolicy``, ``ReportCustomization``).
+    ``name`` is the only strictly required attribute per the SDK, but is
+    marked optional here because it is only required for the update path and
+    is validated at runtime via :func:`validate_required_params`.
+    """
+    recipient_spec = dict(
+        email_address=dict(type="str", required=True),
+        recipient_name=dict(type="str", required=False),
+    )
+
+    notification_policy_spec = dict(
+        recipients=dict(
+            type="list",
+            elements="dict",
+            options=recipient_spec,
+            required=False,
+            obj=ncm_operation_base_platform_sdk.ConfigRecipient,
+        ),
+        recipient_formats=dict(
+            type="list",
+            elements="str",
+            required=False,
+            choices=["PDF", "CSV"],
+        ),
+        email_subject=dict(type="str", required=False),
+        email_body=dict(type="str", required=False),
+    )
+
+    retention_config_spec = dict(
+        retention_period_seconds=dict(type="int", required=False),
+        retention_count=dict(type="int", required=False),
+    )
+
+    report_customization_spec = dict(
+        header_html=dict(type="str", required=False),
+        footer_html=dict(type="str", required=False),
+        css_style_sheet=dict(type="str", required=False),
+        logo_image_ext_id=dict(type="str", required=False),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str", required=False),
+        user_ext_id=dict(type="str", required=True),
+        name=dict(type="str", required=False),
+        retention_config=dict(
+            type="dict",
+            options=retention_config_spec,
+            required=False,
+            obj=ncm_operation_base_platform_sdk.RetentionConfig,
+        ),
+        notification_policy=dict(
+            type="dict",
+            options=notification_policy_spec,
+            required=False,
+            obj=ncm_operation_base_platform_sdk.ConfigNotificationPolicy,
+        ),
+        report_customization=dict(
+            type="dict",
+            options=report_customization_spec,
+            required=False,
+            obj=ncm_operation_base_platform_sdk.ConfigReportCustomization,
+        ),
+    )
+    return module_args
+
+
+def _check_for_idempotency(old_spec_dict, update_spec_dict):
+    """
+    Return True when the current and desired specs describe the same setting.
+
+    Internal / server-only attributes are stripped from both sides before the
+    comparison so fields such as ``$reserved`` and read-only bookkeeping do
+    not create false diffs. Used by :func:`update_global_report_setting` to
+    short-circuit the update call when nothing would actually change.
+    """
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    for field in _READ_ONLY_FIELDS:
+        old_spec_dict.pop(field, None)
+        update_spec_dict.pop(field, None)
+    return old_spec_dict == update_spec_dict
+
+
+def update_global_report_setting(module, api_instance, result):
+    """
+    Update the per-user global report setting.
+
+    Fetches the existing setting for ``user_ext_id``, applies the fields
+    supplied by the caller on top of that spec, and issues the SDK Update
+    (PUT) call. The current ETag is passed as ``if_match`` to satisfy the
+    API's optimistic concurrency requirement. On check mode the module
+    returns the fully-populated spec without contacting the server; on real
+    runs it re-fetches the setting after the update so callers see the
+    canonical server-side state.
+    """
+    validate_required_params(module, ["user_ext_id", "name"])
+    user_ext_id = module.params.get("user_ext_id")
+    result["user_ext_id"] = user_ext_id
+
+    current_resp = get_global_report_setting(module, api_instance, user_ext_id)
+    old_spec = current_resp.data
+    etag = get_etag(data=old_spec)
+    if not etag:
+        module.fail_json(
+            msg=(
+                "Unable to fetch etag for updating global report setting "
+                "for user ext_id: {0}".format(user_ext_id)
+            ),
+            **result,
+        )
+    kwargs = {"if_match": etag}
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating update global report setting spec", **result
+        )
+
+    if update_spec.ext_id:
+        result["ext_id"] = update_spec.ext_id
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if _check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        result["response"] = strip_internal_attributes(old_spec.to_dict())
+        module.exit_json(
+            msg=(
+                "GlobalReportSetting with name '{0}' already matches the "
+                "desired state. Skipping update.".format(module.params.get("name"))
+            ),
+            **result,
+        )
+
+    strip_read_only_fields(update_spec, _READ_ONLY_FIELDS)
+
+    resp = None
+    try:
+        resp = api_instance.update_global_report_setting(
+            userExtId=user_ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating global report setting",
+        )
+
+    # The Update API is synchronous and returns the updated entity directly.
+    if resp is not None and getattr(resp, "data", None) is not None:
+        data = resp.data
+        result["response"] = strip_internal_attributes(data.to_dict())
+        if getattr(data, "ext_id", None):
+            result["ext_id"] = data.ext_id
+
+    # Re-fetch to guarantee the caller sees the canonical server state.
+    if module.params.get("wait"):
+        refreshed = get_global_report_setting(module, api_instance, user_ext_id)
+        result["response"] = strip_internal_attributes(refreshed.data.to_dict())
+        if getattr(refreshed.data, "ext_id", None):
+            result["ext_id"] = refreshed.data.ext_id
+
+    result["changed"] = True
+
+
+def run_module():
+    """
+    Ansible module entry-point.
+
+    Builds the CRUD module, validates SDK availability, dispatches on
+    ``state``, and returns the aggregate result. Only ``state=present`` is
+    supported for GlobalReportSetting; ``state=absent`` fails with a clear
+    message because the underlying v4 API has no delete operation.
+    """
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_opsmgmt_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "user_ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+    }
+    api_instance = get_global_report_setting_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        update_global_report_setting(module, api_instance, result)
+    else:
+        module.fail_json(
+            msg=(
+                "state=absent is not supported for GlobalReportSetting; the "
+                "v4 API only exposes Get and Update. Use state=present with "
+                "the desired values to modify the setting."
+            ),
+            **result,
+        )
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_global_report_settings_info_v2.py
+++ b/plugins/modules/ntnx_global_report_settings_info_v2.py
@@ -1,0 +1,216 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_global_report_settings_info_v2
+short_description: Fetch the global report setting for a user in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about GlobalReportSetting in Nutanix Prism Central.
+  - GlobalReportSetting is a per-user singleton resource; the Nutanix v4 API only exposes a
+    Get-by-user endpoint and does not offer a list, filter, or pagination API.
+  - Supply C(user_ext_id) to fetch the setting owned by that user.
+  - This module uses PC v4 APIs based SDKs
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get the Global Report Setting) -
+      Required Roles: Developer, NCM Admin, Operations Management Admin, Operations Management Viewer, Operator,
+      Prism Admin, Project Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=opsmgmt)"
+options:
+  user_ext_id:
+    description:
+      - External ID (UUID) of the user whose global report setting should be fetched.
+      - Maps to the C(userExtId) path parameter on the underlying v4 API.
+      - Required.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - Optional external ID of the global report setting.
+      - Included so the module can echo it back in the response for logging / assertions;
+        the v4 API does not accept it as a routing parameter.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get global report setting for a user
+  nutanix.ncp.ntnx_global_report_settings_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    user_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC GlobalReportSetting info v4 API.
+    - It contains a single GlobalReportSetting dict since C(user_ext_id) uniquely identifies the resource.
+    - The v4 API does not expose a list endpoint for this entity, so a list response is not possible.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "b1b5b0c4-c8a2-4b58-9f22-2a4b7e8b9a10",
+      "links": null,
+      "name": "global_report_setting_ansible",
+      "notification_policy": {
+          "email_body": "Please find the attached reports.",
+          "email_subject": "Your Nutanix reports",
+          "recipient_formats": ["PDF", "CSV"],
+          "recipients": [
+              {
+                  "email_address": "reports@example.com",
+                  "recipient_name": "Reports Owner"
+              }
+          ]
+      },
+      "report_customization": {
+          "css_style_sheet": "body { font-family: Arial; }",
+          "footer_html": "<p>Copyright Nutanix</p>",
+          "header_html": "<h1>Nutanix reports</h1>",
+          "logo_image_ext_id": null
+      },
+      "retention_config": {
+          "retention_count": 5,
+          "retention_period_seconds": null
+      },
+      "tenant_id": null
+    }
+
+user_ext_id:
+  description: User external ID whose global report setting was fetched.
+  returned: always
+  type: str
+  sample: "00000000-0000-0000-0000-000000000000"
+
+ext_id:
+  description: External ID of the fetched global report setting.
+  type: str
+  returned: when the API returns an ext_id in the response
+  sample: "b1b5b0c4-c8a2-4b58-9f22-2a4b7e8b9a10"
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching global report setting for user ext_id"
+
+error:
+  description: Error information if any error occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: Whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.opsmgmt.api_client import (  # noqa: E402
+    get_global_report_setting_api_instance,
+)
+from ..module_utils.v4.opsmgmt.helpers import get_global_report_setting  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    """
+    Build the argument spec for the info module.
+
+    GlobalReportSetting is a per-user singleton, so the only routing key we
+    expose is ``user_ext_id``. ``ext_id`` is optional and only echoed back in
+    the module response for callers that want to assert on it.
+    """
+    module_args = dict(
+        user_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=False),
+    )
+    return module_args
+
+
+def get_global_report_setting_using_user_ext_id(module, api_instance, result):
+    """
+    Fetch the setting for ``user_ext_id`` and populate ``result``.
+
+    The helper strips SDK internal attributes so callers get a clean dict
+    suitable for assertions. When the API returns an ``ext_id`` on the entity
+    it is copied to the top-level result for convenience.
+    """
+    user_ext_id = module.params.get("user_ext_id")
+    resp = get_global_report_setting(module, api_instance, user_ext_id)
+    data = resp.data
+    result["user_ext_id"] = user_ext_id
+    if getattr(data, "ext_id", None):
+        result["ext_id"] = data.ext_id
+    result["response"] = strip_internal_attributes(data.to_dict())
+
+
+def run_module():
+    """
+    Ansible info-module entry-point.
+    """
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "user_ext_id": None,
+    }
+    api_instance = get_global_report_setting_api_instance(module)
+    get_global_report_setting_using_user_ext_id(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
-ntnx-opsmgmt-py-client==latest
+ntnx-opsmgmt-py-client==26.2.0.21743

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-opsmgmt-py-client==latest

--- a/tests/integration/targets/ntnx_global_report_setting_v2/aliases
+++ b/tests/integration/targets/ntnx_global_report_setting_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_global_report_setting_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_global_report_setting_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_global_report_setting_v2/tasks/global_report_setting.yml
+++ b/tests/integration/targets/ntnx_global_report_setting_v2/tasks/global_report_setting.yml
@@ -1,0 +1,491 @@
+---
+############################################################
+# Test plan for ncm_operation_base_platform GlobalReportSetting v4 modules
+#
+# Modules under test:
+#   - ntnx_global_report_setting_v2       (CRUD; only Update supported by SDK)
+#   - ntnx_global_report_settings_info_v2 (Info; Get-by-user only)
+#
+# Coverage:
+#   1. Discover the admin user's ext_id (used as userExtId path parameter).
+#   2. Save the current setting so we can restore it at teardown.
+#   3. Info: get-by-user succeeds; missing user_ext_id fails required-param check.
+#   4. CRUD check_mode: exactly one check_mode update with ALL attributes.
+#   5. CRUD real update with minimum attributes (only name).
+#   6. CRUD real update with ALL attributes (retention, notification, customization).
+#   7. Info after full update to assert persisted state.
+#   8. State transition update (change retention scheme, add extra recipient, tweak HTML).
+#   9. Idempotency: re-run the same update and assert changed=false + skipped message.
+#   10. Negative: missing required `name`, missing required `user_ext_id`,
+#       invalid enum value in `recipient_formats`, unsupported `state=absent`.
+#   11. Restore the original setting.
+############################################################
+
+- name: Start GlobalReportSetting integration tests
+  ansible.builtin.debug:
+    msg: Start GlobalReportSetting integration tests
+
+- name: Generate random suffix to avoid collisions
+  ansible.builtin.set_fact:
+    grs_suffix: "{{ query('community.general.random_string', numbers=false, special=false, length=10)[0] }}"
+
+- name: Compute test-specific resource names
+  ansible.builtin.set_fact:
+    grs_full_name: "grs_full_{{ grs_suffix }}"
+    grs_min_name: "grs_min_{{ grs_suffix }}"
+    grs_transition_name: "grs_transition_{{ grs_suffix }}"
+
+########################################################################################
+# 1. Discover the admin user's ext_id
+########################################################################################
+
+- name: Discover the admin user's ext_id
+  nutanix.ncp.ntnx_users_info_v2:
+    filter: "username eq 'admin'"
+  register: users_lookup
+  ignore_errors: true
+
+- name: Assert admin user lookup succeeded
+  ansible.builtin.assert:
+    that:
+      - users_lookup is defined
+      - users_lookup.failed == false
+      - users_lookup.changed == false
+      - users_lookup.response is defined
+      - users_lookup.response | length > 0
+      - users_lookup.response[0].ext_id is defined
+    success_msg: "Discovered the admin user's ext_id."
+    fail_msg: "Failed to discover the admin user's ext_id."
+
+- name: Set admin_user_ext_id
+  ansible.builtin.set_fact:
+    admin_user_ext_id: "{{ users_lookup.response[0].ext_id }}"
+
+########################################################################################
+# 2. Snapshot the current global report setting so we can restore it
+########################################################################################
+
+- name: Fetch original global report setting (before test mutations)
+  nutanix.ncp.ntnx_global_report_settings_info_v2:
+    user_ext_id: "{{ admin_user_ext_id }}"
+  register: original_setting
+  ignore_errors: true
+
+- name: Assert original setting fetch succeeded
+  ansible.builtin.assert:
+    that:
+      - original_setting is defined
+      - original_setting.failed == false
+      - original_setting.changed == false
+      - original_setting.response is defined
+      - original_setting.response.name is defined
+      - original_setting.user_ext_id == admin_user_ext_id
+    success_msg: "Fetched original global report setting for restoration."
+    fail_msg: "Failed to fetch original global report setting."
+
+- name: Remember original name for restore step
+  ansible.builtin.set_fact:
+    original_name: "{{ original_setting.response.name }}"
+    original_retention: "{{ original_setting.response.retention_config | default(omit) }}"
+    original_notification: "{{ original_setting.response.notification_policy | default(omit) }}"
+    original_customization: "{{ original_setting.response.report_customization | default(omit) }}"
+
+########################################################################################
+# 3. Info module coverage
+########################################################################################
+
+- name: Info - fetch global report setting using user_ext_id
+  nutanix.ncp.ntnx_global_report_settings_info_v2:
+    user_ext_id: "{{ admin_user_ext_id }}"
+  register: info_by_user
+  ignore_errors: true
+
+- name: Info - assert single entity fetched by user_ext_id
+  ansible.builtin.assert:
+    that:
+      - info_by_user is defined
+      - info_by_user.failed == false
+      - info_by_user.changed == false
+      - info_by_user.response is defined
+      - info_by_user.response.name is defined
+      - info_by_user.user_ext_id == admin_user_ext_id
+    success_msg: "Info module returned the expected singleton setting."
+    fail_msg: "Info module did not return the expected singleton setting."
+
+- name: Info - required user_ext_id missing (negative)  # noqa: args
+  nutanix.ncp.ntnx_global_report_settings_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: info_missing_required
+  ignore_errors: true
+
+- name: Info - assert missing user_ext_id fails with clear message
+  ansible.builtin.assert:
+    that:
+      - info_missing_required is defined
+      - info_missing_required.failed == true
+      - info_missing_required.changed == false
+      - info_missing_required.msg is defined
+      - "'user_ext_id' in info_missing_required.msg"
+    success_msg: "Info module rejected request missing required user_ext_id."
+    fail_msg: "Info module accepted request missing required user_ext_id."
+
+- name: Info - invalid user_ext_id (negative)
+  nutanix.ncp.ntnx_global_report_settings_info_v2:
+    user_ext_id: "00000000-0000-0000-0000-000000000001"
+  register: info_bad_user
+  ignore_errors: true
+
+- name: Info - assert invalid user_ext_id fails
+  ansible.builtin.assert:
+    that:
+      - info_bad_user is defined
+      - info_bad_user.failed == true
+      - info_bad_user.changed == false
+    success_msg: "Info module rejected an invalid user_ext_id."
+    fail_msg: "Info module accepted an invalid user_ext_id."
+
+########################################################################################
+# 4. CRUD check_mode: exactly ONE check_mode update covering ALL attributes
+########################################################################################
+
+- name: CRUD - check_mode update with ALL attributes
+  nutanix.ncp.ntnx_global_report_setting_v2:
+    state: present
+    user_ext_id: "{{ admin_user_ext_id }}"
+    name: "{{ grs_full_name }}"
+    retention_config:
+      retention_count: 7
+    notification_policy:
+      recipients:
+        - email_address: "reports@example.com"
+          recipient_name: "Reports Owner"
+        - email_address: "ops@example.com"
+          recipient_name: "Ops"
+      recipient_formats:
+        - PDF
+        - CSV
+      email_subject: "Weekly report - check mode"
+      email_body: "Body sent in check mode."
+    report_customization:
+      header_html: "<h1>Header check</h1>"
+      footer_html: "<p>Footer check</p>"
+      css_style_sheet: "body { color: darkgray; }"
+  check_mode: true
+  register: check_mode_update
+  ignore_errors: true
+
+- name: CRUD - assert check_mode update generated the expected spec
+  ansible.builtin.assert:
+    that:
+      - check_mode_update is defined
+      - check_mode_update.failed == false
+      - check_mode_update.changed == false
+      - check_mode_update.response is defined
+      - check_mode_update.response.name == grs_full_name
+      - check_mode_update.response.retention_config.retention_count == 7
+      - check_mode_update.response.notification_policy.recipients | length == 2
+      - check_mode_update.response.notification_policy.recipients[0].email_address == "reports@example.com"
+      - check_mode_update.response.notification_policy.recipients[0].recipient_name == "Reports Owner"
+      - check_mode_update.response.notification_policy.recipients[1].email_address == "ops@example.com"
+      - check_mode_update.response.notification_policy.recipient_formats | length == 2
+      - "'PDF' in check_mode_update.response.notification_policy.recipient_formats"
+      - "'CSV' in check_mode_update.response.notification_policy.recipient_formats"
+      - check_mode_update.response.notification_policy.email_subject == "Weekly report - check mode"
+      - check_mode_update.response.notification_policy.email_body == "Body sent in check mode."
+      - check_mode_update.response.report_customization.header_html == "<h1>Header check</h1>"
+      - check_mode_update.response.report_customization.footer_html == "<p>Footer check</p>"
+      - check_mode_update.response.report_customization.css_style_sheet == "body { color: darkgray; }"
+      - check_mode_update.user_ext_id == admin_user_ext_id
+    success_msg: "check_mode update generated the expected spec."
+    fail_msg: "check_mode update did not generate the expected spec."
+
+########################################################################################
+# 5. CRUD real update with the minimum set of attributes
+########################################################################################
+
+- name: CRUD - update with minimum attributes (only name)
+  nutanix.ncp.ntnx_global_report_setting_v2:
+    state: present
+    user_ext_id: "{{ admin_user_ext_id }}"
+    name: "{{ grs_min_name }}"
+  register: min_update
+  ignore_errors: true
+
+- name: CRUD - assert minimum-attributes update succeeded
+  ansible.builtin.assert:
+    that:
+      - min_update is defined
+      - min_update.failed == false
+      - min_update.changed == true
+      - min_update.response is defined
+      - min_update.response.name == grs_min_name
+      - min_update.user_ext_id == admin_user_ext_id
+    success_msg: "Minimum-attributes update applied successfully."
+    fail_msg: "Minimum-attributes update failed."
+
+########################################################################################
+# 6. CRUD real update with ALL attributes
+########################################################################################
+
+- name: CRUD - update with ALL attributes
+  nutanix.ncp.ntnx_global_report_setting_v2:
+    state: present
+    user_ext_id: "{{ admin_user_ext_id }}"
+    name: "{{ grs_full_name }}"
+    retention_config:
+      retention_count: 5
+    notification_policy:
+      recipients:
+        - email_address: "reports@example.com"
+          recipient_name: "Reports Owner"
+      recipient_formats:
+        - PDF
+        - CSV
+      email_subject: "Weekly report"
+      email_body: "Please find the attached reports."
+    report_customization:
+      header_html: "<h1>Nutanix reports</h1>"
+      footer_html: "<p>Copyright Nutanix</p>"
+      css_style_sheet: "body { font-family: Arial; }"
+  register: full_update
+  ignore_errors: true
+
+- name: CRUD - assert full-attributes update succeeded
+  ansible.builtin.assert:
+    that:
+      - full_update is defined
+      - full_update.failed == false
+      - full_update.changed == true
+      - full_update.response is defined
+      - full_update.response.name == grs_full_name
+      - full_update.response.retention_config.retention_count == 5
+      - full_update.response.notification_policy.recipients | length == 1
+      - full_update.response.notification_policy.recipients[0].email_address == "reports@example.com"
+      - full_update.response.notification_policy.recipients[0].recipient_name == "Reports Owner"
+      - full_update.response.notification_policy.recipient_formats | length == 2
+      - "'PDF' in full_update.response.notification_policy.recipient_formats"
+      - "'CSV' in full_update.response.notification_policy.recipient_formats"
+      - full_update.response.notification_policy.email_subject == "Weekly report"
+      - full_update.response.notification_policy.email_body == "Please find the attached reports."
+      - full_update.response.report_customization.header_html == "<h1>Nutanix reports</h1>"
+      - full_update.response.report_customization.footer_html == "<p>Copyright Nutanix</p>"
+      - full_update.response.report_customization.css_style_sheet == "body { font-family: Arial; }"
+      - full_update.user_ext_id == admin_user_ext_id
+    success_msg: "Full-attributes update applied successfully."
+    fail_msg: "Full-attributes update failed."
+
+########################################################################################
+# 7. Info after update
+########################################################################################
+
+- name: Info - re-fetch after the full update
+  nutanix.ncp.ntnx_global_report_settings_info_v2:
+    user_ext_id: "{{ admin_user_ext_id }}"
+  register: after_full_update
+  ignore_errors: true
+
+- name: Info - assert the persisted setting matches the update payload
+  ansible.builtin.assert:
+    that:
+      - after_full_update is defined
+      - after_full_update.failed == false
+      - after_full_update.changed == false
+      - after_full_update.response.name == grs_full_name
+      - after_full_update.response.retention_config.retention_count == 5
+      - after_full_update.response.notification_policy.recipients | length == 1
+      - after_full_update.response.notification_policy.recipients[0].email_address == "reports@example.com"
+      - after_full_update.response.notification_policy.recipient_formats | length == 2
+      - "'PDF' in after_full_update.response.notification_policy.recipient_formats"
+      - "'CSV' in after_full_update.response.notification_policy.recipient_formats"
+      - after_full_update.response.notification_policy.email_subject == "Weekly report"
+      - after_full_update.response.report_customization.header_html == "<h1>Nutanix reports</h1>"
+      - after_full_update.response.report_customization.footer_html == "<p>Copyright Nutanix</p>"
+    success_msg: "Persisted global report setting matches the update payload."
+    fail_msg: "Persisted global report setting does not match the update payload."
+
+########################################################################################
+# 8. State transition update — change scalars, enum list, and add a recipient
+########################################################################################
+
+- name: CRUD - state transition update (change retention scheme, tweak content)
+  nutanix.ncp.ntnx_global_report_setting_v2:
+    state: present
+    user_ext_id: "{{ admin_user_ext_id }}"
+    name: "{{ grs_transition_name }}"
+    retention_config:
+      retention_period_seconds: 259200
+    notification_policy:
+      recipients:
+        - email_address: "reports@example.com"
+          recipient_name: "Reports Owner"
+        - email_address: "ops@example.com"
+          recipient_name: "Ops Team"
+      recipient_formats:
+        - PDF
+      email_subject: "Updated report subject"
+      email_body: "Updated report body."
+    report_customization:
+      header_html: "<h2>Updated header</h2>"
+      footer_html: "<p>Updated footer</p>"
+      css_style_sheet: "body { font-family: Helvetica; }"
+  register: transition_update
+  ignore_errors: true
+
+- name: CRUD - assert state transition update took effect
+  ansible.builtin.assert:
+    that:
+      - transition_update is defined
+      - transition_update.failed == false
+      - transition_update.changed == true
+      - transition_update.response.name == grs_transition_name
+      - transition_update.response.retention_config.retention_period_seconds == 259200
+      - transition_update.response.notification_policy.recipients | length == 2
+      - transition_update.response.notification_policy.recipients[1].email_address == "ops@example.com"
+      - transition_update.response.notification_policy.recipient_formats | length == 1
+      - transition_update.response.notification_policy.recipient_formats[0] == "PDF"
+      - transition_update.response.notification_policy.email_subject == "Updated report subject"
+      - transition_update.response.report_customization.header_html == "<h2>Updated header</h2>"
+    success_msg: "State transition update applied successfully."
+    fail_msg: "State transition update did not apply."
+
+########################################################################################
+# 9. Idempotency: re-run the same update, expect no changes
+########################################################################################
+
+- name: CRUD - idempotency (same payload as transition update)
+  nutanix.ncp.ntnx_global_report_setting_v2:
+    state: present
+    user_ext_id: "{{ admin_user_ext_id }}"
+    name: "{{ grs_transition_name }}"
+    retention_config:
+      retention_period_seconds: 259200
+    notification_policy:
+      recipients:
+        - email_address: "reports@example.com"
+          recipient_name: "Reports Owner"
+        - email_address: "ops@example.com"
+          recipient_name: "Ops Team"
+      recipient_formats:
+        - PDF
+      email_subject: "Updated report subject"
+      email_body: "Updated report body."
+    report_customization:
+      header_html: "<h2>Updated header</h2>"
+      footer_html: "<p>Updated footer</p>"
+      css_style_sheet: "body { font-family: Helvetica; }"
+  register: idempotent_update
+  ignore_errors: true
+
+- name: CRUD - assert idempotent update reports no change
+  ansible.builtin.assert:
+    that:
+      - idempotent_update is defined
+      - idempotent_update.failed == false
+      - idempotent_update.changed == false
+      - idempotent_update.skipped == true
+      - idempotent_update.msg is defined
+      - "'already matches' in idempotent_update.msg"
+    success_msg: "Idempotent update reported no change as expected."
+    fail_msg: "Idempotent update did not report skipped."
+
+########################################################################################
+# 10. Negative tests
+########################################################################################
+
+- name: CRUD - missing required `name` (negative)
+  nutanix.ncp.ntnx_global_report_setting_v2:
+    state: present
+    user_ext_id: "{{ admin_user_ext_id }}"
+  register: missing_name
+  ignore_errors: true
+
+- name: CRUD - assert missing name fails
+  ansible.builtin.assert:
+    that:
+      - missing_name is defined
+      - missing_name.failed == true
+      - missing_name.changed == false
+      - missing_name.msg is defined
+      - "'name' in missing_name.msg"
+    success_msg: "CRUD rejected update missing required name."
+    fail_msg: "CRUD accepted update missing required name."
+
+- name: CRUD - missing required `user_ext_id` (negative)  # noqa: args
+  nutanix.ncp.ntnx_global_report_setting_v2:
+    state: present
+    name: "grs_missing_user"
+  register: missing_user_ext_id
+  ignore_errors: true
+
+- name: CRUD - assert missing user_ext_id fails
+  ansible.builtin.assert:
+    that:
+      - missing_user_ext_id is defined
+      - missing_user_ext_id.failed == true
+      - missing_user_ext_id.changed == false
+      - missing_user_ext_id.msg is defined
+      - "'user_ext_id' in missing_user_ext_id.msg"
+    success_msg: "CRUD rejected update missing required user_ext_id."
+    fail_msg: "CRUD accepted update missing required user_ext_id."
+
+- name: CRUD - invalid recipient_formats enum (negative)  # noqa: args
+  nutanix.ncp.ntnx_global_report_setting_v2:
+    state: present
+    user_ext_id: "{{ admin_user_ext_id }}"
+    name: "grs_bad_enum"
+    notification_policy:
+      recipients:
+        - email_address: "reports@example.com"
+      recipient_formats:
+        - INVALID
+  register: bad_enum
+  ignore_errors: true
+
+- name: CRUD - assert invalid enum is rejected
+  ansible.builtin.assert:
+    that:
+      - bad_enum is defined
+      - bad_enum.failed == true
+      - bad_enum.changed == false
+      - bad_enum.msg is defined
+      - "'INVALID' in (bad_enum.msg | string) or 'value of recipient_formats' in (bad_enum.msg | string) or 'is not one of' in (bad_enum.msg | string)"
+    success_msg: "CRUD rejected an invalid recipient_formats enum value."
+    fail_msg: "CRUD accepted an invalid recipient_formats enum value."
+
+- name: CRUD - unsupported state=absent (negative)
+  nutanix.ncp.ntnx_global_report_setting_v2:
+    state: absent
+    user_ext_id: "{{ admin_user_ext_id }}"
+  register: unsupported_absent
+  ignore_errors: true
+
+- name: CRUD - assert state=absent is rejected with a clear message
+  ansible.builtin.assert:
+    that:
+      - unsupported_absent is defined
+      - unsupported_absent.failed == true
+      - unsupported_absent.changed == false
+      - unsupported_absent.msg is defined
+      - "'not supported' in unsupported_absent.msg"
+    success_msg: "CRUD rejected unsupported state=absent with a clear message."
+    fail_msg: "CRUD accepted unsupported state=absent."
+
+########################################################################################
+# 11. Restore the original setting so subsequent test runs are stable
+########################################################################################
+
+- name: Restore original global report setting name
+  nutanix.ncp.ntnx_global_report_setting_v2:
+    state: present
+    user_ext_id: "{{ admin_user_ext_id }}"
+    name: "{{ original_name }}"
+  register: restore_result
+  ignore_errors: true
+
+- name: Assert restore step reported success
+  ansible.builtin.assert:
+    that:
+      - restore_result is defined
+      - restore_result.failed == false
+    success_msg: "Original global report setting was restored."
+    fail_msg: "Failed to restore the original global report setting."

--- a/tests/integration/targets/ntnx_global_report_setting_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_global_report_setting_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import global_report_setting.yml
+      ansible.builtin.import_tasks: global_report_setting.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **ncm_operation_base_platform** namespace, entity
**GlobalReportSetting**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_global_report_setting_v2`, `ntnx_global_report_settings_info_v2`
- API methods covered: `2` (`GET /api/opsmgmt/v4.1.b1/config/user/{userExtId}/global-report-setting`, `PUT /api/opsmgmt/v4.1.b1/config/user/{userExtId}/global-report-setting`)
- Fields in CRUD module spec: `12` (state, wait, user_ext_id, ext_id, name, retention_config[retention_count, retention_period_seconds], notification_policy[recipients, recipient_formats, email_subject, email_body], report_customization[header_html, footer_html, css_style_sheet, logo_image_ext_id])
- Fields in info module spec: `2` (user_ext_id, ext_id)

## Domain knowledge (from Glean)

`GlobalReportSetting` is a **per-user singleton resource** exposed by the Nutanix
Prism Central Operations Management (NCM Cost Governance / Operations
Management) v4 API. It stores the report-generation preferences that are
applied whenever the calling user asks Nutanix reports to be produced.

- **Namespace / SDK**: `ncm_operation_base_platform`, served by the
  `ntnx-opsmgmt-py-client` SDK (`opsmgmt.v4.config.GlobalReportSetting`).
- **API surface** (from the SDK):
  - `GET /api/opsmgmt/v4.1.b1/config/user/{userExtId}/global-report-setting`
    returns the current setting for `userExtId`.
  - `PUT /api/opsmgmt/v4.1.b1/config/user/{userExtId}/global-report-setting`
    replaces it. The API requires an `If-Match` header carrying the ETag
    of the previously fetched resource for optimistic concurrency.
  - There is **no** POST / DELETE / list endpoint — the resource is a
    per-user singleton created lazily by the platform when the user first
    reads it. The Ansible modules reflect this: only `state=present` is
    supported and there is no list/filter path in the info module.
- **Payload structure** (from `GlobalReportSetting` model):
  - `name` — string, human-readable identifier for the setting profile.
  - `retention_config` — controls how long generated report artifacts are
    kept (`retention_count` and/or `retention_period_seconds`).
  - `notification_policy` — email delivery preferences for generated
    reports:
    - `recipients` — list of `{email_address, recipient_name}`.
    - `recipient_formats` — enum list; supported values are `PDF` and
      `CSV`.
    - `email_subject` / `email_body`.
  - `report_customization` — branding for the generated report artefact:
    `header_html`, `footer_html`, `css_style_sheet`, `logo_image_ext_id`.
- **Where it is used**: This setting is consumed by every report job the
  user schedules or triggers on demand from Prism Central (Cost / Reports
  UI, scheduled `Report` runs, on-demand `Report` generation). Cost /
  Reports use it to look up default recipient list, retention window,
  and styling to apply to the generated PDF/CSV.
- **Behavioural details / prerequisites**:
  - The caller must be authenticated. Required IAM roles (per Nutanix
    v4 docs): `Developer`, `NCM Admin`, `Operations Management Admin`,
    `Operations Management Viewer`, `Operator`, `Prism Admin`,
    `Project Admin`, `Super Admin`. Update needs a role with the
    `updateGlobalReportSetting` privilege.
  - `userExtId` is the caller's user UUID. It can be discovered with
    `ntnx_users_info_v2` (filter `username eq 'admin'`).
  - Update is idempotent: the module compares the current entity to
    the desired spec (with server-managed fields stripped) and skips
    the PUT when unchanged.
  - Because the API is a PUT / replace, every field must be supplied or
    left unset — omitted fields are treated as "leave as is" in the
    module by re-using the current server value where the SDK permits
    it. The v4 API itself is a full replace, so callers should supply
    the full desired state.
- **Glean references**: Glean returned generic Ansible collection design
  guidance and the `nutanix.ansible` reference material (Virtual Switches
  v2, CONTRIBUTING-v4.md). No entity-specific ticket/spec pages were
  surfaced beyond the SDK source. The behaviour above was reconstructed
  from the SDK models (`ntnx_opsmgmt_py_client.models.opsmgmt.v4.config`)
  and the Nutanix v4 API reference at
  https://developers.nutanix.com/api-reference?namespace=opsmgmt.

## Files changed

- `plugins/modules/`
  - `ntnx_global_report_setting_v2.py` (new — CRUD)
  - `ntnx_global_report_settings_info_v2.py` (new — info)
- `plugins/module_utils/v4/opsmgmt/`
  - `__init__.py` (new)
  - `api_client.py` (new — SDK client factory + ETag helper)
  - `helpers.py` (new — `get_global_report_setting`)
- `examples/ncm_operation_base_platform/GlobalReportSetting/`
  - `global_report_setting_v2.yml` (new — end-to-end example playbook)
  - `examples_run.log` (new — captured playbook output)
- `tests/integration/targets/ntnx_global_report_setting_v2/`
  - `aliases` (new — disabled by convention)
  - `meta/main.yml` (new — depends on `prepare_env`)
  - `tasks/main.yml` (new — module_defaults + import)
  - `tasks/global_report_setting.yml` (new — CRUD + info + negative + idempotency + check_mode tests)
- `meta/runtime.yml` — added both new modules to the
  `group/nutanix.ncp.ntnx` action group so `module_defaults` is honoured.
- `requirements.txt` — pinned `ntnx-opsmgmt-py-client==26.2.0.21743`.

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-test integration --allow-unsupported --allow-disabled ntnx_global_report_setting_v2` |
| Total tests         | `1 role (multi-task suite)`                    |
| Passed              | `7 tasks up to Set admin_user_ext_id`          |
| Failed              | `1` (see analysis below)                       |
| Skipped             | `0`                                            |
| Duration            | `0:01:30`                                      |
| Cluster (PC)        | `10.44.76.28:9440`                             |

### Analysis

The test role reaches Prism Central successfully (auth OK, `ntnx_users_info_v2`
returns the admin user ext_id). The first call to
`ntnx_global_report_settings_info_v2` then fails with HTTP `404 NOT FOUND`:

```
Fetch original global report setting (before test mutations)
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND",
  "msg": "Api Exception raised while fetching global report setting for user ext_id",
  "response": {"message": "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again."},
  "status": 404}
```

Direct verification with `curl` against the same URL returns `404` as well:

```
GET https://10.44.76.28:9440/api/opsmgmt/v4.1.b1/config/user/<ext_id>/global-report-setting
=> HTTP/1.1 404 Not Found
```

**Root cause**: The `opsmgmt` service (NCM Cost Governance / Operations
Management) is **not enabled** on the target Prism Central. Every
`/api/opsmgmt/**` path on this PC returns 404 (single-user singleton
endpoint) or 503 "Connection was refused" (collection-level endpoints).
The Ansible modules correctly propagate the SDK exception as a clean
`error` / `msg` / `status` triple; the test target simply cannot exercise
success paths without a PC where the opsmgmt service is deployed.

**Known issue — cluster prerequisite**: To fully green this suite,
re-run it against a Prism Central instance that has the Operations
Management / Cost Governance service installed and reachable
(equivalently: a PC where `GET /api/opsmgmt/v4.1.b1/config/user/{extId}/global-report-setting`
returns 200 or 404 with an `opsmgmt`-shaped error payload, not the
generic web-frontend 404). The tests already fetch the caller's
`user_ext_id` from `ntnx_users_info_v2` so they need no manual data.

**What was validated regardless**:
- `black`, `isort`, `flake8` all pass on the new module + module_utils.
- `ansible-lint` passes on modules, example playbook, and the integration
  target with **0 failures / 0 warnings** at the `production` profile.
- `ansible-test sanity --docker --python 3.12` on the two new modules and
  the new `module_utils/v4/opsmgmt/` package passes **all 32 sanity
  tests** including `validate-modules`, `pep8`, `pylint`, and
  `yamllint`.
- Auth / credential propagation and the `module_defaults` action-group
  wiring (via `meta/runtime.yml`) both work — the module reaches the
  API and gets a real HTTP response.
- SDK exception handling correctness: the info module returns a
  structured error object (not a stack trace), with `changed=false`,
  `failed=true`, `status=404`, and a descriptive `msg`.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Running ntnx_global_report_setting_v2 integration test role
[WARNING]: Found variable using reserved name: port

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_global_report_setting_v2 : Start GlobalReportSetting integration tests] ***
ok: [testhost] => {
    "msg": "Start GlobalReportSetting integration tests"
}

TASK [ntnx_global_report_setting_v2 : Generate random suffix to avoid collisions] ***
[WARNING]: Collection community.general does not support Ansible version 2.16.0
ok: [testhost]

TASK [ntnx_global_report_setting_v2 : Compute test-specific resource names] ****
ok: [testhost]

TASK [ntnx_global_report_setting_v2 : Discover the admin user's ext_id] ********
ok: [testhost]

TASK [ntnx_global_report_setting_v2 : Assert admin user lookup succeeded] ******
ok: [testhost] => {
    "changed": false,
    "msg": "Discovered the admin user's ext_id."
}

TASK [ntnx_global_report_setting_v2 : Set admin_user_ext_id] *******************
ok: [testhost]

TASK [ntnx_global_report_setting_v2 : Fetch original global report setting (before test mutations)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching global report setting for user ext_id", "response": {"message": "The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again."}, "status": 404}
...ignoring

TASK [ntnx_global_report_setting_v2 : Assert original setting fetch succeeded] ***
fatal: [testhost]: FAILED! => {
    "assertion": "original_setting.failed == false",
    "changed": false,
    "evaluated_to": false,
    "msg": "Failed to fetch original global report setting."
}

PLAY RECAP *********************************************************************
testhost                   : ok=8    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=1

NOTICE: To resume at this test target, use the option: --start-at ntnx_global_report_setting_v2
FATAL: Command "ansible-playbook ntnx_global_report_setting_v2-v2bisexa.yml -i inventory" returned exit status 2.
```

</details>

### Example playbook run

The `examples/ncm_operation_base_platform/GlobalReportSetting/global_report_setting_v2.yml`
playbook was executed against the same PC:

```
TASK [Discover the admin user's ext_id]  -> ok
TASK [Set the user_ext_id used by GlobalReportSetting] -> ok
TASK [Get the current global report setting for the admin user]
  fatal: [localhost]: FAILED! => {"error": "NOT FOUND", "status": 404, ...}
```

Same root cause as above — the endpoint is not deployed on the target
cluster. The example demonstrates the intended API surface and stops at
the first `404` because it does not set `ignore_errors: true`; the
integration tests do use `ignore_errors: true` on that same read so the
subsequent assertions provide a clean failure message. The full log is
committed at
`examples/ncm_operation_base_platform/GlobalReportSetting/examples_run.log`.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
