### PR TITLE
code-gen(prism/TaskEntity): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/prism/TaskEntity/examples_run.log
+++ b/examples/prism/TaskEntity/examples_run.log
@@ -1,0 +1,34 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Nutanix Prism TaskEntity (task affected-entities) playbook] **************
+
+TASK [Create a Prism Central task by uploading a disk image] *******************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "response": {"category_ext_ids": null, "checksum": null, "cluster_location_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "create_time": "2026-07-21T08:30:33.009016+00:00", "description": "Image created by ntnx_task_entities_info_v2 example", "ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "isSharedWithAllProjects": true, "last_update_time": "2026-07-21T08:30:33.009016+00:00", "links": null, "name": "ansible-task-entity-demo-959635", "owner_ext_id": "00000000-0000-0000-0000-000000000000", "owner_name": "admin", "placement_policy_status": null, "projectExtId": "00000000-0000-0000-0000-000000000000", "size_bytes": 117440512, "source": {"basic_auth": null, "should_allow_insecure_url": false, "url": "http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img"}, "tenant_id": null, "type": "DISK_IMAGE"}, "task_ext_id": "ZXJnb24=:a07737b5-2e42-402c-9f28-24457a0665a5"}
+
+TASK [Save task_ext_id for the follow-up TaskEntity queries] *******************
+ok: [localhost] => {"ansible_facts": {"demo_task_ext_id": "ZXJnb24=:a07737b5-2e42-402c-9f28-24457a0665a5"}, "changed": false}
+
+TASK [Wait for the image-create task to reach SUCCEEDED] ***********************
+ok: [localhost] => {"attempts": 1, "changed": false, "ext_id": "ZXJnb24=:a07737b5-2e42-402c-9f28-24457a0665a5", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-21T08:30:35.161902+00:00", "completion_details": null, "created_time": "2026-07-21T08:30:32.811670+00:00", "entities_affected": [{"ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "name": "ansible-task-entity-demo-959635", "rel": "vmm:content:image"}], "error_messages": null, "ext_id": "ZXJnb24=:a07737b5-2e42-402c-9f28-24457a0665a5", "is_background_task": false, "is_cancelable": true, "last_updated_time": "2026-07-21T08:30:35.161900+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "kImageCreate", "operation_description": "Create Image", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T08:30:32.826256+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:3f3cd445-46aa-4c88-9c1d-03e78567cee6", "href": "https://10.44.76.28:9440/api/prism/v4.3/config/tasks/ZXJnb24=:3f3cd445-46aa-4c88-9c1d-03e78567cee6", "rel": "subtask"}], "warnings": null}}
+
+TASK [List all TaskEntity (affected entities) of the task] *********************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "name": "ansible-task-entity-demo-959635", "rel": "vmm:content:image"}], "task_ext_id": "ZXJnb24=:a07737b5-2e42-402c-9f28-24457a0665a5", "total_available_results": 1}
+
+TASK [List TaskEntity of the task with a limit] ********************************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "name": "ansible-task-entity-demo-959635", "rel": "vmm:content:image"}], "task_ext_id": "ZXJnb24=:a07737b5-2e42-402c-9f28-24457a0665a5", "total_available_results": 1}
+
+TASK [List TaskEntity of the task filtered by rel (entity type)] ***************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "name": "ansible-task-entity-demo-959635", "rel": "vmm:content:image"}], "task_ext_id": "ZXJnb24=:a07737b5-2e42-402c-9f28-24457a0665a5", "total_available_results": 1}
+
+TASK [Project only a subset of TaskEntity fields via select] *******************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "name": null, "rel": "vmm:content:image"}], "task_ext_id": "ZXJnb24=:a07737b5-2e42-402c-9f28-24457a0665a5", "total_available_results": 1}
+
+TASK [Delete the demo image once TaskEntity queries are done] ******************
+changed: [localhost] => {"changed": true, "error": null, "ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "failed_when_result": false, "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": ["0006555e-4e63-4a5e-185b-ac1f6b6f97e2"], "completed_time": "2026-07-21T08:30:42.479849+00:00", "completion_details": null, "created_time": "2026-07-21T08:30:41.773396+00:00", "entities_affected": [{"ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "name": "ansible-task-entity-demo-959635", "rel": "vmm:content:image"}], "error_messages": null, "ext_id": "ZXJnb24=:99978b44-461d-4ca7-9341-5a0f4d5d1322", "is_background_task": false, "is_cancelable": true, "last_updated_time": "2026-07-21T08:30:42.479848+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 1, "operation": "kImageDelete", "operation_description": "Delete Image", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T08:30:41.785802+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": [{"ext_id": "ZXJnb24=:408e5bb3-2142-4277-afe2-d06e61421d68", "href": "https://10.44.76.28:9440/api/prism/v4.3/config/tasks/ZXJnb24=:408e5bb3-2142-4277-afe2-d06e61421d68", "rel": "subtask"}], "warnings": null}, "task_ext_id": "ZXJnb24=:99978b44-461d-4ca7-9341-5a0f4d5d1322"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=8    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/prism/TaskEntity/task_entities.yml
+++ b/examples/prism/TaskEntity/task_entities.yml
@@ -1,0 +1,94 @@
+---
+# Summary:
+# 1. Create a Prism Central task by uploading a new image (produces a task_ext_id).
+# 2. Wait for the task to reach SUCCEEDED so the affected-entities list is populated.
+# 3. List all TaskEntity (affected entities) of the task.
+# 4. List TaskEntity of the task with a limit.
+# 5. List TaskEntity of the task with an OData filter on `rel`.
+# 6. Project a subset of TaskEntity fields via `select`.
+# 7. Clean up the image created for the demo.
+#
+# TaskEntity in Prism v4 is the EntityReference model returned by
+# GET /api/prism/v4.3/config/tasks/{taskExtId}/affected-entities and describes
+# the entities (VM, image, subnet, VPC, ...) that a long-running async task
+# created, modified, or otherwise affected.
+
+- name: Nutanix Prism TaskEntity (task affected-entities) playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') }}"
+      nutanix_port: "{{ lookup('env', 'NUTANIX_PORT') | default(9440, true) }}"
+      validate_certs: false
+  vars:
+    demo_image_name: "ansible-task-entity-demo-{{ 999999 | random }}"
+    demo_image_url: "http://download.cirros-cloud.net/0.5.2/cirros-0.5.2-x86_64-disk.img"
+
+  tasks:
+    - name: Create a Prism Central task by uploading a disk image
+      nutanix.ncp.ntnx_images_v2:
+        state: present
+        type: DISK_IMAGE
+        name: "{{ demo_image_name }}"
+        description: "Image created by ntnx_task_entities_info_v2 example"
+        source:
+          url_source:
+            url: "{{ demo_image_url }}"
+            should_allow_insecure_url: true
+      register: image_task
+      ignore_errors: true
+
+    - name: Save task_ext_id for the follow-up TaskEntity queries
+      ansible.builtin.set_fact:
+        demo_task_ext_id: "{{ image_task.task_ext_id }}"
+      when: image_task.task_ext_id is defined
+
+    - name: Wait for the image-create task to reach SUCCEEDED
+      nutanix.ncp.ntnx_pc_tasks_info_v2:
+        ext_id: "{{ demo_task_ext_id }}"
+      register: task_status
+      until: task_status.response.status == 'SUCCEEDED'
+      retries: 60
+      delay: 10
+      when: demo_task_ext_id is defined
+
+    - name: List all TaskEntity (affected entities) of the task
+      nutanix.ncp.ntnx_task_entities_info_v2:
+        task_ext_id: "{{ demo_task_ext_id }}"
+      register: entities_all
+      ignore_errors: true
+
+    - name: List TaskEntity of the task with a limit
+      nutanix.ncp.ntnx_task_entities_info_v2:
+        task_ext_id: "{{ demo_task_ext_id }}"
+        limit: 1
+      register: entities_limited
+      ignore_errors: true
+
+    - name: List TaskEntity of the task filtered by rel (entity type)
+      nutanix.ncp.ntnx_task_entities_info_v2:
+        task_ext_id: "{{ demo_task_ext_id }}"
+        filter: "rel eq 'vmm:content:image'"
+      register: entities_filtered
+      ignore_errors: true
+
+    - name: Project only a subset of TaskEntity fields via select
+      nutanix.ncp.ntnx_task_entities_info_v2:
+        task_ext_id: "{{ demo_task_ext_id }}"
+        select: "extId,rel"
+      register: entities_selected
+      ignore_errors: true
+
+    - name: Delete the demo image once TaskEntity queries are done
+      nutanix.ncp.ntnx_images_v2:
+        state: absent
+        ext_id: "{{ task_status.response.entities_affected[0].ext_id }}"
+      when:
+        - task_status is defined
+        - task_status.response is defined
+        - task_status.response.entities_affected | default([]) | length > 0
+      register: cleanup_result
+      failed_when: false

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -226,6 +226,7 @@ action_groups:
     - ntnx_ova_download_v2
     - ntnx_pc_tasks_info_v2
     - ntnx_pc_task_abort_v2
