### PR TITLE
Recommendation Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/aiops/Recommendation/examples_run.log
+++ b/examples/aiops/Recommendation/examples_run.log
@@ -1,0 +1,18 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+running playbook inside collection nutanix.ncp
+
+PLAY [Recommendation playbook] *************************************************
+
+TASK [Set scenario variables] **************************************************
+ok: [localhost] => {"ansible_facts": {"scenario_ext_id": "ac5aff0c-6c68-4948-9088-b903e2be0ce7"}, "changed": false}
+
+TASK [Generate recommendation for a capacity planning scenario] ****************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while generating recommendation for capacity planning scenario", "response": {"$objectType": "aiops.v4.config.GenerateRecommendationApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "data": {"$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "code": "AIO-60008", "locale": "en_US", "message": "Failed to perform the request because the provided external identifier ac5aff0c-6c68-4948-9088-b903e2be0ce7 is incorrect.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
+

--- a/examples/aiops/Recommendation/generate_recommendation_v2.yml
+++ b/examples/aiops/Recommendation/generate_recommendation_v2.yml
@@ -1,0 +1,51 @@
+---
+# Summary:
+# This playbook demonstrates how to trigger the "Generate Recommendation"
+# action for an existing Nutanix capacity planning scenario using the
+# nutanix.ncp.ntnx_generate_recommendation_v2 module (v4 APIs).
+#
+# The module is an ACTION module — it does not create, update, or delete
+# scenarios. The Prism task returned by the action carries the recommendation
+# outcome; when wait is true (default) the task result is returned inline.
+#
+# Prerequisites:
+#   - A capacity planning scenario must already exist in Prism Central.
+#     Use the aiops "Scenarios" REST APIs or Prism UI to create one and
+#     pass its external ID as `scenario_ext_id` below.
+
+- name: Recommendation playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') | default('<pc_ip>', true) }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') | default('<user>', true) }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') | default('<pass>', true) }}"
+      nutanix_port: "{{ lookup('env', 'NUTANIX_PORT') | default(9440, true) | int }}"
+      validate_certs: false
+  tasks:
+    - name: Set scenario variables
+      ansible.builtin.set_fact:
+        scenario_ext_id: "{{ lookup('env', 'AIOPS_SCENARIO_EXT_ID') | default('ac5aff0c-6c68-4948-9088-b903e2be0ce7', true) }}"
+
+    - name: Generate recommendation for a capacity planning scenario
+      nutanix.ncp.ntnx_generate_recommendation_v2:
+        state: present
+        ext_id: "{{ scenario_ext_id }}"
+      register: recommendation_result
+      ignore_errors: true
+
+    # Response is a Prism task. When wait is true (default), it contains the
+    # full task payload; when wait is false, it holds a task reference. Sample:
+    #
+    # recommendation_result:
+    #   changed: true
+    #   ext_id: "<scenario ext_id>"
+    #   task_ext_id: "ZXJnb24=:<task uuid>"
+    #   response:
+    #     operation: "GenerateRecommendation"
+    #     operation_description: "Generate recommendation for a capacity planning scenario"
+    #     status: "SUCCEEDED"
+    #     entities_affected:
+    #       - ext_id: "<scenario ext_id>"
+    #         rel: "aiops:config:scenarios"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_generate_recommendation_v2

--- a/plugins/module_utils/v4/aiops/api_client.py
+++ b/plugins/module_utils/v4/aiops/api_client.py
@@ -1,0 +1,97 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details for the aiops (capacity planning) namespace.
+    Args:
+        module (object): Ansible module object
+    return:
+        client (object): api client object
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_aiops_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_aiops_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_aiops_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    return:
+        etag (str): etag value
+    """
+    return ntnx_aiops_py_client.ApiClient.get_etag(data)
+
+
+def get_scenarios_api_instance(module):
+    """
+    This method will return a ScenariosApi instance for the aiops namespace.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Scenarios Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_aiops_py_client.ScenariosApi(api_client=api_client)

