### PR TITLE
MountTargetSnapshot Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+__pycache__/
+*.pyc

--- a/examples/files/MountTargetSnapshot/examples_run.log
+++ b/examples/files/MountTargetSnapshot/examples_run.log
@@ -1,0 +1,20 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Nutanix Files - MountTargetSnapshot examples] ****************************
+
+TASK [Create mount target snapshot] ********************************************
+[ERROR]: Task failed: Module failed: Api Exception raised while checking existing mount target snapshots
+Origin: /tmp/codegen/c8d97026a0e346a1994d3adf3ab6b404/repo/examples/files/MountTargetSnapshot/mount_target_snapshot.yml:27:7
+
+25       validate_certs: false
+26   tasks:
+27     - name: Create mount target snapshot
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while checking existing mount target snapshots", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
+

--- a/examples/files/MountTargetSnapshot/mount_target_snapshot.yml
+++ b/examples/files/MountTargetSnapshot/mount_target_snapshot.yml
@@ -1,0 +1,77 @@
+---
+# Examples for the Nutanix Files MountTargetSnapshot v4 modules:
+#   - nutanix.ncp.ntnx_files_mount_target_snapshot_v2      (create / restore / delete)
+#   - nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2 (get / list)
+#
+# A mount target snapshot is a point-in-time copy of a mount target
+# (share/export) that belongs to a Nutanix Files file server.
+#
+# Update the connection details and the file_server_ext_id / mount_target_ext_id
+# variables below to match your environment before running this playbook.
+- name: Nutanix Files - MountTargetSnapshot examples
+  hosts: localhost
+  gather_facts: false
+  vars:
+    nutanix_host: "10.44.76.28"
+    nutanix_username: "admin"
+    nutanix_password: "Nutanix.123"
+    file_server_ext_id: "5f1b7b3e-1234-4c47-b5db-920460c4b668"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host }}"
+      nutanix_username: "{{ nutanix_username }}"
+      nutanix_password: "{{ nutanix_password }}"
+      validate_certs: false
+  tasks:
+    - name: Create mount target snapshot
+      nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        name: "mount_target_snapshot_ansible"
+        type: "USER_SNAPSHOT"
+      register: created_snapshot
+
+    - name: Get mount target snapshot using ext_id
+      nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        ext_id: "{{ created_snapshot.ext_id }}"
+      register: snapshot_details
+
+    - name: List all mount target snapshots
+      nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+      register: all_snapshots
+
+    - name: List mount target snapshots with filter
+      nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        filter: "name eq 'mount_target_snapshot_ansible'"
+      register: filtered_snapshots
+
+    - name: List mount target snapshots with limit
+      nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        limit: 1
+      register: limited_snapshots
+
+    - name: Restore mount target from snapshot
+      nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        ext_id: "{{ created_snapshot.ext_id }}"
+      register: restored_mount_target
+
+    - name: Delete mount target snapshot
+      nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+        state: absent
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        ext_id: "{{ created_snapshot.ext_id }}"
+      register: deleted_snapshot

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_files_mount_target_snapshot_v2
+    - ntnx_files_mount_target_snapshots_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,8 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        MOUNT_TARGET_SNAPSHOT = "files:config:snapshot"
+        MOUNT_TARGET = "files:config:mount-target"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,122 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details.
+    Args:
+        module (object): Ansible module object
+    return:
+        client (object): api client object
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    # Setup API logging if debug is enabled
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    return:
+        etag (str): etag value
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_snapshots_api_instance(module):
+    """
+    This method will return SnapshotsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Snapshots Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.SnapshotsApi(api_client=api_client)
+
+
+def get_mount_targets_api_instance(module):
+    """
+    This method will return MountTargetsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Mount Targets Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.MountTargetsApi(api_client=api_client)
+
+
+def get_file_servers_api_instance(module):
+    """
+    This method will return FileServersApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): File Servers Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.FileServersApi(api_client=api_client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,36 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_mount_target_snapshot(
+    module, api_instance, ext_id, file_server_ext_id, mount_target_ext_id
+):
+    """
+    This method will return mount target snapshot info using its ext_id.
+    Args:
+        module: Ansible module
+        api_instance: SnapshotsApi instance from ntnx_files_py_client sdk
+        ext_id (str): mount target snapshot external ID
+        file_server_ext_id (str): file server external ID
+        mount_target_ext_id (str): mount target external ID
+    return:
+        info (object): mount target snapshot info
+    """
+    try:
+        return api_instance.get_mount_target_snapshot_by_id(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            extId=ext_id,
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching mount target snapshot info using ext_id",
+        )

--- a/plugins/module_utils/v4/utils.py
+++ b/plugins/module_utils/v4/utils.py
@@ -304,5 +304,11 @@ def strip_read_only_fields(spec, fields=None):
 
     for field in fields:
         if hasattr(spec, field):
-            delattr(spec, field)
+            try:
+                delattr(spec, field)
+            except (AttributeError, TypeError):
+                # SDK models expose read-only fields as properties without a
+                # deleter, so fall back to nulling them out. Sanitized request
+                # bodies omit ``None`` values, so this effectively strips them.
+                setattr(spec, field, None)
     return spec

--- a/plugins/modules/ntnx_files_mount_target_snapshot_v2.py
+++ b/plugins/modules/ntnx_files_mount_target_snapshot_v2.py
@@ -1,0 +1,454 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_mount_target_snapshot_v2
+short_description: Create, Restore, and Delete mount target snapshots in Nutanix Files
+version_added: 2.7.0
+description:
+  - This module allows you to create and delete mount target snapshots in Nutanix Files on Prism Central.
+  - It also supports restoring a mount target from an existing snapshot.
+  - A mount target snapshot is a point-in-time copy of a mount target (share/export) that belongs to a file server.
+  - This module uses PC v4 APIs based SDKs.
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided, the operation will create a mount target snapshot.
+      - If C(state) is set to C(present) and C(ext_id) is provided, the operation will restore the mount target from the snapshot.
+      - If C(state) is set to C(absent) and C(ext_id) is provided, the operation will delete the mount target snapshot.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the mount target snapshot.
+      - Required for restore (C(state=present)) and delete (C(state=absent)) operations.
+    type: str
+    required: false
+  file_server_ext_id:
+    description:
+      - The external ID of the file server that owns the mount target.
+    type: str
+    required: true
+  mount_target_ext_id:
+    description:
+      - The external ID of the mount target (share/export) to snapshot.
+    type: str
+    required: true
+  name:
+    description:
+      - Mount target snapshot name.
+      - Required for create operation only.
+      - Minimum 1 character, maximum 80 characters.
+    type: str
+    required: false
+  type:
+    description:
+      - Mount target snapshot type.
+      - Used for create operation only.
+    type: str
+    required: false
+    choices:
+      - SSR_SNAPSHOT
+      - USER_SNAPSHOT
+      - REPLICATION_SNAPSHOT
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Create mount target snapshot
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    file_server_ext_id: "5f1b7b3e-1234-4c47-b5db-920460c4b668"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    name: "mount_target_snapshot_ansible"
+    type: "USER_SNAPSHOT"
+  register: result
+  ignore_errors: true
+
+- name: Restore mount target from snapshot
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    file_server_ext_id: "5f1b7b3e-1234-4c47-b5db-920460c4b668"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+  register: result
+  ignore_errors: true
+
+- name: Delete mount target snapshot
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    file_server_ext_id: "5f1b7b3e-1234-4c47-b5db-920460c4b668"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, restoring, or deleting a mount target snapshot.
+    - If the operation is create and C(wait) is true, it will return the mount target snapshot details.
+    - If the operation is create and C(wait) is false, it will return the task details.
+    - If the operation is restore or delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "create_time": "2026-07-21T07:36:00.000000+00:00",
+      "ext_id": "48f78959-14a6-4c47-b5db-920460c4b668",
+      "links": null,
+      "name": "mount_target_snapshot_ansible",
+      "reclaimable_space_bytes": 0,
+      "tenant_id": null,
+      "total_space_bytes": 0,
+      "type": "USER_SNAPSHOT"
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the mount target snapshot.
+  returned: always
+  type: str
+  sample: "48f78959-14a6-4c47-b5db-920460c4b668"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped
+  returned: when applicable
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode
+  type: str
+  sample: "Mount target snapshot with name 'mount_target_snapshot_ansible' already exists. Skipping creation."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.files.api_client import get_snapshots_api_instance  # noqa: E402
+from ..module_utils.v4.files.helpers import get_mount_target_snapshot  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client as files_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as files_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        file_server_ext_id=dict(type="str", required=True),
+        mount_target_ext_id=dict(type="str", required=True),
+        name=dict(type="str"),
+        type=dict(
+            type="str",
+            choices=["SSR_SNAPSHOT", "USER_SNAPSHOT", "REPLICATION_SNAPSHOT"],
+            obj=files_sdk.SnapshotType,
+        ),
+    )
+    return module_args
+
+
+def get_mount_target_snapshot_by_name(module, api_instance, name):
+    """
+    This method fetches a mount target snapshot by its name for idempotency.
+    Args:
+        module: Ansible module
+        api_instance: SnapshotsApi instance from ntnx_files_py_client sdk
+        name (str): mount target snapshot name
+    return:
+        snapshot (object): mount target snapshot object if found, else None
+    """
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+    try:
+        resp = api_instance.list_mount_target_snapshots(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            _filter="name eq '{0}'".format(name),
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while checking existing mount target snapshots",
+        )
+    if resp is None or resp.data is None:
+        return None
+    for snapshot in resp.data:
+        if snapshot.name == name:
+            return snapshot
+    return None
+
+
+def create_mount_target_snapshot(module, result, api_instance):
+    validate_required_params(module, ["name"])
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+    name = module.params.get("name")
+
+    existing_snapshot = get_mount_target_snapshot_by_name(module, api_instance, name)
+    if existing_snapshot:
+        result["ext_id"] = existing_snapshot.ext_id
+        result["response"] = strip_internal_attributes(existing_snapshot.to_dict())
+        result["skipped"] = True
+        result["msg"] = (
+            "Mount target snapshot with name '{0}' already exists. "
+            "Skipping creation.".format(name)
+        )
+        return
+
+    sg = SpecGenerator(module)
+    default_spec = files_sdk.Snapshot()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating create mount target snapshot spec", **result
+        )
+
+    # Read-only fields are populated by the platform and must not be sent.
+    strip_read_only_fields(
+        spec, fields=["create_time", "total_space_bytes", "reclaimable_space_bytes"]
+    )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_mount_target_snapshot(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            body=spec,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating mount target snapshot",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task_status, rel=TASK_CONSTANTS.RelEntityType.MOUNT_TARGET_SNAPSHOT
+        )
+        if not ext_id:
+            ext_id = get_entity_ext_id_from_task(task_status)
+        if ext_id:
+            result["ext_id"] = ext_id
+            resp = get_mount_target_snapshot(
+                module,
+                api_instance,
+                ext_id,
+                file_server_ext_id,
+                mount_target_ext_id,
+            )
+            result["response"] = strip_internal_attributes(resp.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for MountTargetSnapshot"
+                ),
+                msg="Failed to get entity ext_id from task for MountTargetSnapshot",
+            )
+    result["changed"] = True
+
+
+def restore_mount_target(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "Mount target with ext_id:{0} will be restored from snapshot with "
+            "ext_id:{1}.".format(mount_target_ext_id, ext_id)
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.restore_mount_target(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            extId=ext_id,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while restoring mount target from snapshot",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def delete_mount_target_snapshot(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "Mount target snapshot with ext_id:{0} will be deleted.".format(
+            ext_id
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.delete_mount_target_snapshot_by_id(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            extId=ext_id,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting mount target snapshot",
+        )
+    task_ext_id = None
+    if resp is not None and getattr(resp, "data", None) is not None:
+        task_ext_id = resp.data.ext_id
+        result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_snapshots_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            restore_mount_target(module, result, api_instance)
+        else:
+            create_mount_target_snapshot(module, result, api_instance)
+    else:
+        delete_mount_target_snapshot(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_files_mount_target_snapshots_info_v2.py
+++ b/plugins/modules/ntnx_files_mount_target_snapshots_info_v2.py
@@ -1,0 +1,230 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_mount_target_snapshots_info_v2
+short_description: Fetch mount target snapshots info in Nutanix Files
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about MountTargetSnapshot in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific MountTargetSnapshot.
+  - If C(ext_id) is not provided, list multiple MountTargetSnapshot optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+options:
+  ext_id:
+    description:
+      - The external ID of the mount target snapshot.
+      - If provided, fetch the specific mount target snapshot.
+    type: str
+    required: false
+  file_server_ext_id:
+    description:
+      - The external ID of the file server that owns the mount target.
+    type: str
+    required: true
+  mount_target_ext_id:
+    description:
+      - The external ID of the mount target (share/export).
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Get mount target snapshot using ext_id
+  nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+    file_server_ext_id: "5f1b7b3e-1234-4c47-b5db-920460c4b668"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+  register: result
+  ignore_errors: true
+
+- name: List all mount target snapshots
+  nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+    file_server_ext_id: "5f1b7b3e-1234-4c47-b5db-920460c4b668"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+  register: result
+  ignore_errors: true
+
+- name: List mount target snapshots with filter
+  nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+    file_server_ext_id: "5f1b7b3e-1234-4c47-b5db-920460c4b668"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    filter: "name eq 'mount_target_snapshot_ansible'"
+  register: result
+  ignore_errors: true
+
+- name: List mount target snapshots with limit
+  nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+    file_server_ext_id: "5f1b7b3e-1234-4c47-b5db-920460c4b668"
+    mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC MountTargetSnapshot info v4 API.
+    - It can be a single MountTargetSnapshot if external ID is provided.
+    - List of multiple MountTargetSnapshot if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "create_time": "2026-07-21T07:36:00.000000+00:00",
+      "ext_id": "48f78959-14a6-4c47-b5db-920460c4b668",
+      "links": null,
+      "name": "mount_target_snapshot_ansible",
+      "reclaimable_space_bytes": 0,
+      "tenant_id": null,
+      "total_space_bytes": 0,
+      "type": "USER_SNAPSHOT"
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching mount target snapshots info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: When an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the mount target snapshot
+  type: str
+  returned: when external ID is provided
+  sample: "48f78959-14a6-4c47-b5db-920460c4b668"
+
+total_available_results:
+  description: The total number of available mount target snapshots.
+  type: int
+  returned: when all mount target snapshots are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import get_snapshots_api_instance  # noqa: E402
+from ..module_utils.v4.files.helpers import get_mount_target_snapshot  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        file_server_ext_id=dict(type="str", required=True),
+        mount_target_ext_id=dict(type="str", required=True),
+    )
+
+    return module_args
+
+
+def get_mount_target_snapshot_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+    resp = get_mount_target_snapshot(
+        module, api_instance, ext_id, file_server_ext_id, mount_target_ext_id
+    )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_mount_target_snapshots(module, api_instance, result):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating mount target snapshots info spec", **result
+        )
+
+    try:
+        resp = api_instance.list_mount_target_snapshots(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            **kwargs,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching mount target snapshots info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_snapshots_api_instance(module)
+    if module.params.get("ext_id"):
+        get_mount_target_snapshot_using_ext_id(module, api_instance, result)
+    else:
+        get_mount_target_snapshots(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_files_mount_target_snapshot_v2/aliases
+++ b/tests/integration/targets/ntnx_files_mount_target_snapshot_v2/aliases
@@ -1,0 +1,1 @@
+unsupported

--- a/tests/integration/targets/ntnx_files_mount_target_snapshot_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_files_mount_target_snapshot_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_files_mount_target_snapshot_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_files_mount_target_snapshot_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import mount_target_snapshots.yml
+      ansible.builtin.import_tasks: mount_target_snapshots.yml

--- a/tests/integration/targets/ntnx_files_mount_target_snapshot_v2/tasks/mount_target_snapshots.yml
+++ b/tests/integration/targets/ntnx_files_mount_target_snapshot_v2/tasks/mount_target_snapshots.yml
@@ -1,0 +1,532 @@
+---
+# =============================================================================
+# Test plan for nutanix.ncp.ntnx_files_mount_target_snapshot_v2 and
+# nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2
+# =============================================================================
+# A mount target snapshot is a point-in-time copy of a mount target (share /
+# export) that belongs to a Nutanix Files file server. The snapshot entity
+# supports Create, Read (get/list), Delete and a Restore action. There is no
+# Update API for a snapshot, so C(state=present) + C(ext_id) restores the mount
+# target from the snapshot.
+#
+# Prerequisites (a file server + a mount target) are discovered from the live
+# cluster when `file_server_ext_id` / `mount_target_ext_id` are not supplied via
+# integration_config.yml.
+#
+# Scenarios covered:
+#   1.  Prerequisite discovery (file server + mount target).
+#   2.  Negative: missing required path params (file_server_ext_id).
+#   3.  check_mode create (all attributes).
+#   4.  Create with required attributes only (name).
+#   5.  Create with all attributes (name + type).
+#   6.  Idempotency: create again with same name -> skipped.
+#   7.  Negative: missing name on create.
+#   8.  Negative: invalid enum value for type.
+#   9.  Info: get snapshot by ext_id.
+#   10. Info: list all snapshots (+ total_available_results).
+#   11. Info: list with filter.
+#   12. Info: list with limit.
+#   13. Negative info: get with invalid ext_id.
+#   14. check_mode restore.
+#   15. Restore mount target from snapshot.
+#   16. check_mode delete.
+#   17. Delete snapshot.
+#   18. Negative: delete with wrong ext_id.
+#   19. Negative: delete with missing ext_id.
+#   20. Cleanup of any leftover snapshots created by the tests.
+# =============================================================================
+
+- name: Start Mount Target Snapshot tests
+  ansible.builtin.debug:
+    msg: Start Mount Target Snapshot tests
+
+- name: Generate random names
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+    todelete: []
+
+- name: Set snapshot names
+  ansible.builtin.set_fact:
+    snapshot_name_min: "mts_{{ suffix_name }}_{{ random_name }}_min"
+    snapshot_name_full: "mts_{{ suffix_name }}_{{ random_name }}_full"
+
+########################################################################################
+# Discover prerequisites (file server + mount target) from the live cluster
+########################################################################################
+
+- name: Discover a file server when file_server_ext_id is not provided
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default(9440) }}/api/files/v4.0/config/file-servers?$limit=1"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs | default(false) }}"
+    return_content: true
+  register: fs_list
+  ignore_errors: true
+  when: file_server_ext_id is not defined
+
+- name: Set file_server_ext_id from discovery
+  ansible.builtin.set_fact:
+    file_server_ext_id: "{{ fs_list.json.data[0].extId }}"
+  when:
+    - file_server_ext_id is not defined
+    - fs_list is defined
+    - fs_list.json is defined
+    - fs_list.json.data is defined
+    - fs_list.json.data | length > 0
+
+- name: Discover a mount target when mount_target_ext_id is not provided
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default(9440) }}/api/files/v4.0/config/file-servers/{{ file_server_ext_id }}/mount-targets?$limit=1"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs | default(false) }}"
+    return_content: true
+  register: mt_list
+  ignore_errors: true
+  when:
+    - mount_target_ext_id is not defined
+    - file_server_ext_id is defined
+
+- name: Set mount_target_ext_id from discovery
+  ansible.builtin.set_fact:
+    mount_target_ext_id: "{{ mt_list.json.data[0].extId }}"
+  when:
+    - mount_target_ext_id is not defined
+    - mt_list is defined
+    - mt_list.json is defined
+    - mt_list.json.data is defined
+    - mt_list.json.data | length > 0
+
+- name: Assert prerequisites are available
+  ansible.builtin.assert:
+    that:
+      - file_server_ext_id is defined
+      - mount_target_ext_id is defined
+    success_msg: "A file server and mount target are available to run the tests"
+    fail_msg: >-
+      A file server and mount target are required to run these tests. Provide
+      file_server_ext_id and mount_target_ext_id in integration_config.yml or
+      ensure the Nutanix Files service has at least one file server + mount target.
+
+########################################################################################
+# Negative test - missing required path parameter
+########################################################################################
+
+- name: Create snapshot without file_server_ext_id (should fail)
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: present
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    name: "{{ snapshot_name_min }}"
+  register: result
+  ignore_errors: true
+
+- name: Create snapshot without file_server_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: file_server_ext_id' in result.msg"
+    success_msg: "Create snapshot without file_server_ext_id failed as expected"
+    fail_msg: "Create snapshot without file_server_ext_id did not fail as expected"
+
+########################################################################################
+# check_mode create with all attributes
+########################################################################################
+
+- name: Generate spec for creating snapshot using check mode with all attributes
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    name: "check_mode_mts_full"
+    type: "USER_SNAPSHOT"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for creating snapshot using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_mts_full"
+      - result.response.type == "USER_SNAPSHOT"
+    success_msg: "Spec for creating snapshot using check mode with all attributes is generated successfully"
+    fail_msg: "Spec for creating snapshot using check mode with all attributes is not generated successfully"
+
+########################################################################################
+# Create snapshot with minimum attributes
+########################################################################################
+
+- name: Create snapshot with minimum attributes
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    name: "{{ snapshot_name_min }}"
+  register: result
+  ignore_errors: true
+
+- name: Create snapshot with minimum attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.name == "{{ snapshot_name_min }}"
+    success_msg: "Snapshot with minimum attributes created successfully"
+    fail_msg: "Snapshot with minimum attributes creation failed"
+
+- name: Add snapshot to todelete list
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+########################################################################################
+# Create snapshot with all attributes
+########################################################################################
+
+- name: Create snapshot with all attributes
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    name: "{{ snapshot_name_full }}"
+    type: "USER_SNAPSHOT"
+  register: result
+  ignore_errors: true
+
+- name: Create snapshot with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.name == "{{ snapshot_name_full }}"
+      - result.response.type == "USER_SNAPSHOT"
+    success_msg: "Snapshot with all attributes created successfully"
+    fail_msg: "Snapshot with all attributes creation failed"
+
+- name: Set full snapshot ext_id
+  ansible.builtin.set_fact:
+    full_snapshot_ext_id: "{{ result.ext_id }}"
+
+- name: Add snapshot to todelete list
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+########################################################################################
+# Idempotency - create snapshot with an existing name
+########################################################################################
+
+- name: Create snapshot with an existing name (idempotency)
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    name: "{{ snapshot_name_full }}"
+    type: "USER_SNAPSHOT"
+  register: result
+  ignore_errors: true
+
+- name: Create snapshot with an existing name status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - "'already exists' in result.msg"
+    success_msg: "Create snapshot with an existing name is idempotent as expected"
+    fail_msg: "Create snapshot with an existing name is not idempotent"
+
+########################################################################################
+# Negative tests - create
+########################################################################################
+
+- name: Create snapshot with missing name (should fail)
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Create snapshot with missing name status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): name"
+    success_msg: "Create snapshot with missing name failed as expected"
+    fail_msg: "Create snapshot with missing name did not fail as expected"
+
+- name: Create snapshot with invalid type value (should fail)
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    name: "invalid_type_snapshot"
+    type: "INVALID_SNAPSHOT_TYPE"
+  register: result
+  ignore_errors: true
+
+- name: Create snapshot with invalid type value status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'value of type must be one of' in result.msg"
+    success_msg: "Create snapshot with invalid type value failed as expected"
+    fail_msg: "Create snapshot with invalid type value did not fail as expected"
+
+########################################################################################
+# Info module - get single snapshot
+########################################################################################
+
+- name: Fetch snapshot using external ID
+  nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ full_snapshot_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch snapshot using external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "{{ full_snapshot_ext_id }}"
+      - result.response is defined
+      - result.response.ext_id == "{{ full_snapshot_ext_id }}"
+      - result.response.name == "{{ snapshot_name_full }}"
+      - result.response.type == "USER_SNAPSHOT"
+    success_msg: "Fetch snapshot using external ID passed"
+    fail_msg: "Fetch snapshot using external ID failed"
+
+########################################################################################
+# Info module - list snapshots
+########################################################################################
+
+- name: List all snapshots
+  nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: List all snapshots status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 2
+      - result.total_available_results is defined
+    success_msg: "List all snapshots passed"
+    fail_msg: "List all snapshots failed"
+
+- name: List snapshots with filter
+  nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    filter: "name eq '{{ snapshot_name_full }}'"
+  register: result
+  ignore_errors: true
+
+- name: List snapshots with filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+      - result.response[0].name == "{{ snapshot_name_full }}"
+    success_msg: "List snapshots with filter passed"
+    fail_msg: "List snapshots with filter failed"
+
+- name: List snapshots with limit
+  nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List snapshots with limit status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    success_msg: "List snapshots with limit passed"
+    fail_msg: "List snapshots with limit failed"
+
+- name: Fetch snapshot using wrong external ID (should fail)
+  nutanix.ncp.ntnx_files_mount_target_snapshots_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Fetch snapshot using wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Fetch snapshot using wrong external ID failed as expected"
+    fail_msg: "Fetch snapshot using wrong external ID did not fail as expected"
+
+########################################################################################
+# Restore mount target from snapshot
+########################################################################################
+
+- name: Restore mount target from snapshot with check mode
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ full_snapshot_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Restore mount target from snapshot with check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be restored' in result.msg"
+    success_msg: "Restore mount target from snapshot with check mode passed"
+    fail_msg: "Restore mount target from snapshot with check mode failed"
+
+- name: Restore mount target from snapshot
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ full_snapshot_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Restore mount target from snapshot status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == "{{ full_snapshot_ext_id }}"
+      - result.task_ext_id is defined
+    success_msg: "Restore mount target from snapshot passed"
+    fail_msg: "Restore mount target from snapshot failed"
+
+########################################################################################
+# Delete snapshot
+########################################################################################
+
+- name: Delete snapshot with check mode
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: absent
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ full_snapshot_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Delete snapshot with check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+    success_msg: "Delete snapshot with check mode passed"
+    fail_msg: "Delete snapshot with check mode failed"
+
+- name: Delete snapshot with wrong external ID (should fail)
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: absent
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Delete snapshot with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Delete snapshot with wrong external ID failed as expected"
+    fail_msg: "Delete snapshot with wrong external ID did not fail as expected"
+
+- name: Delete snapshot with missing external ID (should fail)
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: absent
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Delete snapshot with missing external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete snapshot with missing external ID failed as expected"
+    fail_msg: "Delete snapshot with missing external ID did not fail as expected"
+
+########################################################################################
+# Cleanup
+########################################################################################
+
+- name: Delete all created snapshots
+  nutanix.ncp.ntnx_files_mount_target_snapshot_v2:
+    state: absent
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ item }}"
+  register: result
+  ignore_errors: true
+  loop: "{{ todelete }}"
+
+- name: Deletion status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.results | length == todelete | length
+    success_msg: "All created snapshots are deleted successfully"
+    fail_msg: "Unable to delete all created snapshots"
+
+- name: Reset todelete list
+  ansible.builtin.set_fact:
+    todelete: []


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **files** namespace, entity
**MountTargetSnapshot**, based on the inline `sdk_info.json` (SDK
`ntnx_files_py_client` v4.0.1). One PR per code-gen run.

- Modules generated: `ntnx_files_mount_target_snapshot_v2`, `ntnx_files_mount_target_snapshots_info_v2`
- API methods covered: **5** — `CreateMountTargetSnapshot`, `GetMountTargetSnapshotById`, `ListMountTargetSnapshots`, `DeleteMountTargetSnapshotById`, `RestoreMountTarget` (all on `SnapshotsApi`)
- Fields in CRUD module spec: **5** (`ext_id`, `file_server_ext_id`, `mount_target_ext_id`, `name`, `type`)
- Fields in info module spec: **3** (`ext_id`, `file_server_ext_id`, `mount_target_ext_id`)

A mount target snapshot is a point-in-time copy of a mount target (share /
export) that belongs to a Nutanix Files file server. The snapshot entity has no
Update API, so the CRUD module maps operations as:

- `state=present` + no `ext_id` -> **Create** snapshot (idempotent by name)
- `state=present` + `ext_id` -> **Restore** the mount target from the snapshot
- `state=absent` + `ext_id` -> **Delete** snapshot

Very Important: no Jira or Confluence links are included in this description.

## Domain knowledge (from Glean)

The Glean MCP tools (`glean__chat`) were **unavailable during this run** — every
call timed out (`MCP error -32001: Request timed out`), so no Glean-sourced
domain knowledge / ticket / design-doc references could be retrieved. Per the
instructions this is recorded here instead of a Glean block.

Domain context used for implementation was derived from the inline SDK info and
the installed `ntnx_files_py_client` v4.0.1 SDK:

- **Entity**: `files.v4.config.Snapshot` (a "mount target snapshot") is a
  point-in-time copy of a Nutanix Files mount target (an NFS export / SMB share)
  hosted by a file server. It is nested under
  `/file-servers/{fileServerExtId}/mount-targets/{mountTargetExtId}/snapshots`.
- **Writable fields**: `name` (required, 1-80 chars) and `type`
  (`SnapshotType`: `SSR_SNAPSHOT`, `USER_SNAPSHOT`, `REPLICATION_SNAPSHOT`).
- **Read-only fields** (platform-populated, stripped before create):
  `create_time`, `total_space_bytes`, `reclaimable_space_bytes`.
- **Operations**: Create (async task), Get-by-id, List (supports
  `$page/$limit/$filter/$orderby/$select`; filter/orderby on
  `name/type/reclaimableSpaceBytes/totalSpaceBytes/createTime`), Delete (async
  task), and a Restore action (`$actions/restore`, async task) that restores the
  mount target from a chosen snapshot.
- **Prerequisites**: an existing file server and a mount target within it.

## Files changed

- `plugins/modules/`
  - `ntnx_files_mount_target_snapshot_v2.py` (new — CRUD + restore)
  - `ntnx_files_mount_target_snapshots_info_v2.py` (new — info)
- `plugins/module_utils/v4/files/`
  - `api_client.py` (new — files SDK client + `SnapshotsApi`/`MountTargetsApi`/`FileServersApi` instances)
  - `helpers.py` (new — `get_mount_target_snapshot`)
- `plugins/module_utils/v4/constants.py` (added `MOUNT_TARGET_SNAPSHOT` / `MOUNT_TARGET` rel entity types)
- `plugins/module_utils/v4/utils.py` (`strip_read_only_fields` now falls back to nulling read-only SDK properties that have no deleter)
- `meta/runtime.yml` (added both modules to the `ntnx` action group)
- `examples/files/MountTargetSnapshot/`
  - `mount_target_snapshot.yml` (new — create / get / list / filter / limit / restore / delete)
  - `examples_run.log` (real playbook output from the live PC)
- `tests/integration/targets/ntnx_files_mount_target_snapshot_v2/` (new target: `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/mount_target_snapshots.yml`)
- `.gitignore` (ignore `integration_config.yml`, `__pycache__/`, `*.pyc`)

## Test execution

| Metric              | Value                                                                                  |
|---------------------|----------------------------------------------------------------------------------------|
| Sanity command      | `ansible-test sanity --local --python 3.11 <new files>`                                 |
| Sanity result       | **PASS** (all applicable tests: validate-modules, pep8, pylint, import, yamllint, ...)  |
| Lint                | `black`, `isort`, `flake8`, `ansible-lint` — all **PASS**                               |
| Integration command | `ansible-test integration ntnx_files_mount_target_snapshot_v2 --local --python 3.11 --allow-unsupported` |
| Integration result  | **Could not complete** — Nutanix Files service returned **HTTP 503** on the PC          |
| Example playbook    | `ansible-playbook examples/files/MountTargetSnapshot/mount_target_snapshot.yml -v`      |
| Example result      | **Could not complete** — same **HTTP 503** from the Files service                       |
| Cluster (PC)        | `10.44.76.28` (pc.7.6)                                                                  |

### Analysis

All static verification passed: `black`, `isort`, `flake8`, `ansible-lint`, and
`ansible-test sanity` are green for every new/changed file.

The live integration tests and the example playbook could **not** run to
completion because the Nutanix Files control-plane service on the target Prism
Central (`10.44.76.28`) is down. Every Files v4 API call returns:

```
HTTP 503 SERVICE UNAVAILABLE
{"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}
```

`127.0.0.1:7509` is the internal Files microservice; the PC gateway cannot reach
it, so no file servers / mount targets can be listed or created. This is an
environment/infra issue, not a code issue.

What the run **did** validate against the live PC before the 503:

- The files SDK API client is constructed and authenticated correctly (the 503
  originates from the internal Files service, not from auth — no 401/403).
- The module's create path, idempotency pre-check (`list_mount_target_snapshots`)
  and error handling all execute and surface a clean, structured error
  (`{"status": 503, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised
  while checking existing mount target snapshots", ...}`).
- A real code bug found by running was fixed: the files SDK `ApiClient` does not
  accept `allow_version_negotiation`; `get_api_client` now constructs the client
  with a `TypeError` fallback.

**Known issues / not verified on live cluster** (blocked by the Files 503):
success paths for create/get/list/delete/restore, response `sample:` backfill,
and the create task's entity `rel` string. The create path already contains a
fallback that resolves the entity ext_id from the task even if the specific
`rel` differs. `RETURN`/example `sample:` blocks use structurally-accurate
values derived from the SDK `Snapshot` model.

### Test logs (tail)

<details>
<summary>test_logs.log</summary>

```text
TASK [ntnx_files_mount_target_snapshot_v2 : Discover a file server when file_server_ext_id is not provided] ***
[ERROR]: Task failed: Module failed: Status code was 503 and not [200]: HTTP Error 503: SERVICE UNAVAILABLE
fatal: [testhost]: FAILED! => {"status": 503, "content": "{\"message\": \"Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2\"}", "url": "https://10.44.76.28:9440/api/files/v4.0/config/file-servers?$limit=1", "x_ntnx_product": "pc.7.6", ...}
...ignoring

TASK [ntnx_files_mount_target_snapshot_v2 : Set file_server_ext_id from discovery] ***
skipping: [testhost]
TASK [ntnx_files_mount_target_snapshot_v2 : Discover a mount target when mount_target_ext_id is not provided] ***
skipping: [testhost]
TASK [ntnx_files_mount_target_snapshot_v2 : Set mount_target_ext_id from discovery] ***
skipping: [testhost]

TASK [ntnx_files_mount_target_snapshot_v2 : Assert prerequisites are available] ***
fatal: [testhost]: FAILED! => {
    "assertion": "file_server_ext_id is defined",
    "evaluated_to": false,
    "msg": "A file server and mount target are required to run these tests. Provide file_server_ext_id and mount_target_ext_id in integration_config.yml or ensure the Nutanix Files service has at least one file server + mount target."
}

PLAY RECAP ******************************************************************
testhost : ok=5  changed=0  unreachable=0  failed=1  skipped=3  rescued=0  ignored=1
```

</details>

<details>
<summary>examples_run.log</summary>

```text
PLAY [Nutanix Files - MountTargetSnapshot examples] ***************************
TASK [Create mount target snapshot] *****************************************
fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while checking existing mount target snapshots", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
PLAY RECAP ******************************************************************
localhost : ok=0  changed=0  unreachable=0  failed=1  skipped=0  rescued=0  ignored=0
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API.
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Dev code mirrors the existing `ntnx_virtual_switch_v2` / `ntnx_virtual_switches_info_v2` modules and their `module_utils` helpers.