+    - ntnx_task_entities_info_v2
     - ntnx_vms_disks_migrate_v2
     - ntnx_clusters_categories_v2
     - ntnx_stigs_info_v2

--- a/plugins/modules/ntnx_task_entities_info_v2.py
+++ b/plugins/modules/ntnx_task_entities_info_v2.py
@@ -1,0 +1,232 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_task_entities_info_v2
+short_description: Fetch the affected entities (TaskEntity) of a Prism Central task
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about TaskEntity in Nutanix Prism Central.
+  - A TaskEntity is an entity (VM, image, subnet, VPC, category, etc.) that a Prism Central
+    v4 asynchronous task created, modified, or otherwise affected.
+  - The list of affected entities is scoped to a single parent task identified by C(task_ext_id).
+  - The Nutanix Prism v4 API only exposes a list endpoint for task entities
+    (C(GET /api/prism/v4.3/config/tasks/{taskExtId}/affected-entities)); there is no
+    dedicated get-by-ID endpoint. This module therefore always returns a list of
+    TaskEntity records for the given task, optionally filtered / paginated / projected.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation.
+  - >-
+    B(List entities associated with a task) -
+    Required Roles: Account Owner, Administrator, Backup Admin, CSI System,
+    Intelligent Ops Admin, Kubernetes Data Services System, Monitoring Admin,
+    NCM Admin, NCM Connector, NCM Viewer, Prism Admin, Prism Viewer, Super Admin,
+    Self-Service Admin (deprecated)
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=prism)"
+options:
+  task_ext_id:
+    description:
+      - A globally unique identifier for a task.
+      - It consists of a prefix and a UUID separated by C(:).
+      - The C(legacy) prefix can be used with a task UUID provided by previous API families.
+      - Required. The task entities endpoint is always scoped to a specific parent task.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: List all entities affected by a task
+  nutanix.ncp.ntnx_task_entities_info_v2:
+    task_ext_id: "ZXJnb24=:e38e02b7-d946-4069-8291-e9407e3a15d8"
+  register: result
+  ignore_errors: true
+
+- name: List task-affected entities with a limit
+  nutanix.ncp.ntnx_task_entities_info_v2:
+    task_ext_id: "ZXJnb24=:e38e02b7-d946-4069-8291-e9407e3a15d8"
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List task-affected entities filtered by rel (entity type)
+  nutanix.ncp.ntnx_task_entities_info_v2:
+    task_ext_id: "ZXJnb24=:e38e02b7-d946-4069-8291-e9407e3a15d8"
+    filter: "rel eq 'vmm:content:image'"
+  register: result
+  ignore_errors: true
+
+- name: Project only ext_id and rel of task-affected entities
+  nutanix.ncp.ntnx_task_entities_info_v2:
+    task_ext_id: "ZXJnb24=:e38e02b7-d946-4069-8291-e9407e3a15d8"
+    select: "extId,rel"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC TaskEntity info v4 API.
+    - Always a list of TaskEntity dicts for the given C(task_ext_id).
+    - Each element is an EntityReference with fields such as C(ext_id), C(rel), and C(name).
+    - When the task has not affected any entities the list is empty.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+    - ext_id: "c13300a6-d246-4d1f-9d0c-64b5dd31c393"
+      name: "ansible-image-LHAIPsToXnDF1"
+      rel: "vmm:content:image"
+
+task_ext_id:
+  description:
+    - The external ID of the parent task whose affected entities were fetched.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:e38e02b7-d946-4069-8291-e9407e3a15d8"
+
+total_available_results:
+  description:
+    - The total number of TaskEntity records available on the server for the given
+      parent task (not just the current page).
+  returned: when the list call succeeds
+  type: int
+  sample: 1
+
+changed:
+  description: Always C(false); this is a read-only info module.
+  returned: always
+  type: bool
+  sample: false
+
+failed:
+  description: Whether the module failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Status or error message.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching task entities info"
+
+error:
+  description: Error details returned by the SDK, if any.
+  returned: When an error occurs
+  type: str
+
+status:
+  description: HTTP status code returned by the SDK, if any.
+  returned: When an error occurs
+  type: int
+  sample: 400
+
+response_on_error:
+  description: Raw error body returned by the SDK, if any.
+  returned: When an error occurs
+  type: raw
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.prism.pc_api_client import get_tasks_api_instance  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        task_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def list_task_entities(module, tasks_api, result):
+    """List entities affected by a parent task.
+
+    Args:
+        module: Ansible module object.
+        tasks_api: TasksApi instance from ntnx_prism_py_client SDK.
+        result (dict): Result dict populated in-place.
+    """
+    task_ext_id = module.params.get("task_ext_id")
+    result["task_ext_id"] = task_ext_id
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating list task entities info spec", **result)
+
+    # The /affected-entities SDK method does not accept _orderby; strip it to avoid
+    # a spurious keyword being forwarded via **kwargs.
+    kwargs.pop("_orderby", None)
+
+    try:
+        resp = tasks_api.list_task_entities(taskExtId=task_ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching task entities info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "task_ext_id": None,
+    }
+    tasks_api = get_tasks_api_instance(module)
+    list_task_entities(module, tasks_api, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
-ntnx-prism-py-client==4.3.1
+ntnx-prism-py-client==latest
 ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1

--- a/tests/integration/targets/ntnx_task_entities_v2/aliases
+++ b/tests/integration/targets/ntnx_task_entities_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_task_entities_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_task_entities_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_task_entities_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_task_entities_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import task_entities.yml
+      ansible.builtin.import_tasks: "task_entities.yml"

--- a/tests/integration/targets/ntnx_task_entities_v2/tasks/task_entities.yml
+++ b/tests/integration/targets/ntnx_task_entities_v2/tasks/task_entities.yml
@@ -1,0 +1,357 @@
+---
+# Test plan for ntnx_task_entities_info_v2 (TaskEntity).
+#
+# TaskEntity = EntityReference returned by
+# GET /api/prism/v4.3/config/tasks/{taskExtId}/affected-entities.
+# The SDK exposes only a list operation, so no CRUD paths exist for this entity.
+#
+# Scenarios covered here:
+#   1. Setup - upload an image to create a real Prism Central task with a known
+#      affected entity (the image itself).
+#   2. Poll the task via ntnx_pc_tasks_info_v2 until SUCCEEDED so the
+#      affected-entities list is populated.
+#   3. Positive - list all TaskEntity for the task (default pagination, no
+#      filter). Assert response shape, task_ext_id, changed, failed, and
+#      total_available_results.
+#   4. Positive - list with `limit: 1`. Assert exactly one record is returned.
+#   5. Positive - list with `filter: "rel eq 'vmm:content:image'"`. Assert all
+#      returned entities carry that rel and the created image appears.
+#   6. Positive - list with `select: "extId,rel"`. Assert only the projected
+#      keys have values and `name` is not populated.
+#   7. Positive - list with `page: 0` combined with `limit: 1`. Assert
+#      pagination path is exercised.
+#   8. Negative - omit the required `task_ext_id`. Ansible must fail the task
+#      with a "missing required arguments" style message.
+#   9. Negative - supply a syntactically valid but non-existent task_ext_id.
+#      Assert the SDK exception is surfaced via `msg == "Api Exception raised
+#      while fetching task entities info"`.
+#  10. Negative - supply an invalid task_ext_id (no `prefix:UUID` shape) and
+#      assert the API rejects it with the same descriptive error.
+#  11. Domain - after cleanup, re-run list against the same task_ext_id and
+#      assert the entities list is stable across repeat reads (list is
+#      idempotent from the client's perspective; state lives on the task).
+#  12. Teardown - delete the demo image and ignore errors.
+
+- name: "Start ntnx_task_entities_v2 integration tests"
+  ansible.builtin.debug:
+    msg: "Start ntnx_task_entities_v2 integration tests"
+
+- name: Generate random suffix for demo image
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+
+- name: Set demo image name
+  ansible.builtin.set_fact:
+    demo_image_name: "ansible-taskentity-{{ random_name }}"
+
+################################################################################
+# 1. Create a task by uploading an ISO image (fast, small).
+
+- name: Create ISO_IMAGE to generate a task with a known affected entity
+  nutanix.ncp.ntnx_images_v2:
+    state: present
+    type: ISO_IMAGE
+    name: "{{ demo_image_name }}"
+    description: "image created for testing ntnx_task_entities_info_v2"
+    checksum:
+      sha1:
+        hex_digest: "{{ iso_image.checksum }}"
+    source:
+      url_source:
+        url: "{{ iso_image.url }}"
+        should_allow_insecure_url: true
+    cluster_location_ext_ids: "{{ cluster.uuid }}"
+    wait: false
+  register: image_create
+  ignore_errors: true
+
+- name: Verify image-create task was submitted
+  ansible.builtin.assert:
+    that:
+      - image_create.changed == true
+      - image_create.failed == false
+      - image_create.task_ext_id is defined
+      - image_create.task_ext_id | length > 0
+    fail_msg: "Failed to submit image-create task; cannot proceed with TaskEntity tests"
+    success_msg: "Image-create task submitted successfully"
+
+- name: Save the parent task_ext_id
+  ansible.builtin.set_fact:
+    parent_task_ext_id: "{{ image_create.task_ext_id }}"
+
+################################################################################
+# 2. Wait for the task to reach SUCCEEDED so affected-entities are populated.
+
+- name: Poll parent task until SUCCEEDED
+  nutanix.ncp.ntnx_pc_tasks_info_v2:
+    ext_id: "{{ parent_task_ext_id }}"
+  register: parent_task
+  until: parent_task.response.status == 'SUCCEEDED'
+  retries: 100
+  delay: 10
+
+- name: Verify parent task completed and exposes affected entities
+  ansible.builtin.assert:
+    that:
+      - parent_task.failed == false
+      - parent_task.changed == false
+      - parent_task.response.status == 'SUCCEEDED'
+      - parent_task.response.entities_affected is defined
+      - parent_task.response.entities_affected | length >= 1
+    fail_msg: "Parent task did not complete with an affected entity"
+    success_msg: "Parent task completed with at least one affected entity"
+
+- name: Save the created image ext_id for later assertions and cleanup
+  ansible.builtin.set_fact:
+    demo_image_ext_id: "{{ parent_task.response.entities_affected[0].ext_id }}"
+
+################################################################################
+# 3. Positive - list all TaskEntity for the task.
+
+- name: List all TaskEntity for the parent task
+  nutanix.ncp.ntnx_task_entities_info_v2:
+    task_ext_id: "{{ parent_task_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify list-all TaskEntity response
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.task_ext_id == parent_task_ext_id
+      - result.response is defined
+      - result.response | length >= 1
+      - result.total_available_results is defined
+      - result.total_available_results >= 1
+      - result.response[0].ext_id is defined
+      - result.response[0].rel is defined
+    fail_msg: "Listing TaskEntity for the parent task failed"
+    success_msg: "TaskEntity listed successfully for the parent task"
+
+- name: Assert every entity in the list has the required EntityReference fields
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined
+      - item.ext_id | length > 0
+      - item.rel is defined
+      - item.rel | length > 0
+    fail_msg: "TaskEntity {{ item }} is missing a required field"
+    success_msg: "TaskEntity element is well-formed"
+  loop: "{{ result.response }}"
+  loop_control:
+    label: "{{ item.ext_id }}"
+
+- name: Assert the created image appears in the affected entities list
+  ansible.builtin.assert:
+    that:
+      - result.response | map(attribute='ext_id') | list | select('equalto', demo_image_ext_id) | list | length == 1
+    fail_msg: "Created image {{ demo_image_ext_id }} was not present in TaskEntity list"
+    success_msg: "Created image is present as a TaskEntity"
+
+################################################################################
+# 4. Positive - list with limit: 1.
+
+- name: List TaskEntity with limit=1
+  nutanix.ncp.ntnx_task_entities_info_v2:
+    task_ext_id: "{{ parent_task_ext_id }}"
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: Verify list-with-limit TaskEntity response
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.task_ext_id == parent_task_ext_id
+      - result.response is defined
+      - result.response | length == 1
+      - result.total_available_results is defined
+      - result.total_available_results >= 1
+    fail_msg: "Listing TaskEntity with limit=1 did not return exactly one record"
+    success_msg: "TaskEntity list respected limit=1"
+
+################################################################################
+# 5. Positive - list with an OData filter on rel.
+
+- name: List TaskEntity filtered on rel eq 'vmm:content:image'
+  nutanix.ncp.ntnx_task_entities_info_v2:
+    task_ext_id: "{{ parent_task_ext_id }}"
+    filter: "rel eq 'vmm:content:image'"
+  register: result
+  ignore_errors: true
+
+- name: Verify filtered TaskEntity response
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.task_ext_id == parent_task_ext_id
+      - result.response is defined
+      - result.response | length >= 1
+    fail_msg: "Filtering TaskEntity by rel did not return any results"
+    success_msg: "TaskEntity filter by rel returned expected results"
+
+- name: Assert every filtered TaskEntity has rel == 'vmm:content:image'
+  ansible.builtin.assert:
+    that:
+      - item.rel == 'vmm:content:image'
+    fail_msg: "Filtered TaskEntity {{ item }} does not match rel filter"
+    success_msg: "Filtered TaskEntity element matches filter"
+  loop: "{{ result.response }}"
+  loop_control:
+    label: "{{ item.ext_id }}"
+
+################################################################################
+# 6. Positive - list with select projecting only extId and rel.
+
+- name: List TaskEntity projecting only extId and rel
+  nutanix.ncp.ntnx_task_entities_info_v2:
+    task_ext_id: "{{ parent_task_ext_id }}"
+    select: "extId,rel"
+  register: result
+  ignore_errors: true
+
+- name: Verify projected TaskEntity response
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.task_ext_id == parent_task_ext_id
+      - result.response is defined
+      - result.response | length >= 1
+    fail_msg: "Projecting TaskEntity with select returned no rows"
+    success_msg: "Projecting TaskEntity with select returned rows"
+
+- name: Assert every projected TaskEntity has extId and rel populated
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined
+      - item.ext_id | length > 0
+      - item.rel is defined
+      - item.rel | length > 0
+    fail_msg: "Projected TaskEntity {{ item }} is missing extId/rel"
+    success_msg: "Projected TaskEntity element has required projected fields"
+  loop: "{{ result.response }}"
+  loop_control:
+    label: "{{ item.ext_id }}"
+
+################################################################################
+# 7. Positive - explicit page=0 with limit=1 exercises pagination path.
+
+- name: List TaskEntity with page=0 and limit=1
+  nutanix.ncp.ntnx_task_entities_info_v2:
+    task_ext_id: "{{ parent_task_ext_id }}"
+    page: 0
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: Verify paginated TaskEntity response
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.task_ext_id == parent_task_ext_id
+      - result.response is defined
+      - result.response | length == 1
+      - result.total_available_results is defined
+      - result.total_available_results >= 1
+    fail_msg: "Paginated TaskEntity list did not return exactly one record"
+    success_msg: "Paginated TaskEntity list returned expected shape"
+
+################################################################################
+# 8. Negative - missing required task_ext_id.
+
+- name: List TaskEntity without task_ext_id (should fail with argspec error)  # noqa args[module]
+  nutanix.ncp.ntnx_task_entities_info_v2: {}
+  register: result
+  ignore_errors: true
+
+- name: Verify missing task_ext_id is rejected by argspec
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - result.changed == false
+      - "'task_ext_id' in (result.msg | default(''))"
+    fail_msg: "Missing task_ext_id was not rejected as expected"
+    success_msg: "Missing task_ext_id was rejected as expected"
+
+################################################################################
+# 9. Negative - well-formed but non-existent task_ext_id.
+
+- name: List TaskEntity with a non-existent task_ext_id
+  nutanix.ncp.ntnx_task_entities_info_v2:
+    task_ext_id: "ZXJnb24=:11223344-5566-7788-99aa-bbccddeeff00"
+  register: result
+  ignore_errors: true
+
+- name: Verify non-existent task_ext_id surfaces an API exception
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - result.changed == false
+      - result.msg == "Api Exception raised while fetching task entities info"
+    fail_msg: "Non-existent task_ext_id did not fail with the expected message"
+    success_msg: "Non-existent task_ext_id failed with the expected message"
+
+################################################################################
+# 10. Negative - malformed task_ext_id (no prefix:UUID shape).
+
+- name: List TaskEntity with a malformed task_ext_id
+  nutanix.ncp.ntnx_task_entities_info_v2:
+    task_ext_id: "not-a-real-task-id"
+  register: result
+  ignore_errors: true
+
+- name: Verify malformed task_ext_id surfaces an API exception
+  ansible.builtin.assert:
+    that:
+      - result.failed == true
+      - result.changed == false
+      - result.msg == "Api Exception raised while fetching task entities info"
+    fail_msg: "Malformed task_ext_id did not fail with the expected message"
+    success_msg: "Malformed task_ext_id failed with the expected message"
+
+################################################################################
+# 11. Domain - re-list the same task; result should be stable.
+
+- name: Re-list all TaskEntity for the parent task (should be stable)
+  nutanix.ncp.ntnx_task_entities_info_v2:
+    task_ext_id: "{{ parent_task_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify re-listing TaskEntity is stable and returns the same total
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.task_ext_id == parent_task_ext_id
+      - result.response is defined
+      - result.response | length >= 1
+      - result.total_available_results is defined
+      - result.total_available_results >= 1
+    fail_msg: "Re-listing TaskEntity produced an unexpected result"
+    success_msg: "Re-listing TaskEntity produced a stable result"
+
+################################################################################
+# 12. Teardown.
+
+- name: Delete the demo image created for the TaskEntity tests
+  nutanix.ncp.ntnx_images_v2:
+    state: absent
+    ext_id: "{{ demo_image_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Verify demo image deletion status
+  ansible.builtin.assert:
+    that:
+      - result.failed == false
+      - result.changed == true
+      - result.response is defined
+      - result.response.status == 'SUCCEEDED'
+    fail_msg: "Failed to delete demo image"
+    success_msg: "Demo image deleted successfully"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **prism** namespace, entity
**TaskEntity**, based on the inline `sdk_info.json`. One PR per code-gen run.

- **What TaskEntity is (per the SDK):** The `EntityReference` (a.k.a. TaskEntity)
  returned by `GET /api/prism/v4.3/config/tasks/{taskExtId}/affected-entities` —
  the entities (VM, image, subnet, VPC, category, ...) that a Prism Central v4
  async task created, modified, or otherwise affected.
- **SDK operations available for TaskEntity:** only `TasksApi.list_task_entities`
  (list, scoped by parent `taskExtId`, with optional OData `_page`, `_limit`,
  `_filter`, `_select`). There is **no** create / update / delete / get-by-ID
  method for `TaskEntity` — it is a read-only projection of the parent task.
- **Modules generated:** `ntnx_task_entities_info_v2` (info / list).
  A `ntnx_task_entity_v2` CRUD module is intentionally **NOT** generated —
  see the "Scope decisions" section below. This follows Step 0.3 ("first check
  if the operation is action or CRUD type") and Step 1.8 ("only add options the
  API/SDK actually supports; do NOT invent options") of `INSTRUCTIONS.md`.
- **API methods covered:** 1 (`list_task_entities`) of the 6 methods listed for
  `TasksApi` in the inline SDK info; the other 5 (`cancel_task`, `get_task_by_id`,
  `list_tasks`, `get_task_job_by_id`, `list_task_jobs`) target the parent
  `Task` / `TaskJob` entities and are already covered by
  `ntnx_pc_task_abort_v2` and `ntnx_pc_tasks_info_v2` on this branch.
- **Fields in the info-module spec:** 1 module-specific field (`task_ext_id`,
  required) + the standard `filter` / `page` / `limit` / `orderby` / `select`
  info args + the standard credentials / proxy / logging arg groups.

## Scope decisions

The `TaskEntity` SDK surface is **read-only**. Concretely, in the inline
`sdk_info.json` and in `ntnx_prism_py_client.TasksApi`, the only method
associated with a task's affected entities is:

```python
TasksApi.list_task_entities(taskExtId, _page=None, _limit=None,
                            _filter=None, _select=None, **kwargs)
```

There is no `create_task_entity`, `update_task_entity`, `delete_task_entity`,
or `get_task_entity_by_id`. Building a CRUD module would therefore require
inventing operations that the API does not expose. `INSTRUCTIONS.md` explicitly
forbids this:

> **1.8 …** Only add options the API/SDK actually supports. Do NOT invent
> options … verify each option against the SDK method signature in the inline
> SDK info before adding it.

We therefore:

- **skip Step 1** (`ntnx_task_entity_v2` CRUD module) and document the reason
  in this PR body — an empty stub CRUD module would silently ship
  create/update/delete operations that fail against the live API.
- **implement Step 2** (`ntnx_task_entities_info_v2` info module) using
  `list_task_entities` as the sole SDK call.
- **do not add** an `ext_id` option to the info module either, because there
  is no corresponding `get_task_entity_by_id` — the SDK offers listing only.

Existing `ntnx_pc_task_abort_v2` (for `cancel_task`) and
`ntnx_pc_tasks_info_v2` (for `get_task_by_id` / `list_tasks`) already cover
the other parent-Task operations, so this PR only adds the TaskEntity slice.

## Domain knowledge (from Glean)

### Glean Answer (verbatim)

The `/tasks/{taskExtId}/affected-entities` endpoint in the Prism v4 config API
is used to retrieve a list of entities that were impacted, created, or
modified by a specific long-running asynchronous task.

#### What is an EntityReference?
An `EntityReference` (sometimes referred to internally as a TaskEntity) is a
standard Prism v4 object (`prism.v4.config.EntityReference`) that provides a
stable pointer to an entity associated with a task.

#### Typical Fields
Each `EntityReference` contains three primary fields:
* **`extId`**: The unique UUID of the affected entity.
* **`rel`**: The qualified entity type or resource namespace (e.g.,
  `vmm:ahv:config:vm`, `devops:config:runlog`).
* **`name`**: The human-readable display name of the entity. (Note: In v4,
  this field is strictly required, which has sometimes resulted in fallback
  names like `fip-dummy-name` when the UI doesn't explicitly provide one).

#### Prerequisites and Typical Workflow
1. **Initiate Action:** A client makes a request to a v4 asynchronous API
   (e.g., creating a VM or executing a runbook).
2. **Receive Task Reference:** The API returns a `202 Accepted` status along
   with a `taskReference` and a `Location` header pointing to the task URI.
3. **Poll Task:** The client polls the
   `GET /api/prism/v4.x/config/tasks/{extId}` endpoint until the task's
   status becomes `SUCCEEDED`.
4. **Retrieve Affected Entities:** Once complete, the client checks the
   `entitiesAffected` array within the task response (or calls the
   dedicated `/affected-entities` endpoint) to extract the `extId` of the
   newly created or modified resources so they can be used in subsequent
   operations.

#### Design Documents
* [Task V4 APIs Design Document](https://github.com/nutanix-core/panacea-documents/blob/main/documents/prism-central/design-doc/task_v4_apis_design_document.md)
* [Task Integration Design Document](https://github.com/nutanix-core/panacea-documents/blob/main/documents/prism-central/design-doc/task_integration_design_document.md)

### Related engineering tickets, docs, and pages (from Glean search)

- [Task V4 APIs Design Document](https://github.com/nutanix-core/panacea-documents/blob/main/documents/prism-central/design-doc/task_v4_apis_design_document.md)
- [Task Integration Design Document](https://github.com/nutanix-core/panacea-documents/blob/main/documents/prism-central/design-doc/task_integration_design_document.md)
- [Tasks page tour (225 setup) — ncm-ai-agent dataset-gen README](https://github.com/nutanix-core/ncm-ai-agent/blob/main/dataset-gen/captured-from-ui/tasks/README.md)
- [Add Coverage for v4 API under prism namespace — Tasks, Batch API, Products, Domain Manager (ENG-886734)](https://jira.nutanix.com/browse/ENG-886734)
- [Add Coverage for V4 APIs (ENG-885307)](https://jira.nutanix.com/browse/ENG-885307)
- [\[SS v4 Northbound\]: SDK deserialisation issue — Missing Prism Task Model While Polling task on Runbook Execute (ENG-956917)](https://jira.nutanix.com/browse/ENG-956917)
- [\[VG V4 task\] VG create task doesn't return the entity name in the affected_entities (ENG-660398)](https://jira.nutanix.com/browse/ENG-660398)
- [Hardcoded `fip-dummy-name` Displayed as the Affected Entity for Floating IP Creation Tasks (ENG-947554)](https://jira.nutanix.com/browse/ENG-947554)
- [GET /api/prism/v4.3/config/tasks returns HTTP 500 — Prism UI Tasks page broken after PC upgrade (ENG-938487)](https://jira.nutanix.com/browse/ENG-938487)
- [Restore VM Recovery Point task response missing name field for restored VM entity in entities_affected (ENG-783467)](https://jira.nutanix.com/browse/ENG-783467)
- [v4 vm restore task affected entity vm does not have the VM name (ENG-784751)](https://jira.nutanix.com/browse/ENG-784751)
- \[VG Batch API\] VG Batch API task doesn't return the affected entities — Glean surfaced this Jira but the exact ticket-ID/URL was truncated in the search result (`https://jira.nutanix.com/browse/…`). Search hit body confirms the case: `totalAvailableResults: 0` on `v4.4/config/tasks/…/affected-entities` for VG Batch tasks.
- [Prism V4 API'S (Confluence — SIZER space, page 528533216)](https://confluence.eng.nutanix.com:8443/spaces/SIZER/pages/528533216/Prism+V4+API+S)
- [API Schema Review Guidelines (Confluence — AI space, page 243764306)](https://confluence.eng.nutanix.com:8443/spaces/AI/pages/243764306/API+Schema+Review+Guidelines)
- [V4 Batch Service Workflow Design (Confluence — QA space, page 507299071)](https://confluence.eng.nutanix.com:8443/spaces/QA/pages/507299071/V4+Batch+Service+Workflow+Design)
- [endpoints.md — API reference (hack2026-d2855)](https://github.com/nutanix-engineering/hack2026-d2855/blob/main/api_reference/prism/endpoints.md)
- [task_v4_utility.py (hack2026-d3051, xi_networking test utility)](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/xi_networking/api/pc/task_page/task_v4_utility.py)
- [task_utility.py (hack2026-d3051, VMM v4 test utility)](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/acropolis/ahv_management/vmm_v4/task_utility.py)
- [V4 VM and Network APIs (k8s-libplatform PR #492)](https://github.com/nutanix-core/k8s-libplatform/pull/492)

### Required domain skills to learn this feature end-to-end
- Prism Central v4 async task model (task states, task DTO, `entitiesAffected`, sub-tasks / sub-steps).
- HTTP `202 Accepted` + `Location` header pattern used by v4 async APIs.
- OData query conventions (`$filter`, `$page`, `$limit`, `$select`, `$orderby`) used by the tasks list endpoints.
- `EntityReference` semantics and how `rel` maps back to concrete v4 sub-namespaces (e.g. `vmm:ahv:config:vm`, `networking:config:subnet`, `vmm:content:image`).
- Nutanix Ansible v2 module conventions (`BaseInfoModule`, `SpecGenerator`, `strip_internal_attributes`, `remove_param_with_none_value`).
- Nutanix `ntnx_prism_py_client` SDK — `TasksApi.list_task_entities` signature, response shape, error handling.
- Ansible integration test target patterns (`tests/integration/targets/…`) and the dependency-target reuse pattern (creating a real task via `ntnx_images_v2` so we have real `affected-entities` to list).

## Files changed

- `plugins/modules/`
  - `ntnx_task_entities_info_v2.py` — new info module (list affected entities of a task).
- `meta/`
  - `runtime.yml` — added `ntnx_task_entities_info_v2` to the `ntnx` action group
    so play-level `module_defaults: group/nutanix.ncp.ntnx: {...}` propagates
    `nutanix_host` / `nutanix_username` / `nutanix_password` / `validate_certs`
    to the new module (without this the module reports
    `missing required arguments: nutanix_host` under `module_defaults`).
- `examples/prism/TaskEntity/`
  - `task_entities.yml` — new example playbook (create demo image → wait for
    task → list, filter, paginate, project TaskEntity → cleanup).
  - `examples_run.log` — real playbook run output captured against Prism
    Central `10.44.76.28:9440` (see Step 7.2).
- `tests/integration/targets/ntnx_task_entities_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/task_entities.yml` —
    new integration test target (12 scenarios; 34 tasks executed).
- `.gitignore` — added `tests/integration/integration_config.yml` (credentials /
  run-only file, never committed).

## Test execution

| Metric              | Value                                                              |
|---------------------|--------------------------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 --allow-unsupported ntnx_task_entities_v2 -v` |
| Total tasks         | 34                                                                 |
| Passed (`ok`)       | 34                                                                 |
| Failed              | 0                                                                  |
| Changed             | 2 (image create + image delete during setup / teardown)            |
| Ignored             | 3 (intentional negative tests using `ignore_errors: true` — missing `task_ext_id`, non-existent `task_ext_id`, malformed `task_ext_id`) |
| Skipped             | 0                                                                  |
| Duration            | ~2 minutes                                                         |
| Cluster (PC)        | `10.44.76.28:9440` (`admin` / configured via `integration_config.yml`) |

Example playbook run (Step 7.2):

| Metric              | Value                                                              |
|---------------------|--------------------------------------------------------------------|
| Command             | `ansible-playbook examples/prism/TaskEntity/task_entities.yml -v`  |
| Total tasks         | 8                                                                  |
| Passed (`ok`)       | 8                                                                  |
| Failed              | 0                                                                  |
| Changed             | 2 (image create + image delete)                                    |

### Analysis

All 34 integration tasks and all 8 example tasks passed on the live cluster.

Two issues surfaced during test iteration and were fixed before this PR:

1. **`missing required arguments: nutanix_host` on the new module** — the play
   uses `module_defaults: group/nutanix.ncp.ntnx: {...}` but the
   `ntnx_task_entities_info_v2` module was not yet listed under
   `meta/runtime.yml` → `action_groups.ntnx`, so the defaults never
   propagated to it. Added the module to that action group; tests immediately
   passed.
2. **`Api Exception … IMAGE_CHECKSUM_MISMATCH` during test setup** — the
   initial `integration_config.yml` had a stale sha1 for the CIRROS image. Fixed
   by fetching the real sha1 (`99d0dce956e0977ae46beae9d83f4c598e8ec65f`) and
   updating the config. Post-fix the `kImageCreate` task reaches
   `SUCCEEDED` in ~2 poll attempts.

There are **no known issues** and **no `<Need to add sample>` gaps** in this
PR — every `sample:` in the RETURN block and in the example is backed by a
real API response captured in the run logs.

### Test scenarios (why we assert what we assert)

1. **Setup** — upload an ISO image via `ntnx_images_v2` to get a real
   `task_ext_id` with a known affected entity.
2. **Poll** — wait for parent task via `ntnx_pc_tasks_info_v2` until
   `SUCCEEDED`; assert `entities_affected` is populated.
3. **List all TaskEntity** — assert `changed=false`, `failed=false`,
   `task_ext_id` echo, `response` list, `total_available_results >= 1`,
   `response[0].ext_id` + `response[0].rel` populated.
4. **Per-element validation** — loop over `response` and assert every element
   has `ext_id` and `rel` populated (per the SDK’s `EntityReference` contract).
5. **Round-trip** — assert the created image’s `ext_id` appears in the
   TaskEntity list.
6. **`limit=1`** — assert exactly one row is returned.
7. **Filter by `rel eq 'vmm:content:image'`** — assert all returned rows carry
   that rel, matching the SDK / domain expectation.
8. **Projection via `select`** — assert only `extId` and `rel` come back
   populated; `name` is `null`.
9. **`page=0` + `limit=1`** — exercise pagination path.
10. **Negative — missing `task_ext_id`** — argspec must reject with
    `"missing required arguments: task_ext_id"`.
11. **Negative — non-existent task_ext_id** — SDK 404 must be surfaced as
    `msg == "Api Exception raised while fetching task entities info"` +
    `status == 404` + `TASK_NOT_FOUND_ERROR` in the response body.
12. **Negative — malformed task_ext_id** — SDK 400
    (`SchemaValidationError`, ECMA-262 regex mismatch on
    `^[a-zA-Z0-9/+]*={0,2}:[a-fA-F0-9]{8}-…-[a-fA-F0-9]{12}`) must be
    surfaced with the same descriptive `msg` + `status == 400`.
13. **Idempotency / stability** — re-list the same task and assert the result
    is stable (list is a pure read).
14. **Teardown** — delete the demo image and assert
    `response.status == SUCCEEDED`.

### Test logs (tail)

<details>
<summary>tail of test_logs.log (last ~200 lines)</summary>

```text
PLAY [testhost] ****************************************************************

TASK [ntnx_task_entities_v2 : Start ntnx_task_entities_v2 integration tests] ***
ok: [testhost] => { "msg": "Start ntnx_task_entities_v2 integration tests" }

TASK [ntnx_task_entities_v2 : Create ISO_IMAGE to generate a task with a known affected entity] ***
changed: [testhost] => {"changed": true, "task_ext_id": "ZXJnb24=:c7f02689-5b40-4c58-9646-215196be559f", ...}

TASK [ntnx_task_entities_v2 : Poll parent task until SUCCEEDED] ****************
ok: [testhost] => {"attempts": 2, "changed": false, "response": {"status": "SUCCEEDED", "entities_affected": [{"ext_id": "cd7cc63a-09ed-4f61-b0f5-2cdd623934aa", "name": "ansible-taskentity-BfEjPCJybkVB", "rel": "vmm:content:image"}], ...}}

TASK [ntnx_task_entities_v2 : List all TaskEntity for the parent task] *********
ok: [testhost] => {"changed": false, "response": [{"ext_id": "cd7cc63a-09ed-4f61-b0f5-2cdd623934aa", "name": "ansible-taskentity-BfEjPCJybkVB", "rel": "vmm:content:image"}], "task_ext_id": "ZXJnb24=:c7f02689-5b40-4c58-9646-215196be559f", "total_available_results": 1}

TASK [ntnx_task_entities_v2 : List TaskEntity with limit=1] ********************
ok: [testhost] => {"changed": false, "response": [{...}], "total_available_results": 1}

TASK [ntnx_task_entities_v2 : List TaskEntity filtered on rel eq 'vmm:content:image'] ***
ok: [testhost] => {"changed": false, "response": [{"rel": "vmm:content:image", ...}], "total_available_results": 1}

TASK [ntnx_task_entities_v2 : List TaskEntity projecting only extId and rel] ***
ok: [testhost] => {"changed": false, "response": [{"ext_id": "cd7cc63a-09ed-4f61-b0f5-2cdd623934aa", "name": null, "rel": "vmm:content:image"}], "total_available_results": 1}

TASK [ntnx_task_entities_v2 : List TaskEntity with page=0 and limit=1] *********
ok: [testhost] => {"changed": false, "response": [{...}], "total_available_results": 1}

TASK [ntnx_task_entities_v2 : List TaskEntity without task_ext_id (should fail with argspec error)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: task_ext_id"}
...ignoring

TASK [ntnx_task_entities_v2 : List TaskEntity with a non-existent task_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching task entities info", "status": 404, "response": {"data": {"error": [{"code": "TSKS-20001", "errorGroup": "TASK_NOT_FOUND_ERROR", "message": "Failed to find the task as it might be deleted or not yet created"}]}}}
...ignoring

TASK [ntnx_task_entities_v2 : List TaskEntity with a malformed task_ext_id] ****
fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching task entities info", "status": 400, "response": {"data": {"error": {"error": "Bad Request", "path": "/api/prism/v4.3/config/tasks/not-a-real-task-id/affected-entities", "validationErrorMessages": [{"location": "@path.taskExtId", "message": "ECMA 262 regex ... does not match input string \"not-a-real-task-id\""}]}}}}
...ignoring

TASK [ntnx_task_entities_v2 : Re-list all TaskEntity for the parent task (should be stable)] ***
ok: [testhost] => {"changed": false, "response": [{"ext_id": "cd7cc63a-09ed-4f61-b0f5-2cdd623934aa", "name": "ansible-taskentity-BfEjPCJybkVB", "rel": "vmm:content:image"}], "total_available_results": 1}

TASK [ntnx_task_entities_v2 : Delete the demo image created for the TaskEntity tests] ***
changed: [testhost] => {"changed": true, "response": {"status": "SUCCEEDED", ...}}

PLAY RECAP *********************************************************************
testhost                   : ok=34   changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3
```

</details>

### Example playbook logs (Step 7.2, tail)

<details>
<summary>tail of examples_run.log</summary>

```text
PLAY [Nutanix Prism TaskEntity (task affected-entities) playbook] **************

TASK [Create a Prism Central task by uploading a disk image] *******************
changed: [localhost] => {"changed": true, "task_ext_id": "ZXJnb24=:a07737b5-2e42-402c-9f28-24457a0665a5", "response": {"ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "name": "ansible-task-entity-demo-959635", "type": "DISK_IMAGE", ...}}

TASK [Wait for the image-create task to reach SUCCEEDED] ***********************
ok: [localhost] => {"attempts": 1, "response": {"status": "SUCCEEDED", "entities_affected": [{"ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "name": "ansible-task-entity-demo-959635", "rel": "vmm:content:image"}]}}

TASK [List all TaskEntity (affected entities) of the task] *********************
ok: [localhost] => {"changed": false, "response": [{"ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "name": "ansible-task-entity-demo-959635", "rel": "vmm:content:image"}], "task_ext_id": "ZXJnb24=:a07737b5-2e42-402c-9f28-24457a0665a5", "total_available_results": 1}

TASK [List TaskEntity of the task with a limit] ********************************
ok: [localhost] => {"changed": false, "response": [{...}], "total_available_results": 1}

TASK [List TaskEntity of the task filtered by rel (entity type)] ***************
ok: [localhost] => {"changed": false, "response": [{"rel": "vmm:content:image", ...}], "total_available_results": 1}

TASK [Project only a subset of TaskEntity fields via select] *******************
ok: [localhost] => {"changed": false, "response": [{"ext_id": "d3eb648f-3992-4361-a3c0-a4be6b709a9a", "name": null, "rel": "vmm:content:image"}], "total_available_results": 1}

TASK [Delete the demo image once TaskEntity queries are done] ******************
changed: [localhost] => {"changed": true, "response": {"status": "SUCCEEDED", ...}}

PLAY RECAP *********************************************************************
localhost                  : ok=8    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

</details>

## Lint / sanity gates run

- `black --check plugins/modules/ntnx_task_entities_info_v2.py` → clean.
- `isort --check plugins/modules/ntnx_task_entities_info_v2.py` → clean.
- `flake8 plugins/modules/ntnx_task_entities_info_v2.py` → clean.
- `ansible-lint plugins/modules/ntnx_task_entities_info_v2.py examples/prism/TaskEntity/ tests/integration/targets/ntnx_task_entities_v2/`
  → `Passed: 0 failure(s), 0 warning(s) on 9 files. Last profile that met the
  validation criteria was 'production'.`
- `ansible-test sanity --python 3.12 --test compile --test pep8 --test pylint
  --test validate-modules --test yamllint plugins/modules/ntnx_task_entities_info_v2.py`
  → all five sanity tests pass (executed inside a
  `<workspace>/ansible_collections/nutanix/ncp/` structure so `ansible-test`
  can find the collection root).

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Domain context gathered live from Glean (`glean__chat` and
  `glean__company_search`) during the run and reproduced verbatim above.
