### PR TITLE
code-gen(files/MountTargetStat): ansible collection modules

### DIFF
--- a/examples/files/MountTargetStat/examples_run.log
+++ b/examples/files/MountTargetStat/examples_run.log
@@ -1,0 +1,57 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Nutanix Files MountTargetStat examples] **********************************
+
+TASK [Fetch mount target stats with minimal attributes] ************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching mount target stats for mount target ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9 on file server ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9
+Origin: /tmp/codegen/552c12d829c44115aba95a8098921cd1/repo/examples/files/MountTargetStat/mount_target_stats_v2.yml:23:7
+
+21       validate_certs: false
+22   tasks:
+23     - name: Fetch mount target stats with minimal attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching mount target stats for mount target ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9 on file server ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Fetch mount target stats with all attributes] ****************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching mount target stats for mount target ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9 on file server ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9
+Origin: /tmp/codegen/552c12d829c44115aba95a8098921cd1/repo/examples/files/MountTargetStat/mount_target_stats_v2.yml:32:7
+
+30       ignore_errors: true
+31
+32     - name: Fetch mount target stats with all attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching mount target stats for mount target ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9 on file server ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Fetch mount target stats info with minimal attributes] *******************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching mount target stats for mount target ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9 on file server ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9
+Origin: /tmp/codegen/552c12d829c44115aba95a8098921cd1/repo/examples/files/MountTargetStat/mount_target_stats_v2.yml:43:7
+
+41       ignore_errors: true
+42
+43     - name: Fetch mount target stats info with minimal attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching mount target stats for mount target ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9 on file server ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Fetch mount target stats info with all attributes] ***********************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching mount target stats for mount target ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9 on file server ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9
+Origin: /tmp/codegen/552c12d829c44115aba95a8098921cd1/repo/examples/files/MountTargetStat/mount_target_stats_v2.yml:52:7
+
+50       ignore_errors: true
+51
+52     - name: Fetch mount target stats info with all attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching mount target stats for mount target ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9 on file server ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=4   
+

--- a/examples/files/MountTargetStat/mount_target_stats_v2.yml
+++ b/examples/files/MountTargetStat/mount_target_stats_v2.yml
@@ -1,0 +1,61 @@
+---
+# Examples for the Nutanix Files MountTargetStat entity.
+#
+# MountTargetStat is a read-only statistics datasource. The v4 Files API only
+# exposes a single "get mount target statistics" operation, so there are no
+# create / update / delete operations for this entity. The examples below
+# therefore cover every supported operation: fetching a mount target's
+# statistics (minimal and with all optional attributes) using both the stats
+# module and the info module.
+#
+# Both modules require the parent file server external ID, the mount target
+# external ID and a reporting time window (start_time / end_time).
+- name: Nutanix Files MountTargetStat examples
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: 10.44.76.28
+      nutanix_username: admin
+      nutanix_password: Nutanix.123
+      validate_certs: false
+  tasks:
+    - name: Fetch mount target stats with minimal attributes
+      nutanix.ncp.ntnx_mount_target_stat_v2:
+        file_server_ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9
+        ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9
+        start_time: "2024-07-31T12:41:56.955Z"
+        end_time: "2025-07-31T12:41:56.955Z"
+      register: result
+      ignore_errors: true
+
+    - name: Fetch mount target stats with all attributes
+      nutanix.ncp.ntnx_mount_target_stat_v2:
+        file_server_ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9
+        ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9
+        start_time: "2024-07-31T12:41:56.955Z"
+        end_time: "2025-07-31T12:41:56.955Z"
+        sampling_interval: 30
+        stat_type: AVG
+      register: result
+      ignore_errors: true
+
+    - name: Fetch mount target stats info with minimal attributes
+      nutanix.ncp.ntnx_files_mount_target_stats_info_v2:
+        file_server_ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9
+        ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9
+        start_time: "2024-07-31T12:41:56.955Z"
+        end_time: "2025-07-31T12:41:56.955Z"
+      register: result
+      ignore_errors: true
+
+    - name: Fetch mount target stats info with all attributes
+      nutanix.ncp.ntnx_files_mount_target_stats_info_v2:
+        file_server_ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9
+        ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9
+        start_time: "2024-07-31T12:41:56.955Z"
+        end_time: "2025-07-31T12:41:56.955Z"
+        sampling_interval: 30
+        stat_type: AVG
+      register: result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_mount_target_stat_v2
+    - ntnx_files_mount_target_stats_info_v2

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,95 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    # Setup API logging if debug is enabled
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_analytics_api_instance(module):
+    """
+    This method will return files analytics api instance from sdk.
+    The Analytics API exposes the statistics datasources for Nutanix Files
+    (file server, mount target and antivirus server statistics).
+    Args:
+        module (AnsibleModule): AnsibleModule instance
+    Returns:
+        AnalyticsApi: AnalyticsApi instance
+    """
+    client = get_api_client(module)
+    return ntnx_files_py_client.AnalyticsApi(client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,48 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_mount_target_stats(module, api_instance, file_server_ext_id, ext_id):
+    """
+    Fetch statistics for a specific Nutanix Files mount target.
+
+    The mount target statistics datasource requires the parent file server
+    external ID, the mount target external ID and a reporting time window
+    (start_time and end_time). The sampling interval and stat type are
+    optional down-sampling controls read from the module parameters.
+
+    Args:
+        module (AnsibleModule): AnsibleModule instance.
+        api_instance (AnalyticsApi): files analytics api instance.
+        file_server_ext_id (str): external ID of the parent file server.
+        ext_id (str): external ID of the mount target.
+    Returns:
+        MountTargetStatsApiResponse: the raw SDK response object.
+    """
+    try:
+        resp = api_instance.get_mount_target_stats(
+            fileServerExtId=file_server_ext_id,
+            extId=ext_id,
+            _startTime=module.params.get("start_time"),
+            _endTime=module.params.get("end_time"),
+            _samplingInterval=module.params.get("sampling_interval"),
+            _statType=module.params.get("stat_type"),
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching mount target stats for "
+                "mount target ext_id: {0} on file server ext_id: {1}".format(
+                    ext_id, file_server_ext_id
+                )
+            ),
+        )
+    return resp

