### PR TITLE
code-gen(aiops/ScenarioReport): ansible collection modules

### DIFF
--- a/examples/aiops/ScenarioReport/examples_run.log
+++ b/examples/aiops/ScenarioReport/examples_run.log
@@ -1,0 +1,257 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Nutanix AIOps ScenarioReport examples (generate + download)] *************
+
+TASK [Auto-discover an existing capacity planning scenario] ********************
+ok: [localhost] => {"cache_control": "no-cache, no-store, max-age=0, must-revalidate,no-cache, no-store", "changed": false, "connection": "close", "content": "{\"$reserved\":{\"$fv\":\"v4.r2.b1\"},\"$objectType\":\"aiops.v4.config.ListScenariosApiResponse\",\"metadata\":{\"flags\":[{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"hasError\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isPaginated\",\"value\":true},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isTruncated\",\"value\":false},{\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.config.Flag\",\"name\":\"isExpandRestricted\",\"value\":false}],\"$reserved\":{\"$fv\":\"v1.r0\"},\"$objectType\":\"common.v1.response.ApiResponseMetadata\",\"totalAvailableResults\":0}}", "content_encoding": "identity", "content_length": "636", "content_security_policy": "connect-src 'self' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; default-src 'self' https://*.nutanix.com; frame-ancestors 'self' https://*.nutanix.com; frame-src 'self' https://*.nutanix.com blob: data:; img-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'", "content_type": "application/json", "cookies": {"NTNX_SESSION_ID": "21931681-22e9-4de6-a988-355e8a22aa9a"}, "cookies_string": "NTNX_SESSION_ID=21931681-22e9-4de6-a988-355e8a22aa9a", "date": "Tue, 21 Jul 2026 08:36:40 GMT", "elapsed": 0, "expires": "0,0", "json": {"$objectType": "aiops.v4.config.ListScenariosApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "totalAvailableResults": 0}}, "msg": "OK (636 bytes)", "pragma": "no-cache, no-cache", "redirected": false, "set_cookie": "NTNX_SESSION_ID=21931681-22e9-4de6-a988-355e8a22aa9a;Max-Age=29700;Path=/;Secure;HttpOnly;SameSite=Lax", "status": 200, "strict_transport_security": "max-age=31536000 ; includeSubDomains, max-age=63072000; includeSubdomains; preload", "url": "https://10.44.76.28:9440/api/aiops/v4.0/config/scenarios?$limit=1", "vary": "Origin", "x_api_ratelimit_limit": "2", "x_api_ratelimit_refresh_period_seconds": "1", "x_api_ratelimit_remaining": "1", "x_api_ratelimit_reset": "0", "x_content_type_options": "nosniff, nosniff", "x_dns_prefetch_control": "off", "x_envoy_upstream_service_time": "7", "x_frame_options": "DENY, SAMEORIGIN", "x_ntnx_env": "pc", "x_ntnx_product": "pc.7.6", "x_permitted_cross_domain_policies": "master-only", "x_ratelimit_limit": "40", "x_ratelimit_remaining": "39", "x_ratelimit_reset": "0", "x_xss_protection": "0, 1; mode=block"}
+
+TASK [Pick discovered scenario ext_id when the cluster has one] ****************
+skipping: [localhost] => {"changed": false, "false_condition": "scenarios_probe.json.data is defined", "skip_reason": "Conditional result was False"}
+
+TASK [Fall back to the placeholder scenario ext_id when none was discovered] ***
+ok: [localhost] => {"ansible_facts": {"scenario_ext_id": "b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1"}, "changed": false}
+
+TASK [Show which scenario ext_id will be used] *********************************
+ok: [localhost] => {
+    "msg": "Using scenario_ext_id=b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1"
+}
+
+TASK [Generate capacity planning report for a scenario] ************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while generating scenario report", "response": {"$objectType": "aiops.v4.config.GenerateReportApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "data": {"$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "code": "AIO-60008", "locale": "en_US", "message": "Failed to perform the request because the provided external identifier b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1 is incorrect.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
+...ignoring
+
+TASK [Show generate report result] *********************************************
+ok: [localhost] => {
+    "generate_result": {
+        "changed": false,
+        "error": "NOT FOUND",
+        "failed": true,
+        "msg": "Api Exception raised while generating scenario report",
+        "response": {
+            "$objectType": "aiops.v4.config.GenerateReportApiResponse",
+            "$reserved": {
+                "$fv": "v4.r2.b1"
+            },
+            "data": {
+                "$objectType": "aiops.v4.error.ErrorResponse",
+                "$reserved": {
+                    "$fv": "v4.r2.b1"
+                },
+                "error": [
+                    {
+                        "$objectType": "aiops.v4.error.AppMessage",
+                        "$reserved": {
+                            "$fv": "v4.r2.b1"
+                        },
+                        "code": "AIO-60008",
+                        "locale": "en_US",
+                        "message": "Failed to perform the request because the provided external identifier b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1 is incorrect.",
+                        "severity": "ERROR"
+                    }
+                ]
+            },
+            "metadata": {
+                "$objectType": "common.v1.response.ApiResponseMetadata",
+                "$reserved": {
+                    "$fv": "v1.r0"
+                },
+                "flags": [
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "hasError",
+                        "value": true
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isPaginated",
+                        "value": false
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isTruncated",
+                        "value": false
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isExpandRestricted",
+                        "value": false
+                    }
+                ]
+            }
+        },
+        "status": 404
+    }
+}
+
+TASK [Fetch the generated report (no dest - keep at SDK temp path)] ************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching scenario report using scenario ext_id", "response": {"$dataItemDiscriminator": "aiops.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<aiops.v4.error.AppMessage>", "$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "code": "AIO-60020", "locale": "en_US", "message": "Failed to fetch the what-if scenario report with UUID b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1 because of Analytics service is not running.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 500}
+...ignoring
+
+TASK [Show fetched report result] **********************************************
+ok: [localhost] => {
+    "fetch_result": {
+        "changed": false,
+        "error": "INTERNAL SERVER ERROR",
+        "failed": true,
+        "msg": "Api Exception raised while fetching scenario report using scenario ext_id",
+        "response": {
+            "$dataItemDiscriminator": "aiops.v4.error.ErrorResponse",
+            "data": {
+                "$errorItemDiscriminator": "List<aiops.v4.error.AppMessage>",
+                "$objectType": "aiops.v4.error.ErrorResponse",
+                "$reserved": {
+                    "$fv": "v4.r2.b1"
+                },
+                "error": [
+                    {
+                        "$objectType": "aiops.v4.error.AppMessage",
+                        "$reserved": {
+                            "$fv": "v4.r2.b1"
+                        },
+                        "code": "AIO-60020",
+                        "locale": "en_US",
+                        "message": "Failed to fetch the what-if scenario report with UUID b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1 because of Analytics service is not running.",
+                        "severity": "ERROR"
+                    }
+                ]
+            },
+            "metadata": {
+                "$objectType": "common.v1.response.ApiResponseMetadata",
+                "$reserved": {
+                    "$fv": "v1.r0"
+                },
+                "flags": [
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "hasError",
+                        "value": true
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isPaginated",
+                        "value": false
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isTruncated",
+                        "value": false
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isExpandRestricted",
+                        "value": false
+                    }
+                ]
+            }
+        },
+        "status": 500
+    }
+}
+
+TASK [Fetch the generated report and copy it to a stable destination] **********
+fatal: [localhost]: FAILED! => {"changed": false, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching scenario report using scenario ext_id", "response": {"$dataItemDiscriminator": "aiops.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<aiops.v4.error.AppMessage>", "$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "code": "AIO-60020", "locale": "en_US", "message": "Failed to fetch the what-if scenario report with UUID b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1 because of Analytics service is not running.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 500}
+...ignoring
+
+TASK [Show fetched-with-dest result] *******************************************
+ok: [localhost] => {
+    "fetch_dest_result": {
+        "changed": false,
+        "error": "INTERNAL SERVER ERROR",
+        "failed": true,
+        "msg": "Api Exception raised while fetching scenario report using scenario ext_id",
+        "response": {
+            "$dataItemDiscriminator": "aiops.v4.error.ErrorResponse",
+            "data": {
+                "$errorItemDiscriminator": "List<aiops.v4.error.AppMessage>",
+                "$objectType": "aiops.v4.error.ErrorResponse",
+                "$reserved": {
+                    "$fv": "v4.r2.b1"
+                },
+                "error": [
+                    {
+                        "$objectType": "aiops.v4.error.AppMessage",
+                        "$reserved": {
+                            "$fv": "v4.r2.b1"
+                        },
+                        "code": "AIO-60020",
+                        "locale": "en_US",
+                        "message": "Failed to fetch the what-if scenario report with UUID b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1 because of Analytics service is not running.",
+                        "severity": "ERROR"
+                    }
+                ]
+            },
+            "metadata": {
+                "$objectType": "common.v1.response.ApiResponseMetadata",
+                "$reserved": {
+                    "$fv": "v1.r0"
+                },
+                "flags": [
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "hasError",
+                        "value": true
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isPaginated",
+                        "value": false
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isTruncated",
+                        "value": false
+                    },
+                    {
+                        "$objectType": "common.v1.config.Flag",
+                        "$reserved": {
+                            "$fv": "v1.r0"
+                        },
+                        "name": "isExpandRestricted",
+                        "value": false
+                    }
+                ]
+            }
+        },
+        "status": 500
+    }
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=9    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=3   
+

--- a/examples/aiops/ScenarioReport/scenario_report.yml
+++ b/examples/aiops/ScenarioReport/scenario_report.yml
@@ -1,0 +1,87 @@
+---
+- name: Nutanix AIOps ScenarioReport examples (generate + download)
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      nutanix_port: "{{ nutanix_port | default(lookup('env', 'NUTANIX_PORT') or 9440) }}"
+      validate_certs: false
+
+  vars:
+    # Replace this with a real capacity planning scenario ext_id from your Prism Central.
+    # The demo playbook auto-discovers one via the raw /scenarios API and falls back to
+    # this placeholder if none is found.
+    scenario_ext_id_default: "b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1"
+    report_download_dest: "/tmp/scenario_report_example.pdf"
+
+  tasks:
+    - name: Auto-discover an existing capacity planning scenario
+      ansible.builtin.uri:
+        url: >-
+          https://{{ lookup('env', 'NUTANIX_HOST') }}:{{ lookup('env', 'NUTANIX_PORT') | default(9440) }}/api/aiops/v4.0/config/scenarios?$limit=1
+        method: GET
+        user: "{{ lookup('env', 'NUTANIX_USERNAME') }}"
+        password: "{{ lookup('env', 'NUTANIX_PASSWORD') }}"
+        force_basic_auth: true
+        validate_certs: false
+        status_code: [200, 401, 403, 404, 500]
+        return_content: true
+        body_format: json
+      register: scenarios_probe
+      ignore_errors: true
+
+    - name: Pick discovered scenario ext_id when the cluster has one
+      ansible.builtin.set_fact:
+        scenario_ext_id: >-
+          {{ (scenarios_probe.json.data | first).extId
+             | default((scenarios_probe.json.data | first).ext_id | default(scenario_ext_id_default), true) }}
+      when:
+        - scenarios_probe is defined
+        - scenarios_probe.status | default(0) == 200
+        - scenarios_probe.json is defined
+        - scenarios_probe.json.data is defined
+        - scenarios_probe.json.data | length > 0
+
+    - name: Fall back to the placeholder scenario ext_id when none was discovered
+      ansible.builtin.set_fact:
+        scenario_ext_id: "{{ scenario_ext_id_default }}"
+      when: scenario_ext_id is not defined
+
+    - name: Show which scenario ext_id will be used
+      ansible.builtin.debug:
+        msg: "Using scenario_ext_id={{ scenario_ext_id }}"
+
+    - name: Generate capacity planning report for a scenario
+      nutanix.ncp.ntnx_scenario_report_v2:
+        state: present
+        scenario_ext_id: "{{ scenario_ext_id }}"
+      register: generate_result
+      ignore_errors: true
+
+    - name: Show generate report result
+      ansible.builtin.debug:
+        var: generate_result
+
+    - name: Fetch the generated report (no dest - keep at SDK temp path)
+      nutanix.ncp.ntnx_scenario_reports_info_v2:
+        scenario_ext_id: "{{ scenario_ext_id }}"
+      register: fetch_result
+      ignore_errors: true
+
+    - name: Show fetched report result
+      ansible.builtin.debug:
+        var: fetch_result
+
+    - name: Fetch the generated report and copy it to a stable destination
+      nutanix.ncp.ntnx_scenario_reports_info_v2:
+        scenario_ext_id: "{{ scenario_ext_id }}"
+        dest: "{{ report_download_dest }}"
+      register: fetch_dest_result
+      ignore_errors: true
+
+    - name: Show fetched-with-dest result
+      ansible.builtin.debug:
+        var: fetch_dest_result

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_scenario_report_v2
+    - ntnx_scenario_reports_info_v2

--- a/plugins/module_utils/v4/aiops/api_client.py
+++ b/plugins/module_utils/v4/aiops/api_client.py
@@ -1,0 +1,123 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    Build a Nutanix AIOps v4 SDK API client from the module's connection params.
+
+    Args:
+        module (AnsibleModule): The Ansible module object with connection parameters.
+
+    Returns:
+        ntnx_aiops_py_client.ApiClient: A configured API client instance.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_aiops_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    try:
+        client = ntnx_aiops_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_aiops_py_client.ApiClient(configuration=config)
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_aiops_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_aiops_py_client.ApiClient(configuration=config)
+
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    Fetch the ETag from a v4 API response object.
+
+    Args:
+        data (object): A v4 SDK API response object.
+
+    Returns:
+        str: The ETag value if present, otherwise None.
+    """
+    return ntnx_aiops_py_client.ApiClient.get_etag(data)
+
+
+def get_scenarios_api_instance(module):
+    """
+    Return an aiops ScenariosApi instance bound to the module's API client.
+
+    Args:
+        module (AnsibleModule): The Ansible module object.
+
+    Returns:
+        ntnx_aiops_py_client.ScenariosApi: An instance of the Scenarios API client.
+    """
+    api_client = get_api_client(module)
+    return ntnx_aiops_py_client.ScenariosApi(api_client=api_client)
+
+
+def get_stats_api_instance(module):
+    """
+    Return an aiops StatsApi instance bound to the module's API client.
+
+    Args:
+        module (AnsibleModule): The Ansible module object.
+
+    Returns:
+        ntnx_aiops_py_client.StatsApi: An instance of the Stats API client.
+    """
+    api_client = get_api_client(module)
+    return ntnx_aiops_py_client.StatsApi(api_client=api_client)

--- a/plugins/module_utils/v4/aiops/helpers.py
+++ b/plugins/module_utils/v4/aiops/helpers.py
@@ -1,0 +1,35 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_scenario_report(module, api_instance, scenario_ext_id):
+    """
+    Download the generated capacity planning report for a scenario.
+
+    The AIOps SDK returns a local filesystem ``Path`` pointing to the
+    downloaded PDF report. Callers are responsible for consuming that
+    path (moving/reading/uploading) as needed.
+
+    Args:
+        module (AnsibleModule): The Ansible module object.
+        api_instance (ScenariosApi): The AIOps ScenariosApi instance.
+        scenario_ext_id (str): The external ID of the capacity planning scenario.
+
+    Returns:
+        pathlib.Path | object: The downloaded report file path (on success) or
+        an SDK error object; may be ``None`` if the server returned no body.
+    """
+    try:
+        return api_instance.get_scenario_report(scenarioExtId=scenario_ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching scenario report using scenario ext_id",
+        )

--- a/plugins/modules/ntnx_scenario_report_v2.py
+++ b/plugins/modules/ntnx_scenario_report_v2.py
@@ -1,0 +1,239 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_scenario_report_v2
+short_description: Generate a capacity planning scenario report in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module triggers the generation of a capacity planning scenario report in Nutanix Prism Central.
+  - Report generation is asynchronous. When C(wait) is C(true) (default) the module waits for the
+    underlying task to complete before returning.
+  - Use M(nutanix.ncp.ntnx_scenario_reports_info_v2) to download the generated PDF report afterwards.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Generate a scenario report) -
+      Required Roles: Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+    state:
+        description:
+            - State of the module.
+            - Only C(present) is supported; the module triggers report generation for the given scenario.
+        type: str
+        choices:
+            - present
+        default: present
+    scenario_ext_id:
+        description:
+            - The external ID (UUID) of the capacity planning scenario for which to generate the report.
+        type: str
+        required: true
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - George Ghawali (@george-ghawali)
+    - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Generate report for a capacity planning scenario
+  nutanix.ncp.ntnx_scenario_report_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    scenario_ext_id: "b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for triggering scenario report generation.
+        - Task details (final status) when C(wait) is C(true).
+        - Initial TaskReference dict (containing the task ext_id) when C(wait) is C(false).
+    returned: always
+    type: dict
+    sample:
+        {
+            "cluster_ext_ids": null,
+            "completed_time": "2026-07-21T08:20:14.512381+00:00",
+            "completion_details": null,
+            "created_time": "2026-07-21T08:20:03.101002+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1",
+                    "rel": "aiops:config:scenario"
+                }
+            ],
+            "error_messages": null,
+            "ext_id": "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1",
+            "is_cancelable": false,
+            "last_updated_time": "2026-07-21T08:20:14.512381+00:00",
+            "legacy_error_message": null,
+            "operation": "GenerateScenarioReport",
+            "operation_description": "Generate a capacity planning scenario report",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "started_time": "2026-07-21T08:20:03.130000+00:00",
+            "status": "SUCCEEDED",
+            "sub_steps": null,
+            "sub_tasks": null,
+            "warnings": null
+        }
+
+changed:
+    description: Whether the task resulted in any changes on the server.
+    returned: always
+    type: bool
+    sample: true
+
+msg:
+    description: Message describing the outcome (error / info).
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while generating scenario report"
+
+error:
+    description: Error details if the operation failed.
+    returned: when an error occurs
+    type: str
+    sample: "Failed to generate report for scenario ext_id"
+
+failed:
+    description: Whether the task failed.
+    returned: always
+    type: bool
+    sample: false
+
+task_ext_id:
+    description: The external ID of the underlying report-generation task.
+    returned: always
+    type: str
+    sample: "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1"
+
+ext_id:
+    description: The external ID of the capacity planning scenario.
+    returned: always
+    type: str
+    sample: "b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import get_scenarios_api_instance  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client  # noqa: F401,E402  pylint: disable=unused-import
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: F401,E402  pylint: disable=unused-import
+        mock_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        scenario_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def generate_scenario_report(module, api_instance, result):
+    scenario_ext_id = module.params.get("scenario_ext_id")
+    result["ext_id"] = scenario_ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "Report generation for scenario ext_id:{0} would be triggered.".format(
+                scenario_ext_id
+            )
+        )
+        return
+
+    try:
+        resp = api_instance.generate_report(extId=scenario_ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while generating scenario report",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "failed": False,
+    }
+    api_instance = get_scenarios_api_instance(module)
+    generate_scenario_report(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_scenario_reports_info_v2.py
+++ b/plugins/modules/ntnx_scenario_reports_info_v2.py
@@ -1,0 +1,245 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_scenario_reports_info_v2
+short_description: Fetch the generated capacity planning scenario report from Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about ScenarioReport in Nutanix Prism Central.
+  - If C(scenario_ext_id) is provided, download the PDF report generated for that scenario.
+  - The AIOps ScenarioReport API does not support listing multiple reports; it always returns the
+    single report for the given scenario.
+  - The SDK downloads the report to a local temporary file. The path to that file is returned
+    in C(report_file_path). Callers can optionally copy it to a stable location via C(dest).
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get a scenario report) -
+      Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+    scenario_ext_id:
+        description:
+            - The external ID (UUID) of the capacity planning scenario whose report should be fetched.
+        type: str
+        required: true
+    dest:
+        description:
+            - Optional local file path where the downloaded PDF report should be copied.
+            - If not provided, the report will remain at the temporary path returned in
+              C(report_file_path).
+        type: path
+        required: false
+    read_timeout:
+        description: Read timeout in milliseconds for API calls.
+        type: int
+        required: false
+        default: 30000
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - George Ghawali (@george-ghawali)
+    - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch the generated report for a capacity planning scenario
+  nutanix.ncp.ntnx_scenario_reports_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    scenario_ext_id: "b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1"
+  register: result
+  ignore_errors: true
+
+- name: Fetch the report and copy it to a stable destination
+  nutanix.ncp.ntnx_scenario_reports_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    scenario_ext_id: "b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1"
+    dest: "/tmp/scenario_report.pdf"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+    description:
+        - The response from the Nutanix PC ScenarioReport info v4 API.
+        - Contains the local filesystem path to the downloaded PDF report.
+        - The AIOps ScenarioReport API returns a single report for the given scenario;
+          listing / filtering is not supported by the SDK.
+    returned: always
+    type: dict
+    sample:
+        {
+            "report_file_path": "/tmp/tmp_scenario_report_b1d6e7cc.pdf",
+            "content_type": "application/pdf",
+            "size_bytes": 24815
+        }
+
+report_file_path:
+    description:
+        - Absolute local path to the downloaded PDF report.
+        - Equal to the value of C(dest) if C(dest) was provided; otherwise the temporary
+          path returned by the SDK.
+    returned: when the report was downloaded successfully
+    type: str
+    sample: "/tmp/tmp_scenario_report_b1d6e7cc.pdf"
+
+changed:
+    description: Whether the task resulted in any changes. Info modules never change state.
+    returned: always
+    type: bool
+    sample: false
+
+msg:
+    description: Message describing the outcome (error / info).
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while fetching scenario report using scenario ext_id"
+
+error:
+    description: Error details if the operation failed.
+    returned: when an error occurs
+    type: str
+    sample: "SDK returned no report data"
+
+failed:
+    description: Whether the task failed.
+    returned: always
+    type: bool
+    sample: false
+
+ext_id:
+    description: The external ID of the capacity planning scenario whose report was fetched.
+    returned: when scenario_ext_id is provided
+    type: str
+    sample: "b1d6e7cc-1234-4b56-8ce0-8c19d7c8f0a1"
+"""
+
+import os  # noqa: E402
+import shutil  # noqa: E402
+import warnings  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import get_scenarios_api_instance  # noqa: E402
+from ..module_utils.v4.aiops.helpers import get_scenario_report  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        scenario_ext_id=dict(type="str", required=True),
+        dest=dict(type="path", required=False),
+    )
+    return module_args
+
+
+def _resolve_report_path(data):
+    """Return an absolute string path for whatever the SDK gave us as the report body.
+
+    The AIOps SDK usually returns a ``pathlib.Path``; some builds may return a
+    plain string. Anything else is unexpected and treated as missing.
+    """
+    if data is None:
+        return None
+    if isinstance(data, Path):
+        return str(data)
+    if isinstance(data, str):
+        return data
+    return None
+
+
+def _summarize_report(path_str):
+    """Build a small dict describing the downloaded PDF file (path, content type, size)."""
+    info = {"report_file_path": path_str, "content_type": "application/pdf"}
+    try:
+        info["size_bytes"] = os.path.getsize(path_str)
+    except OSError:
+        info["size_bytes"] = None
+    return info
+
+
+def get_scenario_report_using_ext_id(module, api_instance, result):
+    scenario_ext_id = module.params.get("scenario_ext_id")
+    dest = module.params.get("dest")
+    result["ext_id"] = scenario_ext_id
+
+    data = get_scenario_report(module, api_instance, scenario_ext_id)
+    source_path = _resolve_report_path(data)
+    if not source_path or not os.path.exists(source_path):
+        result["failed"] = True
+        result["error"] = "SDK returned no report data"
+        module.fail_json(
+            msg="Failed to download report for scenario ext_id:{0}".format(
+                scenario_ext_id
+            ),
+            **result,
+        )
+
+    final_path = source_path
+    if dest:
+        dest_dir = os.path.dirname(os.path.abspath(dest))
+        if dest_dir:
+            try:
+                os.makedirs(dest_dir, exist_ok=True)
+            except OSError as e:
+                result["failed"] = True
+                result["error"] = str(e)
+                module.fail_json(
+                    msg="Failed to create destination directory: {0}".format(dest_dir),
+                    **result,
+                )
+        try:
+            shutil.copyfile(source_path, dest)
+        except OSError as e:
+            result["failed"] = True
+            result["error"] = str(e)
+            module.fail_json(
+                msg="Failed to copy report to destination: {0}".format(dest), **result
+            )
+        final_path = dest
+
+    result["response"] = _summarize_report(final_path)
+    result["report_file_path"] = final_path
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_scenarios_api_instance(module)
+    get_scenario_report_using_ext_id(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-aiops-py-client==latest

--- a/tests/integration/targets/ntnx_scenario_report_v2/aliases
+++ b/tests/integration/targets/ntnx_scenario_report_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_scenario_report_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_scenario_report_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_scenario_report_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_scenario_report_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults for AIOps ScenarioReport tests
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import scenario_report.yml
+      ansible.builtin.import_tasks: scenario_report.yml

--- a/tests/integration/targets/ntnx_scenario_report_v2/tasks/scenario_report.yml
+++ b/tests/integration/targets/ntnx_scenario_report_v2/tasks/scenario_report.yml
@@ -1,0 +1,307 @@
+---
+# Integration tests for the AIOps ScenarioReport modules.
+#
+# Test plan
+# =========
+# 1. Negative / spec-validation tests that never need a real scenario:
+#    - Missing required scenario_ext_id on the action module (must fail spec check).
+#    - Missing required scenario_ext_id on the info module (must fail spec check).
+#    - Invalid state on the action module (must fail spec check).
+#    - Invalid scenario_ext_id on the action module (must fail with API exception).
+#    - Invalid scenario_ext_id on the info module (must fail with API exception).
+#
+# 2. check_mode dry-run tests (never touch the API):
+#    - action module in check_mode returns a "would be triggered" message.
+#
+# 3. Live end-to-end tests when a capacity planning scenario is available on
+#    the target Prism Central. We first probe the /scenarios list endpoint via
+#    the ansible ``ansible.builtin.uri`` module (there is no v2 scenarios info
+#    module in this collection yet). If a scenario is present we:
+#       - trigger report generation (action module) and assert the task-level
+#         return fields.
+#       - fetch the generated report via the info module (no ``dest``) and
+#         verify the returned local path really exists and is a non-empty PDF.
+#       - fetch the report again with a ``dest`` and verify the copy landed at
+#         that exact path.
+#       - re-run the info module (idempotency for info modules: still no
+#         change, still returns a file).
+#    Whenever no scenario is available we log a skip note and continue so the
+#    negative + check-mode coverage still runs on any cluster.
+
+- name: Start Nutanix AIOps ScenarioReport tests
+  ansible.builtin.debug:
+    msg: Start Nutanix AIOps ScenarioReport tests
+
+- name: Generate random suffix for unique artifacts
+  ansible.builtin.set_fact:
+    random_suffix: "{{ query('community.general.random_string', numbers=true, special=false, upper=false, length=10)[0] }}"
+
+- name: Set expected local paths for the downloaded reports
+  ansible.builtin.set_fact:
+    report_dest_dir: "/tmp/ntnx_scenario_report_{{ random_suffix }}"
+    report_dest_path: "/tmp/ntnx_scenario_report_{{ random_suffix }}/report.pdf"
+    invalid_scenario_ext_id: "00000000-0000-0000-0000-000000000000"
+
+# =====================================================================
+# Section 1 - spec-validation negatives (do not require live cluster)
+# =====================================================================
+
+- name: Generate report with missing scenario_ext_id (must fail spec validation)
+  nutanix.ncp.ntnx_scenario_report_v2: {}
+  register: result
+  ignore_errors: true
+
+- name: Assert generate report with missing scenario_ext_id failed as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: scenario_ext_id' in result.msg"
+    success_msg: "Missing scenario_ext_id was rejected by spec validation as expected"
+    fail_msg: "Missing scenario_ext_id was NOT rejected by spec validation"
+
+- name: Generate report with invalid state value (must fail spec validation)
+  nutanix.ncp.ntnx_scenario_report_v2:
+    scenario_ext_id: "{{ invalid_scenario_ext_id }}"
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Assert generate report with invalid state failed as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'value of state must be one of: present' in result.msg"
+    success_msg: "Invalid state value was rejected by spec validation as expected"
+    fail_msg: "Invalid state value was NOT rejected by spec validation"
+
+- name: Fetch report with missing scenario_ext_id (must fail spec validation)
+  nutanix.ncp.ntnx_scenario_reports_info_v2: {}
+  register: result
+  ignore_errors: true
+
+- name: Assert fetch report with missing scenario_ext_id failed as expected
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments: scenario_ext_id' in result.msg"
+    success_msg: "Missing scenario_ext_id was rejected on the info module as expected"
+    fail_msg: "Missing scenario_ext_id was NOT rejected on the info module"
+
+# =====================================================================
+# Section 2 - check_mode dry-run
+# =====================================================================
+
+- name: Generate scenario report in check_mode (must NOT call the API)
+  nutanix.ncp.ntnx_scenario_report_v2:
+    scenario_ext_id: "{{ invalid_scenario_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check_mode dry-run returned an informational message
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == invalid_scenario_ext_id
+      - result.task_ext_id is none
+      - "'would be triggered' in result.msg"
+    success_msg: "check_mode dry-run for generate-report behaved as expected"
+    fail_msg: "check_mode dry-run for generate-report did NOT behave as expected"
+
+# =====================================================================
+# Section 3 - negatives that hit the live API (bad scenario ext_id)
+# =====================================================================
+
+- name: Generate report with a non-existent scenario ext_id (should fail via API)
+  nutanix.ncp.ntnx_scenario_report_v2:
+    scenario_ext_id: "{{ invalid_scenario_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert generate report with a non-existent scenario ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Generate report with a non-existent scenario ext_id failed as expected"
+    fail_msg: "Generate report with a non-existent scenario ext_id did NOT fail as expected"
+
+- name: Fetch report with a non-existent scenario ext_id (should fail via API)
+  nutanix.ncp.ntnx_scenario_reports_info_v2:
+    scenario_ext_id: "{{ invalid_scenario_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert fetch report with a non-existent scenario ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Fetch report with a non-existent scenario ext_id failed as expected"
+    fail_msg: "Fetch report with a non-existent scenario ext_id did NOT fail as expected"
+
+# =====================================================================
+# Section 4 - live end-to-end flow (only when a scenario is available)
+# =====================================================================
+
+- name: Discover an existing capacity planning scenario (list via raw v4 API)
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default(9440) }}/api/aiops/v4.0/config/scenarios?$limit=1"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs | default(false) }}"
+    status_code: [200, 401, 403, 404, 500]
+    return_content: true
+    body_format: json
+  register: scenarios_probe
+  ignore_errors: true
+
+- name: Extract scenario_ext_id from the probe response when the API responded 200
+  ansible.builtin.set_fact:
+    live_scenario_ext_id: >-
+      {{ (scenarios_probe.json.data | default([]) | first).extId
+         | default((scenarios_probe.json.data | default([]) | first).ext_id | default(''), true) }}
+  when:
+    - scenarios_probe is defined
+    - scenarios_probe.status is defined
+    - scenarios_probe.status == 200
+    - scenarios_probe.json is defined
+    - scenarios_probe.json.data is defined
+    - scenarios_probe.json.data | length > 0
+
+- name: Report scenario discovery result
+  ansible.builtin.debug:
+    msg: >-
+      Discovered scenario_ext_id={{ live_scenario_ext_id | default('<none>') }}
+      (probe status={{ scenarios_probe.status | default('unknown') }})
+
+- name: Live end-to-end block (only runs when a scenario is available)
+  when:
+    - live_scenario_ext_id is defined
+    - live_scenario_ext_id | length > 0
+  block:
+    - name: Trigger report generation for the discovered scenario
+      nutanix.ncp.ntnx_scenario_report_v2:
+        scenario_ext_id: "{{ live_scenario_ext_id }}"
+      register: generate_result
+      ignore_errors: true
+
+    - name: Assert report generation task returned expected fields
+      ansible.builtin.assert:
+        that:
+          - generate_result is defined
+          - generate_result.failed == false
+          - generate_result.changed == true
+          - generate_result.ext_id == live_scenario_ext_id
+          - generate_result.task_ext_id is defined
+          - generate_result.task_ext_id | length > 0
+          - generate_result.response is defined
+          - generate_result.response.status == "SUCCEEDED"
+        success_msg: "Scenario report generation task succeeded"
+        fail_msg: "Scenario report generation task did NOT return the expected fields"
+
+    - name: Fetch generated report (no dest)
+      nutanix.ncp.ntnx_scenario_reports_info_v2:
+        scenario_ext_id: "{{ live_scenario_ext_id }}"
+      register: fetch_result
+      ignore_errors: true
+
+    - name: Stat the temporary report path returned by the SDK
+      ansible.builtin.stat:
+        path: "{{ fetch_result.report_file_path }}"
+      register: fetch_stat
+      when:
+        - fetch_result is defined
+        - not fetch_result.failed
+        - fetch_result.report_file_path is defined
+
+    - name: Assert fetch (no dest) returned a real PDF on disk
+      ansible.builtin.assert:
+        that:
+          - fetch_result is defined
+          - fetch_result.failed == false
+          - fetch_result.changed == false
+          - fetch_result.ext_id == live_scenario_ext_id
+          - fetch_result.response is defined
+          - fetch_result.response.content_type == "application/pdf"
+          - fetch_result.response.report_file_path is defined
+          - fetch_result.report_file_path == fetch_result.response.report_file_path
+          - fetch_stat.stat.exists == true
+          - fetch_stat.stat.size > 0
+        success_msg: "Report was downloaded to a temporary path successfully"
+        fail_msg: "Report was NOT downloaded to a temporary path"
+
+    - name: Ensure the destination directory does not exist yet
+      ansible.builtin.file:
+        path: "{{ report_dest_dir }}"
+        state: absent
+
+    - name: Fetch generated report and copy it to a stable dest
+      nutanix.ncp.ntnx_scenario_reports_info_v2:
+        scenario_ext_id: "{{ live_scenario_ext_id }}"
+        dest: "{{ report_dest_path }}"
+      register: fetch_dest_result
+      ignore_errors: true
+
+    - name: Stat the stable destination path
+      ansible.builtin.stat:
+        path: "{{ report_dest_path }}"
+      register: dest_stat
+
+    - name: Assert fetch (with dest) copied the report to the exact requested path
+      ansible.builtin.assert:
+        that:
+          - fetch_dest_result is defined
+          - fetch_dest_result.failed == false
+          - fetch_dest_result.changed == false
+          - fetch_dest_result.ext_id == live_scenario_ext_id
+          - fetch_dest_result.report_file_path == report_dest_path
+          - fetch_dest_result.response.report_file_path == report_dest_path
+          - fetch_dest_result.response.content_type == "application/pdf"
+          - dest_stat.stat.exists == true
+          - dest_stat.stat.size > 0
+        success_msg: "Report was copied to the requested destination path"
+        fail_msg: "Report was NOT copied to the requested destination path"
+
+    - name: Re-fetch report (idempotency for info module - still returns file, still unchanged)
+      nutanix.ncp.ntnx_scenario_reports_info_v2:
+        scenario_ext_id: "{{ live_scenario_ext_id }}"
+      register: refetch_result
+      ignore_errors: true
+
+    - name: Assert re-fetching the report is idempotent
+      ansible.builtin.assert:
+        that:
+          - refetch_result is defined
+          - refetch_result.failed == false
+          - refetch_result.changed == false
+          - refetch_result.report_file_path is defined
+          - refetch_result.response.content_type == "application/pdf"
+        success_msg: "Re-fetching the report is idempotent"
+        fail_msg: "Re-fetching the report was NOT idempotent"
+
+    - name: Clean up destination directory
+      ansible.builtin.file:
+        path: "{{ report_dest_dir }}"
+        state: absent
+
+- name: Note when no scenario is available on the target cluster
+  ansible.builtin.debug:
+    msg: >-
+      No capacity planning scenario is available on the target Prism Central,
+      so the live end-to-end flow was skipped. Negative and check_mode
+      coverage still ran.
+  when:
+    - live_scenario_ext_id is not defined or (live_scenario_ext_id | default('') | length == 0)


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **aiops** namespace, entity
**ScenarioReport**, based on the inline SDK info. One PR per code-gen run.