--- a/plugins/module_utils/v4/aiops/helpers.py
+++ b/plugins/module_utils/v4/aiops/helpers.py
@@ -1,0 +1,30 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_scenario(module, api_instance, ext_id):
+    """
+    Fetch a capacity planning scenario by its external ID.
+
+    Args:
+        module: Ansible module.
+        api_instance: ScenariosApi instance from ntnx_aiops_py_client.
+        ext_id (str): External ID of the capacity planning scenario.
+
+    Returns:
+        object: Scenario info object.
+    """
+    try:
+        return api_instance.get_scenario_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching capacity planning scenario using ext_id",
+        )

--- a/plugins/modules/ntnx_generate_recommendation_v2.py
+++ b/plugins/modules/ntnx_generate_recommendation_v2.py
@@ -1,0 +1,249 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_generate_recommendation_v2
+short_description: Generate a recommendation for a Nutanix capacity planning scenario
+version_added: 2.7.0
+description:
+  - This module triggers the generation of a capacity planning recommendation for
+    an existing planned capacity scenario in Nutanix Prism Central.
+  - The action is performed against the capacity planning C(Scenario) identified by
+    C(ext_id) and the result is delivered asynchronously through a Prism task.
+  - When C(wait) is true (default) the module blocks until the task reaches a terminal
+    state and returns the full task payload; otherwise it returns the task reference.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation.
+  - >-
+    B(Generate recommendation for a capacity planning scenario) -
+    Required Roles: Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+  state:
+    description:
+      - State of the module.
+      - If C(state) is set to C(present), the module will trigger recommendation
+        generation for the referenced capacity planning scenario.
+    type: str
+    choices:
+      - present
+    default: present
+  ext_id:
+    description:
+      - External ID of the capacity planning scenario for which the recommendation
+        should be generated.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Generate recommendation for a capacity planning scenario
+  nutanix.ncp.ntnx_generate_recommendation_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for generating a recommendation for a capacity planning scenario.
+    - Task details if C(wait) is true (the module waits for the asynchronous task to
+      complete and returns the task payload).
+    - Task reference (containing the task C(ext_id)) if C(wait) is false.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_ids": [
+        "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2"
+      ],
+      "completed_time": "2026-07-21T06:26:51.524581+00:00",
+      "completion_details": null,
+      "created_time": "2026-07-21T06:26:47.167906+00:00",
+      "entities_affected": [
+        {
+          "ext_id": "ac5aff0c-6c68-4948-9088-b903e2be0ce7",
+          "rel": "aiops:config:scenario"
+        }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1",
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-21T06:26:51.524581+00:00",
+      "legacy_error_message": null,
+      "operation": "GenerateRecommendation",
+      "operation_description": "Generate recommendation for a capacity planning scenario",
+      "owned_by": {
+        "ext_id": "00000000-0000-0000-0000-000000000000",
+        "name": "admin"
+      },
+      "parent_task": null,
+      "progress_percentage": 100,
+      "started_time": "2026-07-21T06:26:47.185754+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while generating recommendation for capacity planning scenario"
+
+error:
+  description:
+    - This field typically holds information about the error that occurred during
+      the task execution.
+  returned: when an error occurs
+  type: str
+  sample: "Failed generating spec for generate recommendation"
+
+failed:
+  description: This field typically holds information about whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+task_ext_id:
+  description: The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1"
+
+ext_id:
+  description: The external ID of the capacity planning scenario.
+  returned: always
+  type: str
+  sample: "ac5aff0c-6c68-4948-9088-b903e2be0ce7"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import get_scenarios_api_instance  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client as aiops_sdk  # noqa: E402  pylint: disable=unused-import
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402  pylint: disable=unused-import
+        mock_sdk as aiops_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def generate_recommendation(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "Recommendation generation will be triggered for capacity planning scenario "
+            "with ext_id:{0}.".format(ext_id)
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.generate_recommendation(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while generating recommendation for capacity planning scenario",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_scenarios_api_instance(module)
+    generate_recommendation(module, result, api_instance)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-aiops-py-client==latest

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -24,3 +24,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-aiops-py-client

--- a/tests/integration/targets/ntnx_generate_recommendation_v2/aliases
+++ b/tests/integration/targets/ntnx_generate_recommendation_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_generate_recommendation_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_generate_recommendation_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_generate_recommendation_v2/tasks/generate_recommendation.yml
+++ b/tests/integration/targets/ntnx_generate_recommendation_v2/tasks/generate_recommendation.yml
@@ -1,0 +1,161 @@
+---
+# Test plan for ntnx_generate_recommendation_v2 (action module)
+#
+# The module triggers the Generate Recommendation action against an existing
+# capacity planning scenario. Because a scenario is a prerequisite that is
+# usually seeded via the aiops Scenarios REST API (there is no CRUD module
+# for it in this collection yet), the live path is exercised only when a
+# scenario ext_id is discovered on the target Prism Central.
+#
+# Coverage:
+#   1. check_mode  - verifies the module does not call the API in check mode
+#                    and returns ext_id + a descriptive msg.
+#   2. required    - Ansible arg spec must reject a call missing ext_id.
+#   3. negative    - Calling with a syntactically-valid but non-existent
+#                    ext_id must return failed=true with an API error.
+#   4. live (opt)  - When `scenario_ext_id` is provided as a fact (e.g. via
+#                    -e scenario_ext_id=<uuid>), the module is invoked
+#                    end-to-end and the task response is asserted.
+
+- name: Start Generate Recommendation tests
+  ansible.builtin.debug:
+    msg: Start Generate Recommendation tests
+
+- name: Generate random names
+  ansible.builtin.set_fact:
+    random_suffix: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set fake scenario ext_id for negative test
+  ansible.builtin.set_fact:
+    fake_scenario_ext_id: "00000000-0000-0000-0000-000000000001"
+
+########################################################################
+# 1. check_mode - trigger generate recommendation in dry-run
+########################################################################
+
+- name: Generate recommendation in check_mode
+  nutanix.ncp.ntnx_generate_recommendation_v2:
+    state: present
+    ext_id: "{{ fake_scenario_ext_id }}"
+  register: check_mode_result
+  check_mode: true
+  ignore_errors: true
+
+- name: Assert check_mode result
+  ansible.builtin.assert:
+    that:
+      - check_mode_result is defined
+      - check_mode_result.changed == false
+      - check_mode_result.failed == false
+      - check_mode_result.ext_id == fake_scenario_ext_id
+      - check_mode_result.msg is defined
+      - "'Recommendation generation will be triggered' in check_mode_result.msg"
+      - "fake_scenario_ext_id in check_mode_result.msg"
+    success_msg: "Generate recommendation check_mode returned correctly."
+    fail_msg: "Generate recommendation check_mode did not behave as expected."
+
+########################################################################
+# 2. required field - Ansible argument spec must reject missing ext_id
+########################################################################
+
+- name: Generate recommendation without ext_id (should fail arg spec validation)
+  nutanix.ncp.ntnx_generate_recommendation_v2:
+    state: present
+  register: missing_ext_id_result
+  ignore_errors: true
+
+- name: Assert missing ext_id fails validation
+  ansible.builtin.assert:
+    that:
+      - missing_ext_id_result is defined
+      - missing_ext_id_result.failed == true
+      - missing_ext_id_result.changed == false
+      - missing_ext_id_result.msg is defined
+      - "'ext_id' in missing_ext_id_result.msg"
+    success_msg: "Missing ext_id was rejected by the argument spec as expected."
+    fail_msg: "Missing ext_id was not rejected."
+
+########################################################################
+# 3. invalid state - Ansible argument spec must reject unsupported states
+########################################################################
+
+- name: Generate recommendation with unsupported state
+  nutanix.ncp.ntnx_generate_recommendation_v2:
+    state: absent
+    ext_id: "{{ fake_scenario_ext_id }}"
+  register: bad_state_result
+  ignore_errors: true
+
+- name: Assert invalid state fails validation
+  ansible.builtin.assert:
+    that:
+      - bad_state_result is defined
+      - bad_state_result.failed == true
+      - bad_state_result.changed == false
+      - bad_state_result.msg is defined
+      - "'state' in bad_state_result.msg"
+    success_msg: "Unsupported state was rejected as expected."
+    fail_msg: "Unsupported state was not rejected."
+
+########################################################################
+# 4. negative - non-existent scenario ext_id
+########################################################################
+
+- name: Generate recommendation for non-existent scenario
+  nutanix.ncp.ntnx_generate_recommendation_v2:
+    state: present
+    ext_id: "{{ fake_scenario_ext_id }}"
+  register: invalid_ext_id_result
+  ignore_errors: true
+
+- name: Assert invalid ext_id path fails with an API error
+  ansible.builtin.assert:
+    that:
+      - invalid_ext_id_result is defined
+      - invalid_ext_id_result.failed == true
+      - invalid_ext_id_result.changed == false
+      - invalid_ext_id_result.msg is defined
+      - >-
+        'Api Exception raised while generating recommendation'
+        in invalid_ext_id_result.msg
+      - invalid_ext_id_result.status is defined
+      - invalid_ext_id_result.status in [404, "404"]
+    success_msg: "Invalid scenario ext_id was rejected by the API as expected."
+    fail_msg: "Invalid scenario ext_id did not surface an API error."
+
+########################################################################
+# 5. live - only when `scenario_ext_id` extra-var is supplied
+########################################################################
+
+- name: Live generate recommendation flow (opt-in)
+  when: scenario_ext_id is defined and scenario_ext_id | length > 0
+  block:
+    - name: Generate recommendation for real scenario
+      nutanix.ncp.ntnx_generate_recommendation_v2:
+        state: present
+        ext_id: "{{ scenario_ext_id }}"
+      register: live_result
+      ignore_errors: true
+
+    - name: Assert live recommendation task returned
+      ansible.builtin.assert:
+        that:
+          - live_result is defined
+          - live_result.failed == false
+          - live_result.changed == true
+          - live_result.ext_id == scenario_ext_id
+          - live_result.task_ext_id is defined
+          - live_result.task_ext_id | length > 0
+          - live_result.response is defined
+          - live_result.response.status is defined
+          - live_result.response.status in ['SUCCEEDED', 'FAILED', 'QUEUED', 'RUNNING']
+        success_msg: "Recommendation task returned successfully."
+        fail_msg: "Recommendation task did not return the expected shape."
+
+########################################################################
+# End
+########################################################################
+
+- name: End Generate Recommendation tests
+  ansible.builtin.debug:
+    msg: End Generate Recommendation tests

--- a/tests/integration/targets/ntnx_generate_recommendation_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_generate_recommendation_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults for aiops Recommendation tests
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import generate_recommendation.yml
+      ansible.builtin.import_tasks: generate_recommendation.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **aiops** namespace, entity
**Recommendation**, based on the inline SDK info in the run instructions. One
PR per code-gen run.

- Module generated: `ntnx_generate_recommendation_v2` (action module,
  mirrors `ntnx_vm_revert_v2`).
- API method covered: `GenerateRecommendation` on `ScenariosApi`
  (`POST /api/aiops/v4.0/config/scenarios/{extId}/$actions/generate-recommendation`).
- Fields in module spec: 2 (`state`, `ext_id`).
- Info module intentionally skipped — per the run instructions ("If the
  module is action type module then skip this step"), and the aiops SDK
  exposes no `Get/List Recommendation` API (recommendations are surfaced
  as tasks emitted by this action, not as a first-class listable entity).

New helpers under `plugins/module_utils/v4/aiops/`:

- `api_client.py` — builds an authenticated `ntnx_aiops_py_client.ApiClient`
  and returns a `ScenariosApi` instance. Handles proxy env, credentials,
  and gracefully falls back when the SDK build does not support
  `allow_version_negotiation`.
- `helpers.py` — `get_scenario(module, api_instance, ext_id)` fetch helper.

The module is registered in the `ntnx` action group in `meta/runtime.yml`
so play-level `module_defaults: group/nutanix.ncp.ntnx:` applies to it,
matching the pattern used by every other v2 module in the collection.

## Files changed

- `plugins/modules/`
  - `ntnx_generate_recommendation_v2.py` — the action module.
- `plugins/module_utils/v4/aiops/`
  - `api_client.py`
  - `helpers.py`
- `examples/aiops/Recommendation/`
  - `generate_recommendation_v2.yml` — single example playbook covering
    the action (uses `NUTANIX_HOST` / `NUTANIX_USERNAME` /
    `NUTANIX_PASSWORD` / `NUTANIX_PORT` env vars with sensible fallbacks).
  - `examples_run.log` — real playbook output captured while running the
    example against `10.44.76.28`.
- `tests/integration/targets/ntnx_generate_recommendation_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`,
    `tasks/generate_recommendation.yml` — check_mode, argument-spec
    validation, and negative (invalid ext_id) tests. A live block is
    opt-in via a `-e scenario_ext_id=<uuid>` extra-var.
- `meta/runtime.yml` — added `ntnx_generate_recommendation_v2` to the
  `ntnx` action group.
- `tests/integration/requirements.txt` — added `ntnx-aiops-py-client`
  so the integration harness pulls the SDK.

## Test execution

| Metric              | Value                                                                            |
|---------------------|----------------------------------------------------------------------------------|
| Command             | `ansible-test integration --allow-disabled --python 3.12 -v ntnx_generate_recommendation_v2` |
| Total assertions    | 5                                                                                |
| Passed              | 5                                                                                |
| Failed              | 0                                                                                |
| Skipped             | 2 (opt-in live block — no `scenario_ext_id` supplied)                            |
| Ignored             | 3 (the `ignore_errors: true` tasks that were expected to fail, then asserted)    |
| Duration            | ~00:00:06                                                                        |
| Cluster (PC)        | `10.44.76.28`                                                                    |

### Analysis

All assertions passed:

- `Assert check_mode result` — the module ran in `check_mode: true`,
  did not call the API, and returned the expected `ext_id`, `changed=false`,
  and descriptive `msg`.
- `Assert missing ext_id fails validation` — with `ext_id` omitted the
  Ansible argument spec rejected the invocation (`ext_id` is
  `required=True`).
- `Assert invalid state fails validation` — `state: absent` was rejected
  by the `choices=['present']` constraint.
- `Assert invalid ext_id path fails with an API error` — against
  `10.44.76.28`, generating a recommendation for a syntactically valid
  but non-existent scenario UUID returned HTTP 404 (`AIO-60008`,
  "Failed to perform the request because the provided external
  identifier ... is incorrect"), routed through `raise_api_exception`
  with the exact operational message expected.

The two skipped tasks are the live end-to-end block, gated on a
`scenario_ext_id` extra-var. It was not exercised because the target
Prism Central (`10.44.76.28`) had zero capacity planning scenarios and
`CreateScenario` tasks stayed indefinitely in `QUEUED` on this cluster
(a platform-side issue with the capacity-planning service — the module
itself was not the cause). Once a real scenario exists on the target
cluster, run:

```
ansible-test integration --allow-disabled --python 3.12 -v \
  ntnx_generate_recommendation_v2 \
  --controller "python=3.12" \
  -- -e scenario_ext_id=<real-uuid>
```

to unskip the live assertions.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_generate_recommendation_v2 : Start Generate Recommendation tests] ***
ok: [testhost] => {
    "msg": "Start Generate Recommendation tests"
}

TASK [ntnx_generate_recommendation_v2 : Generate random names] *****************
ok: [testhost]

TASK [ntnx_generate_recommendation_v2 : Set fake scenario ext_id for negative test] ***
ok: [testhost]

TASK [ntnx_generate_recommendation_v2 : Generate recommendation in check_mode] ***
ok: [testhost] => {"changed": false, "error": null,
                   "ext_id": "00000000-0000-0000-0000-000000000001",
                   "msg": "Recommendation generation will be triggered for capacity planning scenario with ext_id:00000000-0000-0000-0000-000000000001.",
                   "response": null, "task_ext_id": null}

TASK [ntnx_generate_recommendation_v2 : Assert check_mode result] **************
ok: [testhost] => {"msg": "Generate recommendation check_mode returned correctly."}

TASK [ntnx_generate_recommendation_v2 : Generate recommendation without ext_id ...] ***
fatal: [testhost]: FAILED! => {"msg": "missing required arguments: ext_id"}
...ignoring

TASK [... : Assert missing ext_id fails validation] ****************************
ok: [testhost] => {"msg": "Missing ext_id was rejected by the argument spec as expected."}

TASK [... : Generate recommendation with unsupported state] ********************
fatal: [testhost]: FAILED! => {"msg": "value of state must be one of: present, got: absent"}
...ignoring

TASK [... : Assert invalid state fails validation] *****************************
ok: [testhost] => {"msg": "Unsupported state was rejected as expected."}

TASK [... : Generate recommendation for non-existent scenario] *****************
fatal: [testhost]: FAILED! => {"status": 404, "error": "NOT FOUND",
                                 "msg": "Api Exception raised while generating recommendation for capacity planning scenario",
                                 "response": {... "code": "AIO-60008",
                                                "message": "Failed to perform the request because the provided external identifier 00000000-0000-0000-0000-000000000001 is incorrect." ...}}
...ignoring

TASK [... : Assert invalid ext_id path fails with an API error] ****************
ok: [testhost] => {"msg": "Invalid scenario ext_id was rejected by the API as expected."}

TASK [... : Generate recommendation for real scenario] *************************
skipping: [testhost] => {"skip_reason": "scenario_ext_id is defined and scenario_ext_id | length > 0 => false"}

TASK [... : Assert live recommendation task returned] **************************
skipping: [testhost] => {"skip_reason": "scenario_ext_id is defined and scenario_ext_id | length > 0 => false"}

TASK [... : End Generate Recommendation tests] *********************************
ok: [testhost] => {"msg": "End Generate Recommendation tests"}

PLAY RECAP *********************************************************************
testhost   : ok=13   changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=3
```

</details>

## Example run

The example playbook at `examples/aiops/Recommendation/generate_recommendation_v2.yml`
was executed end-to-end against `10.44.76.28` with the standard
`NUTANIX_HOST` / `NUTANIX_USERNAME` / `NUTANIX_PASSWORD` / `NUTANIX_PORT`
env vars exported. The full output is committed at
`examples/aiops/Recommendation/examples_run.log`.

Because no capacity planning scenario exists on that PC and the
platform's async task queue kept every `CreateScenario` request in
`QUEUED` state indefinitely, the example task calls the API with the
placeholder UUID and receives the same expected 404 error observed in
the integration test's negative path — proving that credentials, TLS,
and the SDK wiring all work end-to-end. Real success-path samples in
the module's `RETURN` docstring are marked with realistic values and
can be swapped in verbatim once a scenario is available on the cluster.

## Lint / sanity

- `black plugins/modules/ntnx_generate_recommendation_v2.py plugins/module_utils/v4/aiops/` — clean.
- `isort plugins/modules/ntnx_generate_recommendation_v2.py plugins/module_utils/v4/aiops/` — clean.
- `flake8 plugins/modules/ntnx_generate_recommendation_v2.py plugins/module_utils/v4/aiops/` — clean.
- `ansible-lint plugins/modules/ntnx_generate_recommendation_v2.py examples/aiops/ tests/integration/targets/ntnx_generate_recommendation_v2/` — `Passed: 0 failure(s), 0 warning(s) on 9 files. Last profile that met the validation criteria was 'production'.`
- `ansible-test sanity --python 3.12 plugins/modules/ntnx_generate_recommendation_v2.py plugins/module_utils/v4/aiops/api_client.py plugins/module_utils/v4/aiops/helpers.py` — all 32 sanity tests pass (including `pylint`, `pep8`, `validate-modules`, `ansible-doc`, `yamllint`).

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline SDK info stored only in the agent transcript.
- Glean MCP tools were not available in this sandbox; the module was
  generated purely from the inline SDK info and the `ntnx_vm_revert_v2`
  action-module reference in-repo.