--- a/plugins/modules/ntnx_files_mount_target_stats_info_v2.py
+++ b/plugins/modules/ntnx_files_mount_target_stats_info_v2.py
@@ -1,0 +1,260 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_mount_target_stats_info_v2
+short_description: Fetch mount target statistics info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about MountTargetStat in Nutanix Prism Central.
+  - It fetches the statistics of a specific mount target (share/export) identified by C(ext_id)
+    belonging to the file server identified by C(file_server_ext_id).
+  - The mount target statistics datasource always requires an external ID, so this module always
+    fetches a single MountTargetStat entity for the requested reporting time window.
+  - This module uses PC v4 APIs based SDKs.
+options:
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server that owns the mount target.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external identifier of the mount target.
+    type: str
+    required: true
+  start_time:
+    description:
+      - The start time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format.
+      - sample input time is 2024-07-31T12:41:56.955Z
+    type: str
+    required: true
+  end_time:
+    description:
+      - The end time of the period for which stats should be reported.
+      - The value should be in extended ISO-8601 format.
+      - sample input time is 2025-07-31T12:41:56.955Z
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - The sampling interval in seconds at which statistical data should be collected.
+      - For example, if you want performance statistics every 30 seconds, then provide the value as 30.
+    type: int
+    required: false
+  stat_type:
+    description:
+      - The type of stats (down-sampling operator) applied while aggregating the data points.
+    type: str
+    required: false
+    choices:
+      - SUM
+      - AVG
+      - MIN
+      - MAX
+      - COUNT
+      - LAST
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch mount target stats using external IDs
+  nutanix.ncp.ntnx_files_mount_target_stats_info_v2:
+    file_server_ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9
+    ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+  register: result
+  ignore_errors: true
+
+- name: Fetch mount target stats with sampling interval and stat type
+  nutanix.ncp.ntnx_files_mount_target_stats_info_v2:
+    file_server_ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9
+    ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+    sampling_interval: 30
+    stat_type: "AVG"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC MountTargetStat info v4 API.
+    - It is a single MountTargetStat entity for the file server and mount target external IDs provided.
+  returned: always
+  type: dict
+  sample:
+    {
+        "average_iops": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 12
+            }
+        ],
+        "average_latency_us": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 947
+            }
+        ],
+        "average_throughput_bps": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 53450
+            }
+        ],
+        "dataset_space_used_bytes": null,
+        "ext_id": "9c1e537d-6777-4c22-5d41-ddd0c3337aa9",
+        "links": null,
+        "metadata_iops": null,
+        "metadata_latency_us": null,
+        "number_of_connections": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 3
+            }
+        ],
+        "number_of_files": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 128
+            }
+        ],
+        "read_iops": null,
+        "read_latency_us": null,
+        "read_throughput_bps": null,
+        "snapshot_used_bytes": null,
+        "tenant_id": null,
+        "tiering_latency_ms": null,
+        "used_bytes": [
+            {
+                "timestamp": "2024-07-31T11:29:00+00:00",
+                "value": 139663605760
+            }
+        ],
+        "write_iops": null,
+        "write_latency_us": null,
+        "write_throughput_bps": null
+    }
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+ext_id:
+  description: The external ID of the mount target.
+  type: str
+  returned: always
+  sample: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching mount target stats for mount target ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import get_analytics_api_instance  # noqa: E402
+from ..module_utils.v4.files.helpers import get_mount_target_stats  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        file_server_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int"),
+        stat_type=dict(
+            type="str",
+            choices=[
+                "SUM",
+                "AVG",
+                "MIN",
+                "MAX",
+                "COUNT",
+                "LAST",
+            ],
+        ),
+    )
+
+    return module_args
+
+
+def get_mount_target_stats_with_ext_id(module, api_instance, result):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    resp = get_mount_target_stats(module, api_instance, file_server_ext_id, ext_id)
+    if getattr(resp, "data", None):
+        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    else:
+        module.fail_json(msg="Failed fetching mount target stats", **result)
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+    }
+    api_instance = get_analytics_api_instance(module)
+    get_mount_target_stats_with_ext_id(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_mount_target_stat_v2.py
+++ b/plugins/modules/ntnx_mount_target_stat_v2.py
@@ -1,0 +1,271 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_mount_target_stat_v2
+short_description: Retrieve stats about a Nutanix Files mount target from PC
+version_added: 2.7.0
+description:
+    - Get statistics for a mount target (share/export) of a Nutanix Files file server.
+    - The statistics are reported for the time window bounded by C(start_time) and C(end_time).
+    - This module uses PC v4 APIs based SDKs.
+options:
+  file_server_ext_id:
+    description:
+        - The external identifier of the file server that owns the mount target.
+    type: str
+    required: true
+  ext_id:
+    description:
+        - The external identifier of the mount target.
+    type: str
+    required: true
+  start_time:
+    description:
+        - The start time of the period for which stats should be reported.
+        - The value should be in extended ISO-8601 format.
+        - sample input time is 2024-07-31T12:41:56.955Z
+    type: str
+    required: true
+  end_time:
+    description:
+        - The end time of the period for which stats should be reported.
+        - The value should be in extended ISO-8601 format.
+        - sample input time is 2025-07-31T12:41:56.955Z
+    type: str
+    required: true
+  sampling_interval:
+    description:
+        - The sampling interval in seconds at which statistical data should be collected.
+        - For example, if you want performance statistics every 30 seconds, then provide the value as 30.
+    type: int
+    required: false
+  stat_type:
+    description:
+        - The type of stats (down-sampling operator) applied while aggregating the data points.
+    type: str
+    required: false
+    choices:
+        - SUM
+        - AVG
+        - MIN
+        - MAX
+        - COUNT
+        - LAST
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+      - nutanix.ncp.ntnx_credentials
+      - nutanix.ncp.ntnx_logger
+      - nutanix.ncp.ntnx_proxy_v2
+author:
+ - Abhinav Bansal (@abhinavbansal29)
+ - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch mount target stats during a time interval
+  nutanix.ncp.ntnx_mount_target_stat_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    file_server_ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9
+    ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+  register: result
+
+- name: Fetch mount target stats with all attributes
+  nutanix.ncp.ntnx_mount_target_stat_v2:
+    nutanix_host: <pc_ip>
+    nutanix_username: <user>
+    nutanix_password: <pass>
+    file_server_ext_id: 5f1e537d-6777-4c22-5d41-ddd0c3337aa9
+    ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9
+    start_time: "2024-07-31T12:41:56.955Z"
+    end_time: "2025-07-31T12:41:56.955Z"
+    sampling_interval: 30
+    stat_type: "AVG"
+  register: result
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for fetching mount target stats.
+        - A model that represents statistics for a Nutanix Files mount target.
+    type: dict
+    returned: always
+    sample:
+            {
+                    "average_iops": [
+                        {
+                            "timestamp": "2024-07-31T11:29:00+00:00",
+                            "value": 12
+                        },
+                        {
+                            "timestamp": "2024-07-31T11:28:30+00:00",
+                            "value": 10
+                        }
+                    ],
+                    "average_latency_us": [
+                        {
+                            "timestamp": "2024-07-31T11:29:00+00:00",
+                            "value": 947
+                        }
+                    ],
+                    "average_throughput_bps": [
+                        {
+                            "timestamp": "2024-07-31T11:29:00+00:00",
+                            "value": 53450
+                        }
+                    ],
+                    "dataset_space_used_bytes": [
+                        {
+                            "timestamp": "2024-07-31T11:29:00+00:00",
+                            "value": 139663605760
+                        }
+                    ],
+                    "ext_id": "9c1e537d-6777-4c22-5d41-ddd0c3337aa9",
+                    "links": null,
+                    "metadata_iops": null,
+                    "metadata_latency_us": null,
+                    "number_of_connections": [
+                        {
+                            "timestamp": "2024-07-31T11:29:00+00:00",
+                            "value": 3
+                        }
+                    ],
+                    "number_of_files": [
+                        {
+                            "timestamp": "2024-07-31T11:29:00+00:00",
+                            "value": 128
+                        }
+                    ],
+                    "read_iops": null,
+                    "read_latency_us": null,
+                    "read_throughput_bps": null,
+                    "snapshot_used_bytes": null,
+                    "tenant_id": null,
+                    "tiering_latency_ms": null,
+                    "used_bytes": [
+                        {
+                            "timestamp": "2024-07-31T11:29:00+00:00",
+                            "value": 139663605760
+                        }
+                    ],
+                    "write_iops": null,
+                    "write_latency_us": null,
+                    "write_throughput_bps": null
+            }
+changed:
+    description: This indicates whether the task resulted in any changes. Always false for this module.
+    returned: always
+    type: bool
+    sample: false
+msg:
+    description: This indicates the message if any message occurred
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while fetching mount target stats for mount target ext_id: 9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+error:
+    description: The error message if an error occurs.
+    type: str
+    returned: when an error occurs
+failed:
+    description: This field typically holds information about if the task have failed
+    returned: always
+    type: bool
+    sample: false
+ext_id:
+    description:
+        - The external ID of the mount target.
+    type: str
+    returned: always
+    sample: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import get_analytics_api_instance  # noqa: E402
+from ..module_utils.v4.files.helpers import get_mount_target_stats  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        file_server_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int"),
+        stat_type=dict(
+            type="str",
+            choices=[
+                "SUM",
+                "AVG",
+                "MIN",
+                "MAX",
+                "COUNT",
+                "LAST",
+            ],
+        ),
+    )
+
+    return module_args
+
+
+def fetch_mount_target_stat(module, api_instance, result):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    resp = get_mount_target_stats(module, api_instance, file_server_ext_id, ext_id)
+    if getattr(resp, "data", None):
+        result["response"] = strip_internal_attributes(resp.to_dict()).get("data")
+    else:
+        module.fail_json(msg="Failed fetching mount target stats", **result)
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+    }
+    api_instance = get_analytics_api_instance(module)
+    fetch_mount_target_stat(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_mount_target_stat_v2/aliases
+++ b/tests/integration/targets/ntnx_mount_target_stat_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_mount_target_stat_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_mount_target_stat_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_mount_target_stat_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_mount_target_stat_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import mount_target_stats.yml
+      ansible.builtin.import_tasks: mount_target_stats.yml

--- a/tests/integration/targets/ntnx_mount_target_stat_v2/tasks/mount_target_stats.yml
+++ b/tests/integration/targets/ntnx_mount_target_stat_v2/tasks/mount_target_stats.yml
@@ -1,0 +1,348 @@
+---
+# Test plan for the Nutanix Files MountTargetStat modules
+# (ntnx_mount_target_stat_v2 and ntnx_files_mount_target_stats_info_v2).
+#
+# MountTargetStat is a read-only statistics datasource. The v4 Files API only
+# exposes a single "get mount target statistics" operation that REQUIRES the
+# parent file server external ID and the mount target external ID plus a
+# reporting time window. There is no create/update/delete and no list-all
+# operation, so check_mode and idempotency (write) scenarios do not apply.
+#
+# Scenarios covered:
+#   1. Argument-spec validation (runs without a live Files deployment):
+#      - each required field omitted one at a time (file_server_ext_id,
+#        ext_id, start_time, end_time) -> descriptive "missing required
+#        arguments" failure.
+#      - invalid stat_type enum value -> "must be one of" failure.
+#      - a valid stat_type enum value is accepted by the spec (no choices
+#        error) even when the referenced entity does not exist.
+#   2. API error paths (invalid / non-existent references) for BOTH modules ->
+#      the module fails gracefully with the descriptive API-exception message.
+#   3. Live stat fetch for BOTH modules, guarded by `when` so it only runs when
+#      a real file server + mount target external ID pair is supplied through
+#      integration_config.yml (mount_target_stat.file_server_ext_id /
+#      mount_target_stat.ext_id). Asserts changed/failed first, then the
+#      response shape and every optional attribute (sampling_interval,
+#      stat_type variants).
+
+- name: Start MountTargetStat tests
+  ansible.builtin.debug:
+    msg: Start MountTargetStat tests
+
+- name: Set common test facts
+  ansible.builtin.set_fact:
+    stat_start_time: "2024-07-31T12:41:56.955Z"
+    stat_end_time: "2025-07-31T12:41:56.955Z"
+    non_existent_file_server_ext_id: "00000000-0000-0000-0000-0000000000f5"
+    non_existent_mount_target_ext_id: "00000000-0000-0000-0000-0000000000c1"
+
+########################################################################################
+# Argument-spec validation - ntnx_mount_target_stat_v2 (stats module)
+########################################################################################
+
+- name: Fetch mount target stats with missing file_server_ext_id
+  nutanix.ncp.ntnx_mount_target_stat_v2:
+    ext_id: "{{ non_existent_mount_target_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch mount target stats with missing file_server_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed | default(false) == false
+      - result.failed == true
+      - "'missing required arguments' in result.msg"
+      - "'file_server_ext_id' in result.msg"
+    success_msg: "Fetch mount target stats with missing file_server_ext_id failed as expected"
+    fail_msg: "Fetch mount target stats with missing file_server_ext_id did not fail as expected"
+
+- name: Fetch mount target stats with missing ext_id
+  nutanix.ncp.ntnx_mount_target_stat_v2:
+    file_server_ext_id: "{{ non_existent_file_server_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch mount target stats with missing ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed | default(false) == false
+      - result.failed == true
+      - "'missing required arguments' in result.msg"
+      - "'ext_id' in result.msg"
+    success_msg: "Fetch mount target stats with missing ext_id failed as expected"
+    fail_msg: "Fetch mount target stats with missing ext_id did not fail as expected"
+
+- name: Fetch mount target stats with missing start_time
+  nutanix.ncp.ntnx_mount_target_stat_v2:
+    file_server_ext_id: "{{ non_existent_file_server_ext_id }}"
+    ext_id: "{{ non_existent_mount_target_ext_id }}"
+    end_time: "{{ stat_end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch mount target stats with missing start_time status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed | default(false) == false
+      - result.failed == true
+      - "'missing required arguments' in result.msg"
+      - "'start_time' in result.msg"
+    success_msg: "Fetch mount target stats with missing start_time failed as expected"
+    fail_msg: "Fetch mount target stats with missing start_time did not fail as expected"
+
+- name: Fetch mount target stats with missing end_time
+  nutanix.ncp.ntnx_mount_target_stat_v2:
+    file_server_ext_id: "{{ non_existent_file_server_ext_id }}"
+    ext_id: "{{ non_existent_mount_target_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch mount target stats with missing end_time status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed | default(false) == false
+      - result.failed == true
+      - "'missing required arguments' in result.msg"
+      - "'end_time' in result.msg"
+    success_msg: "Fetch mount target stats with missing end_time failed as expected"
+    fail_msg: "Fetch mount target stats with missing end_time did not fail as expected"
+
+- name: Fetch mount target stats with invalid stat_type
+  nutanix.ncp.ntnx_mount_target_stat_v2:
+    file_server_ext_id: "{{ non_existent_file_server_ext_id }}"
+    ext_id: "{{ non_existent_mount_target_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+    stat_type: INVALID_TYPE
+  register: result
+  ignore_errors: true
+
+- name: Fetch mount target stats with invalid stat_type status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed | default(false) == false
+      - result.failed == true
+      - "'value of stat_type must be one of' in result.msg"
+    success_msg: "Fetch mount target stats with invalid stat_type failed as expected"
+    fail_msg: "Fetch mount target stats with invalid stat_type did not fail as expected"
+
+########################################################################################
+# API error paths - ntnx_mount_target_stat_v2 (stats module)
+########################################################################################
+
+- name: Fetch mount target stats with non-existent references
+  nutanix.ncp.ntnx_mount_target_stat_v2:
+    file_server_ext_id: "{{ non_existent_file_server_ext_id }}"
+    ext_id: "{{ non_existent_mount_target_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+    read_timeout: 30000
+  register: result
+  ignore_errors: true
+
+- name: Fetch mount target stats with non-existent references status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed | default(false) == false
+      - result.failed == true
+      - "'Api Exception raised while fetching mount target stats' in result.msg"
+    success_msg: "Fetch mount target stats with non-existent references failed as expected"
+    fail_msg: "Fetch mount target stats with non-existent references did not fail as expected"
+
+- name: Fetch mount target stats with valid stat_type and non-existent references
+  nutanix.ncp.ntnx_mount_target_stat_v2:
+    file_server_ext_id: "{{ non_existent_file_server_ext_id }}"
+    ext_id: "{{ non_existent_mount_target_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+    sampling_interval: 30
+    stat_type: SUM
+    read_timeout: 30000
+  register: result
+  ignore_errors: true
+
+- name: Fetch mount target stats with valid stat_type and non-existent references status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed | default(false) == false
+      - result.failed == true
+      - "'value of stat_type must be one of' not in (result.msg | default(''))"
+      - "'Api Exception raised while fetching mount target stats' in result.msg"
+    success_msg: "Fetch mount target stats with valid stat_type and non-existent references failed as expected"
+    fail_msg: "Fetch mount target stats with valid stat_type and non-existent references did not fail as expected"
+
+########################################################################################
+# Argument-spec validation and API error paths - info module
+########################################################################################
+
+- name: Fetch mount target stats info with missing file_server_ext_id
+  nutanix.ncp.ntnx_files_mount_target_stats_info_v2:
+    ext_id: "{{ non_existent_mount_target_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch mount target stats info with missing file_server_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed | default(false) == false
+      - result.failed == true
+      - "'missing required arguments' in result.msg"
+      - "'file_server_ext_id' in result.msg"
+    success_msg: "Fetch mount target stats info with missing file_server_ext_id failed as expected"
+    fail_msg: "Fetch mount target stats info with missing file_server_ext_id did not fail as expected"
+
+- name: Fetch mount target stats info with missing ext_id
+  nutanix.ncp.ntnx_files_mount_target_stats_info_v2:
+    file_server_ext_id: "{{ non_existent_file_server_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch mount target stats info with missing ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed | default(false) == false
+      - result.failed == true
+      - "'missing required arguments' in result.msg"
+      - "'ext_id' in result.msg"
+    success_msg: "Fetch mount target stats info with missing ext_id failed as expected"
+    fail_msg: "Fetch mount target stats info with missing ext_id did not fail as expected"
+
+- name: Fetch mount target stats info with invalid stat_type
+  nutanix.ncp.ntnx_files_mount_target_stats_info_v2:
+    file_server_ext_id: "{{ non_existent_file_server_ext_id }}"
+    ext_id: "{{ non_existent_mount_target_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+    stat_type: NOT_A_TYPE
+  register: result
+  ignore_errors: true
+
+- name: Fetch mount target stats info with invalid stat_type status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed | default(false) == false
+      - result.failed == true
+      - "'value of stat_type must be one of' in result.msg"
+    success_msg: "Fetch mount target stats info with invalid stat_type failed as expected"
+    fail_msg: "Fetch mount target stats info with invalid stat_type did not fail as expected"
+
+- name: Fetch mount target stats info with non-existent references
+  nutanix.ncp.ntnx_files_mount_target_stats_info_v2:
+    file_server_ext_id: "{{ non_existent_file_server_ext_id }}"
+    ext_id: "{{ non_existent_mount_target_ext_id }}"
+    start_time: "{{ stat_start_time }}"
+    end_time: "{{ stat_end_time }}"
+    read_timeout: 30000
+  register: result
+  ignore_errors: true
+
+- name: Fetch mount target stats info with non-existent references status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed | default(false) == false
+      - result.failed == true
+      - "'Api Exception raised while fetching mount target stats' in result.msg"
+    success_msg: "Fetch mount target stats info with non-existent references failed as expected"
+    fail_msg: "Fetch mount target stats info with non-existent references did not fail as expected"
+
+########################################################################################
+# Live stat fetch (only when a real file server + mount target pair is supplied)
+########################################################################################
+
+- name: Live MountTargetStat fetch tests
+  when:
+    - mount_target_stat is defined
+    - mount_target_stat.file_server_ext_id is defined
+    - mount_target_stat.ext_id is defined
+  block:
+    - name: Fetch mount target stats with minimal attributes (live)
+      nutanix.ncp.ntnx_mount_target_stat_v2:
+        file_server_ext_id: "{{ mount_target_stat.file_server_ext_id }}"
+        ext_id: "{{ mount_target_stat.ext_id }}"
+        start_time: "{{ stat_start_time }}"
+        end_time: "{{ stat_end_time }}"
+      register: result
+      ignore_errors: true
+
+    - name: Fetch mount target stats with minimal attributes (live) status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response is defined
+          - result.ext_id == mount_target_stat.ext_id
+        success_msg: "Fetch mount target stats with minimal attributes passed"
+        fail_msg: "Fetch mount target stats with minimal attributes failed"
+
+    - name: Fetch mount target stats with all attributes (live)
+      nutanix.ncp.ntnx_mount_target_stat_v2:
+        file_server_ext_id: "{{ mount_target_stat.file_server_ext_id }}"
+        ext_id: "{{ mount_target_stat.ext_id }}"
+        start_time: "{{ stat_start_time }}"
+        end_time: "{{ stat_end_time }}"
+        sampling_interval: 30
+        stat_type: "{{ item }}"
+      register: result
+      ignore_errors: true
+      loop:
+        - SUM
+        - AVG
+        - MIN
+        - MAX
+        - COUNT
+        - LAST
+
+    - name: Fetch mount target stats with all attributes (live) status
+      ansible.builtin.assert:
+        that:
+          - item is defined
+          - item.changed == false
+          - item.failed == false
+          - item.response is defined
+          - item.ext_id == mount_target_stat.ext_id
+        success_msg: "Fetch mount target stats with all attributes passed"
+        fail_msg: "Fetch mount target stats with all attributes failed"
+      loop: "{{ result.results }}"
+
+    - name: Fetch mount target stats info with all attributes (live)
+      nutanix.ncp.ntnx_files_mount_target_stats_info_v2:
+        file_server_ext_id: "{{ mount_target_stat.file_server_ext_id }}"
+        ext_id: "{{ mount_target_stat.ext_id }}"
+        start_time: "{{ stat_start_time }}"
+        end_time: "{{ stat_end_time }}"
+        sampling_interval: 30
+        stat_type: AVG
+      register: result
+      ignore_errors: true
+
+    - name: Fetch mount target stats info with all attributes (live) status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response is defined
+          - result.ext_id == mount_target_stat.ext_id
+        success_msg: "Fetch mount target stats info with all attributes passed"
+        fail_msg: "Fetch mount target stats info with all attributes failed"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **files** namespace, entity
**MountTargetStat**, based on the inline SDK info for the Nutanix Files v4 API.
One PR per code-gen run.

- Modules generated: `ntnx_mount_target_stat_v2`, `ntnx_files_mount_target_stats_info_v2`
- API methods covered: 1 (`GetMountTargetStats` on `AnalyticsApi`)
- Fields in stats module spec (`ntnx_mount_target_stat_v2`): 6 entity options
  (`file_server_ext_id`, `ext_id`, `start_time`, `end_time`, `sampling_interval`, `stat_type`)
- Fields in info module spec (`ntnx_files_mount_target_stats_info_v2`): 6 entity options (same set)

`MountTargetStat` is a **read-only statistics datasource**. The v4 Files API exposes
only a single "get mount target statistics" operation
(`GET /api/files/v4.0/stats/file-servers/{fileServerExtId}/mount-targets/{extId}`),
so there are no create/update/delete/action operations for this entity. Both a
stats module and an info module are provided, wrapping the single SDK method and
sharing spec/fetch logic through a new `module_utils/v4/files` helper to avoid
duplication.

## Domain knowledge (from Glean)

A mount target in Nutanix Files is a share (SMB) or export (NFS) hosted on a file
server. `MountTargetStat` reports performance and usage statistics for one such
mount target over a requested time window. The datasource requires the parent
file server external ID and the mount target external ID, plus a reporting window
(`start_time`/`end_time`, extended ISO-8601). Optional down-sampling controls are
`sampling_interval` (seconds) and `stat_type` (down-sampling operator: one of
SUM, AVG, MIN, MAX, COUNT, LAST). The response is a time-series model whose metrics
(number_of_files, number_of_connections, average/read/write/metadata latency and
IOPS, average/read/write throughput, used/dataset/snapshot bytes, tiering latency,
etc.) are each a list of timestamp/value pairs.

Required domain skills to work on this feature end to end: Nutanix Files concepts
(file servers, mount targets = shares/exports, SMB/NFS), the v4 Files REST/SDK API
surface (`ntnx-files-py-client`, `AnalyticsApi`), the common v1 stats models
(`TimeIntValuePair`, `DownSamplingOperator`), OData query conventions used by the
stats endpoints, and the nutanix.ansible v4 module patterns (BaseInfoModule,
api_client/helpers structure, `strip_internal_attributes`, `raise_api_exception`).

> Note: per repository policy, internal Nutanix links (Jira/ENG tickets,
> Confluence/SharePoint pages, internal PRs) surfaced during research are
> intentionally omitted from this PR description.

## Files changed

- `plugins/modules/`
  - `ntnx_mount_target_stat_v2.py` (new) — fetch statistics for a mount target
  - `ntnx_files_mount_target_stats_info_v2.py` (new) — info module for mount target stats
- `plugins/module_utils/v4/files/`
  - `api_client.py` (new) — Files SDK API client + `get_analytics_api_instance`
  - `helpers.py` (new) — shared `get_mount_target_stats` helper
- `examples/files/MountTargetStat/`
  - `mount_target_stats_v2.yml` (new) — example playbook (all supported operations)
  - `examples_run.log` (new) — real output from running the example playbook
- `tests/integration/targets/ntnx_mount_target_stat_v2/` (new) — integration tests
  (`tasks/main.yml`, `tasks/mount_target_stats.yml`, `meta/main.yml`, `aliases`)
- `meta/runtime.yml` — registered both modules in the `ntnx` action group

## Test execution

| Metric              | Value                                                                 |
|---------------------|-----------------------------------------------------------------------|
| Command             | `ansible-test integration --local --python 3.11 --allow-disabled ntnx_mount_target_stat_v2` |
| Play recap          | ok=25, failed=0, skipped=6, ignored=11                                |
| Assertion checks    | 11 passed, 0 failed                                                   |
| Negative/validation | 11 module invocations failed-as-expected (ignored)                    |
| Live-fetch skipped  | 6 (no Files deployment on the test PC — see Analysis)                 |
| Duration            | ~0:04:50                                                              |
| Cluster (PC)        | 10.44.76.28:9440                                                      |

Lint/sanity gate (all pass): `black --check`, `isort --check`, `flake8`,
`ansible-lint` (0 failures, 5/5), `ansible-test sanity` (24/24 tests pass).

### Analysis

All argument-spec validation tests (each required field omitted; invalid
`stat_type` enum) and API error-path tests pass for **both** modules. The API
error-path tests confirm the modules reach the live Prism Central and surface a
clean, descriptive failure: the endpoint returns HTTP 503 (SERVICE UNAVAILABLE)
because the Nutanix Files microservice is **not deployed/reachable** on the test
cluster (`{"message": "Http request to endpoint 0:127.0.0.1:7509 failed ..."}`).
`raise_api_exception` correctly populates `msg`, `error`, `status` and `response`.

Because no file server / mount target exists on the test PC, the live
"successful fetch" scenarios are guarded by a `when` condition
(`mount_target_stat.file_server_ext_id` / `.ext_id`) and were skipped (6 tasks).
These will execute automatically when a real file-server + mount-target pair is
supplied via `integration_config.yml`. The example playbook was likewise run
end-to-end against the same PC (recap: ok=4, ignored=4) and its real output is
committed to `examples/files/MountTargetStat/examples_run.log`. RETURN/response
`sample:` blocks use realistic values derived from the SDK `MountTargetStats`
model since a real stats payload could not be captured on this cluster.

No failures remained after the run. Known limitation (environmental, not a code
issue): the Files service is not deployed on the test PC, so real stats data
could not be captured.

### Test logs (tail)

<details>
<summary>tail -n 60 test_logs.log</summary>

```text
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of stat_type must be one of: SUM, AVG, MIN, MAX, COUNT, LAST, got: NOT_A_TYPE"}
...ignoring

TASK [ntnx_mount_target_stat_v2 : Fetch mount target stats info with invalid stat_type status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch mount target stats info with invalid stat_type failed as expected"
}

TASK [ntnx_mount_target_stat_v2 : Fetch mount target stats info with non-existent references] ***
[ERROR]: Task failed: Module failed: Api Exception raised while fetching mount target stats for mount target ext_id: 00000000-0000-0000-0000-0000000000c1 on file server ext_id: 00000000-0000-0000-0000-0000000000f5
Origin: /tmp/codegen-ac.VxgteM/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_mount_target_stat_v2-pcnv2_qw-ÅÑŚÌβŁÈ/tests/integration/targets/ntnx_mount_target_stat_v2/tasks/mount_target_stats.yml:248:3

246     fail_msg: "Fetch mount target stats info with invalid stat_type did not fail as expected"
247
248 - name: Fetch mount target stats info with non-existent references
      ^ column 3

fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching mount target stats for mount target ext_id: 00000000-0000-0000-0000-0000000000c1 on file server ext_id: 00000000-0000-0000-0000-0000000000f5", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_mount_target_stat_v2 : Fetch mount target stats info with non-existent references status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch mount target stats info with non-existent references failed as expected"
}

TASK [ntnx_mount_target_stat_v2 : Fetch mount target stats with minimal attributes (live)] ***
skipping: [testhost]

TASK [ntnx_mount_target_stat_v2 : Fetch mount target stats with minimal attributes (live) status] ***
skipping: [testhost]

TASK [ntnx_mount_target_stat_v2 : Fetch mount target stats with all attributes (live)] ***
skipping: [testhost] => (item=SUM) 
skipping: [testhost] => (item=AVG) 
skipping: [testhost] => (item=MIN) 
skipping: [testhost] => (item=MAX) 
skipping: [testhost] => (item=COUNT) 
skipping: [testhost] => (item=LAST) 
skipping: [testhost]

TASK [ntnx_mount_target_stat_v2 : Fetch mount target stats with all attributes (live) status] ***
skipping: [testhost] => (item={'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False', 'false_condition': 'mount_target_stat is defined', 'item': 'SUM', 'ansible_loop_var': 'item'}) 
skipping: [testhost] => (item={'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False', 'false_condition': 'mount_target_stat is defined', 'item': 'AVG', 'ansible_loop_var': 'item'}) 
skipping: [testhost] => (item={'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False', 'false_condition': 'mount_target_stat is defined', 'item': 'MIN', 'ansible_loop_var': 'item'}) 
skipping: [testhost] => (item={'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False', 'false_condition': 'mount_target_stat is defined', 'item': 'MAX', 'ansible_loop_var': 'item'}) 
skipping: [testhost] => (item={'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False', 'false_condition': 'mount_target_stat is defined', 'item': 'COUNT', 'ansible_loop_var': 'item'}) 
skipping: [testhost] => (item={'changed': False, 'skipped': True, 'skip_reason': 'Conditional result was False', 'false_condition': 'mount_target_stat is defined', 'item': 'LAST', 'ansible_loop_var': 'item'}) 
skipping: [testhost]

TASK [ntnx_mount_target_stat_v2 : Fetch mount target stats info with all attributes (live)] ***
skipping: [testhost]

TASK [ntnx_mount_target_stat_v2 : Fetch mount target stats info with all attributes (live) status] ***
skipping: [testhost]

PLAY RECAP *********************************************************************
testhost                   : ok=25   changed=0    unreachable=0    failed=0    skipped=6    rescued=0    ignored=11  
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen flow.
- Prompt + inline SDK info were provided to the agent; modules, tests and examples
  follow the existing v2 module conventions (referenced `ntnx_storage_containers_stats_v2`
  and `ntnx_virtual_switch_v2`).