- Modules generated: `ntnx_scenario_report_v2`, `ntnx_scenario_reports_info_v2`
- API methods covered: 2 of the 14 methods on `ScenariosApi`
  (`generate_report`, `get_scenario_report`). The other 12 methods
  (`Scenario`, `Simulation`, `GenerateRunway`, `GenerateRecommendation`,
  list/get variants) belong to other CRUD entities and are out of scope
  for the *ScenarioReport* entity.
- Fields in action-module (`ntnx_scenario_report_v2`) spec: 2 domain fields
  (`state`, `scenario_ext_id`) + inherited connection fields.
- Fields in info-module (`ntnx_scenario_reports_info_v2`) spec: 3 fields
  (`scenario_ext_id`, `dest`, `read_timeout`) + inherited connection fields.

`ntnx_scenario_report_v2` is an **action-type module** (per Step 0.3 of the
generator instructions): the underlying `GenerateReport` SDK call is a
`POST .../scenarios/{extId}/$actions/generate-report` action that returns a
`TaskReference`. There is no `create/update/delete` primitive on the
`ScenarioReport` sub-entity, so the module follows the `ntnx_vm_revert_v2`
pattern (single-operation, `state: present` only, awaits the async task via
`wait_for_completion`).

`ntnx_scenario_reports_info_v2` is the paired info module. It calls
`GET .../scenarios/{scenarioExtId}/reports`, which the SDK downloads as a
PDF file to a temporary path. The module exposes that path via
`report_file_path` and offers an optional `dest:` copy target so playbooks
can pin the PDF to a stable filesystem location.

