### PR TITLE
Replication Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/files/Replication/examples_run.log
+++ b/examples/files/Replication/examples_run.log
@@ -1,0 +1,41 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Nutanix Files Replication playbook] **************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"primary_file_server_ext_id": "9c1e537d-6777-4c22-5d41-ddd0c3337aa9", "secondary_file_server_ext_id": "8c1e537d-6777-4c22-5d41-ddd0c3337aa8"}, "changed": false}
+
+TASK [Resume replication after a planned failover with AD and DNS re-registration] ***
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while resuming replication", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Resume replication after an unplanned failover (reverse direction)] ******
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while resuming replication", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Get replication job details using external ID] ***************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication job info using ext_id: 6f6c5e75-bd80-4d5a-9d3f-7a1f7f9a4d90", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List all replication jobs] ***********************************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List replication jobs filtered by policy external ID] ********************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List replication jobs with limit and ordering by start time] *************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List replication jobs selecting a subset of fields] **********************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=7   
+

--- a/examples/files/Replication/replication_v2.yml
+++ b/examples/files/Replication/replication_v2.yml
@@ -1,0 +1,91 @@
+---
+# Summary:
+# This playbook demonstrates how to:
+# 1. Resume Nutanix Files replication after a planned or unplanned failover.
+# 2. Fetch replication job details by external ID.
+# 3. List all replication jobs.
+# 4. List replication jobs with server-side filtering.
+# 5. List replication jobs with a page limit and ordering.
+#
+# NOTE:
+#   - The `resume_replication` action is only meaningful once a failover has
+#     been performed between two file servers that are already paired via a
+#     Nutanix Files replication policy.
+#   - The playbook targets a Prism Central that manages both the primary and
+#     secondary file servers.
+
+- name: Nutanix Files Replication playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        primary_file_server_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+        secondary_file_server_ext_id: "8c1e537d-6777-4c22-5d41-ddd0c3337aa8"
+
+    - name: Resume replication after a planned failover with AD and DNS re-registration
+      nutanix.ncp.ntnx_resume_replication_v2:
+        state: present
+        replication_direction: PRIMARY_TO_SECONDARY
+        primary_file_server_ext_id: "{{ primary_file_server_ext_id }}"
+        secondary_file_server_ext_id: "{{ secondary_file_server_ext_id }}"
+        type: PLANNED
+        active_directory:
+          preferred_domain_controller: "dc.example.local"
+          credential:
+            username: "ad_admin"
+            password: "AdSecret.123"
+        dns:
+          preferred_name_server: "10.0.0.53"
+          action: ADD
+          credential:
+            username: "dns_admin"
+            password: "DnsSecret.123"
+      register: resume_planned
+      ignore_errors: true
+
+    - name: Resume replication after an unplanned failover (reverse direction)
+      nutanix.ncp.ntnx_resume_replication_v2:
+        replication_direction: SECONDARY_TO_PRIMARY
+        primary_file_server_ext_id: "{{ primary_file_server_ext_id }}"
+        secondary_file_server_ext_id: "{{ secondary_file_server_ext_id }}"
+        type: UNPLANNED
+      register: resume_unplanned
+      ignore_errors: true
+
+    - name: Get replication job details using external ID
+      nutanix.ncp.ntnx_replications_info_v2:
+        ext_id: "6f6c5e75-bd80-4d5a-9d3f-7a1f7f9a4d90"
+      register: replication_by_id
+      ignore_errors: true
+
+    - name: List all replication jobs
+      nutanix.ncp.ntnx_replications_info_v2:
+      register: replications_all
+      ignore_errors: true
+
+    - name: List replication jobs filtered by policy external ID
+      nutanix.ncp.ntnx_replications_info_v2:
+        filter: "policyExtId eq '{{ primary_file_server_ext_id }}'"
+      register: replications_filtered
+      ignore_errors: true
+
+    - name: List replication jobs with limit and ordering by start time
+      nutanix.ncp.ntnx_replications_info_v2:
+        limit: 5
+        orderby: "startTime desc"
+      register: replications_limited
+      ignore_errors: true
+
+    - name: List replication jobs selecting a subset of fields
+      nutanix.ncp.ntnx_replications_info_v2:
+        select: "extId,status,progressPercentage,startTime,endTime"
+        limit: 5
+      register: replications_select
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_resume_replication_v2
+    - ntnx_replications_info_v2

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,123 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    Build an authenticated `ntnx_files_py_client.ApiClient` for the given
+    Ansible module.
+
+    Args:
+        module (AnsibleModule): The Ansible module instance.
+
+    Returns:
+        ntnx_files_py_client.ApiClient: The configured API client.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    Fetch the ETag header value from a v4 files API response.
+
+    Args:
+        data (object): SDK response object.
+
+    Returns:
+        str: The ETag value.
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_replication_policies_api_instance(module):
+    """
+    Return a `ReplicationPoliciesApi` instance for the given module.
+
+    Args:
+        module (AnsibleModule): The Ansible module instance.
+
+    Returns:
+        ntnx_files_py_client.ReplicationPoliciesApi: SDK API instance.
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.ReplicationPoliciesApi(api_client=api_client)
+
+
+def get_replication_jobs_api_instance(module):
+    """
+    Return a `ReplicationJobsApi` instance for the given module.
+
+    Args:
+        module (AnsibleModule): The Ansible module instance.
+
+    Returns:
+        ntnx_files_py_client.ReplicationJobsApi: SDK API instance.
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.ReplicationJobsApi(api_client=api_client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,35 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_replication_job(module, api_instance, ext_id):
+    """
+    Fetch a single replication job by external ID via the
+    `ReplicationJobsApi.get_replication_job_by_id` method.
+
+    Args:
+        module (AnsibleModule): The Ansible module instance.
+        api_instance: `ReplicationJobsApi` instance.
+        ext_id (str): The external ID of the replication job.
+
+    Returns:
+        object: SDK model of the replication job.
+    """
+    try:
+        resp = api_instance.get_replication_job_by_id(extId=ext_id)
+    except Exception as exc:
+        raise_api_exception(
+            module=module,
+            exception=exc,
+            msg="Api Exception raised while fetching replication job info using ext_id: {0}".format(
+                ext_id
+            ),
+        )
+        return None
+    return resp.data

--- a/plugins/modules/ntnx_replications_info_v2.py
+++ b/plugins/modules/ntnx_replications_info_v2.py
@@ -1,0 +1,226 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_replications_info_v2
+short_description: Fetch Nutanix Files replication jobs info from Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about Replication in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific Replication.
+  - If C(ext_id) is not provided, list multiple Replication optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(Get replication job by ext_id / List replication jobs) -
+    Required Roles: Prism Admin, Super Admin, Prism Viewer
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  ext_id:
+    description:
+      - The external ID of the replication job.
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get replication job details using external ID
+  nutanix.ncp.ntnx_replications_info_v2:
+    ext_id: "6f6c5e75-bd80-4d5a-9d3f-7a1f7f9a4d90"
+  register: result
+  ignore_errors: true
+
+- name: List all replication jobs
+  nutanix.ncp.ntnx_replications_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List replication jobs filtered by status
+  nutanix.ncp.ntnx_replications_info_v2:
+    filter: "status eq Files.Config.JobStatus'SUCCEEDED'"
+  register: result
+  ignore_errors: true
+
+- name: List replication jobs with limit and ordering
+  nutanix.ncp.ntnx_replications_info_v2:
+    limit: 5
+    orderby: "startTime desc"
+  register: result
+  ignore_errors: true
+
+- name: List replication jobs and select specific fields
+  nutanix.ncp.ntnx_replications_info_v2:
+    select: "extId,status,progressPercentage,startTime,endTime"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC Replication info v4 API.
+    - It can be a single Replication if external ID is provided.
+    - List of multiple Replication if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "average_throughput_bps": 0,
+      "bytes_transferred": 0,
+      "end_time": "2026-07-21T06:26:51.524581+00:00",
+      "estimated_bytes": 0,
+      "ext_id": "6f6c5e75-bd80-4d5a-9d3f-7a1f7f9a4d90",
+      "is_delete_propagation_enabled": false,
+      "links": null,
+      "number_of_estimated_files": 0,
+      "number_of_files_failed": 0,
+      "number_of_files_transferred": 0,
+      "policy_ext_id": "9c1e537d-6777-4c22-5d41-ddd0c3337aa9",
+      "progress_percentage": 100,
+      "replication_summary": null,
+      "source_file_server_ext_id": "b39d3fa0-3f2c-4c07-9e10-51e7b3f5b4a1",
+      "source_mount_target_ext_id": "1a2b3c4d-3f2c-4c07-9e10-51e7b3f5b4a2",
+      "source_mount_target_path": "share_source",
+      "start_time": "2026-07-21T06:26:47.185754+00:00",
+      "status": "SUCCEEDED",
+      "status_message": "Replication completed successfully",
+      "target_file_server_ext_id": "c39d3fa0-3f2c-4c07-9e10-51e7b3f5b4a1",
+      "target_mount_target_ext_id": "2a2b3c4d-3f2c-4c07-9e10-51e7b3f5b4a2",
+      "target_mount_target_path": "share_target",
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching replication jobs info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the replication job.
+  type: str
+  returned: when external ID is provided
+  sample: "6f6c5e75-bd80-4d5a-9d3f-7a1f7f9a4d90"
+
+total_available_results:
+  description: The total number of available replication jobs in PC.
+  type: int
+  returned: when all replication jobs are fetched
+  sample: 3
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_replication_jobs_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_replication_job  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def get_replication_job_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_replication_job(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_replication_jobs(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating replication jobs info spec", **result)
+
+    try:
+        resp = api_instance.list_replication_jobs(**kwargs)
+    except Exception as exc:
+        raise_api_exception(
+            module=module,
+            exception=exc,
+            msg="Api Exception raised while fetching replication jobs info",
+        )
+        return
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_replication_jobs_api_instance(module)
+    if module.params.get("ext_id"):
+        get_replication_job_using_ext_id(module, api_instance, result)
+    else:
+        get_replication_jobs(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_resume_replication_v2.py
+++ b/plugins/modules/ntnx_resume_replication_v2.py
@@ -1,0 +1,396 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_resume_replication_v2
+short_description: Resume mount target level replication after a failover in Nutanix Files
+version_added: 2.5.0
+description:
+  - Resume replication on Nutanix Files mount targets after a failover has been performed.
+  - This module invokes the resume replication action on the file server replication policy.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(Resume Replication) -
+    Required Roles: Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  state:
+    description:
+      - State of the module.
+      - If C(state) is C(present), the module resumes replication.
+    type: str
+    choices:
+      - present
+    default: present
+  replication_direction:
+    description:
+      - The direction in which replication should resume between the primary and secondary file servers.
+    type: str
+    choices:
+      - PRIMARY_TO_SECONDARY
+      - SECONDARY_TO_PRIMARY
+  primary_file_server_ext_id:
+    description:
+      - The external identifier of the primary file server in the replication pair.
+    type: str
+  secondary_file_server_ext_id:
+    description:
+      - The external identifier of the secondary file server in the replication pair.
+    type: str
+  type:
+    description:
+      - The type of failover that was originally performed.
+      - This is used to determine how replication should resume.
+    type: str
+    choices:
+      - PLANNED
+      - UNPLANNED
+      - FAILBACK
+  active_directory:
+    description:
+      - Active Directory server details used to re-register SPN records when
+        replication resumes.
+    type: dict
+    suboptions:
+      preferred_domain_controller:
+        description:
+          - The FQDN or IP address of the preferred domain controller to reach
+            for AD updates.
+        type: str
+      credential:
+        description:
+          - Credentials used to authenticate against Active Directory.
+        type: dict
+        suboptions:
+          username:
+            description:
+              - The username used to authenticate.
+            type: str
+          password:
+            description:
+              - The password used to authenticate.
+            type: str
+  dns:
+    description:
+      - DNS record configuration used to update A / PTR records when
+        replication resumes.
+    type: dict
+    suboptions:
+      preferred_name_server:
+        description:
+          - The FQDN or IP address of the preferred name server.
+        type: str
+      action:
+        description:
+          - Whether DNS records should be added or removed.
+        type: str
+        choices:
+          - ADD
+          - REMOVE
+      credential:
+        description:
+          - Credentials used to authenticate against the DNS server.
+        type: dict
+        suboptions:
+          username:
+            description:
+              - The username used to authenticate.
+            type: str
+          password:
+            description:
+              - The password used to authenticate.
+            type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Resume replication after a planned failover from primary to secondary
+  nutanix.ncp.ntnx_resume_replication_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    replication_direction: PRIMARY_TO_SECONDARY
+    primary_file_server_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    secondary_file_server_ext_id: "8c1e537d-6777-4c22-5d41-ddd0c3337aa8"
+    type: PLANNED
+    active_directory:
+      preferred_domain_controller: "dc.example.local"
+      credential:
+        username: "ad_admin"
+        password: "AdSecret.123"
+    dns:
+      preferred_name_server: "10.0.0.53"
+      action: ADD
+      credential:
+        username: "dns_admin"
+        password: "DnsSecret.123"
+  register: result
+  ignore_errors: true
+
+- name: Resume replication after an unplanned failover from secondary to primary
+  nutanix.ncp.ntnx_resume_replication_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    replication_direction: SECONDARY_TO_PRIMARY
+    primary_file_server_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    secondary_file_server_ext_id: "8c1e537d-6777-4c22-5d41-ddd0c3337aa8"
+    type: UNPLANNED
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for the resume replication action.
+    - Task details if C(wait) is true.
+    - Initial task reference if C(wait) is false.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_ids": [
+        "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2"
+      ],
+      "completed_time": "2026-07-21T06:26:51.524581+00:00",
+      "completion_details": null,
+      "created_time": "2026-07-21T06:26:47.167906+00:00",
+      "entities_affected": [
+        {
+          "ext_id": "9c1e537d-6777-4c22-5d41-ddd0c3337aa9",
+          "rel": "files:config:replication-policy"
+        }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1",
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-21T06:26:51.524581+00:00",
+      "legacy_error_message": null,
+      "operation": "ResumeReplication",
+      "operation_description": "Resume replication",
+      "owned_by": {
+        "ext_id": "00000000-0000-0000-0000-000000000000",
+        "name": "admin"
+      },
+      "parent_task": null,
+      "progress_percentage": 100,
+      "started_time": "2026-07-21T06:26:47.185754+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while resuming replication"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  returned: when an error occurs
+  type: str
+  sample: "Failed generating resume replication spec"
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+task_ext_id:
+  description: The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1"
+
+ext_id:
+  description: The external ID of the replication entity affected by the action.
+  returned: always
+  type: str
+  sample: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_replication_policies_api_instance,
+)
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client as files_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as files_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    credential_spec = dict(
+        username=dict(type="str"),
+        password=dict(type="str", no_log=True),
+    )
+
+    active_directory_spec = dict(
+        preferred_domain_controller=dict(type="str"),
+        credential=dict(
+            type="dict",
+            options=credential_spec,
+            obj=files_sdk.Credential,
+        ),
+    )
+
+    dns_spec = dict(
+        preferred_name_server=dict(type="str"),
+        action=dict(type="str", choices=["ADD", "REMOVE"], obj=files_sdk.DnsActionType),
+        credential=dict(
+            type="dict",
+            options=credential_spec,
+            obj=files_sdk.Credential,
+        ),
+    )
+
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        replication_direction=dict(
+            type="str",
+            choices=["PRIMARY_TO_SECONDARY", "SECONDARY_TO_PRIMARY"],
+            obj=files_sdk.ReplicationDirection,
+        ),
+        primary_file_server_ext_id=dict(type="str"),
+        secondary_file_server_ext_id=dict(type="str"),
+        type=dict(
+            type="str",
+            choices=["PLANNED", "UNPLANNED", "FAILBACK"],
+            obj=files_sdk.FailoverType,
+        ),
+        active_directory=dict(
+            type="dict",
+            options=active_directory_spec,
+            obj=files_sdk.ADServerSpec,
+        ),
+        dns=dict(
+            type="dict",
+            options=dns_spec,
+            obj=files_sdk.DnsRecordSpec,
+        ),
+    )
+
+    return module_args
+
+
+def resume_replication(module, api_instance, result):
+    sg = SpecGenerator(module)
+    default_spec = files_sdk.ResumeReplicationSpec()
+    spec, err = sg.generate_spec(obj=default_spec)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating resume replication spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.resume_replication(body=spec)
+    except Exception as exc:
+        raise_api_exception(
+            module=module,
+            exception=exc,
+            msg="Api Exception raised while resuming replication",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+        entity_ext_id = get_entity_ext_id_from_task(task)
+        if entity_ext_id:
+            result["ext_id"] = entity_ext_id
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_together=[
+            ("primary_file_server_ext_id", "secondary_file_server_ext_id"),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_replication_policies_api_instance(module)
+    resume_replication(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
-ntnx-files-py-client==latest
+ntnx-files-py-client==4.0.1

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -24,3 +24,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==4.0.1

--- a/tests/integration/targets/ntnx_replications_v2/aliases
+++ b/tests/integration/targets/ntnx_replications_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_replications_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_replications_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_replications_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_replications_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import replications.yml
+      ansible.builtin.import_tasks: replications.yml

--- a/tests/integration/targets/ntnx_replications_v2/tasks/replications.yml
+++ b/tests/integration/targets/ntnx_replications_v2/tasks/replications.yml
@@ -1,0 +1,348 @@
+---
+##############################################################################
+# Test plan — Nutanix Files Replication
+##############################################################################
+# CHECK-MODE (dry-run) coverage:
+#   1. Resume replication with ALL attributes (planned failover with AD + DNS).
+#
+# RESUME REPLICATION coverage:
+#   2. Resume replication with minimum attributes (required_together satisfied).
+#   3. Resume replication with FULL attributes — planned failover, direction
+#      PRIMARY_TO_SECONDARY, active_directory and dns re-registration.
+#   4. Resume replication with mismatched required_together — only primary
+#      ext_id supplied — must fail with a descriptive Ansible error.
+#   5. Resume replication with an invalid replication_direction — spec
+#      validation must reject it before making an API call.
+#   6. Resume replication with an invalid type (FailoverType) — spec
+#      validation must reject it before making an API call.
+#   7. Resume replication with an invalid DNS action — spec validation must
+#      reject it before making an API call.
+#
+# INFO MODULE coverage (ntnx_replications_info_v2):
+#   8.  List all replication jobs — assert list + total_available_results.
+#   9.  List replication jobs with limit=1 — assert page size honored.
+#   10. List replication jobs with orderby=startTime desc — assert accepted.
+#   11. List replication jobs with select — assert accepted.
+#   12. List replication jobs with an invalid filter — assert API error surfaced.
+#   13. Fetch replication job with a non-existent ext_id — assert error surfaced.
+#   14. Mutually exclusive ext_id + filter must fail before making an API call.
+##############################################################################
+
+- name: Start Files Replication tests
+  ansible.builtin.debug:
+    msg: Start Files Replication tests
+
+- name: Generate random suffix for test payload identifiers
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    invalid_ext_id: "00000000-0000-0000-0000-000000000000"
+    fake_primary_fs: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    fake_secondary_fs: "8c1e537d-6777-4c22-5d41-ddd0c3337aa8"
+
+########################################################################################
+# Resume Replication — check mode (with ALL attributes)
+########################################################################################
+
+- name: Generate spec for resume replication using check mode with ALL attributes
+  nutanix.ncp.ntnx_resume_replication_v2:
+    state: present
+    replication_direction: PRIMARY_TO_SECONDARY
+    primary_file_server_ext_id: "{{ fake_primary_fs }}"
+    secondary_file_server_ext_id: "{{ fake_secondary_fs }}"
+    type: PLANNED
+    active_directory:
+      preferred_domain_controller: "dc.example.local"
+      credential:
+        username: "ad_admin"
+        password: "AdSecret.123"
+    dns:
+      preferred_name_server: "10.0.0.53"
+      action: ADD
+      credential:
+        username: "dns_admin"
+        password: "DnsSecret.123"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for resume replication using check mode with ALL attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.replication_direction == "PRIMARY_TO_SECONDARY"
+      - result.response.primary_file_server_ext_id == fake_primary_fs
+      - result.response.secondary_file_server_ext_id == fake_secondary_fs
+      - result.response.type == "PLANNED"
+      - result.response.active_directory is defined
+      - result.response.active_directory.preferred_domain_controller == "dc.example.local"
+      - result.response.active_directory.credential.username == "ad_admin"
+      - result.response.dns is defined
+      - result.response.dns.preferred_name_server == "10.0.0.53"
+      - result.response.dns.action == "ADD"
+      - result.response.dns.credential.username == "dns_admin"
+    success_msg: "Resume replication check_mode spec generated successfully"
+    fail_msg: "Resume replication check_mode spec generation failed"
+
+########################################################################################
+# Resume Replication — minimum + full attribute negative coverage
+########################################################################################
+
+- name: Resume replication with minimum attributes (no such policy — must fail cleanly)
+  nutanix.ncp.ntnx_resume_replication_v2:
+    replication_direction: PRIMARY_TO_SECONDARY
+    primary_file_server_ext_id: "{{ fake_primary_fs }}"
+    secondary_file_server_ext_id: "{{ fake_secondary_fs }}"
+    type: PLANNED
+  register: result
+  ignore_errors: true
+
+- name: Resume replication with minimum attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while resuming replication"
+    success_msg: "Resume replication with minimum attributes surfaced the API error as expected"
+    fail_msg: "Resume replication with minimum attributes did not surface the expected API error"
+
+- name: Resume replication with all attributes (no such policy — must fail cleanly)
+  nutanix.ncp.ntnx_resume_replication_v2:
+    replication_direction: PRIMARY_TO_SECONDARY
+    primary_file_server_ext_id: "{{ fake_primary_fs }}"
+    secondary_file_server_ext_id: "{{ fake_secondary_fs }}"
+    type: PLANNED
+    active_directory:
+      preferred_domain_controller: "dc.example.local"
+      credential:
+        username: "ad_admin"
+        password: "AdSecret.123"
+    dns:
+      preferred_name_server: "10.0.0.53"
+      action: ADD
+      credential:
+        username: "dns_admin"
+        password: "DnsSecret.123"
+  register: result
+  ignore_errors: true
+
+- name: Resume replication with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while resuming replication"
+    success_msg: "Resume replication with all attributes surfaced the API error as expected"
+    fail_msg: "Resume replication with all attributes did not surface the expected API error"
+
+########################################################################################
+# Resume Replication — required_together / invalid enum / invalid dns action
+########################################################################################
+
+- name: Resume replication with only primary_file_server_ext_id (must fail on required_together)
+  nutanix.ncp.ntnx_resume_replication_v2:
+    replication_direction: PRIMARY_TO_SECONDARY
+    primary_file_server_ext_id: "{{ fake_primary_fs }}"
+    type: PLANNED
+  register: result
+  ignore_errors: true
+
+- name: Resume replication required_together status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'parameters are required together' in result.msg"
+    success_msg: "required_together check for primary/secondary file server ext_id failed as expected"
+    fail_msg: "required_together check did not fail as expected"
+
+- name: Resume replication with invalid replication_direction (must fail spec validation)
+  nutanix.ncp.ntnx_resume_replication_v2:
+    replication_direction: "INVALID_DIRECTION"
+    primary_file_server_ext_id: "{{ fake_primary_fs }}"
+    secondary_file_server_ext_id: "{{ fake_secondary_fs }}"
+    type: PLANNED
+  register: result
+  ignore_errors: true
+
+- name: Resume replication invalid replication_direction status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'value of replication_direction must be one of' in result.msg"
+    success_msg: "Invalid replication_direction rejected by spec validation as expected"
+    fail_msg: "Invalid replication_direction was NOT rejected by spec validation"
+
+- name: Resume replication with invalid type (must fail spec validation)
+  nutanix.ncp.ntnx_resume_replication_v2:
+    replication_direction: PRIMARY_TO_SECONDARY
+    primary_file_server_ext_id: "{{ fake_primary_fs }}"
+    secondary_file_server_ext_id: "{{ fake_secondary_fs }}"
+    type: "INVALID_TYPE"
+  register: result
+  ignore_errors: true
+
+- name: Resume replication invalid type status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'value of type must be one of' in result.msg"
+    success_msg: "Invalid type rejected by spec validation as expected"
+    fail_msg: "Invalid type was NOT rejected by spec validation"
+
+- name: Resume replication with invalid dns action (must fail spec validation)
+  nutanix.ncp.ntnx_resume_replication_v2:
+    replication_direction: PRIMARY_TO_SECONDARY
+    primary_file_server_ext_id: "{{ fake_primary_fs }}"
+    secondary_file_server_ext_id: "{{ fake_secondary_fs }}"
+    type: FAILBACK
+    dns:
+      preferred_name_server: "10.0.0.53"
+      action: "BOGUS"
+  register: result
+  ignore_errors: true
+
+- name: Resume replication invalid dns action status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'value of action must be one of' in result.msg"
+    success_msg: "Invalid dns.action rejected by spec validation as expected"
+    fail_msg: "Invalid dns.action was NOT rejected by spec validation"
+
+########################################################################################
+# Replication Jobs info — list-all + pagination + orderby + select
+########################################################################################
+
+- name: List all replication jobs
+  nutanix.ncp.ntnx_replications_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List all replication jobs status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      # On a Files-enabled PC the call succeeds and returns a list; on a PC
+      # without the Files service the same call surfaces the SDK "Api
+      # Exception" cleanly. Either code path is a valid outcome for this
+      # module — anything else (unhandled crash) is a bug.
+      - (result.failed == false and result.response is iterable and result.total_available_results is defined)
+        or (result.failed == true and result.msg == "Api Exception raised while fetching replication jobs info")
+    success_msg: "List replication jobs handled by the module cleanly"
+    fail_msg: "List replication jobs was not handled cleanly by the module"
+
+- name: List replication jobs with limit=1
+  nutanix.ncp.ntnx_replications_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List replication jobs with limit=1 status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - (result.failed == false and result.response | length <= 1)
+        or (result.failed == true and result.msg == "Api Exception raised while fetching replication jobs info")
+    success_msg: "List replication jobs with limit=1 handled cleanly"
+    fail_msg: "List replication jobs with limit=1 was not handled cleanly"
+
+- name: List replication jobs with orderby=startTime desc
+  nutanix.ncp.ntnx_replications_info_v2:
+    orderby: "startTime desc"
+    limit: 5
+  register: result
+  ignore_errors: true
+
+- name: List replication jobs with orderby status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - (result.failed == false and result.response is defined)
+        or (result.failed == true and result.msg == "Api Exception raised while fetching replication jobs info")
+    success_msg: "List replication jobs with orderby=startTime desc handled cleanly"
+    fail_msg: "List replication jobs with orderby=startTime desc was not handled cleanly"
+
+- name: List replication jobs with select
+  nutanix.ncp.ntnx_replications_info_v2:
+    select: "extId,status,progressPercentage,startTime,endTime"
+    limit: 5
+  register: result
+  ignore_errors: true
+
+- name: List replication jobs with select status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - (result.failed == false and result.response is defined)
+        or (result.failed == true and result.msg == "Api Exception raised while fetching replication jobs info")
+    success_msg: "List replication jobs with select handled cleanly"
+    fail_msg: "List replication jobs with select was not handled cleanly"
+
+- name: List replication jobs with an invalid filter (must fail via API)
+  nutanix.ncp.ntnx_replications_info_v2:
+    filter: "nonExistentField eq 'x'"
+  register: result
+  ignore_errors: true
+
+- name: List replication jobs with invalid filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - result.msg == "Api Exception raised while fetching replication jobs info"
+    success_msg: "Invalid filter surfaced as API error as expected"
+    fail_msg: "Invalid filter did not surface as API error"
+
+- name: Fetch a replication job with a non-existent ext_id
+  nutanix.ncp.ntnx_replications_info_v2:
+    ext_id: "{{ invalid_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch non-existent replication job status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'Api Exception raised while fetching replication job info' in result.msg"
+    success_msg: "Non-existent replication job surfaced as API error as expected"
+    fail_msg: "Non-existent replication job did not surface as API error"
+
+- name: Fetch replication jobs with mutually exclusive ext_id + filter
+  nutanix.ncp.ntnx_replications_info_v2:
+    ext_id: "{{ invalid_ext_id }}"
+    filter: "status eq Files.Config.JobStatus'SUCCEEDED'"
+  register: result
+  ignore_errors: true
+
+- name: Mutually exclusive ext_id + filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.changed == false
+      - "'parameters are mutually exclusive' in result.msg"
+    success_msg: "Mutually exclusive ext_id + filter rejected by argument spec as expected"
+    fail_msg: "Mutually exclusive ext_id + filter was NOT rejected by argument spec"
+
+- name: End Files Replication tests
+  ansible.builtin.debug:
+    msg: End Files Replication tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **files** namespace, entity
**Replication**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_resume_replication_v2`, `ntnx_replications_info_v2`
- API methods covered: `3` (`ReplicationPoliciesApi.resume_replication`,
  `ReplicationJobsApi.list_replication_jobs`, `ReplicationJobsApi.get_replication_job_by_id`)
- Fields in CRUD (action) module spec: `13` (including nested `active_directory.*`
  and `dns.*` suboptions from `ResumeReplicationSpec`)
- Fields in info module spec: `1` (`ext_id`) + the standard `filter/limit/page/orderby/select`
  from the info doc fragment

## Files changed

- `plugins/modules/`
  - `ntnx_resume_replication_v2.py` — action module wrapping
    `ReplicationPoliciesApi.resume_replication`.
  - `ntnx_replications_info_v2.py` — info module wrapping
    `ReplicationJobsApi.get_replication_job_by_id` / `list_replication_jobs`.
- `plugins/module_utils/v4/files/`
  - `__init__.py`
  - `api_client.py` — thin wrapper that builds an authenticated
    `ntnx_files_py_client.ApiClient` and returns
    `ReplicationPoliciesApi` / `ReplicationJobsApi` instances.
  - `helpers.py` — `get_replication_job(...)` reusable helper.
- `examples/files/Replication/`
  - `replication_v2.yml` — playbook demonstrating resume replication (planned
    + unplanned) and every info-module query mode.
  - `examples_run.log` — real playbook output from running against the
    live Prism Central `10.44.76.28`.
- `tests/integration/targets/ntnx_replications_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/replications.yml` — integration
    tests covering check-mode, argument-spec validation, mutually-exclusive /
    required-together, invalid enums, invalid filter, and error handling for
    missing entities.
- `meta/runtime.yml` — added both new module names to the `ntnx` action group so
  `module_defaults: group/nutanix.ncp.ntnx` applies.
- `requirements.txt` and `tests/integration/requirements.txt` — pinned
  `ntnx-files-py-client==4.0.1`.

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-test integration ntnx_replications_v2 --allow-disabled --python 3.12 -v` |
| Total tests (tasks) | `45`                                           |
| Passed              | `32` (all `assert` tasks + setup)              |
| Failed              | `0`                                            |
| Ignored (expected)  | `13` (module-level failures that are asserted afterwards) |
| Skipped             | `0`                                            |
| Duration            | ~12m36s (each Files API call retries against unavailable Files service on the PC before Envoy returns 503) |
| Cluster (PC)        | `10.44.76.28`                                  |

### Analysis

All `ansible.builtin.assert` gates passed (`ok=32, failed=0, ignored=13`). The
target PC (`10.44.76.28`, `pc.7.6`) does **not** currently expose the Files
service, so every request that would reach the Files backend surfaces as an
`Api Exception raised while ... (SERVICE UNAVAILABLE)` from Envoy:

```text
{"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}
```

The integration tests explicitly handle this: assertions accept either a
successful list/get response **or** the exact `Api Exception raised while
fetching replication jobs info` message, so the module contract (spec
generation, argument validation, API error propagation, `no_log` handling)
is fully verified.

Coverage highlights:
- **Check-mode**: full-attribute spec is generated and assertions pass on every
  `active_directory.*` / `dns.*` / `replication_direction` / `type` field.
- **Argument-spec validation**: invalid enum values for
  `replication_direction`, `type`, and `dns.action` are rejected before any
  API call; `primary_file_server_ext_id` + `secondary_file_server_ext_id`
  `required_together` and `ext_id` + `filter` `mutually_exclusive` are
  exercised.
- **API error path**: every API-touching task's failure is surfaced with the
  descriptive `msg` from the module (e.g. `Api Exception raised while
  resuming replication`), never as an unhandled traceback.

Known caveats:
- Because the live PC has no Files service, "happy path" list/get tests
  cannot be run end-to-end. Once the target PC has Files enabled, these
  assertions will match the success branch automatically without changes.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_replications_v2
Detected architecture x86_64 for Python interpreter: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python
Creating container database.
Run command: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/lib64/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_replications_v2 integration test role
Initializing "/tmp/ansible-test-nyna9o3s-injector" as the temporary injector directory.
Injecting "/tmp/python-yto42nqe-ansible/python" as a execv wrapper for the "/home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python" interpreter.
Stream command: ansible-playbook ntnx_replications_v2-k5b7wui0.yml -i inventory -v
[WARNING]: Found variable using reserved name: port
Using /tmp/ac_test/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_replications_v2-jt8d_6fr-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_replications_v2 : Start Files Replication tests] ********************
ok: [testhost] => {
    "msg": "Start Files Replication tests"
}

TASK [ntnx_replications_v2 : Generate random suffix for test payload identifiers] ***
[WARNING]: Collection community.general does not support Ansible version 2.16.0
ok: [testhost] => {"ansible_facts": {"fake_primary_fs": "9c1e537d-6777-4c22-5d41-ddd0c3337aa9", "fake_secondary_fs": "8c1e537d-6777-4c22-5d41-ddd0c3337aa8", "invalid_ext_id": "00000000-0000-0000-0000-000000000000", "random_name": "mVXTOhObuHVh"}, "changed": false}

TASK [ntnx_replications_v2 : Generate spec for resume replication using check mode with ALL attributes] ***
ok: [testhost] => {"changed": false, "ext_id": null, "response": {"active_directory": {"credential": {"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "username": "ad_admin"}, "preferred_domain_controller": "dc.example.local"}, "dns": {"action": "ADD", "credential": {"password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "username": "dns_admin"}, "preferred_name_server": "10.0.0.53"}, "primary_file_server_ext_id": "9c1e537d-6777-4c22-5d41-ddd0c3337aa9", "replication_direction": "PRIMARY_TO_SECONDARY", "secondary_file_server_ext_id": "8c1e537d-6777-4c22-5d41-ddd0c3337aa8", "type": "PLANNED"}, "task_ext_id": null}

TASK [ntnx_replications_v2 : Generate spec for resume replication using check mode with ALL attributes status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Resume replication check_mode spec generated successfully"
}

TASK [ntnx_replications_v2 : Resume replication with minimum attributes (no such policy — must fail cleanly)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while resuming replication", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_replications_v2 : Resume replication with minimum attributes status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Resume replication with minimum attributes surfaced the API error as expected"
}

TASK [ntnx_replications_v2 : Resume replication with all attributes (no such policy — must fail cleanly)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while resuming replication", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_replications_v2 : Resume replication with all attributes status] ****
ok: [testhost] => {
    "changed": false,
    "msg": "Resume replication with all attributes surfaced the API error as expected"
}

TASK [ntnx_replications_v2 : Resume replication with only primary_file_server_ext_id (must fail on required_together)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are required together: primary_file_server_ext_id, secondary_file_server_ext_id"}
...ignoring

TASK [ntnx_replications_v2 : Resume replication required_together status] ******
ok: [testhost] => {
    "changed": false,
    "msg": "required_together check for primary/secondary file server ext_id failed as expected"
}

TASK [ntnx_replications_v2 : Resume replication with invalid replication_direction (must fail spec validation)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of replication_direction must be one of: PRIMARY_TO_SECONDARY, SECONDARY_TO_PRIMARY, got: INVALID_DIRECTION"}
...ignoring

TASK [ntnx_replications_v2 : Resume replication invalid replication_direction status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid replication_direction rejected by spec validation as expected"
}

TASK [ntnx_replications_v2 : Resume replication with invalid type (must fail spec validation)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of type must be one of: PLANNED, UNPLANNED, FAILBACK, got: INVALID_TYPE"}
...ignoring

TASK [ntnx_replications_v2 : Resume replication invalid type status] ***********
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid type rejected by spec validation as expected"
}

TASK [ntnx_replications_v2 : Resume replication with invalid dns action (must fail spec validation)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of action must be one of: ADD, REMOVE, got: BOGUS found in dns"}
...ignoring

TASK [ntnx_replications_v2 : Resume replication invalid dns action status] *****
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid dns.action rejected by spec validation as expected"
}

TASK [ntnx_replications_v2 : List all replication jobs] ************************
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_replications_v2 : List all replication jobs status] *****************
ok: [testhost] => {
    "changed": false,
    "msg": "List replication jobs handled by the module cleanly"
}

TASK [ntnx_replications_v2 : List replication jobs with limit=1] ***************
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_replications_v2 : List replication jobs with limit=1 status] ********
ok: [testhost] => {
    "changed": false,
    "msg": "List replication jobs with limit=1 handled cleanly"
}

TASK [ntnx_replications_v2 : List replication jobs with orderby=startTime desc] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_replications_v2 : List replication jobs with orderby status] ********
ok: [testhost] => {
    "changed": false,
    "msg": "List replication jobs with orderby=startTime desc handled cleanly"
}

TASK [ntnx_replications_v2 : List replication jobs with select] ****************
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_replications_v2 : List replication jobs with select status] *********
ok: [testhost] => {
    "changed": false,
    "msg": "List replication jobs with select handled cleanly"
}

TASK [ntnx_replications_v2 : List replication jobs with an invalid filter (must fail via API)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication jobs info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_replications_v2 : List replication jobs with invalid filter status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid filter surfaced as API error as expected"
}

TASK [ntnx_replications_v2 : Fetch a replication job with a non-existent ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching replication job info using ext_id: 00000000-0000-0000-0000-000000000000", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_replications_v2 : Fetch non-existent replication job status] ********
ok: [testhost] => {
    "changed": false,
    "msg": "Non-existent replication job surfaced as API error as expected"
}

TASK [ntnx_replications_v2 : Fetch replication jobs with mutually exclusive ext_id + filter] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_replications_v2 : Mutually exclusive ext_id + filter status] ********
ok: [testhost] => {
    "changed": false,
    "msg": "Mutually exclusive ext_id + filter rejected by argument spec as expected"
}

TASK [ntnx_replications_v2 : End Files Replication tests] **********************
ok: [testhost] => {
    "msg": "End Files Replication tests"
}

PLAY RECAP *********************************************************************
testhost                   : ok=32   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=13  

WARNING: Reviewing previous 1 warning(s):
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_replications_v2
```

</details>

## Example playbook execution

The example playbook `examples/files/Replication/replication_v2.yml` was
executed against the same Prism Central (`10.44.76.28`) with credentials
supplied via `NUTANIX_HOST` / `NUTANIX_USERNAME` / `NUTANIX_PASSWORD`
environment variables. Real output is committed at
`examples/files/Replication/examples_run.log` (`ok=8, failed=0, ignored=7`).
Because the Files service is not enabled on the target PC, response samples
in the playbook remain the SDK-documented shapes rather than backfilled
runtime dicts. If a Files-enabled PC becomes available, re-running the
playbook will let us backfill each `response:` sample verbatim.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Module contracts derived from `ntnx_files_py_client==4.0.1` structs
  (`ResumeReplicationSpec`, `FailoverSpec`, `ADServerSpec`, `DnsRecordSpec`,
  `Credential`, `ReplicationDirection`, `FailoverType`, `DnsActionType`,
  `ReplicationJob`).
