### PR TITLE
feat(monitoring): add ntnx_cluster_config_v2 and ntnx_cluster_configs_info_v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+

--- a/examples/monitoring/ClusterConfig/cluster_config_v2.yml
+++ b/examples/monitoring/ClusterConfig/cluster_config_v2.yml
@@ -1,0 +1,101 @@
+---
+# Summary:
+# This playbook will do:
+# 1. List all ClusterConfig entries for a chosen SDA policy
+# 2. Get a specific ClusterConfig by (system_defined_policy_ext_id, cluster ext_id)
+# 3. Update a ClusterConfig - toggle isEnabled + adjust scheduleIntervalSeconds
+# 4. Update a ClusterConfig - full spec including alert_config severity overrides
+# 5. Delete a ClusterConfig - the Monitoring v4 API does NOT support delete;
+#    the module fails with a descriptive message. Kept as documentation.
+#
+# Pass real IDs via -e sda_policy_ext_id=<...> -e cluster_config_ext_id=<...>
+# The defaults are placeholders and WILL be rejected by the API.
+
+- name: ClusterConfig playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') | default('10.44.76.28', true) }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') | default('admin', true) }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') | default('Nutanix.123', true) }}"
+      validate_certs: false
+  tasks:
+    - name: List all ClusterConfigs for the SDA policy
+      nutanix.ncp.ntnx_cluster_configs_info_v2:
+        system_defined_policy_ext_id: "{{ sda_policy_ext_id | default('6c3f96e8-4d63-4a91-a2b4-4f6ce7de7f22') }}"
+      register: cluster_configs_list
+      ignore_errors: true
+
+    - name: Get a specific ClusterConfig by (SDA policy ext_id, cluster ext_id)
+      nutanix.ncp.ntnx_cluster_configs_info_v2:
+        system_defined_policy_ext_id: "{{ sda_policy_ext_id | default('6c3f96e8-4d63-4a91-a2b4-4f6ce7de7f22') }}"
+        ext_id: "{{ cluster_config_ext_id | default('0005f36a-b46f-8d0e-0000-000000000000') }}"
+      register: cluster_config_single
+      ignore_errors: true
+
+    - name: Update ClusterConfig - toggle isEnabled and adjust schedule interval
+      nutanix.ncp.ntnx_cluster_config_v2:
+        state: present
+        system_defined_policy_ext_id: "{{ sda_policy_ext_id | default('6c3f96e8-4d63-4a91-a2b4-4f6ce7de7f22') }}"
+        ext_id: "{{ cluster_config_ext_id | default('0005f36a-b46f-8d0e-0000-000000000000') }}"
+        is_enabled: true
+        schedule_interval_seconds: 600
+      register: cluster_config_update_min
+      ignore_errors: true
+
+    # NOTE: The exact shape of alert_config that a specific SDA policy accepts is
+    # policy-dependent. Not every policy exposes critical/warning/info severity
+    # overrides or configurable_parameters - the API rejects severities that the
+    # underlying NCC check does not define. The block below shows the FULL
+    # module surface for reference. When running against your cluster, use only
+    # the fields your target policy actually supports.
+    - name: Update ClusterConfig - full spec (shape-of-all-attrs reference)
+      nutanix.ncp.ntnx_cluster_config_v2:
+        state: present
+        system_defined_policy_ext_id: "{{ sda_policy_ext_id | default('6c3f96e8-4d63-4a91-a2b4-4f6ce7de7f22') }}"
+        ext_id: "{{ cluster_config_ext_id | default('0005f36a-b46f-8d0e-0000-000000000000') }}"
+        is_enabled: true
+        schedule_interval_seconds: 600
+        configurable_parameters:
+          - name: "sample_param"
+            display_name: "Sample Param"
+            unit: "seconds"
+            param_value:
+              int_value:
+                default_int_value: 60
+                current_int_value: 120
+        alert_config:
+          auto_resolve: ENABLED
+          critical_severity:
+            state: ENABLED
+            threshold_parameters:
+              - name: "critical_threshold"
+                display_name: "Critical Threshold"
+                unit: "%"
+                param_value:
+                  int_value:
+                    default_int_value: 90
+                    current_int_value: 95
+          warning_severity:
+            state: ENABLED
+            threshold_parameters:
+              - name: "warning_threshold"
+                display_name: "Warning Threshold"
+                unit: "%"
+                param_value:
+                  int_value:
+                    default_int_value: 75
+                    current_int_value: 80
+          info_severity:
+            state: DISABLED
+      register: cluster_config_update_full
+      ignore_errors: true
+
+    - name: Delete ClusterConfig (API does NOT support delete - documented failure)
+      nutanix.ncp.ntnx_cluster_config_v2:
+        state: absent
+        system_defined_policy_ext_id: "{{ sda_policy_ext_id | default('6c3f96e8-4d63-4a91-a2b4-4f6ce7de7f22') }}"
+        ext_id: "{{ cluster_config_ext_id | default('0005f36a-b46f-8d0e-0000-000000000000') }}"
+      register: cluster_config_delete
+      ignore_errors: true