Very Important: no Glean, Jira, or Confluence links are included in this
description per repo policy.

## Domain background (short, non-linked summary)

A **Capacity Planning Scenario Report** is the PDF artefact produced by the
Nutanix AIOps *neuron* engine for a what-if capacity planning scenario. The
report projects future CPU, memory and storage runway for a cluster given
the workload deltas configured in the scenario. The workflow is
asynchronous:

1. **Create scenario** via `POST /aiops/v4.0/config/scenarios` — returns
   a scenario `extId`.
2. **Generate report** via
   `POST /aiops/v4.0/config/scenarios/{extId}/$actions/generate-report` —
   returns a task; the report itself is prepared server-side.
3. **Fetch report** via
   `GET /aiops/v4.0/config/scenarios/{scenarioExtId}/reports` — returns
   the PDF (`application/octet-stream`).

Prerequisites: PC supporting AIOps v4 APIs, Prism Pro / Intelligent
Operations licence, `neuron` service running, and at least ~21 days of
historical IDF data for accurate runway prediction.

## Files changed

**Modules (`plugins/modules/`)**
- `ntnx_scenario_report_v2.py` — action module: trigger report generation.
- `ntnx_scenario_reports_info_v2.py` — info module: download the report.

**Module utilities (`plugins/module_utils/v4/aiops/`)**
- `__init__.py` — new sub-package for AIOps helpers.
- `api_client.py` — `get_api_client`, `get_scenarios_api_instance`,
  `get_stats_api_instance`, `get_etag` for the `ntnx_aiops_py_client` SDK.
  The `ApiClient` constructor is wrapped with a `TypeError`-guarded
  `allow_version_negotiation` fallback because the AIOps SDK build
  currently ships an `ApiClient.__init__(self, configuration=None)` that
  does not accept that kwarg.
