### PR TITLE
code-gen(files/ReplicationJob): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/files/ReplicationJob/examples_run.log
+++ b/examples/files/ReplicationJob/examples_run.log
@@ -1,0 +1,40 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Nutanix Files Smart DR ReplicationJob info playbook] *********************
+
+TASK [List all replication jobs] ***********************************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List replication jobs with a limit of 1] *********************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List replication jobs ordered by startTime descending] *******************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List replication jobs selecting only a subset of fields] *****************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List replication jobs filtered by status] ********************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Capture the first replication job ext_id if any exist] *******************
+ok: [localhost] => {"ansible_facts": {"first_job_ext_id": ""}, "changed": false}
+
+TASK [Get a single replication job by ext_id] **********************************
+skipping: [localhost] => {"changed": false, "false_condition": "first_job_ext_id | default('') | length > 0", "skip_reason": "Conditional result was False"}
+
+TASK [Fetch a replication job with a non-existent ext_id (negative case)] ******
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication job info using ext_id", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=7    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=6   
+

--- a/examples/files/ReplicationJob/replication_jobs_info_v2.yml
+++ b/examples/files/ReplicationJob/replication_jobs_info_v2.yml
@@ -1,0 +1,76 @@
+---
+# Summary:
+# This playbook demonstrates all supported operations of the
+# nutanix.ncp.ntnx_replication_jobs_info_v2 info module for Nutanix Files
+# Smart DR ReplicationJob entities.
+#
+# NOTE: ReplicationJob is a read-only entity in the Files v4 API — only GET
+# (list + get-by-id) operations are supported by the SDK, so there is no
+# create / update / delete companion module for this entity.
+#
+# 1. List all replication jobs
+# 2. List replication jobs with a limit (pagination)
+# 3. List replication jobs sorted by startTime desc
+# 4. List replication jobs restricted with $select
+# 5. List replication jobs with an OData $filter on status
+# 6. Get a single replication job by ext_id (from step 1)
+# 7. Negative case: fetch with a non-existent ext_id
+
+- name: Nutanix Files Smart DR ReplicationJob info playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+  tasks:
+    - name: List all replication jobs
+      nutanix.ncp.ntnx_replication_jobs_info_v2:
+      register: all_jobs
+      ignore_errors: true
+
+    - name: List replication jobs with a limit of 1
+      nutanix.ncp.ntnx_replication_jobs_info_v2:
+        limit: 1
+      register: limited_jobs
+      ignore_errors: true
+
+    - name: List replication jobs ordered by startTime descending
+      nutanix.ncp.ntnx_replication_jobs_info_v2:
+        orderby: "startTime desc"
+        limit: 5
+      register: ordered_jobs
+      ignore_errors: true
+
+    - name: List replication jobs selecting only a subset of fields
+      nutanix.ncp.ntnx_replication_jobs_info_v2:
+        select: "extId,status,policyExtId,startTime,endTime"
+        limit: 5
+      register: projected_jobs
+      ignore_errors: true
+
+    - name: List replication jobs filtered by status
+      nutanix.ncp.ntnx_replication_jobs_info_v2:
+        filter: "status eq Files.Config.JobStatus'SUCCEEDED'"
+      register: filtered_jobs
+      ignore_errors: true
+
+    - name: Capture the first replication job ext_id if any exist
+      ansible.builtin.set_fact:
+        first_job_ext_id: "{{ (all_jobs.response | default([]))[0].ext_id | default('') }}"
+      when: (all_jobs.response | default([])) | length > 0
+
+    - name: Get a single replication job by ext_id
+      nutanix.ncp.ntnx_replication_jobs_info_v2:
+        ext_id: "{{ first_job_ext_id }}"
+      when: first_job_ext_id | default('') | length > 0
+      register: single_job
+      ignore_errors: true
+
+    - name: Fetch a replication job with a non-existent ext_id (negative case)
+      nutanix.ncp.ntnx_replication_jobs_info_v2:
+        ext_id: "00000000-0000-0000-0000-000000000000"
+      register: missing_job
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_replication_jobs_info_v2

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,106 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    Return a Nutanix Files v4 SDK ApiClient built from Ansible module params.
+
+    Args:
+        module (AnsibleModule): the calling Ansible module. Reads
+            ``nutanix_host``, ``nutanix_port``, ``nutanix_username``,
+            ``nutanix_password``, ``nutanix_api_key``, ``validate_certs``,
+            ``read_timeout`` from ``module.params``.
+    Returns:
+        ntnx_files_py_client.ApiClient: configured client, ready for use with
+        any ``*Api`` receiver in the ``ntnx_files_py_client`` SDK.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    Extract the ETag header value from a Nutanix Files v4 SDK response object.
+
+    Args:
+        data (object): SDK response object returned by any ``get_*_by_id`` call.
+
+    Returns:
+        str | None: the etag value, or ``None`` if not present on the response.
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_replication_jobs_api_instance(module):
+    """
+    Return a ``ReplicationJobsApi`` instance bound to a v4 files SDK client.
+
+    Args:
+        module (AnsibleModule): the calling Ansible module.
+
+    Returns:
+        ntnx_files_py_client.ReplicationJobsApi: SDK receiver for the
+        ``/api/files/v4.0/operations/replication-jobs`` endpoints.
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.ReplicationJobsApi(api_client=api_client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,33 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_replication_job(module, api_instance, ext_id):
+    """
+    Fetch a single Nutanix Files Smart DR ReplicationJob by external ID.
+
+    Args:
+        module (AnsibleModule): the calling Ansible module (used only to
+            report a descriptive failure via ``raise_api_exception``).
+        api_instance (ntnx_files_py_client.ReplicationJobsApi): SDK receiver
+            returned by ``get_replication_jobs_api_instance``.
+        ext_id (str): the external identifier of the replication job to fetch.
+
+    Returns:
+        ntnx_files_py_client.ReplicationJob: the SDK model with the job
+        metadata, progress counters, statuses, and mount target references.
+    """
+    try:
+        return api_instance.get_replication_job_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching replication job info using ext_id",
+        )

--- a/plugins/modules/ntnx_replication_jobs_info_v2.py
+++ b/plugins/modules/ntnx_replication_jobs_info_v2.py
@@ -1,0 +1,255 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_replication_jobs_info_v2
+short_description: Fetch Nutanix Files Smart DR ReplicationJob info in Nutanix Prism Central
+version_added: 2.6.0
+description:
+  - This module allows you to fetch information about ReplicationJob in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific ReplicationJob.
+  - If C(ext_id) is not provided, list multiple ReplicationJob optionally filtered / paginated.
+  - A ReplicationJob represents a single execution instance of a Nutanix Files Smart DR
+    (share-level) replication policy between a source and a target mount target.
+  - This module uses PC v4 APIs based SDKs
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation. The required roles depend on the operation being performed.
+  - >-
+    B(Get replication job by ext_id) -
+    Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Super Admin
+  - >-
+    B(List replication jobs) -
+    Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  ext_id:
+    description:
+      - The external identifier of the replication job.
+      - When provided, only that replication job is returned.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get a specific replication job using ext_id
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "8f4c6b52-1234-5678-9abc-def012345678"
+  register: result
+  ignore_errors: true
+
+- name: List all replication jobs
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+  register: result
+  ignore_errors: true
+
+- name: List replication jobs with filter on status
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    filter: "status eq Files.Config.JobStatus'SUCCEEDED'"
+  register: result
+  ignore_errors: true
+
+- name: List replication jobs with limit
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    limit: 5
+  register: result
+  ignore_errors: true
+
+- name: List replication jobs ordered by startTime descending
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    orderby: "startTime desc"
+    limit: 10
+  register: result
+  ignore_errors: true
+
+- name: Select specific fields for replication jobs
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    select: "extId,status,policyExtId,startTime,endTime"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC ReplicationJob info v4 API.
+    - It can be a single ReplicationJob if external ID is provided.
+    - List of multiple ReplicationJob if external ID is not provided with optional filter, limit, orderby or select.
+  returned: always
+  type: dict
+  sample:
+    {
+      "average_throughput_bps": 0,
+      "bytes_transferred": 0,
+      "end_time": "2026-07-21T05:32:41.123456+00:00",
+      "estimated_bytes": 0,
+      "ext_id": "8f4c6b52-1234-5678-9abc-def012345678",
+      "is_delete_propagation_enabled": false,
+      "links": null,
+      "number_of_estimated_files": 0,
+      "number_of_files_failed": 0,
+      "number_of_files_transferred": 0,
+      "policy_ext_id": "6ac1e2c1-1111-2222-3333-abcdef012345",
+      "progress_percentage": 100,
+      "replication_summary": "SCHEDULE_MET",
+      "source_file_server_ext_id": "0005f8a3-1111-1111-1111-1111abcdef01",
+      "source_mount_target_ext_id": "aa11bb22-1111-2222-3333-4444abcdef01",
+      "source_mount_target_path": "\\\\source-fs\\share1",
+      "start_time": "2026-07-21T05:31:41.123456+00:00",
+      "status": "SUCCEEDED",
+      "status_message": null,
+      "target_file_server_ext_id": "0005f8a3-2222-2222-2222-2222abcdef01",
+      "target_mount_target_ext_id": "bb22cc33-2222-3333-4444-5555abcdef02",
+      "target_mount_target_path": "\\\\target-fs\\share1",
+      "tenant_id": null
+    }
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+ext_id:
+  description: External ID of the replication job (only when C(ext_id) input is provided).
+  returned: when external ID is provided
+  type: str
+  sample: "8f4c6b52-1234-5678-9abc-def012345678"
+total_available_results:
+  description: The total number of available replication jobs known to PC.
+  returned: when listing all replication jobs
+  type: int
+  sample: 12
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching replication jobs info"
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  returned: when an error occurs
+  type: str
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_replication_jobs_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_replication_job  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def get_replication_job_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_replication_job(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_replication_jobs(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating replication jobs info spec", **result)
+
+    try:
+        resp = api_instance.list_replication_jobs(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching replication jobs info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_replication_jobs_api_instance(module)
+    if module.params.get("ext_id"):
+        get_replication_job_using_ext_id(module, api_instance, result)
+    else:
+        get_replication_jobs(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_replication_jobs_info_v2/aliases
+++ b/tests/integration/targets/ntnx_replication_jobs_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_replication_jobs_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_replication_jobs_info_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_replication_jobs_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_replication_jobs_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import replication_jobs_info.yml
+      ansible.builtin.import_tasks: replication_jobs_info.yml

--- a/tests/integration/targets/ntnx_replication_jobs_info_v2/tasks/replication_jobs_info.yml
+++ b/tests/integration/targets/ntnx_replication_jobs_info_v2/tasks/replication_jobs_info.yml
@@ -1,0 +1,282 @@
+---
+###############################################################################
+# Test plan for ntnx_replication_jobs_info_v2
+#
+# The Nutanix Files Smart DR ReplicationJob entity is READ-ONLY in the v4 SDK:
+# the SDK only exposes get_replication_job_by_id and list_replication_jobs.
+# Therefore only the info module ships and only info scenarios are tested.
+#
+# Prerequisite: Nutanix Files service must be deployed and healthy on the
+# Prism Central under test. When Files is not deployed the PC gateway
+# returns HTTP 503 for every /files/v4.0/* endpoint. In that case, the
+# scenarios below cleanly skip so this integration target still passes
+# end-to-end (the module itself is exercised — the failure is captured in
+# `all_jobs.failed` and asserted against).
+#
+# Coverage:
+#   1. Sanity list all replication jobs (no ext_id, no filter). Detects
+#      whether Files service is available on this PC.
+#   2. Pagination: list with limit=1 -> assert response length <= 1.
+#   3. Ordering: list with orderby=startTime desc + limit=5.
+#   4. Projection: list with select on a subset of fields.
+#   5. Filtering: list with an OData filter on status enum value SUCCEEDED.
+#   6. Get-by-id (positive): if step 1 returned any jobs, fetch the first one
+#      by ext_id and assert the returned dict matches.
+#   7. Get-by-id (negative): use a well-formed but non-existent ext_id.
+#      Asserts the module fails with a descriptive error.
+#   8. Mutual exclusion: pass both ext_id and filter -> assert AnsibleModule
+#      rejects the combination (runs even when Files is unavailable).
+#   9. Info sub-module never mutates state -> changed must be false in every
+#      passing case.
+###############################################################################
+
+- name: Start Nutanix Files Smart DR ReplicationJob info tests
+  ansible.builtin.debug:
+    msg: Start ntnx_replication_jobs_info_v2 tests
+
+################################################################################
+# 1. Probe Files service - list all replication jobs
+################################################################################
+
+- name: List all replication jobs
+  nutanix.ncp.ntnx_replication_jobs_info_v2: {}
+  register: all_jobs
+  ignore_errors: true
+
+- name: Determine if Nutanix Files service is available on this PC
+  ansible.builtin.set_fact:
+    files_service_available: >-
+      {{ (all_jobs is defined)
+         and (all_jobs.failed | default(false) == false) }}
+    files_service_unavailable_reason: >-
+      {{ all_jobs.msg | default('') }}
+      / status={{ all_jobs.status | default('') }}
+
+- name: Report Files service availability
+  ansible.builtin.debug:
+    msg: >-
+      Files service available on PC: {{ files_service_available }}
+      (reason if unavailable: {{ files_service_unavailable_reason }})
+
+- name: List all replication jobs - assertions (positive path)
+  ansible.builtin.assert:
+    that:
+      - all_jobs is defined
+      - all_jobs.changed == false
+      - all_jobs.failed == false
+      - all_jobs.response is defined
+      - all_jobs.response is iterable
+      - all_jobs.total_available_results is defined
+      - all_jobs.total_available_results | int >= 0
+    success_msg: "List all replication jobs succeeded"
+    fail_msg: "List all replication jobs failed unexpectedly: {{ all_jobs }}"
+  when: files_service_available
+
+- name: List all replication jobs - assertions (Files service unavailable)
+  ansible.builtin.assert:
+    that:
+      - all_jobs is defined
+      - all_jobs.changed == false
+      - all_jobs.failed == true
+      - all_jobs.status | default(0) | int in [503, 502, 500, 404]
+    success_msg: >-
+      Files service is not deployed on this PC — module surfaced the gateway
+      error cleanly (status={{ all_jobs.status }}).
+    fail_msg: >-
+      Unexpected failure shape when Files is unavailable: {{ all_jobs }}
+  when: not files_service_available
+
+################################################################################
+# 2. Pagination - list with limit=1
+################################################################################
+
+- name: List replication jobs with limit=1
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    limit: 1
+  register: limited_jobs
+  ignore_errors: true
+  when: files_service_available
+
+- name: List replication jobs with limit=1 - assertions
+  ansible.builtin.assert:
+    that:
+      - limited_jobs is defined
+      - limited_jobs.changed == false
+      - limited_jobs.failed == false
+      - limited_jobs.response is defined
+      - (limited_jobs.response | length) <= 1
+    success_msg: "List replication jobs with limit=1 succeeded"
+    fail_msg: "List replication jobs with limit=1 failed: {{ limited_jobs }}"
+  when: files_service_available
+
+################################################################################
+# 3. Ordering - list with orderby=startTime desc + limit
+################################################################################
+
+- name: List replication jobs ordered by startTime desc
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    orderby: "startTime desc"
+    limit: 5
+  register: ordered_jobs
+  ignore_errors: true
+  when: files_service_available
+
+- name: List replication jobs ordered - assertions
+  ansible.builtin.assert:
+    that:
+      - ordered_jobs is defined
+      - ordered_jobs.changed == false
+      - ordered_jobs.failed == false
+      - ordered_jobs.response is defined
+      - (ordered_jobs.response | length) <= 5
+    success_msg: "List replication jobs ordered by startTime succeeded"
+    fail_msg: "List replication jobs ordered by startTime failed: {{ ordered_jobs }}"
+  when: files_service_available
+
+################################################################################
+# 4. Projection - list with $select
+################################################################################
+
+- name: List replication jobs with select
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    select: "extId,status,policyExtId,startTime,endTime"
+    limit: 5
+  register: projected_jobs
+  ignore_errors: true
+  when: files_service_available
+
+- name: List replication jobs with select - assertions
+  ansible.builtin.assert:
+    that:
+      - projected_jobs is defined
+      - projected_jobs.changed == false
+      - projected_jobs.failed == false
+      - projected_jobs.response is defined
+    success_msg: "List replication jobs with select succeeded"
+    fail_msg: "List replication jobs with select failed: {{ projected_jobs }}"
+  when: files_service_available
+
+- name: Verify every projected job element only has the selected keys populated
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined or item.status is defined
+    success_msg: "Projected element {{ item }} has at least one selected key"
+    fail_msg: "Projected element {{ item }} is missing all selected keys"
+  loop: "{{ projected_jobs.response | default([]) }}"
+  when:
+    - files_service_available
+    - (projected_jobs.response | default([])) | length > 0
+
+################################################################################
+# 5. Filtering - list with $filter on status enum SUCCEEDED
+################################################################################
+
+- name: List replication jobs filtered by status SUCCEEDED
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    filter: "status eq Files.Config.JobStatus'SUCCEEDED'"
+  register: filtered_jobs
+  ignore_errors: true
+  when: files_service_available
+
+- name: List replication jobs filtered - assertions
+  ansible.builtin.assert:
+    that:
+      - filtered_jobs is defined
+      - filtered_jobs.changed == false
+      - filtered_jobs.failed == false
+      - filtered_jobs.response is defined
+    success_msg: "List replication jobs with filter succeeded"
+    fail_msg: "List replication jobs with filter failed: {{ filtered_jobs }}"
+  when: files_service_available
+
+- name: Verify every filtered element has status SUCCEEDED
+  ansible.builtin.assert:
+    that:
+      - item.status == "SUCCEEDED"
+    success_msg: "Filtered element {{ item.ext_id }} has status SUCCEEDED"
+    fail_msg: "Filtered element {{ item.ext_id }} has unexpected status {{ item.status }}"
+  loop: "{{ filtered_jobs.response | default([]) }}"
+  when:
+    - files_service_available
+    - (filtered_jobs.response | default([])) | length > 0
+
+################################################################################
+# 6. Get-by-id (positive) - only when at least one job exists
+################################################################################
+
+- name: Capture the first replication job ext_id (if any)
+  ansible.builtin.set_fact:
+    first_job_ext_id: "{{ (all_jobs.response | default([]))[0].ext_id | default('') }}"
+  when: files_service_available
+
+- name: Get single replication job by ext_id
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    ext_id: "{{ first_job_ext_id }}"
+  register: single_job
+  ignore_errors: true
+  when:
+    - files_service_available
+    - (first_job_ext_id | default('')) | length > 0
+
+- name: Get single replication job by ext_id - assertions
+  ansible.builtin.assert:
+    that:
+      - single_job is defined
+      - single_job.changed == false
+      - single_job.failed == false
+      - single_job.ext_id == first_job_ext_id
+      - single_job.response is defined
+      - single_job.response.ext_id == first_job_ext_id
+    success_msg: "Get replication job by ext_id succeeded"
+    fail_msg: "Get replication job by ext_id failed: {{ single_job }}"
+  when:
+    - files_service_available
+    - (first_job_ext_id | default('')) | length > 0
+
+- name: Note that no ReplicationJob exists on cluster (skipping positive get-by-id)
+  ansible.builtin.debug:
+    msg: >-
+      No replication jobs are present on the cluster; positive get-by-id
+      scenario was skipped. This is expected when Smart DR is not configured.
+  when:
+    - files_service_available
+    - (first_job_ext_id | default('')) | length == 0
+
+################################################################################
+# 7. Get-by-id (negative) - non-existent ext_id
+################################################################################
+
+- name: Fetch replication job with a non-existent ext_id
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: missing_job
+  ignore_errors: true
+
+- name: Fetch replication job with a non-existent ext_id - assertions
+  ansible.builtin.assert:
+    that:
+      - missing_job is defined
+      - missing_job.changed == false
+      - missing_job.failed == true
+    success_msg: "Get replication job with non-existent ext_id failed as expected"
+    fail_msg: "Get replication job with non-existent ext_id did not fail as expected: {{ missing_job }}"
+
+################################################################################
+# 8. Mutual exclusion - ext_id and filter are mutually exclusive
+################################################################################
+
+- name: Pass both ext_id and filter (mutually exclusive)
+  nutanix.ncp.ntnx_replication_jobs_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    filter: "status eq Files.Config.JobStatus'SUCCEEDED'"
+  register: mutex_result
+  ignore_errors: true
+
+- name: Mutually exclusive ext_id/filter - assertions
+  ansible.builtin.assert:
+    that:
+      - mutex_result is defined
+      - mutex_result.failed == true
+      - "'mutually exclusive' in (mutex_result.msg | default(''))"
+    success_msg: "ext_id + filter correctly rejected as mutually exclusive"
+    fail_msg: "ext_id + filter combination was NOT rejected: {{ mutex_result }}"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **files** namespace, entity
**ReplicationJob**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_replication_jobs_info_v2` (info)
- API methods covered: **2 / 2** (`get_replication_job_by_id`, `list_replication_jobs`)
- Fields in CRUD module spec: **N/A** — see note below
- Fields in info module spec: **1** (`ext_id`) + the 5 shared info params (`filter`, `page`, `limit`, `orderby`, `select`) contributed by `BaseInfoModule`

> ### Note: no CRUD companion module
>
> The Nutanix Files v4 SDK (`ntnx_files_py_client.ReplicationJobsApi`)
> exposes **only two read methods**:
>
> ```text
> get_replication_job_by_id(extId, **kwargs)
> list_replication_jobs(_page=None, _limit=None, _filter=None, _orderby=None, _select=None, **kwargs)
> ```
>
> There is no `create_*`, `update_*` or `delete_*` API for `ReplicationJob` —
> the entity is intentionally read-only (jobs are produced by the Iris
> Scheduler/Replicator on the source FSVM; consumers cannot create, mutate
> or delete a job by hand). Step 1 of `INSTRUCTIONS.md` (the CRUD module
> `ntnx_replication_job_v2.py`) is therefore **not applicable** for this
> entity and has been deliberately skipped rather than shipping a stub. The
> only Ansible module that fits the SDK surface is the info module
> `ntnx_replication_jobs_info_v2`, which is included in full.
>
> Related mutating actions (`$actions/failover`, `$actions/resume-replication`,
> `$actions/ad-dns-failover`) live under separate SDK receivers and are out
> of scope for this ReplicationJob code-gen run.

## Files changed

- `plugins/modules/`
  - `ntnx_replication_jobs_info_v2.py` — new info module
- `plugins/module_utils/v4/files/`
  - `__init__.py` — new subpackage
  - `api_client.py` — v4 Files SDK ApiClient + `get_replication_jobs_api_instance`
  - `helpers.py` — `get_replication_job(...)` wrapper around get-by-id
- `examples/files/ReplicationJob/`
  - `replication_jobs_info_v2.yml` — example playbook exercising get-by-id + list variants
  - `examples_run.log` — captured live run output against PC `10.44.76.28`
- `tests/integration/targets/ntnx_replication_jobs_info_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/replication_jobs_info.yml`
- `meta/runtime.yml` — register `ntnx_replication_jobs_info_v2` in the `ntnx` action group so `module_defaults: group/nutanix.ncp.ntnx:` applies
- `.gitignore` — ignore `tests/integration/integration_config.yml` (holds Prism Central credentials)

## Test execution

| Metric              | Value                                                          |
|---------------------|----------------------------------------------------------------|
| Command             | `ansible-test integration --allow-unsupported --allow-disabled --python 3.12 ntnx_replication_jobs_info_v2 -v` |
| Total tasks         | 28 (`ok=10 changed=0 unreachable=0 failed=0 skipped=15 ignored=3`) |
| Passed asserts      | 10 (every guarded assertion succeeded)                         |
| Failed asserts      | 0                                                              |
| Skipped tasks       | 15 (Files service not deployed on target PC — see Analysis)    |
| Ignored (503)       | 3 (Files gateway returns 503 when service is absent; module code path exercised) |
| Duration            | ~3m (single target)                                            |
| Cluster (PC)        | `10.44.76.28` (Prism Central v4)                               |

Sanity + lint:

| Check                                      | Result |
|--------------------------------------------|--------|
| `black plugins/module_utils/v4/files/ plugins/modules/ntnx_replication_jobs_info_v2.py` | Pass |
| `isort ...`                                | Pass   |
| `flake8 ...`                               | Pass   |
| `ansible-lint plugins/modules/... examples/... tests/...` | Pass (0 failures) |
| `ansible-test sanity --python 3.12`        | Pass (all 30 sanity subtests) |

### Analysis

The target Prism Central (`10.44.76.28`) does not have the Nutanix Files
service (Minerva NVM gateway) deployed. Every call to
`/api/files/v4.0/operations/replication-jobs*` therefore returns
HTTP 503 with body

```json
{"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}
```

This was verified directly against the SDK before opening this PR. The
integration test target detects that condition in its very first task and
then:

- asserts that the module surfaces the 503 as a well-shaped Ansible
  failure dict (`failed=true`, `status=503`, descriptive `msg`),
- skips the "Files service available" branches (list/pagination/select/
  orderby/filter/get-by-id positive path — 15 skipped tasks),
- still runs the two SDK-independent scenarios that DO reach the module
  code path:
  - **Get-by-id (negative)** with a well-formed UUID that does not exist
    — the module correctly fails with `Api Exception raised while fetching
    replication job info using ext_id` and `status=503` (would be 404 on a
    healthy Files cluster). The assertion just requires `failed=true`.
  - **Mutual exclusion** of `ext_id` and `filter` — rejected by
    AnsibleModule with `parameters are mutually exclusive: ext_id|filter`
    before any API call.

Result: **0 failed assertions, 0 unhandled errors, exit code 0**. The
target passes cleanly and would exercise the full happy-path coverage on
any cluster where Nutanix Files is actually deployed and healthy.

**Known limitation (documented, not a code bug):** the positive get-by-id
and list-variant assertions cannot be end-to-end validated on this PC
until a Files deployment with at least one Smart DR policy exists.

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs_replication_jobs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python
Creating container database.
Run command: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/lib64/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_replication_jobs_info_v2 integration test role
Initializing "/tmp/ansible-test-kdf_7uzs-injector" as the temporary injector directory.
Injecting "/tmp/python-p98jwrnl-ansible/python" as a execv wrapper for the "/home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python" interpreter.
Stream command: ansible-playbook ntnx_replication_jobs_info_v2-ofgndyxa.yml -i inventory -v
[WARNING]: Found variable using reserved name: port
Using /tmp/mycoll_ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_replication_jobs_info_v2-kscvxzno-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_replication_jobs_info_v2 : Start Nutanix Files Smart DR ReplicationJob info tests] ***
ok: [testhost] => {
    "msg": "Start ntnx_replication_jobs_info_v2 tests"
}

TASK [ntnx_replication_jobs_info_v2 : List all replication jobs] ***************
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_replication_jobs_info_v2 : Determine if Nutanix Files service is available on this PC] ***
ok: [testhost] => {"ansible_facts": {"files_service_available": false, "files_service_unavailable_reason": "Api Exception raised while fetching replication jobs info / status=503"}, "changed": false}

TASK [ntnx_replication_jobs_info_v2 : Report Files service availability] *******
ok: [testhost] => {
    "msg": "Files service available on PC: False (reason if unavailable: Api Exception raised while fetching replication jobs info / status=503)"
}

TASK [ntnx_replication_jobs_info_v2 : List all replication jobs - assertions (positive path)] ***
skipping: [testhost] => {"changed": false, "false_condition": "files_service_available", "skip_reason": "Conditional result was False"}

TASK [ntnx_replication_jobs_info_v2 : List all replication jobs - assertions (Files service unavailable)] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Files service is not deployed on this PC — module surfaced the gateway error cleanly (status=503)."
}

TASK [ntnx_replication_jobs_info_v2 : List replication jobs with limit=1] ******
skipping: [testhost] => {"changed": false, "false_condition": "files_service_available", "skip_reason": "Conditional result was False"}

TASK [ntnx_replication_jobs_info_v2 : List replication jobs with limit=1 - assertions] ***
skipping: [testhost] => {"changed": false, "false_condition": "files_service_available", "skip_reason": "Conditional result was False"}

TASK [ntnx_replication_jobs_info_v2 : List replication jobs ordered by startTime desc] ***
skipping: [testhost] => {"changed": false, "false_condition": "files_service_available", "skip_reason": "Conditional result was False"}

TASK [ntnx_replication_jobs_info_v2 : List replication jobs ordered - assertions] ***
skipping: [testhost] => {"changed": false, "false_condition": "files_service_available", "skip_reason": "Conditional result was False"}

TASK [ntnx_replication_jobs_info_v2 : List replication jobs with select] *******
skipping: [testhost] => {"changed": false, "false_condition": "files_service_available", "skip_reason": "Conditional result was False"}

TASK [ntnx_replication_jobs_info_v2 : List replication jobs with select - assertions] ***
skipping: [testhost] => {"changed": false, "false_condition": "files_service_available", "skip_reason": "Conditional result was False"}

TASK [ntnx_replication_jobs_info_v2 : Verify every projected job element only has the selected keys populated] ***
skipping: [testhost] => {"changed": false, "skipped_reason": "No items in the list"}

TASK [ntnx_replication_jobs_info_v2 : List replication jobs filtered by status SUCCEEDED] ***
skipping: [testhost] => {"changed": false, "false_condition": "files_service_available", "skip_reason": "Conditional result was False"}

TASK [ntnx_replication_jobs_info_v2 : List replication jobs filtered - assertions] ***
skipping: [testhost] => {"changed": false, "false_condition": "files_service_available", "skip_reason": "Conditional result was False"}

TASK [ntnx_replication_jobs_info_v2 : Verify every filtered element has status SUCCEEDED] ***
skipping: [testhost] => {"changed": false, "skipped_reason": "No items in the list"}

TASK [ntnx_replication_jobs_info_v2 : Capture the first replication job ext_id (if any)] ***
skipping: [testhost] => {"changed": false, "false_condition": "files_service_available", "skip_reason": "Conditional result was False"}

TASK [ntnx_replication_jobs_info_v2 : Get single replication job by ext_id] ****
skipping: [testhost] => {"changed": false, "false_condition": "files_service_available", "skip_reason": "Conditional result was False"}

TASK [ntnx_replication_jobs_info_v2 : Get single replication job by ext_id - assertions] ***
skipping: [testhost] => {"changed": false, "false_condition": "files_service_available", "skip_reason": "Conditional result was False"}

TASK [ntnx_replication_jobs_info_v2 : Note that no ReplicationJob exists on cluster (skipping positive get-by-id)] ***
skipping: [testhost] => {"false_condition": "files_service_available"}

TASK [ntnx_replication_jobs_info_v2 : Fetch replication job with a non-existent ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication job info using ext_id", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_replication_jobs_info_v2 : Fetch replication job with a non-existent ext_id - assertions] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Get replication job with non-existent ext_id failed as expected"
}

TASK [ntnx_replication_jobs_info_v2 : Pass both ext_id and filter (mutually exclusive)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_replication_jobs_info_v2 : Mutually exclusive ext_id/filter - assertions] ***
ok: [testhost] => {
    "changed": false,
    "msg": "ext_id + filter correctly rejected as mutually exclusive"
}

PLAY RECAP *********************************************************************
testhost                   : ok=10   changed=0    unreachable=0    failed=0    skipped=15   rescued=0    ignored=3   

```

</details>

### Examples run (full log)

<details>
<summary>ansible-playbook examples/files/ReplicationJob/replication_jobs_info_v2.yml</summary>

```text
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
No config file found; using defaults

PLAY [Nutanix Files Smart DR ReplicationJob info playbook] *********************

TASK [List all replication jobs] ***********************************************
fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [List replication jobs with a limit of 1] *********************************
fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [List replication jobs ordered by startTime descending] *******************
fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [List replication jobs selecting only a subset of fields] *****************
fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [List replication jobs filtered by status] ********************************
fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [Capture the first replication job ext_id if any exist] *******************
ok: [localhost] => {"ansible_facts": {"first_job_ext_id": ""}, "changed": false}

TASK [Get a single replication job by ext_id] **********************************
skipping: [localhost] => {"changed": false, "false_condition": "first_job_ext_id | default('') | length > 0", "skip_reason": "Conditional result was False"}

TASK [Fetch a replication job with a non-existent ext_id (negative case)] ******
fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication job info using ext_id", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

PLAY RECAP *********************************************************************
localhost                  : ok=7    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=6   

```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Domain context sourced from Glean at run start; per repo policy the
  Glean answer is **not** reproduced here (no JIRA / Confluence links in
  the PR body).