--- a/plugins/module_utils/v4/monitoring/api_client.py
+++ b/plugins/module_utils/v4/monitoring/api_client.py
@@ -1,0 +1,102 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_monitoring_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    Build a Nutanix Monitoring API client from module credentials.
+
+    Args:
+        module (object): Ansible module object.
+    Returns:
+        client (object): Configured ntnx_monitoring_py_client.ApiClient.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_monitoring_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_monitoring_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    try:
+        client = ntnx_monitoring_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_monitoring_py_client.ApiClient(configuration=config)
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    client = ntnx_monitoring_py_client.ApiClient(
+        configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+    )
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    Fetch the etag header value from a Monitoring v4 API response.
+
+    Args:
+        data (object): v4 api response object.
+    Returns:
+        etag (str): etag value or None.
+    """
+    return ntnx_monitoring_py_client.ApiClient.get_etag(data)
+
+
+def get_system_defined_policies_api_instance(module):
+    """
+    Build a SystemDefinedPoliciesApi instance.
+
+    Args:
+        module (object): Ansible module object.
+    Returns:
+        api_instance (object): SystemDefinedPoliciesApi instance.
+    """
+    api_client = get_api_client(module)
+    return ntnx_monitoring_py_client.SystemDefinedPoliciesApi(api_client=api_client)

--- a/plugins/module_utils/v4/monitoring/helpers.py
+++ b/plugins/module_utils/v4/monitoring/helpers.py
@@ -1,0 +1,55 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_cluster_config(module, api_instance, sda_policy_ext_id, ext_id):
+    """
+    Fetch a single ClusterConfig for a given SDA policy and cluster.
+
+    Args:
+        module: Ansible module.
+        api_instance: SystemDefinedPoliciesApi instance from ntnx_monitoring_py_client.
+        sda_policy_ext_id (str): The System-Defined Alert policy external ID.
+        ext_id (str): The cluster external ID (also acts as ClusterConfig ext_id).
+
+    Returns:
+        info (object): ClusterConfig response object (with etag reserved metadata).
+    """
+    try:
+        return api_instance.get_cluster_config_by_id(
+            systemDefinedPolicyExtId=sda_policy_ext_id, extId=ext_id
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching cluster config using ext_id",
+        )
+
+
+def get_sda_policy(module, api_instance, ext_id):
+    """
+    Fetch a single System-Defined Alert policy by ext_id.
+
+    Args:
+        module: Ansible module.
+        api_instance: SystemDefinedPoliciesApi instance from ntnx_monitoring_py_client.
+        ext_id (str): SDA policy external ID.
+
+    Returns:
+        info (object): SystemDefinedPolicy response object.
+    """
+    try:
+        return api_instance.get_sda_policy_by_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching SDA policy using ext_id",
+        )

--- a/plugins/module_utils/v4/utils.py
+++ b/plugins/module_utils/v4/utils.py
@@ -292,6 +292,13 @@ def strip_read_only_fields(spec, fields=None):
 
     The spec is mutated in place; it is also returned so callers can chain.
 
+    Some SDK-generated model classes expose read-only attributes as
+    ``@property`` descriptors without a deleter (e.g. monitoring.ClusterConfig
+    ``last_modified_by_user``). In that case ``delattr`` raises
+    ``AttributeError``; we fall back to setting the attribute to ``None``,
+    which mirrors ``delattr`` from the serializer's perspective (the field is
+    omitted / null on the wire).
+
     Args:
         spec (object): SDK model object to mutate.
         fields (Iterable[str] | None): Attribute names to remove.
@@ -304,5 +311,11 @@ def strip_read_only_fields(spec, fields=None):
 
     for field in fields:
         if hasattr(spec, field):
-            delattr(spec, field)
+            try:
+                delattr(spec, field)
+            except AttributeError:
+                try:
+                    setattr(spec, field, None)
+                except AttributeError:
+                    pass
     return spec

--- a/plugins/modules/ntnx_cluster_config_v2.py
+++ b/plugins/modules/ntnx_cluster_config_v2.py
@@ -1,0 +1,994 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_cluster_config_v2
+short_description: Update cluster-specific configuration of a System-Defined Alert Policy in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to update cluster-specific configuration (ClusterConfig)
+    associated with a System-Defined Alert (SDA) Policy in Nutanix Prism Central.
+  - ClusterConfig captures the overrides for an SDA policy on a specific cluster,
+    including enable/disable state, schedule interval, per-severity thresholds and
+    auto-resolve behaviour.
+  - The Nutanix Monitoring v4 API does not support create or delete for
+    ClusterConfig - it is auto-provisioned per cluster whenever an SDA policy
+    is present. Only update is supported.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation. The required roles depend on the operation being performed.
+  - >-
+    B(Update a ClusterConfig for a System-Defined Alert Policy) -
+    Required Roles: Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=monitoring)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be update ClusterConfig.
+      - The Monitoring v4 API does not support create/delete for ClusterConfig; other combinations will fail with a descriptive error.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The Cluster UUID whose ClusterConfig entry (under the given SDA policy) should be updated.
+      - Required for update.
+    type: str
+    required: false
+  system_defined_policy_ext_id:
+    description:
+      - The unique external ID of the parent System-Defined Alert (SDA) Policy.
+      - Required for update.
+    type: str
+    required: false
+  is_enabled:
+    description:
+      - Indicates whether the SDA policy is enabled or not on the cluster.
+    type: bool
+    required: false
+  schedule_interval_seconds:
+    description:
+      - Interval in seconds defining how often the health check/policy runs on this cluster.
+    type: int
+    required: false
+  configurable_parameters:
+    description:
+      - Parameters of the SDA that are configurable by a user.
+      - Each entry captures the parameter name and its per-cluster value.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      name:
+        description:
+          - Unique identifier name for the parameter.
+        type: str
+        required: false
+      display_name:
+        description:
+          - Display name of the parameter.
+        type: str
+        required: false
+      unit:
+        description:
+          - Unit for the parameter (e.g., seconds, count, MB).
+        type: str
+        required: false
+      param_value:
+        description:
+          - The value assigned to the parameter for this cluster.
+          - Exactly ONE of C(int_value), C(float_value), C(bool_value) or C(string_value)
+            may be provided.
+        type: dict
+        required: false
+        suboptions:
+          int_value:
+            description:
+              - Value when the parameter is an integer.
+            type: dict
+            required: false
+            suboptions:
+              default_int_value:
+                description:
+                  - Captures the default value of the parameter.
+                type: int
+                required: false
+              current_int_value:
+                description:
+                  - Captures the current value of the parameter for this cluster.
+                type: int
+                required: false
+          float_value:
+            description:
+              - Value when the parameter is a float.
+            type: dict
+            required: false
+            suboptions:
+              default_float_value:
+                description:
+                  - Captures the default value of the parameter.
+                type: float
+                required: false
+              current_float_value:
+                description:
+                  - Captures the current value of the parameter for this cluster.
+                type: float
+                required: false
+          bool_value:
+            description:
+              - Value when the parameter is a boolean.
+            type: dict
+            required: false
+            suboptions:
+              default_bool_value:
+                description:
+                  - Captures the default value of the parameter.
+                type: bool
+                required: false
+              current_bool_value:
+                description:
+                  - Captures the current value of the parameter for this cluster.
+                type: bool
+                required: false
+          string_value:
+            description:
+              - Value when the parameter is a string.
+            type: dict
+            required: false
+            suboptions:
+              default_str_value:
+                description:
+                  - Captures the default value of the parameter.
+                type: str
+                required: false
+              current_str_value:
+                description:
+                  - Captures the current value of the parameter for this cluster.
+                type: str
+                required: false
+  alert_config:
+    description:
+      - Alert specific properties associated with the policy on this cluster.
+    type: dict
+    required: false
+    suboptions:
+      auto_resolve:
+        description:
+          - Auto resolve state for the alert.
+        type: str
+        required: false
+        choices:
+          - DISABLED
+          - ENABLED
+          - NOT_SUPPORTED
+      critical_severity:
+        description:
+          - Critical severity override configuration.
+        type: dict
+        required: false
+        suboptions:
+          state:
+            description:
+              - Enable/disable state for this severity.
+            type: str
+            required: false
+            choices:
+              - DISABLED
+              - ENABLED
+              - NOT_SUPPORTED
+          threshold_parameters:
+            description:
+              - Alert-related thresholds that correspond to this severity.
+            type: list
+            elements: dict
+            required: false
+            suboptions:
+              name:
+                description:
+                  - Unique identifier name for the parameter.
+                type: str
+                required: false
+              display_name:
+                description:
+                  - Display name of the parameter.
+                type: str
+                required: false
+              unit:
+                description:
+                  - Unit for the parameter.
+                type: str
+                required: false
+              param_value:
+                description:
+                  - The value assigned to the parameter for this severity.
+                  - Exactly ONE of C(int_value), C(float_value), C(bool_value) or C(string_value)
+                    may be provided.
+                type: dict
+                required: false
+                suboptions:
+                  int_value:
+                    description:
+                      - Value when the threshold is an integer.
+                    type: dict
+                    required: false
+                    suboptions:
+                      default_int_value:
+                        description:
+                          - Captures the default value of the parameter.
+                        type: int
+                        required: false
+                      current_int_value:
+                        description:
+                          - Captures the current value of the parameter for this cluster.
+                        type: int
+                        required: false
+                  float_value:
+                    description:
+                      - Value when the threshold is a float.
+                    type: dict
+                    required: false
+                    suboptions:
+                      default_float_value:
+                        description:
+                          - Captures the default value of the parameter.
+                        type: float
+                        required: false
+                      current_float_value:
+                        description:
+                          - Captures the current value of the parameter for this cluster.
+                        type: float
+                        required: false
+                  bool_value:
+                    description:
+                      - Value when the threshold is a boolean.
+                    type: dict
+                    required: false
+                    suboptions:
+                      default_bool_value:
+                        description:
+                          - Captures the default value of the parameter.
+                        type: bool
+                        required: false
+                      current_bool_value:
+                        description:
+                          - Captures the current value of the parameter for this cluster.
+                        type: bool
+                        required: false
+                  string_value:
+                    description:
+                      - Value when the threshold is a string.
+                    type: dict
+                    required: false
+                    suboptions:
+                      default_str_value:
+                        description:
+                          - Captures the default value of the parameter.
+                        type: str
+                        required: false
+                      current_str_value:
+                        description:
+                          - Captures the current value of the parameter for this cluster.
+                        type: str
+                        required: false
+      warning_severity:
+        description:
+          - Warning severity override configuration.
+        type: dict
+        required: false
+        suboptions:
+          state:
+            description:
+              - Enable/disable state for this severity.
+            type: str
+            required: false
+            choices:
+              - DISABLED
+              - ENABLED
+              - NOT_SUPPORTED
+          threshold_parameters:
+            description:
+              - Alert-related thresholds that correspond to this severity.
+            type: list
+            elements: dict
+            required: false
+            suboptions:
+              name:
+                description:
+                  - Unique identifier name for the parameter.
+                type: str
+                required: false
+              display_name:
+                description:
+                  - Display name of the parameter.
+                type: str
+                required: false
+              unit:
+                description:
+                  - Unit for the parameter.
+                type: str
+                required: false
+              param_value:
+                description:
+                  - Same shape as C(alert_config.critical_severity.threshold_parameters.param_value).
+                type: dict
+                required: false
+                suboptions:
+                  int_value:
+                    description:
+                      - Value when the threshold is an integer.
+                    type: dict
+                    required: false
+                    suboptions:
+                      default_int_value:
+                        description:
+                          - Captures the default value of the parameter.
+                        type: int
+                        required: false
+                      current_int_value:
+                        description:
+                          - Captures the current value of the parameter for this cluster.
+                        type: int
+                        required: false
+                  float_value:
+                    description:
+                      - Value when the threshold is a float.
+                    type: dict
+                    required: false
+                    suboptions:
+                      default_float_value:
+                        description:
+                          - Captures the default value of the parameter.
+                        type: float
+                        required: false
+                      current_float_value:
+                        description:
+                          - Captures the current value of the parameter for this cluster.
+                        type: float
+                        required: false
+                  bool_value:
+                    description:
+                      - Value when the threshold is a boolean.
+                    type: dict
+                    required: false
+                    suboptions:
+                      default_bool_value:
+                        description:
+                          - Captures the default value of the parameter.
+                        type: bool
+                        required: false
+                      current_bool_value:
+                        description:
+                          - Captures the current value of the parameter for this cluster.
+                        type: bool
+                        required: false
+                  string_value:
+                    description:
+                      - Value when the threshold is a string.
+                    type: dict
+                    required: false
+                    suboptions:
+                      default_str_value:
+                        description:
+                          - Captures the default value of the parameter.
+                        type: str
+                        required: false
+                      current_str_value:
+                        description:
+                          - Captures the current value of the parameter for this cluster.
+                        type: str
+                        required: false
+      info_severity:
+        description:
+          - Info severity override configuration.
+        type: dict
+        required: false
+        suboptions:
+          state:
+            description:
+              - Enable/disable state for this severity.
+            type: str
+            required: false
+            choices:
+              - DISABLED
+              - ENABLED
+              - NOT_SUPPORTED
+          threshold_parameters:
+            description:
+              - Alert-related thresholds that correspond to this severity.
+            type: list
+            elements: dict
+            required: false
+            suboptions:
+              name:
+                description:
+                  - Unique identifier name for the parameter.
+                type: str
+                required: false
+              display_name:
+                description:
+                  - Display name of the parameter.
+                type: str
+                required: false
+              unit:
+                description:
+                  - Unit for the parameter.
+                type: str
+                required: false
+              param_value:
+                description:
+                  - Same shape as C(alert_config.critical_severity.threshold_parameters.param_value).
+                type: dict
+                required: false
+                suboptions:
+                  int_value:
+                    description:
+                      - Value when the threshold is an integer.
+                    type: dict
+                    required: false
+                    suboptions:
+                      default_int_value:
+                        description:
+                          - Captures the default value of the parameter.
+                        type: int
+                        required: false
+                      current_int_value:
+                        description:
+                          - Captures the current value of the parameter for this cluster.
+                        type: int
+                        required: false
+                  float_value:
+                    description:
+                      - Value when the threshold is a float.
+                    type: dict
+                    required: false
+                    suboptions:
+                      default_float_value:
+                        description:
+                          - Captures the default value of the parameter.
+                        type: float
+                        required: false
+                      current_float_value:
+                        description:
+                          - Captures the current value of the parameter for this cluster.
+                        type: float
+                        required: false
+                  bool_value:
+                    description:
+                      - Value when the threshold is a boolean.
+                    type: dict
+                    required: false
+                    suboptions:
+                      default_bool_value:
+                        description:
+                          - Captures the default value of the parameter.
+                        type: bool
+                        required: false
+                      current_bool_value:
+                        description:
+                          - Captures the current value of the parameter for this cluster.
+                        type: bool
+                        required: false
+                  string_value:
+                    description:
+                      - Value when the threshold is a string.
+                    type: dict
+                    required: false
+                    suboptions:
+                      default_str_value:
+                        description:
+                          - Captures the default value of the parameter.
+                        type: str
+                        required: false
+                      current_str_value:
+                        description:
+                          - Captures the current value of the parameter for this cluster.
+                        type: str
+                        required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Update ClusterConfig - toggle isEnabled and adjust schedule interval
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: present
+    system_defined_policy_ext_id: "6c3f96e8-4d63-4a91-a2b4-4f6ce7de7f22"
+    ext_id: "0005f36a-b46f-8d0e-0000-000000000000"
+    is_enabled: true
+    schedule_interval_seconds: 600
+  register: result
+  ignore_errors: true
+
+- name: Update ClusterConfig - full spec with alert_config severities
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: present
+    system_defined_policy_ext_id: "6c3f96e8-4d63-4a91-a2b4-4f6ce7de7f22"
+    ext_id: "0005f36a-b46f-8d0e-0000-000000000000"
+    is_enabled: true
+    schedule_interval_seconds: 300
+    configurable_parameters:
+      - name: "sample_param"
+        display_name: "Sample Param"
+        unit: "seconds"
+        param_value:
+          int_value:
+            default_int_value: 60
+            current_int_value: 120
+    alert_config:
+      auto_resolve: ENABLED
+      critical_severity:
+        state: ENABLED
+        threshold_parameters:
+          - name: "critical_threshold"
+            display_name: "Critical Threshold"
+            unit: "%"
+            param_value:
+              int_value:
+                default_int_value: 90
+                current_int_value: 95
+      warning_severity:
+        state: ENABLED
+        threshold_parameters:
+          - name: "warning_threshold"
+            display_name: "Warning Threshold"
+            unit: "%"
+            param_value:
+              int_value:
+                default_int_value: 75
+                current_int_value: 80
+      info_severity:
+        state: DISABLED
+  register: result
+  ignore_errors: true
+
+- name: Delete ClusterConfig (not supported by API — fails gracefully)
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: absent
+    system_defined_policy_ext_id: "6c3f96e8-4d63-4a91-a2b4-4f6ce7de7f22"
+    ext_id: "0005f36a-b46f-8d0e-0000-000000000000"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for updating a ClusterConfig.
+    - If the operation is update and C(wait) is true, it will return the ClusterConfig details.
+    - If the operation is update and C(wait) is false, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "alert_config": {
+        "auto_resolve": "ENABLED",
+        "critical_severity": {"state": "ENABLED", "threshold_parameters": null},
+        "info_severity": {"state": "DISABLED", "threshold_parameters": null},
+        "warning_severity": {"state": "ENABLED", "threshold_parameters": null}
+      },
+      "configurable_parameters": null,
+      "ext_id": "0005f36a-b46f-8d0e-0000-000000000000",
+      "is_enabled": true,
+      "last_modified_by_user": "admin",
+      "last_modified_time": "2026-07-21T10:15:22.123456+00:00",
+      "links": null,
+      "schedule_interval_seconds": 600,
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID (Cluster UUID) of the ClusterConfig.
+  returned: always
+  type: str
+  sample: "0005f36a-b46f-8d0e-0000-000000000000"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode
+  type: str
+  sample: "Api Exception raised while updating ClusterConfig"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.monitoring.api_client import (  # noqa: E402
+    get_etag,
+    get_system_defined_policies_api_instance,
+)
+from ..module_utils.v4.monitoring.helpers import get_cluster_config  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_monitoring_py_client as monitoring_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as monitoring_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def _param_value_spec():
+    """Argument-spec dict for AlertPolicyConfigurableParameterparam_value oneOf wrapper."""
+    return dict(
+        int_value=dict(
+            type="dict",
+            required=False,
+            options=dict(
+                default_int_value=dict(type="int", required=False),
+                current_int_value=dict(type="int", required=False),
+            ),
+            obj=monitoring_sdk.IntConfigurableParamValue,
+        ),
+        float_value=dict(
+            type="dict",
+            required=False,
+            options=dict(
+                default_float_value=dict(type="float", required=False),
+                current_float_value=dict(type="float", required=False),
+            ),
+            obj=monitoring_sdk.FloatConfigurableParamValue,
+        ),
+        bool_value=dict(
+            type="dict",
+            required=False,
+            options=dict(
+                default_bool_value=dict(type="bool", required=False),
+                current_bool_value=dict(type="bool", required=False),
+            ),
+            obj=monitoring_sdk.BooleanConfigurableParamValue,
+        ),
+        string_value=dict(
+            type="dict",
+            required=False,
+            options=dict(
+                default_str_value=dict(type="str", required=False),
+                current_str_value=dict(type="str", required=False),
+            ),
+            obj=monitoring_sdk.StringConfigurableParamValue,
+        ),
+    )
+
+
+def _configurable_parameter_spec():
+    """Argument-spec dict for AlertPolicyConfigurableParameter."""
+    return dict(
+        name=dict(type="str", required=False),
+        display_name=dict(type="str", required=False),
+        unit=dict(type="str", required=False),
+        param_value=dict(
+            type="dict",
+            required=False,
+            options=_param_value_spec(),
+            obj={
+                "int_value": monitoring_sdk.IntConfigurableParamValue,
+                "float_value": monitoring_sdk.FloatConfigurableParamValue,
+                "bool_value": monitoring_sdk.BooleanConfigurableParamValue,
+                "string_value": monitoring_sdk.StringConfigurableParamValue,
+            },
+            mutually_exclusive=[
+                ("int_value", "float_value", "bool_value", "string_value")
+            ],
+        ),
+    )
+
+
+def _severity_config_spec():
+    """Argument-spec dict for SeverityConfig."""
+    return dict(
+        state=dict(
+            type="str",
+            required=False,
+            choices=["DISABLED", "ENABLED", "NOT_SUPPORTED"],
+            obj=monitoring_sdk.PropertyState,
+        ),
+        threshold_parameters=dict(
+            type="list",
+            elements="dict",
+            required=False,
+            options=_configurable_parameter_spec(),
+            obj=monitoring_sdk.AlertPolicyConfigurableParameter,
+        ),
+    )
+
+
+def get_module_spec():
+
+    alert_config_spec = dict(
+        auto_resolve=dict(
+            type="str",
+            required=False,
+            choices=["DISABLED", "ENABLED", "NOT_SUPPORTED"],
+            obj=monitoring_sdk.AutoResolveState,
+        ),
+        critical_severity=dict(
+            type="dict",
+            required=False,
+            options=_severity_config_spec(),
+            obj=monitoring_sdk.SeverityConfig,
+        ),
+        warning_severity=dict(
+            type="dict",
+            required=False,
+            options=_severity_config_spec(),
+            obj=monitoring_sdk.SeverityConfig,
+        ),
+        info_severity=dict(
+            type="dict",
+            required=False,
+            options=_severity_config_spec(),
+            obj=monitoring_sdk.SeverityConfig,
+        ),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str", required=False),
+        system_defined_policy_ext_id=dict(type="str", required=False),
+        is_enabled=dict(type="bool", required=False),
+        schedule_interval_seconds=dict(type="int", required=False),
+        configurable_parameters=dict(
+            type="list",
+            elements="dict",
+            required=False,
+            options=_configurable_parameter_spec(),
+            obj=monitoring_sdk.AlertPolicyConfigurableParameter,
+        ),
+        alert_config=dict(
+            type="dict",
+            required=False,
+            options=alert_config_spec,
+            obj=monitoring_sdk.AlertConfig,
+        ),
+    )
+    return module_args
+
+
+def _fetch_current_cluster_config(module, api_instance):
+    """Fetch the current ClusterConfig object (already unwrapped via .data)."""
+    sda_policy_ext_id = module.params.get("system_defined_policy_ext_id")
+    ext_id = module.params.get("ext_id")
+    resp = get_cluster_config(module, api_instance, sda_policy_ext_id, ext_id)
+    return resp
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    """Compare stripped dicts and return True if they are effectively equal."""
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    # last_modified_* fields are server-populated and MUST NOT drive idempotency
+    for key in ("last_modified_by_user", "last_modified_time"):
+        old_spec_dict.pop(key, None)
+        update_spec_dict.pop(key, None)
+    return old_spec_dict == update_spec_dict
+
+
+def _sanitize_alert_config_for_update(spec):
+    """
+    The Monitoring v4 API returns ``state: NOT_SUPPORTED`` on severities the
+    underlying NCC check does not expose, but rejects that value on write with
+    ``MON-30018 invalid argument for key alertConfig/<severity>/state``. The
+    same applies to ``auto_resolve``. Detach any such severity before we PUT
+    the spec back so we do not re-post a server-populated marker as user
+    input.
+    """
+    ac = getattr(spec, "alert_config", None)
+    if ac is None:
+        return
+    if getattr(ac, "auto_resolve", None) == "NOT_SUPPORTED":
+        try:
+            ac.auto_resolve = None
+        except AttributeError:
+            pass
+    for sev_attr in ("critical_severity", "warning_severity", "info_severity"):
+        sev = getattr(ac, sev_attr, None)
+        if sev is None:
+            continue
+        if getattr(sev, "state", None) == "NOT_SUPPORTED":
+            try:
+                setattr(ac, sev_attr, None)
+            except AttributeError:
+                pass
+
+
+def create_ClusterConfig(module, result, api_instance):
+    """Create is not supported by the Monitoring v4 API for ClusterConfig."""
+    result["failed"] = True
+    module.fail_json(
+        msg=(
+            "Create is not supported for ClusterConfig by the Monitoring v4 API. "
+            "ClusterConfig entries are auto-provisioned for each cluster when a "
+            "System-Defined Alert Policy is present. Provide 'ext_id' and "
+            "'system_defined_policy_ext_id' to update an existing ClusterConfig."
+        ),
+        **result,
+    )
+
+
+def update_ClusterConfig(module, result, api_instance):
+    validate_required_params(module, ["ext_id", "system_defined_policy_ext_id"])
+    sda_policy_ext_id = module.params.get("system_defined_policy_ext_id")
+    ext_id = module.params.get("ext_id")
+
+    result["ext_id"] = ext_id
+
+    current = _fetch_current_cluster_config(module, api_instance)
+    old_spec = current.data
+    etag = get_etag(data=current)
+    if not etag:
+        return module.fail_json(
+            msg=(
+                "Unable to fetch etag for updating ClusterConfig with cluster ext_id: "
+                "{0} under System-Defined Alert Policy: {1}".format(
+                    ext_id, sda_policy_ext_id
+                )
+            ),
+            **result,
+        )
+    kwargs = {"if_match": etag}
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update ClusterConfig spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        result["response"] = strip_internal_attributes(old_spec.to_dict())
+        module.exit_json(
+            msg="Nothing to change. ClusterConfig is already in the desired state.",
+            **result,
+        )
+
+    strip_read_only_fields(
+        update_spec, fields=["last_modified_by_user", "last_modified_time"]
+    )
+    _sanitize_alert_config_for_update(update_spec)
+
+    resp = None
+    try:
+        resp = api_instance.update_cluster_config_by_id(
+            systemDefinedPolicyExtId=sda_policy_ext_id,
+            extId=ext_id,
+            body=update_spec,
+            **kwargs,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating ClusterConfig",
+        )
+
+    task_ext_id = getattr(resp.data, "ext_id", None)
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        refreshed = _fetch_current_cluster_config(module, api_instance)
+        result["response"] = strip_internal_attributes(refreshed.data.to_dict())
+    result["changed"] = True
+
+
+def delete_ClusterConfig(module, result, api_instance):
+    """Delete is not supported by the Monitoring v4 API for ClusterConfig."""
+    result["failed"] = True
+    module.fail_json(
+        msg=(
+            "Delete is not supported for ClusterConfig by the Monitoring v4 API. "
+            "ClusterConfig entries are auto-managed by the platform for each "
+            "System-Defined Alert Policy and cannot be removed via API."
+        ),
+        **result,
+    )
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id", "system_defined_policy_ext_id")),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_monitoring_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_system_defined_policies_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_ClusterConfig(module, result, api_instance)
+        else:
+            create_ClusterConfig(module, result, api_instance)
+    else:
+        delete_ClusterConfig(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_cluster_configs_info_v2.py
+++ b/plugins/modules/ntnx_cluster_configs_info_v2.py
@@ -1,0 +1,229 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_cluster_configs_info_v2
+short_description: Fetch ClusterConfig info of a System-Defined Alert Policy in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about ClusterConfig in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific ClusterConfig (single entity).
+  - If C(ext_id) is not provided, list all ClusterConfig entries for the given
+    System-Defined Alert (SDA) Policy - optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation.
+  - >-
+    B(Get / List ClusterConfig) -
+    Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=monitoring)"
+options:
+  ext_id:
+    description:
+      - The Cluster UUID (ClusterConfig external ID).
+      - When provided, a single ClusterConfig entry is fetched.
+    type: str
+    required: false
+  system_defined_policy_ext_id:
+    description:
+      - The unique external ID of the parent System-Defined Alert (SDA) Policy.
+      - Required for both single-fetch and list operations.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get ClusterConfig using ext_id
+  nutanix.ncp.ntnx_cluster_configs_info_v2:
+    system_defined_policy_ext_id: "6c3f96e8-4d63-4a91-a2b4-4f6ce7de7f22"
+    ext_id: "0005f36a-b46f-8d0e-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: List all ClusterConfigs for an SDA policy
+  nutanix.ncp.ntnx_cluster_configs_info_v2:
+    system_defined_policy_ext_id: "6c3f96e8-4d63-4a91-a2b4-4f6ce7de7f22"
+  register: result
+  ignore_errors: true
+
+- name: List ClusterConfigs with limit and pagination
+  nutanix.ncp.ntnx_cluster_configs_info_v2:
+    system_defined_policy_ext_id: "6c3f96e8-4d63-4a91-a2b4-4f6ce7de7f22"
+    limit: 5
+    page: 0
+  register: result
+  ignore_errors: true
+
+- name: List ClusterConfigs sorted by extId
+  nutanix.ncp.ntnx_cluster_configs_info_v2:
+    system_defined_policy_ext_id: "6c3f96e8-4d63-4a91-a2b4-4f6ce7de7f22"
+    orderby: "extId asc"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC ClusterConfig info v4 API.
+    - It can be a single ClusterConfig if external ID is provided.
+    - List of multiple ClusterConfig if external ID is not provided
+      (optionally paginated by C(limit) / C(page) or ordered by C(orderby)).
+    - The C(filter) parameter is not supported for this endpoint.
+  returned: always
+  type: dict
+  sample:
+    {
+      "alert_config": {
+        "auto_resolve": "ENABLED",
+        "critical_severity": {"state": "ENABLED", "threshold_parameters": null},
+        "info_severity": {"state": "DISABLED", "threshold_parameters": null},
+        "warning_severity": {"state": "ENABLED", "threshold_parameters": null}
+      },
+      "configurable_parameters": null,
+      "ext_id": "0005f36a-b46f-8d0e-0000-000000000000",
+      "is_enabled": true,
+      "last_modified_by_user": "admin",
+      "last_modified_time": "2026-07-21T10:15:22.123456+00:00",
+      "links": null,
+      "schedule_interval_seconds": 600,
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching ClusterConfig info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the ClusterConfig (Cluster UUID)
+  type: str
+  returned: when external ID is provided
+  sample: "0005f36a-b46f-8d0e-0000-000000000000"
+
+total_available_results:
+  description: The total number of available ClusterConfig entries for the SDA policy in PC.
+  type: int
+  returned: when ClusterConfigs are listed
+  sample: 3
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.monitoring.api_client import (  # noqa: E402
+    get_system_defined_policies_api_instance,
+)
+from ..module_utils.v4.monitoring.helpers import get_cluster_config  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str", required=False),
+        system_defined_policy_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_cluster_config_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    sda_policy_ext_id = module.params.get("system_defined_policy_ext_id")
+    resp = get_cluster_config(module, api_instance, sda_policy_ext_id, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+
+def get_cluster_configs(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating ClusterConfig info spec", **result)
+
+    sda_policy_ext_id = module.params.get("system_defined_policy_ext_id")
+
+    try:
+        resp = api_instance.list_cluster_configs_by_sda_id(
+            systemDefinedPolicyExtId=sda_policy_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching ClusterConfig info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_system_defined_policies_api_instance(module)
+    if module.params.get("ext_id"):
+        get_cluster_config_using_ext_id(module, api_instance, result)
+    else:
+        get_cluster_configs(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-monitoring-py-client==latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
-ntnx-monitoring-py-client==latest
+ntnx-monitoring-py-client==4.2.2

--- a/tests/integration/targets/ntnx_cluster_config_v2/aliases
+++ b/tests/integration/targets/ntnx_cluster_config_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_cluster_config_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_cluster_config_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_cluster_config_v2/tasks/_bootstrap_pick_policy.yml
+++ b/tests/integration/targets/ntnx_cluster_config_v2/tasks/_bootstrap_pick_policy.yml
@@ -1,0 +1,18 @@
+---
+# Iterate SDA policies until one whose ClusterConfig list has at least one
+# entry with `schedule_interval_seconds != null` is found. Some NCC checks are
+# event-driven and have no schedule interval - those cannot be safely used to
+# verify update-of-schedule_interval_seconds.
+
+- name: Try up to 60 SDA policies to find one with schedule-driven ClusterConfigs
+  ansible.builtin.include_tasks: _bootstrap_probe_policy.yml
+  loop: "{{ sda_list_raw.json.data[0:60] }}"
+  loop_control:
+    loop_var: candidate_sda
+    label: "{{ candidate_sda.extId }}"
+  when: >-
+    cluster_configs_list_bootstrap.response is not defined
+    or (cluster_configs_list_bootstrap.response
+        | selectattr('schedule_interval_seconds', 'defined')
+        | selectattr('schedule_interval_seconds', 'ne', None)
+        | list | length) == 0

--- a/tests/integration/targets/ntnx_cluster_config_v2/tasks/_bootstrap_probe_policy.yml
+++ b/tests/integration/targets/ntnx_cluster_config_v2/tasks/_bootstrap_probe_policy.yml
@@ -1,0 +1,39 @@
+---
+# Probe one SDA policy candidate for ClusterConfig entries with a non-null
+# schedule_interval_seconds. If one is found, adopt it as sda_policy_ext_id
+# and stash the filtered list in cluster_configs_list_bootstrap.
+
+- name: Compute already-adopted flag
+  ansible.builtin.set_fact:
+    already_adopted: >-
+      {{ cluster_configs_list_bootstrap.response is defined
+         and (cluster_configs_list_bootstrap.response
+              | selectattr('schedule_interval_seconds', 'defined')
+              | selectattr('schedule_interval_seconds', 'ne', None)
+              | list | length) > 0 }}
+
+- name: Query ClusterConfigs for candidate SDA policy {{ candidate_sda.extId }}
+  nutanix.ncp.ntnx_cluster_configs_info_v2:
+    system_defined_policy_ext_id: "{{ candidate_sda.extId }}"
+  register: candidate_list
+  ignore_errors: true
+  when: not (already_adopted | bool)
+
+- name: Compute scheduled entries for this candidate
+  ansible.builtin.set_fact:
+    candidate_scheduled_entries: >-
+      {{ (candidate_list.response | default([]))
+         | selectattr('schedule_interval_seconds', 'defined')
+         | selectattr('schedule_interval_seconds', 'ne', None)
+         | list }}
+  when: not (already_adopted | bool)
+
+- name: Adopt candidate if it has scheduled entries
+  ansible.builtin.set_fact:
+    sda_policy_ext_id: "{{ candidate_sda.extId }}"
+    cluster_configs_list_bootstrap:
+      response: "{{ candidate_scheduled_entries }}"
+      total_available_results: "{{ candidate_list.total_available_results | default(candidate_scheduled_entries | length) }}"
+      failed: false
+      changed: false
+  when: not (already_adopted | bool) and (candidate_scheduled_entries | default([]) | length) > 0

--- a/tests/integration/targets/ntnx_cluster_config_v2/tasks/cluster_config.yml
+++ b/tests/integration/targets/ntnx_cluster_config_v2/tasks/cluster_config.yml
@@ -1,0 +1,557 @@
+---
+##############################################################################
+# Integration tests for ntnx_cluster_config_v2 and ntnx_cluster_configs_info_v2
+#
+# Test plan:
+#   1. Bootstrap: fetch an SDA policy ext_id and a ClusterConfig ext_id via the
+#      raw v4 REST API (no dedicated SDA info module in this collection).
+#   2. Info: list all ClusterConfigs for the SDA policy, then get by ext_id.
+#      Assert both shapes plus `total_available_results` for the list.
+#   3. Info: list with limit=1, with orderby=extId asc.
+#   4. Info: negative - fetch with an invalid ext_id (assert failure).
+#   5. Info: negative - list without required system_defined_policy_ext_id
+#      (assert failure).
+#   6. CRUD (check_mode):
+#        one Create check_mode task, one Update check_mode task (all attrs),
+#        one Delete check_mode task.
+#   7. CRUD (real):
+#        - Update with minimal fields (schedule_interval_seconds); assert change.
+#        - Update again with the same values; assert idempotent skipped=true.
+#        - Full update including alert_config severities.
+#        - Restore original scheduleIntervalSeconds so we do not leave the
+#          cluster mis-configured.
+#   8. Negative CRUD:
+#        - state=present without ext_id -> "not supported" fail msg.
+#        - state=absent (delete not supported by API) -> "not supported" fail msg.
+#        - state=absent without ext_id / policy -> required_if fail msg.
+#        - Update with invalid ext_id -> API error surfaced.
+##############################################################################
+
+- name: Start ClusterConfig tests
+  ansible.builtin.debug:
+    msg: Start ClusterConfig integration tests
+
+##############################################################################
+# Bootstrap - discover SDA policy ext_id and a ClusterConfig ext_id
+##############################################################################
+
+- name: Fetch SDA policies via raw v4 API (limit=100)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default(9440) }}/api/monitoring/v4.0/serviceability/alerts/system-defined-policies?$limit=100"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    return_content: true
+    headers:
+      Accept: application/json
+  register: sda_list_raw
+  ignore_errors: true
+  no_log: false
+
+- name: Assert we could reach the Monitoring API
+  ansible.builtin.assert:
+    that:
+      - sda_list_raw is defined
+      - sda_list_raw.status == 200
+      - sda_list_raw.json is defined
+      - sda_list_raw.json.data is defined
+      - sda_list_raw.json.data | length > 0
+    success_msg: "SDA policies fetched (count={{ sda_list_raw.json.data | length }})"
+    fail_msg: "Could not fetch SDA policies - test environment is not usable"
+
+- name: Pick the first SDA policy ext_id
+  ansible.builtin.set_fact:
+    sda_policy_ext_id: "{{ sda_list_raw.json.data[0].extId }}"
+
+- name: Reset bootstrap holder
+  ansible.builtin.set_fact:
+    cluster_configs_list_bootstrap: {}
+
+- name: Search SDA policies until one has a ClusterConfig w/ schedule_interval_seconds != null
+  ansible.builtin.include_tasks: _bootstrap_pick_policy.yml
+
+- name: Assert bootstrap ClusterConfig list succeeded
+  ansible.builtin.assert:
+    that:
+      - cluster_configs_list_bootstrap is defined
+      - cluster_configs_list_bootstrap.failed == false
+      - cluster_configs_list_bootstrap.changed == false
+      - cluster_configs_list_bootstrap.response is defined
+      - cluster_configs_list_bootstrap.response | length > 0
+      - cluster_configs_list_bootstrap.total_available_results is defined
+      - cluster_configs_list_bootstrap.total_available_results | int > 0
+    success_msg: "Bootstrap ClusterConfig list succeeded (count={{ cluster_configs_list_bootstrap.response | length }})"
+    fail_msg: "Bootstrap ClusterConfig list failed"
+
+- name: Pick first ClusterConfig ext_id + capture original values
+  vars:
+    _picked: "{{ cluster_configs_list_bootstrap.response[0] }}"
+    _ac: "{{ _picked.alert_config | default(None) }}"
+  ansible.builtin.set_fact:
+    cluster_config_ext_id: "{{ _picked.ext_id }}"
+    original_is_enabled: "{{ _picked.is_enabled }}"
+    original_schedule_interval_seconds: "{{ _picked.schedule_interval_seconds }}"
+    original_alert_config: "{{ _ac }}"
+    original_alert_config_present: "{{ (_ac is not none) and (_ac != {}) }}"
+
+- name: Show discovered bootstrap values
+  ansible.builtin.debug:
+    msg:
+      - "sda_policy_ext_id: {{ sda_policy_ext_id }}"
+      - "cluster_config_ext_id: {{ cluster_config_ext_id }}"
+      - "original_is_enabled: {{ original_is_enabled }}"
+      - "original_schedule_interval_seconds: {{ original_schedule_interval_seconds }}"
+
+##############################################################################
+# Info module - positive tests
+##############################################################################
+
+- name: Info - list all ClusterConfigs for SDA policy
+  nutanix.ncp.ntnx_cluster_configs_info_v2:
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+  register: info_list_all
+  ignore_errors: true
+
+- name: Info - assert list-all shape
+  ansible.builtin.assert:
+    that:
+      - info_list_all is defined
+      - info_list_all.failed == false
+      - info_list_all.changed == false
+      - info_list_all.response is defined
+      - info_list_all.response is iterable
+      - info_list_all.response | length > 0
+      - info_list_all.total_available_results is defined
+      - info_list_all.total_available_results | int > 0
+      - info_list_all.ext_id is not defined or info_list_all.ext_id is none
+    success_msg: "Info list-all returned {{ info_list_all.response | length }} entries"
+    fail_msg: "Info list-all did not return expected shape"
+
+- name: Info - assert every item in list has ClusterConfig fields
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined
+      - item.is_enabled is defined
+      - item.schedule_interval_seconds is defined
+    success_msg: "ClusterConfig list item {{ item.ext_id }} has all required fields"
+    fail_msg: "ClusterConfig list item is missing required fields"
+  loop: "{{ info_list_all.response }}"
+  loop_control:
+    label: "{{ item.ext_id }}"
+
+- name: Info - get by ext_id (single entity)
+  nutanix.ncp.ntnx_cluster_configs_info_v2:
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    ext_id: "{{ cluster_config_ext_id }}"
+  register: info_single
+  ignore_errors: true
+
+- name: Info - assert single-entity shape
+  ansible.builtin.assert:
+    that:
+      - info_single is defined
+      - info_single.failed == false
+      - info_single.changed == false
+      - info_single.response is defined
+      - info_single.response.ext_id == cluster_config_ext_id
+      - info_single.ext_id == cluster_config_ext_id
+      - info_single.response.is_enabled is defined
+      - info_single.response.schedule_interval_seconds is defined
+    success_msg: "Info single-entity fetch matched cluster_config_ext_id"
+    fail_msg: "Info single-entity shape mismatch"
+
+- name: Info - list with limit=1
+  nutanix.ncp.ntnx_cluster_configs_info_v2:
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    limit: 1
+  register: info_limit
+  ignore_errors: true
+
+- name: Info - assert limit=1
+  ansible.builtin.assert:
+    that:
+      - info_limit is defined
+      - info_limit.failed == false
+      - info_limit.changed == false
+      - info_limit.response is defined
+      - info_limit.response | length == 1
+    success_msg: "Info limit=1 returned exactly 1 entry"
+    fail_msg: "Info limit=1 did not honor the limit"
+
+- name: Info - list with orderby=extId asc
+  nutanix.ncp.ntnx_cluster_configs_info_v2:
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    orderby: "extId"
+  register: info_orderby
+  ignore_errors: true
+
+- name: Info - assert orderby=extId asc
+  ansible.builtin.assert:
+    that:
+      - info_orderby is defined
+      - info_orderby.failed == false
+      - info_orderby.changed == false
+      - info_orderby.response is defined
+      - info_orderby.response | length > 0
+      - (info_orderby.response | map(attribute='ext_id') | list) == (info_orderby.response | map(attribute='ext_id') | list | sort)
+    success_msg: "Info orderby=extId returned ascending-sorted results"
+    fail_msg: "Info orderby=extId did not sort results ascending"
+
+##############################################################################
+# Info module - negative tests
+##############################################################################
+
+- name: Info - fetch with an invalid ClusterConfig ext_id
+  nutanix.ncp.ntnx_cluster_configs_info_v2:
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: info_bad_ext_id
+  ignore_errors: true
+
+- name: Info - assert invalid ext_id surfaces error
+  ansible.builtin.assert:
+    that:
+      - info_bad_ext_id is defined
+      - info_bad_ext_id.failed == true
+      - info_bad_ext_id.changed == false
+    success_msg: "Info with invalid ext_id failed as expected"
+    fail_msg: "Info with invalid ext_id did NOT fail as expected"
+
+- name: Info - list without system_defined_policy_ext_id (missing required)
+  nutanix.ncp.ntnx_cluster_configs_info_v2: {}
+  register: info_missing_policy
+  ignore_errors: true
+
+- name: Info - assert missing required parameter fails
+  ansible.builtin.assert:
+    that:
+      - info_missing_policy is defined
+      - info_missing_policy.failed == true
+      - info_missing_policy.changed == false
+      - info_missing_policy.msg is search('system_defined_policy_ext_id')
+    success_msg: "Info list without system_defined_policy_ext_id failed as expected"
+    fail_msg: "Info list without system_defined_policy_ext_id did NOT fail as expected"
+
+##############################################################################
+# CRUD module - check_mode tests (exactly one per Create/Update/Delete)
+##############################################################################
+
+- name: Check mode - Create (unsupported, expected to fail even in check_mode)
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: present
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    is_enabled: true
+    schedule_interval_seconds: 900
+    configurable_parameters: []
+    alert_config:
+      auto_resolve: ENABLED
+      critical_severity:
+        state: ENABLED
+      warning_severity:
+        state: ENABLED
+      info_severity:
+        state: DISABLED
+  check_mode: true
+  register: check_create
+  ignore_errors: true
+
+- name: Check mode - Create asserts (state=present without ext_id must fail)
+  ansible.builtin.assert:
+    that:
+      - check_create is defined
+      - check_create.failed == true
+      - check_create.changed == false
+      - check_create.msg is search('Create is not supported')
+    success_msg: "Check-mode Create fails as expected (create not supported)"
+    fail_msg: "Check-mode Create did NOT fail with 'not supported' message"
+
+- name: Check mode - Update with ALL attributes
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: present
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    ext_id: "{{ cluster_config_ext_id }}"
+    is_enabled: "{{ (original_is_enabled | bool) }}"
+    schedule_interval_seconds: "{{ original_schedule_interval_seconds | int }}"
+    configurable_parameters: []
+    alert_config:
+      auto_resolve: ENABLED
+      critical_severity:
+        state: ENABLED
+        threshold_parameters:
+          - name: "critical_threshold_cm"
+            display_name: "Critical Threshold CM"
+            unit: "%"
+            param_value:
+              int_value:
+                default_int_value: 90
+                current_int_value: 95
+      warning_severity:
+        state: ENABLED
+        threshold_parameters:
+          - name: "warning_threshold_cm"
+            display_name: "Warning Threshold CM"
+            unit: "%"
+            param_value:
+              int_value:
+                default_int_value: 75
+                current_int_value: 80
+      info_severity:
+        state: DISABLED
+  check_mode: true
+  register: check_update
+  ignore_errors: true
+
+- name: Check mode - Update asserts
+  ansible.builtin.assert:
+    that:
+      - check_update is defined
+      - check_update.failed == false
+      - check_update.response is defined
+      - check_update.response.ext_id == cluster_config_ext_id
+      - check_update.response.is_enabled == (original_is_enabled | bool)
+      - check_update.response.schedule_interval_seconds == (original_schedule_interval_seconds | int)
+      - check_update.response.alert_config is defined
+      - check_update.response.alert_config.critical_severity.state == "ENABLED"
+      - check_update.response.alert_config.warning_severity.state == "ENABLED"
+      - check_update.response.alert_config.info_severity.state == "DISABLED"
+      - check_update.response.alert_config.auto_resolve == "ENABLED"
+      - check_update.ext_id == cluster_config_ext_id
+    success_msg: "Check-mode Update generated the expected spec"
+    fail_msg: "Check-mode Update spec mismatch"
+
+- name: Check mode - Delete (unsupported)
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: absent
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    ext_id: "{{ cluster_config_ext_id }}"
+  check_mode: true
+  register: check_delete
+  ignore_errors: true
+
+- name: Check mode - Delete asserts
+  ansible.builtin.assert:
+    that:
+      - check_delete is defined
+      - check_delete.failed == true
+      - check_delete.changed == false
+      - check_delete.msg is search('Delete is not supported')
+    success_msg: "Check-mode Delete fails as expected (delete not supported)"
+    fail_msg: "Check-mode Delete did NOT fail with 'not supported' message"
+
+##############################################################################
+# CRUD module - real Update (minimal attrs)
+##############################################################################
+
+- name: Compute a fresh scheduleIntervalSeconds different from current
+  ansible.builtin.set_fact:
+    new_schedule_interval: >-
+      {{ 600 if (original_schedule_interval_seconds | int) != 600 else 900 }}
+
+- name: Update ClusterConfig - real, change scheduleIntervalSeconds
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: present
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    ext_id: "{{ cluster_config_ext_id }}"
+    schedule_interval_seconds: "{{ new_schedule_interval | int }}"
+  register: update_min
+  ignore_errors: true
+
+- name: Update ClusterConfig - assert real update succeeded
+  ansible.builtin.assert:
+    that:
+      - update_min is defined
+      - update_min.failed == false
+      - update_min.changed == true
+      - update_min.ext_id == cluster_config_ext_id
+      - update_min.task_ext_id is defined
+      - update_min.response is defined
+      - update_min.response.schedule_interval_seconds == (new_schedule_interval | int)
+    success_msg: "Real Update: scheduleIntervalSeconds successfully changed"
+    fail_msg: "Real Update: scheduleIntervalSeconds change failed"
+
+##############################################################################
+# CRUD module - idempotency
+##############################################################################
+
+- name: Update ClusterConfig - idempotency (same value)
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: present
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    ext_id: "{{ cluster_config_ext_id }}"
+    schedule_interval_seconds: "{{ new_schedule_interval | int }}"
+  register: update_idem
+  ignore_errors: true
+
+- name: Update ClusterConfig - assert idempotency
+  ansible.builtin.assert:
+    that:
+      - update_idem is defined
+      - update_idem.failed == false
+      - update_idem.changed == false
+      - update_idem.skipped == true
+      - update_idem.msg is search('Nothing to change')
+    success_msg: "Idempotency check passed - re-apply reported skipped"
+    fail_msg: "Idempotency check FAILED - re-apply did not report skipped"
+
+##############################################################################
+# CRUD module - full-attrs real update (alert_config + configurable_parameters)
+##############################################################################
+
+- name: Update ClusterConfig - full spec (alert_config auto_resolve)
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: present
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    ext_id: "{{ cluster_config_ext_id }}"
+    is_enabled: "{{ (original_is_enabled | bool) }}"
+    schedule_interval_seconds: "{{ new_schedule_interval | int }}"
+    alert_config:
+      auto_resolve: ENABLED
+  register: update_full
+  ignore_errors: true
+  when: original_alert_config_present | bool
+
+- name: Update ClusterConfig - assert full-spec response (only when policy supports it)
+  ansible.builtin.assert:
+    that:
+      - update_full is defined
+      - update_full.failed == false
+      - update_full.response is defined
+      - update_full.ext_id == cluster_config_ext_id
+      - update_full.response.schedule_interval_seconds == (new_schedule_interval | int)
+      - update_full.response.alert_config is defined
+      - update_full.response.alert_config.auto_resolve == "ENABLED"
+    success_msg: "Full-spec update landed on server with alert_config"
+    fail_msg: "Full-spec update did not land on server"
+  when: original_alert_config_present | bool
+
+- name: Skip note - selected SDA policy does not expose alert_config
+  ansible.builtin.debug:
+    msg: >-
+      Selected SDA policy {{ sda_policy_ext_id }} has no alert_config on
+      ClusterConfig {{ cluster_config_ext_id }} - the API rejects alert_config
+      updates for this policy family. Full-spec test skipped.
+  when: not (original_alert_config_present | bool)
+
+##############################################################################
+# Cleanup - restore original scheduleIntervalSeconds
+##############################################################################
+
+- name: Restore original scheduleIntervalSeconds
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: present
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    ext_id: "{{ cluster_config_ext_id }}"
+    schedule_interval_seconds: "{{ original_schedule_interval_seconds | int }}"
+  register: restore_schedule
+  ignore_errors: true
+
+- name: Assert restore succeeded
+  ansible.builtin.assert:
+    that:
+      - restore_schedule is defined
+      - restore_schedule.failed == false
+      - restore_schedule.response.schedule_interval_seconds == (original_schedule_interval_seconds | int)
+    success_msg: "Original scheduleIntervalSeconds restored"
+    fail_msg: "Failed to restore original scheduleIntervalSeconds"
+
+##############################################################################
+# CRUD module - negative tests
+##############################################################################
+
+- name: Negative - state=absent (delete not supported)
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: absent
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    ext_id: "{{ cluster_config_ext_id }}"
+  register: neg_delete
+  ignore_errors: true
+
+- name: Negative - assert delete-not-supported
+  ansible.builtin.assert:
+    that:
+      - neg_delete is defined
+      - neg_delete.failed == true
+      - neg_delete.changed == false
+      - neg_delete.msg is search('Delete is not supported')
+    success_msg: "Delete correctly reported as unsupported"
+    fail_msg: "Delete did not surface the 'not supported' message"
+
+- name: Negative - state=absent missing ext_id (required_if triggers)
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: absent
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+  register: neg_absent_missing
+  ignore_errors: true
+
+- name: Negative - assert required_if failure
+  ansible.builtin.assert:
+    that:
+      - neg_absent_missing is defined
+      - neg_absent_missing.failed == true
+      - neg_absent_missing.changed == false
+      - neg_absent_missing.msg is search('ext_id')
+    success_msg: "required_if enforced ext_id + system_defined_policy_ext_id for state=absent"
+    fail_msg: "required_if did NOT enforce required attrs for state=absent"
+
+- name: Negative - state=present without ext_id (create not supported)
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: present
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    is_enabled: true
+    schedule_interval_seconds: 300
+  register: neg_create
+  ignore_errors: true
+
+- name: Negative - assert create-not-supported
+  ansible.builtin.assert:
+    that:
+      - neg_create is defined
+      - neg_create.failed == true
+      - neg_create.changed == false
+      - neg_create.msg is search('Create is not supported')
+    success_msg: "Create correctly reported as unsupported"
+    fail_msg: "Create did not surface the 'not supported' message"
+
+- name: Negative - update with invalid ClusterConfig ext_id
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: present
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    schedule_interval_seconds: 600
+  register: neg_bad_ext_id
+  ignore_errors: true
+
+- name: Negative - assert invalid ext_id surfaces API error
+  ansible.builtin.assert:
+    that:
+      - neg_bad_ext_id is defined
+      - neg_bad_ext_id.failed == true
+      - neg_bad_ext_id.changed == false
+      - neg_bad_ext_id.msg is search('Api Exception') or neg_bad_ext_id.msg is search('Unable to fetch etag')
+    success_msg: "Invalid ClusterConfig ext_id surfaces error as expected"
+    fail_msg: "Invalid ClusterConfig ext_id did NOT surface an error"
+
+- name: Negative - invalid alert_config.auto_resolve enum
+  nutanix.ncp.ntnx_cluster_config_v2:
+    state: present
+    system_defined_policy_ext_id: "{{ sda_policy_ext_id }}"
+    ext_id: "{{ cluster_config_ext_id }}"
+    alert_config:
+      auto_resolve: NOT_A_VALID_STATE
+  register: neg_bad_enum
+  ignore_errors: true
+
+- name: Negative - assert invalid enum rejected
+  ansible.builtin.assert:
+    that:
+      - neg_bad_enum is defined
+      - neg_bad_enum.failed == true
+      - neg_bad_enum.changed == false
+    success_msg: "Invalid auto_resolve enum rejected by argument-spec"
+    fail_msg: "Invalid auto_resolve enum was NOT rejected"
+
+- name: End ClusterConfig tests
+  ansible.builtin.debug:
+    msg: "ClusterConfig integration tests complete"

--- a/tests/integration/targets/ntnx_cluster_config_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_cluster_config_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import cluster_config.yml
+      ansible.builtin.import_tasks: cluster_config.yml


### PR DESCRIPTION
# Add Ansible v2 modules for Monitoring ClusterConfig (ntnx_cluster_config_v2 + info)

## Summary

Adds a pair of Ansible modules that wrap the Nutanix Monitoring v4
`SystemDefinedPoliciesApi.*ClusterConfig*` endpoints so users can manage
cluster-specific overrides of System-Defined Alert (SDA) policies from
Ansible:

- **`ntnx_cluster_config_v2`** (CRUD-style) — the Monitoring API only
  supports update on ClusterConfig (create/delete are auto-managed by
  the platform), so this module implements update with full argspec
  coverage (`is_enabled`, `schedule_interval_seconds`,
  `configurable_parameters`, `alert_config` with all three severities
  + `auto_resolve`) and fails fast with a descriptive error on
  create/delete attempts.
- **`ntnx_cluster_configs_info_v2`** (Info) — single-entity fetch by
  `ext_id` and list mode for a given `system_defined_policy_ext_id`,
  with `limit` / `page` / `orderby` support. The list endpoint does not
  support `$filter`, and the module documents that explicitly.

Both modules follow the ntnx_virtual_switch_v2 pattern, use
`BaseModuleV4` / `BaseInfoModule`, share a new
`plugins/module_utils/v4/monitoring/` package (api client + typed
helpers), respect `ETag`, honour `check_mode`, are idempotent, and
surface SDK errors through `raise_api_exception`.

## Details

### New

- `plugins/modules/ntnx_cluster_config_v2.py` — CRUD (update only).
  Sanitises server-only `NOT_SUPPORTED` severity markers before
  writing back (hardening for `MON-30018 invalid argument for key
  alertConfig/<severity>/state`).
- `plugins/modules/ntnx_cluster_configs_info_v2.py` — Info (get + list).
- `plugins/module_utils/v4/monitoring/api_client.py` — builds a
  `ntnx_monitoring_py_client.ApiClient`, wires proxy/logging, provides
  `get_etag()` and `get_system_defined_policies_api_instance()`.
- `plugins/module_utils/v4/monitoring/helpers.py` — typed
  `get_cluster_config(...)` and `get_sda_policy(...)` fetch helpers
  that route errors through `raise_api_exception`.
- `examples/monitoring/ClusterConfig/cluster_config_v2.yml` —
  end-to-end demo playbook (list, get, minimal update, full-spec
  reference update, plus the deliberately-failing delete path).
- `tests/integration/targets/ntnx_cluster_config_v2/` — full
  integration test target:
  - Bootstraps a schedule-driven SDA policy at runtime by iterating
    up to 60 policies until it finds a ClusterConfig with a non-null
    `schedule_interval_seconds`.
  - Info tests: list, get-by-id, `limit=1`, `orderby=extId`, and
    negatives (invalid `ext_id`, missing required `system_defined_policy_ext_id`).
  - CRUD tests: check_mode create / update (all attrs) / delete, real
    update with a fresh schedule interval, idempotency re-apply,
    optional full-spec `alert_config` update (skipped when the picked
    policy exposes no `alert_config`), and a cleanup step that restores
    the original `schedule_interval_seconds`.
  - Negative CRUD: `state=absent` (delete-not-supported), `required_if`
    trigger for `state=absent` without `ext_id`, `state=present`
    without `ext_id` (create-not-supported), update with an invalid
    `ext_id`, and invalid `alert_config.auto_resolve` enum.

### Changed

- `plugins/module_utils/v4/utils.py` — `strip_read_only_fields` now
  tolerates read-only SDK properties that have no deleter (e.g.
  `monitoring.ClusterConfig.last_modified_by_user`) by falling back to
  `setattr(spec, field, None)`. This is a strict superset of the
  previous behaviour (existing callers still work) and unblocks the
  Monitoring SDK model classes.
- `requirements.txt` — pin `ntnx-monitoring-py-client==4.2.2`
  (previously `latest`, which broke reproducible installs).
- `.gitignore` — add `tests/integration/integration_config.yml` so
  local dev PC credentials never get committed.

## Test plan / evidence

Everything below was run against the live PC at `10.44.76.28`.

### Linting / sanity

```
# from repo root
black --check plugins/modules/ntnx_cluster_config_v2.py plugins/modules/ntnx_cluster_configs_info_v2.py plugins/module_utils/v4/monitoring/
isort --check-only plugins/modules/ntnx_cluster_config_v2.py plugins/modules/ntnx_cluster_configs_info_v2.py plugins/module_utils/v4/monitoring/
flake8 --max-line-length=200 plugins/modules/ntnx_cluster_config_v2.py plugins/modules/ntnx_cluster_configs_info_v2.py plugins/module_utils/v4/monitoring/
ansible-lint plugins/modules/ntnx_cluster_config_v2.py plugins/modules/ntnx_cluster_configs_info_v2.py plugins/module_utils/v4/monitoring/ examples/monitoring/ClusterConfig/ tests/integration/targets/ntnx_cluster_config_v2/
ansible-test sanity --python 3.11 plugins/modules/ntnx_cluster_config_v2.py plugins/modules/ntnx_cluster_configs_info_v2.py plugins/module_utils/v4/monitoring/api_client.py plugins/module_utils/v4/monitoring/helpers.py plugins/module_utils/v4/utils.py
```

All five tools pass cleanly (ansible-lint: `Passed: 0 failure(s), 0
warning(s) on 18 files. Last profile that met the validation criteria
was 'production'`).

### Examples

```
ansible-playbook examples/monitoring/ClusterConfig/cluster_config_v2.yml -v \
  -e "sda_policy_ext_id=110200" \
  -e "cluster_config_ext_id=0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
```

`PLAY RECAP → ok=5 changed=1 failed=0 ignored=2` (the two ignored
tasks are the intentional full-spec update on a policy that doesn't
expose `alert_config`, and the intentional `state=absent` failure).

### Integration tests

```
ansible-playbook tests/integration/targets/ntnx_cluster_config_v2/tasks/main.yml \
  -e "ip=10.44.76.28 username=admin password=Nutanix.123 validate_certs=false port=9440"
```

`PLAY RECAP → ok=177 changed=2 failed=0 ignored=9 skipped=172`.
The `ignored`/`skipped` counts are structural: every negative test is
`ignore_errors: true` (fatal → ignored) with an assert task that turns
the negative into a pass, plus the alert_config full-spec block is
skipped when the runtime-picked SDA policy does not expose one.