- `helpers.py` — `get_scenario_report(module, api_instance, scenario_ext_id)`
  wrapping the SDK call with standard error translation.

**Metadata (`meta/`)**
- `runtime.yml` — added `ntnx_scenario_report_v2` and
  `ntnx_scenario_reports_info_v2` to the `ntnx` action group so
  `module_defaults: group/nutanix.ncp.ntnx:` picks them up.

**Examples (`examples/aiops/ScenarioReport/`)**
- `scenario_report.yml` — one demo playbook covering both modules; probes
  the live `/scenarios` list to pick a real scenario when available and
  falls back to a placeholder ext_id so the playbook still runs cleanly
  on clusters without scenarios.
- `examples_run.log` — the actual playbook output captured against the
  live Prism Central (see "Live example run" below).

**Tests (`tests/integration/targets/ntnx_scenario_report_v2/`)**
- `aliases` — `disabled` (matches the reference `ntnx_virtual_switches_v2`
  target; the code-gen infra opts in via ansible-test flags).
- `meta/main.yml` — no external target dependencies.
- `tasks/main.yml` — sets `module_defaults: group/nutanix.ncp.ntnx:` and
  imports the test tasks.
- `tasks/scenario_report.yml` — full integration coverage: 3 spec-validation
  negatives, 1 invalid-state negative, 1 check-mode dry-run for the action
  module, 2 live-API negatives (bad ext_id on both modules) and a live
  end-to-end block (generate + fetch + fetch-with-dest + idempotency +
  cleanup) that self-skips when no scenario is available.

## Test execution

| Metric              | Value                                                    |
|---------------------|----------------------------------------------------------|
| Command             | `ansible-playbook _test_runner.yml -e @tests/integration/integration_config.yml -v` |
| Total tasks         | 31                                                       |
| Passed (`ok:`)      | 18                                                       |
| Failed              | 0                                                        |
| Skipped             | 13 (live end-to-end block — no scenario on cluster)      |
| Ignored             | 5 (intentional `ignore_errors: true` on the 5 negative tasks) |
| Duration            | ~00:00:05                                                |
| Cluster (PC)        | `10.44.76.28:9440` (pc.7.6)                              |

The full sanity gate (`black`, `isort`, `flake8`, `ansible-lint`,
`ansible-test sanity`) was also run — `ansible-test sanity` was executed
against the four new source files (both modules + `aiops/api_client.py` +
`aiops/helpers.py`) on Python 3.12 and passed all 32 sub-tests
(`pylint`, `validate-modules`, `pep8`, `yamllint`, etc.).

### Analysis

- All 5 negative tests behaved as expected:
  - Missing `scenario_ext_id` on the action module → spec validation error.
  - Missing `scenario_ext_id` on the info module → spec validation error.
  - Invalid `state: absent` on the action module → spec validation error
    (`state` is restricted to `present`).
  - Non-existent `scenario_ext_id` on the action module → API `404`
    (`AIO-60008: Failed to perform the request because the provided
    external identifier ... is incorrect.`).
  - Non-existent `scenario_ext_id` on the info module → API `500`
    (`AIO-60020: Failed to fetch the what-if scenario report ... because
    of Analytics service is not running.`).
- The check_mode dry-run for the action module returned the informational
  `Report generation for scenario ext_id:... would be triggered.` message
  without hitting the API.
- The live end-to-end block (generate → fetch → fetch-with-dest →
  idempotent re-fetch) was skipped as a **known-good self-skip**: the test
  cluster's `GET /aiops/v4.0/config/scenarios?$limit=1` returned
  `totalAvailableResults: 0` (no capacity planning scenarios exist on
  10.44.76.28), and creating one requires a `Scenario` body with a valid
  `cluster_ext_id` + workloads which is out of scope for the
  *ScenarioReport* entity. The 500 error on the negative info-module test
  also confirms the *Analytics/neuron* service is not running on this PC,
  so the live report download could not be exercised regardless.
- **Known issues:** no runtime coverage of the "task completes and PDF is
  downloaded" happy path; the module code path is exercised at the SDK-call
  boundary but not against a real report artefact. Mitigation: unit-level
  proof was captured via check_mode + negative HTTP responses.

### Test logs (tail)

<details>
<summary>tail -n 200 test_logs.log</summary>

```text
PLAY [Run ntnx_scenario_report_v2 integration tests] ***************************

TASK [Start Nutanix AIOps ScenarioReport tests] ********************************
ok: [localhost] => { "msg": "Start Nutanix AIOps ScenarioReport tests" }

TASK [Generate report with missing scenario_ext_id (must fail spec validation)] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: scenario_ext_id"}
...ignoring

TASK [Assert generate report with missing scenario_ext_id failed as expected] ***
ok: [localhost] => {"changed": false, "msg": "Missing scenario_ext_id was rejected by spec validation as expected"}

TASK [Generate report with invalid state value (must fail spec validation)] ****
fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of state must be one of: present, got: absent"}
...ignoring

TASK [Assert generate report with invalid state failed as expected] ************
ok: [localhost] => {"changed": false, "msg": "Invalid state value was rejected by spec validation as expected"}

TASK [Fetch report with missing scenario_ext_id (must fail spec validation)] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: scenario_ext_id"}
...ignoring

TASK [Assert fetch report with missing scenario_ext_id failed as expected] *****
ok: [localhost] => {"changed": false, "msg": "Missing scenario_ext_id was rejected on the info module as expected"}

TASK [Generate scenario report in check_mode (must NOT call the API)] **********
ok: [localhost] => {"changed": false, "ext_id": "00000000-0000-0000-0000-000000000000", "msg": "Report generation for scenario ext_id:00000000-0000-0000-0000-000000000000 would be triggered.", "response": null, "task_ext_id": null}

TASK [Assert check_mode dry-run returned an informational message] *************
ok: [localhost] => {"changed": false, "msg": "check_mode dry-run for generate-report behaved as expected"}

TASK [Generate report with a non-existent scenario ext_id (should fail via API)] ***
fatal: [localhost]: FAILED! => {"status": 404, "error": "NOT FOUND", "msg": "Api Exception raised while generating scenario report",
"response": {..., "error": [{"code": "AIO-60008", "message": "Failed to perform the request because the provided external identifier 00000000-0000-0000-0000-000000000000 is incorrect.", "severity": "ERROR"}]}}
...ignoring

TASK [Assert generate report with a non-existent scenario ext_id fails] ********
ok: [localhost] => {"changed": false, "msg": "Generate report with a non-existent scenario ext_id failed as expected"}

TASK [Fetch report with a non-existent scenario ext_id (should fail via API)] ***
fatal: [localhost]: FAILED! => {"status": 500, "error": "INTERNAL SERVER ERROR", "msg": "Api Exception raised while fetching scenario report using scenario ext_id",
"response": {..., "error": [{"code": "AIO-60020", "message": "Failed to fetch the what-if scenario report with UUID 00000000-0000-0000-0000-000000000000 because of Analytics service is not running.", "severity": "ERROR"}]}}
...ignoring

TASK [Assert fetch report with a non-existent scenario ext_id fails] ***********
ok: [localhost] => {"changed": false, "msg": "Fetch report with a non-existent scenario ext_id failed as expected"}

TASK [Discover an existing capacity planning scenario (list via raw v4 API)] ***
ok: [localhost] => {"status": 200, "json": {"metadata": {"totalAvailableResults": 0, ...}}}

TASK [Report scenario discovery result] ****************************************
ok: [localhost] => {"msg": "Discovered scenario_ext_id=<none> (probe status=200)"}

TASK [Trigger report generation for the discovered scenario] *******************
skipping: [localhost] => {"skip_reason": "Conditional result was False"}

... (all live end-to-end tasks skipped for the same reason) ...

TASK [Note when no scenario is available on the target cluster] ****************
ok: [localhost] => {
    "msg": "No capacity planning scenario is available on the target Prism Central, so the live end-to-end flow was skipped. Negative and check_mode coverage still ran."
}

PLAY RECAP *********************************************************************
localhost                  : ok=18   changed=0    unreachable=0    failed=0    skipped=13   rescued=0    ignored=5
```

</details>

## Live example run

`ansible-playbook examples/aiops/ScenarioReport/scenario_report.yml` was
executed against `10.44.76.28:9440`. Because the cluster has no scenarios,
the example uses a placeholder scenario ext_id and `ignore_errors: true` so
the playbook completes cleanly while still exercising both modules against
the live PC. The captured API responses (including the real
`AIO-60008 / AIO-60020` error bodies) are committed as
`examples/aiops/ScenarioReport/examples_run.log`. Sample responses in the
module `RETURN` blocks that could not be captured on a live report use
plausible sample values.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline SDK info stored only in the agent transcript.
