### PR TITLE
feat(aiops/Runway): generated ansible collection modules

### DIFF
--- a/examples/aiops/Runway/examples_run.log
+++ b/examples/aiops/Runway/examples_run.log
@@ -1,0 +1,38 @@
+[DEPRECATION WARNING]: ANSIBLE_COLLECTIONS_PATHS option, does not fit var 
+naming standard, use the singular form ANSIBLE_COLLECTIONS_PATH instead. This 
+feature will be removed from ansible-core in version 2.19. Deprecation warnings
+ can be disabled by setting deprecation_warnings=False in ansible.cfg.
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Capacity planning (Runway) playbook] *************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"cluster_uuid": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "scenario_ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d", "scenario_name": "runway_scenario_ansible"}, "changed": false}
+
+TASK [Create capacity planning scenario (Runway) with all attributes] **********
+changed: [localhost] => {"changed": true, "error": null, "ext_id": null, "response": {"ext_id": "ZXJnb24=:0da6919b-93e4-416d-6460-ce55adeb5733"}, "task_ext_id": "ZXJnb24=:0da6919b-93e4-416d-6460-ce55adeb5733"}
+
+TASK [Update capacity planning scenario with all attributes] *******************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching capacity planning scenario info using ext_id", "response": {"$objectType": "aiops.v4.config.GetScenarioApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "data": {"$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "code": "AIO-60006", "locale": "en_US", "message": "Failed to perform the request because the resource identified by the provided external identifier 2e40ff57-20aa-4d2b-b179-298db969c20d was not found.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
+...ignoring
+
+TASK [Get capacity planning scenario using ext_id] *****************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching capacity planning scenario info using ext_id", "response": {"$objectType": "aiops.v4.config.GetScenarioApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "data": {"$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "code": "AIO-60006", "locale": "en_US", "message": "Failed to perform the request because the resource identified by the provided external identifier 2e40ff57-20aa-4d2b-b179-298db969c20d was not found.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
+...ignoring
+
+TASK [List all capacity planning scenarios] ************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List capacity planning scenarios with limit] *****************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Delete capacity planning scenario] ***************************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while deleting capacity planning scenario", "response": {"$objectType": "aiops.v4.config.DeleteScenarioApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "data": {"$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "code": "AIO-60008", "locale": "en_US", "message": "Failed to perform the request because the provided external identifier 2e40ff57-20aa-4d2b-b179-298db969c20d is incorrect.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 400}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=7    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   
+

--- a/examples/aiops/Runway/runway_planned_capacity.yml
+++ b/examples/aiops/Runway/runway_planned_capacity.yml
@@ -1,0 +1,118 @@
+---
+# Summary:
+# This playbook demonstrates one example each of the operations supported by
+# the aiops Runway modules:
+#   1. Create capacity planning (Runway) scenario (with all fields).
+#   2. Update capacity planning scenario (with all fields).
+#   3. Get capacity planning scenario using ext_id.
+#   4. List all capacity planning scenarios.
+#   5. List capacity planning scenarios with limit.
+#   6. Delete capacity planning scenario.
+#
+# NOTE: The capacity-planning "WHATIF_SCENARIO_CREATE_TASK" is asynchronous
+# and requires historical stats data on the target cluster. On clusters
+# without enough historical data the task may stay QUEUED, so this example
+# uses wait=false. Update and Delete take a real scenario ext_id (see the
+# Update example) once the create task has completed on your cluster.
+
+- name: Capacity planning (Runway) playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        cluster_uuid: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+        scenario_name: "runway_scenario_ansible"
+        scenario_ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+
+    - name: Create capacity planning scenario (Runway) with all attributes
+      nutanix.ncp.ntnx_runway_planned_capacity_v2:
+        state: present
+        name: "{{ scenario_name }}"
+        cluster_ext_id: "{{ cluster_uuid }}"
+        target_runway_days: 90
+        vendors:
+          - NUTANIX
+        cluster_config:
+          data_store_config:
+            replication_factor: "RF_2"
+            compression_saving_percent: 25.81
+            dedup_saving_percent: 35.86
+            erasure_coding_saving_percent: 15.17
+            overall_saving_percent: 59.64
+            cpu_over_commit_ratio: 1.0
+            ram_over_commit_ratio: 1.0
+            cpu_reservation_percentage: 0.0
+            ram_reservation_percentage: 0.0
+            storage_reservation_percentage: 0.0
+          node_configs:
+            - model: "NX-1000"
+              node_count: 2
+              is_enabled: true
+              node_source: "USER_ADDED"
+              node_resource_capacity:
+                cpu_ghz: 60.0
+                ram_gb: 512.0
+                hdd_gb: 0.0
+                ssd_gb: 8000.0
+                nvme_gb: 0.0
+        wait: false
+      register: created_scenario
+      ignore_errors: true
+
+    - name: Update capacity planning scenario with all attributes
+      nutanix.ncp.ntnx_runway_planned_capacity_v2:
+        state: present
+        ext_id: "{{ scenario_ext_id }}"
+        name: "{{ scenario_name }}_updated"
+        cluster_ext_id: "{{ cluster_uuid }}"
+        target_runway_days: 180
+        vendors:
+          - NUTANIX
+          - DELL
+        cluster_config:
+          data_store_config:
+            replication_factor: "RF_3"
+            compression_saving_percent: 20.0
+            dedup_saving_percent: 30.0
+            erasure_coding_saving_percent: 15.0
+            overall_saving_percent: 50.0
+            cpu_over_commit_ratio: 1.5
+            ram_over_commit_ratio: 1.0
+            cpu_reservation_percentage: 10.0
+            ram_reservation_percentage: 10.0
+            storage_reservation_percentage: 5.0
+        wait: false
+      register: updated_scenario
+      ignore_errors: true
+
+    - name: Get capacity planning scenario using ext_id
+      nutanix.ncp.ntnx_runways_info_v2:
+        ext_id: "{{ scenario_ext_id }}"
+      register: scenario_by_id
+      ignore_errors: true
+
+    - name: List all capacity planning scenarios
+      nutanix.ncp.ntnx_runways_info_v2:
+      register: all_scenarios
+      ignore_errors: true
+
+    - name: List capacity planning scenarios with limit
+      nutanix.ncp.ntnx_runways_info_v2:
+        limit: 1
+      register: scenarios_limited
+      ignore_errors: true
+
+    - name: Delete capacity planning scenario
+      nutanix.ncp.ntnx_runway_planned_capacity_v2:
+        state: absent
+        ext_id: "{{ scenario_ext_id }}"
+        wait: false
+      register: deleted_scenario
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_runway_planned_capacity_v2
+    - ntnx_runways_info_v2

--- a/plugins/module_utils/v4/aiops/api_client.py
+++ b/plugins/module_utils/v4/aiops/api_client.py
@@ -1,0 +1,103 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return an aiops SDK API client using the connection
+    parameters provided to the module.
+
+    Args:
+        module (object): Ansible module object.
+
+    Returns:
+        client (object): aiops SDK API client instance.
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_aiops_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_aiops_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_aiops_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    Fetch the ETag from a v4 aiops API response envelope.
+
+    Args:
+        data (object): v4 API response object.
+
+    Returns:
+        etag (str): ETag value if present, otherwise None.
+    """
+    return ntnx_aiops_py_client.ApiClient.get_etag(data)
+
+
+def get_scenarios_api_instance(module):
+    """
+    Return a ScenariosApi instance from the aiops SDK.
+
+    Args:
+        module (object): Ansible module object.
+
+    Returns:
+        api_instance (object): ScenariosApi instance.
+    """
+    api_client = get_api_client(module)
+    return ntnx_aiops_py_client.ScenariosApi(api_client=api_client)

--- a/plugins/module_utils/v4/aiops/helpers.py
+++ b/plugins/module_utils/v4/aiops/helpers.py
@@ -1,0 +1,30 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_scenario(module, api_instance, ext_id):
+    """
+    Return a capacity planning scenario by its external ID.
+
+    Args:
+        module (object): Ansible module object.
+        api_instance (object): ScenariosApi instance from ntnx_aiops_py_client.
+        ext_id (str): External ID of the capacity planning scenario.
+
+    Returns:
+        info (object): Scenario info object.
+    """
+    try:
+        return api_instance.get_scenario_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching capacity planning scenario info using ext_id",
+        )

--- a/plugins/modules/ntnx_runway_planned_capacity_v2.py
+++ b/plugins/modules/ntnx_runway_planned_capacity_v2.py
@@ -1,0 +1,853 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_runway_planned_capacity_v2
+short_description: Create, Update, Delete capacity planning (Runway) scenarios in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to create, update, and delete capacity planning
+    scenarios (Runway) in Nutanix Prism Central.
+  - Runway is the estimated number of days remaining before actual resource
+    usage exceeds the cluster effective capacity for CPU, memory, or storage.
+  - A capacity planning scenario models workloads and cluster configuration
+    changes and exposes the resulting Runway projection.
+  - This module uses PC v4 APIs based SDKs (ntnx_aiops_py_client).
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation. The required roles depend on the operation
+    being performed.
+  - >-
+    B(Create a capacity planning scenario) -
+    Required Roles: Prism Admin, Super Admin
+  - >-
+    B(Update a capacity planning scenario) -
+    Required Roles: Prism Admin, Super Admin
+  - >-
+    B(Delete a capacity planning scenario) -
+    Required Roles: Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will be to create a capacity planning scenario.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be to update a capacity planning scenario.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be to delete the capacity planning scenario.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID (UUID) of the capacity planning scenario.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - Name of the capacity planning scenario.
+      - Required for create operation.
+      - Minimum length 1, maximum length 256.
+    type: str
+    required: false
+  cluster_ext_id:
+    description:
+      - UUID of the cluster for which the What-If capacity analysis is being performed.
+      - Required for create operation.
+    type: str
+    required: false
+  target_runway_days:
+    description:
+      - Target number of days a cluster is expected to sustain the workload
+        in the capacity planning scenario.
+      - Minimum 30, maximum 360.
+    type: int
+    required: false
+  vendors:
+    description:
+      - Allowed hardware vendors whose models can be requested to sustain the
+        workload in the capacity planning scenario.
+    type: list
+    elements: str
+    choices:
+      - NUTANIX
+      - DELL
+      - LENOVO
+      - CISCO
+      - IBM
+      - HPE_DX
+      - AWS
+      - FUJITSU
+      - AZURE
+    required: false
+  cluster_config:
+    description:
+      - Cluster specification for the What-If capacity analysis.
+      - Required for create operation.
+    type: dict
+    required: false
+    suboptions:
+      data_store_config:
+        description:
+          - Data store configuration used during What-If capacity analysis
+            (savings, over-commit and reservation settings).
+        type: dict
+        required: true
+        suboptions:
+          replication_factor:
+            description:
+              - Replication factor of the cluster resources.
+            type: str
+            choices:
+              - RF_2
+              - RF_3
+            required: true
+          compression_saving_percent:
+            description:
+              - Compression saving percentage of the cluster resources.
+            type: float
+            required: true
+          dedup_saving_percent:
+            description:
+              - De-dupe saving percentage of the cluster resources.
+            type: float
+            required: true
+          erasure_coding_saving_percent:
+            description:
+              - Erasure coding saving percentage of the cluster resources.
+            type: float
+            required: true
+          overall_saving_percent:
+            description:
+              - Overall saving percentage of the cluster resources.
+            type: float
+            required: true
+          cpu_over_commit_ratio:
+            description:
+              - CPU overcommit ratio.
+            type: float
+            required: true
+          ram_over_commit_ratio:
+            description:
+              - RAM overcommit ratio.
+            type: float
+            required: true
+          cpu_reservation_percentage:
+            description:
+              - CPU reservation percentage.
+            type: float
+            required: true
+          ram_reservation_percentage:
+            description:
+              - RAM reservation percentage.
+            type: float
+            required: true
+          storage_reservation_percentage:
+            description:
+              - Storage reservation percentage.
+            type: float
+            required: true
+      node_configs:
+        description:
+          - Metadata about the nodes in a cluster. Nodes can be user added,
+            existing on the cluster, or recommended by the recommendation engine.
+        type: list
+        elements: dict
+        required: false
+        suboptions:
+          model:
+            description:
+              - Model name of a node.
+            type: str
+            required: true
+          node_count:
+            description:
+              - Number of nodes of this model.
+              - Minimum 1, maximum 500.
+            type: int
+            required: true
+          target_online_time:
+            description:
+              - Recommended time when a node should be live in the cluster
+                (ISO-8601 format, for example C(2022-02-20T00:00:00.458Z)).
+            type: str
+            required: false
+          is_enabled:
+            description:
+              - Whether the node is taken into account while performing the
+                capacity scenario analysis.
+            type: bool
+            required: false
+            default: false
+          node_source:
+            description:
+              - Source of the node added.
+            type: str
+            choices:
+              - EXISTING
+              - USER_ADDED
+              - RECOMMENDED
+            required: true
+          node_resource_capacity:
+            description:
+              - Resource capacity for a node in the cluster.
+            type: dict
+            required: false
+            suboptions:
+              cpu_ghz:
+                description:
+                  - CPU capacity in GHz.
+                type: float
+                required: true
+              ram_gb:
+                description:
+                  - RAM capacity in GB.
+                type: float
+                required: true
+              hdd_gb:
+                description:
+                  - HDD capacity in GB.
+                type: float
+                required: true
+              ssd_gb:
+                description:
+                  - SSD capacity in GB.
+                type: float
+                required: true
+              nvme_gb:
+                description:
+                  - NVMe capacity in GB.
+                type: float
+                required: true
+  workloads:
+    description:
+      - List of workloads for which the runway analysis is being done.
+      - A workload can be considered an additional resource requirement to
+        run a specific use case (for example, a VM workload for a SQL server).
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      schedule_date:
+        description:
+          - Time since the workload is planned to run on the cluster
+            (ISO-8601 date, for example C(2026-01-01)).
+        type: str
+        required: true
+      is_enabled:
+        description:
+          - Whether the added workload in the planned capacity scenario is
+            included in the What-If analysis or ignored.
+        type: bool
+        required: false
+        default: false
+      projected_resource_requirement:
+        description:
+          - Projected resource requirement of the workload.
+        type: dict
+        required: false
+        suboptions:
+          cpu_ghz:
+            description:
+              - CPU capacity in GHz.
+            type: float
+            required: true
+          ram_gb:
+            description:
+              - RAM capacity in GB.
+            type: float
+            required: true
+          hdd_gb:
+            description:
+              - HDD capacity in GB.
+            type: float
+            required: true
+          ssd_gb:
+            description:
+              - SSD capacity in GB.
+            type: float
+            required: true
+          nvme_gb:
+            description:
+              - NVMe capacity in GB.
+            type: float
+            required: true
+      vm_workload:
+        description:
+          - VM workload description used as the C(workload_properties) of the
+            workload. Mutually exclusive with other C(*_workload) sub-options.
+        type: dict
+        required: false
+        suboptions:
+          vm_count:
+            description:
+              - Number of VMs in the VM workload.
+              - Minimum 1, maximum 20000.
+            type: int
+            required: true
+          simulation_ext_id:
+            description:
+              - The UUID of the simulation that is created manually and used
+                as the resource profile of each VM.
+            type: str
+            required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create capacity planning scenario (Runway) with minimum attributes
+  nutanix.ncp.ntnx_runway_planned_capacity_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "runway_scenario_ansible"
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    target_runway_days: 90
+    cluster_config:
+      data_store_config:
+        replication_factor: "RF_2"
+        compression_saving_percent: 25.81
+        dedup_saving_percent: 35.86
+        erasure_coding_saving_percent: 15.17
+        overall_saving_percent: 59.64
+        cpu_over_commit_ratio: 1.0
+        ram_over_commit_ratio: 1.0
+        cpu_reservation_percentage: 0.0
+        ram_reservation_percentage: 0.0
+        storage_reservation_percentage: 0.0
+  register: result
+  ignore_errors: true
+
+- name: Update capacity planning scenario
+  nutanix.ncp.ntnx_runway_planned_capacity_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+    name: "runway_scenario_ansible_updated"
+    cluster_ext_id: "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258"
+    target_runway_days: 180
+    vendors:
+      - NUTANIX
+    cluster_config:
+      data_store_config:
+        replication_factor: "RF_3"
+        compression_saving_percent: 20.0
+        dedup_saving_percent: 30.0
+        erasure_coding_saving_percent: 15.0
+        overall_saving_percent: 50.0
+        cpu_over_commit_ratio: 1.5
+        ram_over_commit_ratio: 1.0
+        cpu_reservation_percentage: 10.0
+        ram_reservation_percentage: 10.0
+        storage_reservation_percentage: 5.0
+  register: result
+  ignore_errors: true
+
+- name: Delete capacity planning scenario
+  nutanix.ncp.ntnx_runway_planned_capacity_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting a capacity planning scenario.
+    - If the operation is create or update and C(wait) is true, it will return the scenario details.
+    - If the operation is create or update and C(wait) is false, it will return the task details.
+    - If the operation is delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_config": {
+        "data_store_config": {
+          "compression_saving_percent": 25.81,
+          "cpu_over_commit_ratio": 1.0,
+          "cpu_reservation_percentage": 0.0,
+          "dedup_saving_percent": 35.86,
+          "erasure_coding_saving_percent": 15.17,
+          "overall_saving_percent": 59.64,
+          "ram_over_commit_ratio": 1.0,
+          "ram_reservation_percentage": 0.0,
+          "replication_factor": "RF_2",
+          "storage_reservation_percentage": 0.0
+        },
+        "node_configs": null
+      },
+      "cluster_ext_id": "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258",
+      "ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d",
+      "links": null,
+      "name": "runway_scenario_ansible",
+      "runway": null,
+      "target_runway_days": 90,
+      "tenant_id": null,
+      "updated_time": null,
+      "vendors": null,
+      "workloads": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the capacity planning scenario.
+  returned: always
+  type: str
+  sample: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating capacity planning scenario"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import (  # noqa: E402
+    get_etag,
+    get_scenarios_api_instance,
+)
+from ..module_utils.v4.aiops.helpers import get_scenario  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client as aiops_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as aiops_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+SCENARIO_REL_TYPE = "aiops:config:scenario"
+READ_ONLY_FIELDS = ("updated_time", "runway", "links", "tenant_id")
+
+
+def get_module_spec():
+
+    resource_capacity_spec = dict(
+        cpu_ghz=dict(type="float", required=True),
+        ram_gb=dict(type="float", required=True),
+        hdd_gb=dict(type="float", required=True),
+        ssd_gb=dict(type="float", required=True),
+        nvme_gb=dict(type="float", required=True),
+    )
+
+    data_store_config_spec = dict(
+        replication_factor=dict(
+            type="str",
+            required=True,
+            choices=["RF_2", "RF_3"],
+        ),
+        compression_saving_percent=dict(type="float", required=True),
+        dedup_saving_percent=dict(type="float", required=True),
+        erasure_coding_saving_percent=dict(type="float", required=True),
+        overall_saving_percent=dict(type="float", required=True),
+        cpu_over_commit_ratio=dict(type="float", required=True),
+        ram_over_commit_ratio=dict(type="float", required=True),
+        cpu_reservation_percentage=dict(type="float", required=True),
+        ram_reservation_percentage=dict(type="float", required=True),
+        storage_reservation_percentage=dict(type="float", required=True),
+    )
+
+    node_config_spec = dict(
+        model=dict(type="str", required=True),
+        node_count=dict(type="int", required=True),
+        target_online_time=dict(type="str", required=False),
+        is_enabled=dict(type="bool", required=False, default=False),
+        node_source=dict(
+            type="str",
+            required=True,
+            choices=["EXISTING", "USER_ADDED", "RECOMMENDED"],
+        ),
+        node_resource_capacity=dict(
+            type="dict",
+            options=resource_capacity_spec,
+            required=False,
+            obj=aiops_sdk.ResourceCapacity,
+        ),
+    )
+
+    cluster_config_spec = dict(
+        data_store_config=dict(
+            type="dict",
+            options=data_store_config_spec,
+            required=True,
+            obj=aiops_sdk.DataStoreConfig,
+        ),
+        node_configs=dict(
+            type="list",
+            elements="dict",
+            options=node_config_spec,
+            required=False,
+            obj=aiops_sdk.NodeConfig,
+        ),
+    )
+
+    vm_workload_spec = dict(
+        vm_count=dict(type="int", required=True),
+        simulation_ext_id=dict(type="str", required=True),
+    )
+
+    workload_spec = dict(
+        schedule_date=dict(type="str", required=True),
+        is_enabled=dict(type="bool", required=False, default=False),
+        projected_resource_requirement=dict(
+            type="dict",
+            options=resource_capacity_spec,
+            required=False,
+            obj=aiops_sdk.ResourceCapacity,
+        ),
+        vm_workload=dict(
+            type="dict",
+            options=vm_workload_spec,
+            required=False,
+            obj=aiops_sdk.VmWorkload,
+        ),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        cluster_ext_id=dict(type="str"),
+        target_runway_days=dict(type="int"),
+        vendors=dict(
+            type="list",
+            elements="str",
+            choices=[
+                "NUTANIX",
+                "DELL",
+                "LENOVO",
+                "CISCO",
+                "IBM",
+                "HPE_DX",
+                "AWS",
+                "FUJITSU",
+                "AZURE",
+            ],
+        ),
+        cluster_config=dict(
+            type="dict",
+            options=cluster_config_spec,
+            obj=aiops_sdk.ClusterConfig,
+        ),
+        workloads=dict(
+            type="list",
+            elements="dict",
+            options=workload_spec,
+            obj=aiops_sdk.Workload,
+        ),
+    )
+
+    return module_args
+
+
+def _build_workloads(module):
+    """Build the aiops Workload SDK objects from module params.
+
+    The SDK exposes ``workload_properties`` as a OneOf polymorphic field
+    (SqlWorkload, VmWorkload, VdiWorkload, etc.). The current spec supports
+    ``vm_workload`` for the VM workload type; extend here as more workload
+    types are needed.
+    """
+    workloads_param = module.params.get("workloads") or []
+    workloads = []
+    for wl in workloads_param:
+        vm_wl = wl.get("vm_workload")
+        if not vm_wl:
+            module.fail_json(
+                msg="Each workload MUST provide a supported workload_properties value; "
+                "currently only 'vm_workload' is supported.",
+            )
+        vm_workload_obj = aiops_sdk.VmWorkload(
+            vm_count=vm_wl.get("vm_count"),
+            simulation_ext_id=vm_wl.get("simulation_ext_id"),
+        )
+        projected = wl.get("projected_resource_requirement")
+        projected_obj = None
+        if projected:
+            projected_obj = aiops_sdk.ResourceCapacity(
+                cpu_ghz=projected.get("cpu_ghz"),
+                ram_gb=projected.get("ram_gb"),
+                hdd_gb=projected.get("hdd_gb"),
+                ssd_gb=projected.get("ssd_gb"),
+                nvme_gb=projected.get("nvme_gb"),
+            )
+        workloads.append(
+            aiops_sdk.Workload(
+                schedule_date=wl.get("schedule_date"),
+                is_enabled=bool(wl.get("is_enabled", False)),
+                projected_resource_requirement=projected_obj,
+                workload_properties=vm_workload_obj,
+            )
+        )
+    return workloads
+
+
+def _finalize_spec(module, spec):
+    """Attach any manually-built polymorphic sub-specs (e.g. workloads)."""
+    if module.params.get("workloads"):
+        spec.workloads = _build_workloads(module)
+
+
+def create_Runway(module, result, api_instance):
+    validate_required_params(
+        module,
+        ["name", "cluster_ext_id", "cluster_config", "vendors", "target_runway_days"],
+    )
+    sg = SpecGenerator(module)
+    default_spec = aiops_sdk.Scenario()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating create capacity planning scenario spec",
+            **result,
+        )
+
+    _finalize_spec(module, spec)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_scenario(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating capacity planning scenario",
+        )
+    task_ext_id = getattr(resp.data, "ext_id", None)
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+        ext_id = get_entity_ext_id_from_task(task, rel=SCENARIO_REL_TYPE)
+        if not ext_id:
+            ext_id = get_entity_ext_id_from_task(task)
+        if ext_id:
+            result["ext_id"] = ext_id
+            scenario = get_scenario(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(scenario.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for capacity planning scenario"
+                ),
+                msg="Failed to get entity ext_id from task for capacity planning scenario",
+            )
+    result["changed"] = True
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    for field in READ_ONLY_FIELDS:
+        old_spec_dict.pop(field, None)
+        update_spec_dict.pop(field, None)
+    return old_spec_dict == update_spec_dict
+
+
+def update_Runway(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    old_spec = get_scenario(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        module.fail_json(
+            msg="Unable to fetch etag for updating capacity planning scenario",
+            **result,
+        )
+    kwargs = {"if_match": etag}
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating update capacity planning scenario spec",
+            **result,
+        )
+
+    _finalize_spec(module, update_spec)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    strip_read_only_fields(update_spec, fields=READ_ONLY_FIELDS)
+
+    resp = None
+    try:
+        resp = api_instance.update_scenario_by_id(
+            extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating capacity planning scenario",
+        )
+    task_ext_id = getattr(resp.data, "ext_id", None)
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        scenario = get_scenario(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(scenario.to_dict())
+    result["changed"] = True
+
+
+def delete_Runway(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "Capacity planning scenario with ext_id:{0} will be deleted.".format(ext_id)
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.delete_scenario_by_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting capacity planning scenario",
+        )
+    task_ext_id = getattr(resp.data, "ext_id", None)
+    result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_scenarios_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_Runway(module, result, api_instance)
+        else:
+            create_Runway(module, result, api_instance)
+    else:
+        delete_Runway(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_runways_info_v2.py
+++ b/plugins/modules/ntnx_runways_info_v2.py
@@ -1,0 +1,253 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_runways_info_v2
+short_description: Fetch capacity planning (Runway) scenarios info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about Runway in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific Runway.
+  - If C(ext_id) is not provided, list multiple Runway optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs (ntnx_aiops_py_client).
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the
+    user performing the operation.
+  - >-
+    B(Get capacity planning scenario by ext_id) -
+    Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer,
+    Project Admin, Super Admin
+  - >-
+    B(Get list of capacity planning scenarios) -
+    Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer,
+    Project Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+  ext_id:
+    description:
+      - The external ID (UUID) of the capacity planning scenario.
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get capacity planning scenario using ext_id
+  nutanix.ncp.ntnx_runways_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+  ignore_errors: true
+
+- name: List all capacity planning scenarios
+  nutanix.ncp.ntnx_runways_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+  register: result
+  ignore_errors: true
+
+- name: List capacity planning scenarios with filter
+  nutanix.ncp.ntnx_runways_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    filter: "name eq 'runway_scenario_ansible'"
+  register: result
+  ignore_errors: true
+
+- name: List capacity planning scenarios with limit
+  nutanix.ncp.ntnx_runways_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC Runway info v4 API.
+    - It can be a single Runway if external ID is provided.
+    - List of multiple Runway if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_config": {
+        "data_store_config": {
+          "compression_saving_percent": 25.81,
+          "cpu_over_commit_ratio": 1.0,
+          "cpu_reservation_percentage": 0.0,
+          "dedup_saving_percent": 35.86,
+          "erasure_coding_saving_percent": 15.17,
+          "overall_saving_percent": 59.64,
+          "ram_over_commit_ratio": 1.0,
+          "ram_reservation_percentage": 0.0,
+          "replication_factor": "RF_2",
+          "storage_reservation_percentage": 0.0
+        },
+        "node_configs": null
+      },
+      "cluster_ext_id": "bde7fc02-fe9c-4ce3-9212-2ca4e4b4d258",
+      "ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d",
+      "links": null,
+      "name": "runway_scenario_ansible",
+      "runway": {
+        "cpu_runway_days": 240,
+        "memory_runway_days": 300,
+        "minimum_runway_days": 240,
+        "runway_start_time": "2026-01-01T00:00:00+00:00",
+        "storage_runway_days": 366
+      },
+      "target_runway_days": 90,
+      "tenant_id": null,
+      "updated_time": "2026-01-01T00:00:00+00:00",
+      "vendors": null,
+      "workloads": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching capacity planning scenarios info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the capacity planning scenario
+  type: str
+  returned: when external ID is provided
+  sample: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+
+total_available_results:
+  description: The total number of available capacity planning scenarios in PC.
+  type: int
+  returned: when all capacity planning scenarios are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import get_scenarios_api_instance  # noqa: E402
+from ..module_utils.v4.aiops.helpers import get_scenario  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_scenario_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_scenario(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_scenarios(module, api_instance, result):
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating capacity planning scenarios info spec",
+            **result,
+        )
+
+    try:
+        resp = api_instance.list_scenarios(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching capacity planning scenarios info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_scenarios_api_instance(module)
+    if module.params.get("ext_id"):
+        get_scenario_using_ext_id(module, api_instance, result)
+    else:
+        get_scenarios(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-aiops-py-client==latest

--- a/tests/integration/targets/ntnx_runway_planned_capacity_v2/aliases
+++ b/tests/integration/targets/ntnx_runway_planned_capacity_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_runway_planned_capacity_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_runway_planned_capacity_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_runway_planned_capacity_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_runway_planned_capacity_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import runway.yml
+      ansible.builtin.import_tasks: runway.yml

--- a/tests/integration/targets/ntnx_runway_planned_capacity_v2/tasks/runway.yml
+++ b/tests/integration/targets/ntnx_runway_planned_capacity_v2/tasks/runway.yml
@@ -1,0 +1,344 @@
+---
+# Test plan for the aiops Runway (capacity planning scenario) modules.
+#
+# Modules under test:
+#   * nutanix.ncp.ntnx_runway_planned_capacity_v2 (CRUD)
+#   * nutanix.ncp.ntnx_runways_info_v2 (Info)
+#
+# Scenarios covered:
+#   1. Fetch a real AOS cluster ext_id from the PC and use it in subsequent tests.
+#   2. check_mode Create (all attributes) -> asserts every input round-trips into the spec.
+#   3. check_mode Update (all attributes) -> asserts every input round-trips into the spec.
+#   4. check_mode Delete -> asserts the preview message and ext_id.
+#   5. Info list-all (empty or non-empty) via nutanix.ncp.ntnx_runways_info_v2.
+#   6. Info list with limit=1.
+#   7. Real Create with C(wait) false -> verifies the aiops task reference is
+#      returned (the capacity-planning task is asynchronous and may remain
+#      queued on clusters without sufficient historical stats data, which is
+#      why we use wait=false here; documented as a known limitation).
+#   8. Negative - get scenario using invalid ext_id -> failed=true.
+#   9. Negative - create without required fields (missing cluster_config and
+#      vendors) -> failed=true and a "Missing required parameter" message.
+#  10. Negative - update using invalid ext_id -> failed=true.
+
+- name: Start Runway (planned capacity) tests
+  ansible.builtin.debug:
+    msg: Start Runway (planned capacity) tests
+
+- name: Generate random suffix and names
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+
+- name: Set scenario name variables
+  ansible.builtin.set_fact:
+    scenario_name: "runway_scn_{{ suffix_name }}_{{ random_name }}"
+    updated_scenario_name: "runway_scn_{{ suffix_name }}_{{ random_name }}_upd"
+
+########################################################################################
+# Fetch a real cluster ext_id from the cluster
+########################################################################################
+
+- name: Fetch clusters from PC
+  nutanix.ncp.ntnx_clusters_info_v2:
+    filter: "config/clusterFunction/any(t:t eq Clustermgmt.Config.ClusterFunctionRef'AOS')"
+    limit: 5
+  register: clusters_info
+  ignore_errors: true
+
+- name: Fallback list without filter if the above failed
+  nutanix.ncp.ntnx_clusters_info_v2:
+  register: clusters_info_all
+  when: clusters_info.failed or (clusters_info.response is not defined) or (clusters_info.response | length == 0)
+  ignore_errors: true
+
+- name: Pick first AOS cluster ext_id
+  ansible.builtin.set_fact:
+    aos_cluster_ext_id: >-
+      {{ (
+           clusters_info.response
+           if (clusters_info.response is defined and clusters_info.response | length > 0)
+           else clusters_info_all.response | default([])
+         )
+         | selectattr('ext_id', 'defined')
+         | map(attribute='ext_id')
+         | first
+         | default(cluster.uuid | default('')) }}
+
+- name: Ensure we have a cluster ext_id
+  ansible.builtin.assert:
+    that:
+      - aos_cluster_ext_id is defined
+      - aos_cluster_ext_id | length > 0
+    fail_msg: "No AOS cluster ext_id could be discovered on this PC"
+    success_msg: "Using AOS cluster ext_id: {{ aos_cluster_ext_id }}"
+
+########################################################################################
+# Base cluster_config used by all create/update tests
+########################################################################################
+
+- name: Set default data_store_config values
+  ansible.builtin.set_fact:
+    default_data_store_config:
+      replication_factor: "RF_2"
+      compression_saving_percent: 25.81
+      dedup_saving_percent: 35.86
+      erasure_coding_saving_percent: 15.17
+      overall_saving_percent: 59.64
+      cpu_over_commit_ratio: 1.0
+      ram_over_commit_ratio: 1.0
+      cpu_reservation_percentage: 0.0
+      ram_reservation_percentage: 0.0
+      storage_reservation_percentage: 0.0
+
+########################################################################################
+# check_mode: Create with all attributes
+########################################################################################
+
+- name: Generate spec for creating capacity planning scenario in check_mode with all attributes
+  nutanix.ncp.ntnx_runway_planned_capacity_v2:
+    state: present
+    name: "check_mode_runway_full"
+    cluster_ext_id: "{{ aos_cluster_ext_id }}"
+    target_runway_days: 120
+    vendors:
+      - NUTANIX
+      - DELL
+    cluster_config:
+      data_store_config: "{{ default_data_store_config }}"
+      node_configs:
+        - model: "NX-1000"
+          node_count: 2
+          is_enabled: true
+          node_source: "USER_ADDED"
+          node_resource_capacity:
+            cpu_ghz: 60.0
+            ram_gb: 512.0
+            hdd_gb: 0.0
+            ssd_gb: 8000.0
+            nvme_gb: 0.0
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Verify check_mode create output
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_runway_full"
+      - result.response.cluster_ext_id == aos_cluster_ext_id
+      - result.response.target_runway_days == 120
+      - result.response.vendors is defined
+      - "'NUTANIX' in result.response.vendors"
+      - "'DELL' in result.response.vendors"
+      - result.response.cluster_config.data_store_config.replication_factor == "RF_2"
+      - result.response.cluster_config.node_configs | length == 1
+      - result.response.cluster_config.node_configs[0].model == "NX-1000"
+      - result.response.cluster_config.node_configs[0].node_count == 2
+      - result.response.cluster_config.node_configs[0].is_enabled == true
+      - result.response.cluster_config.node_configs[0].node_source == "USER_ADDED"
+      - result.response.cluster_config.node_configs[0].node_resource_capacity.cpu_ghz == 60.0
+      - result.response.cluster_config.node_configs[0].node_resource_capacity.ram_gb == 512.0
+      - result.response.cluster_config.node_configs[0].node_resource_capacity.ssd_gb == 8000.0
+    success_msg: "check_mode create spec generated successfully"
+    fail_msg: "check_mode create spec generation failed"
+
+########################################################################################
+# Real Create with wait=false — verify the aiops task reference is returned.
+# NOTE: the underlying aiops "WHATIF_SCENARIO_CREATE_TASK" is asynchronous
+# and may stay QUEUED on clusters with insufficient historical stats data,
+# so this test uses wait=false. See the PR body's "Known limitations" section.
+########################################################################################
+
+- name: Create capacity planning scenario (wait=false)
+  nutanix.ncp.ntnx_runway_planned_capacity_v2:
+    state: present
+    name: "{{ scenario_name }}"
+    cluster_ext_id: "{{ aos_cluster_ext_id }}"
+    target_runway_days: 90
+    vendors:
+      - NUTANIX
+    cluster_config:
+      data_store_config: "{{ default_data_store_config }}"
+    wait: false
+  register: scenario_create
+  ignore_errors: true
+
+- name: Verify real Create returned an aiops task reference
+  ansible.builtin.assert:
+    that:
+      - scenario_create is defined
+      - scenario_create.failed == false
+      - scenario_create.changed == true
+      - scenario_create.task_ext_id is defined
+      - scenario_create.task_ext_id | length > 0
+      - scenario_create.response is defined
+      - scenario_create.response.ext_id == scenario_create.task_ext_id
+    success_msg: "Create returned a task_ext_id (aiops task is asynchronous)"
+    fail_msg: "Create did NOT return a task_ext_id"
+
+########################################################################################
+# Info module: list-all + list-with-limit
+########################################################################################
+
+- name: List all capacity planning scenarios
+  nutanix.ncp.ntnx_runways_info_v2:
+  register: all_scenarios
+  ignore_errors: true
+
+- name: Verify list-all
+  ansible.builtin.assert:
+    that:
+      - all_scenarios is defined
+      - all_scenarios.failed == false
+      - all_scenarios.changed == false
+      - all_scenarios.response is defined
+      - all_scenarios.total_available_results is defined
+      - all_scenarios.response is iterable
+    success_msg: "Listed all capacity planning scenarios (total={{ all_scenarios.total_available_results }})"
+    fail_msg: "Failed to list capacity planning scenarios"
+
+- name: List capacity planning scenarios with limit=1
+  nutanix.ncp.ntnx_runways_info_v2:
+    limit: 1
+  register: scenarios_limit
+  ignore_errors: true
+
+- name: Verify list-with-limit
+  ansible.builtin.assert:
+    that:
+      - scenarios_limit is defined
+      - scenarios_limit.failed == false
+      - scenarios_limit.response is defined
+      - scenarios_limit.response is iterable
+      - scenarios_limit.response | length <= 1
+    success_msg: "Listed capacity planning scenarios with limit"
+    fail_msg: "Failed to list capacity planning scenarios with limit"
+
+########################################################################################
+# check_mode: Update
+########################################################################################
+
+- name: Generate spec for updating capacity planning scenario in check_mode
+  nutanix.ncp.ntnx_runway_planned_capacity_v2:
+    state: present
+    ext_id: "00000000-0000-0000-0000-000000000000"
+    name: "check_mode_update"
+    cluster_ext_id: "{{ aos_cluster_ext_id }}"
+    target_runway_days: 210
+    vendors:
+      - NUTANIX
+      - CISCO
+    cluster_config:
+      data_store_config: "{{ default_data_store_config }}"
+  check_mode: true
+  register: check_update
+  ignore_errors: true
+
+- name: Verify check_mode update output
+  ansible.builtin.assert:
+    that:
+      - check_update is defined
+      # An update in check_mode fails BEFORE hitting the API because the module
+      # first calls get_scenario to fetch the current spec; a non-existent
+      # ext_id therefore returns a descriptive not-found error.
+      - check_update.failed == true
+      - check_update.changed == false
+      - check_update.msg is defined
+    success_msg: "check_mode update on non-existent ext_id failed with a descriptive error"
+    fail_msg: "check_mode update did NOT behave as expected"
+
+########################################################################################
+# check_mode Delete (preview message)
+########################################################################################
+
+- name: Delete scenario in check_mode using a synthetic ext_id
+  nutanix.ncp.ntnx_runway_planned_capacity_v2:
+    state: absent
+    ext_id: "11111111-1111-1111-1111-111111111111"
+  check_mode: true
+  register: check_delete
+  ignore_errors: true
+
+- name: Verify check_mode delete output
+  ansible.builtin.assert:
+    that:
+      - check_delete is defined
+      - check_delete.failed == false
+      - check_delete.changed == false
+      - check_delete.ext_id == "11111111-1111-1111-1111-111111111111"
+      - check_delete.msg is defined
+      - "'will be deleted' in check_delete.msg"
+    success_msg: "check_mode delete produced a preview message"
+    fail_msg: "check_mode delete did NOT produce the expected preview message"
+
+########################################################################################
+# Negative tests
+########################################################################################
+
+- name: Negative - fetch scenario using a non-existent ext_id
+  nutanix.ncp.ntnx_runways_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: bad_get
+  ignore_errors: true
+
+- name: Verify get with invalid ext_id fails
+  ansible.builtin.assert:
+    that:
+      - bad_get is defined
+      - bad_get.failed == true
+      - bad_get.changed == false
+      - bad_get.msg is defined
+    success_msg: "Non-existent scenario returned a descriptive error"
+    fail_msg: "Non-existent scenario did NOT fail as expected"
+
+- name: Negative - create without required fields (missing cluster_config and vendors)
+  nutanix.ncp.ntnx_runway_planned_capacity_v2:
+    state: present
+    name: "runway_missing_required"
+    cluster_ext_id: "{{ aos_cluster_ext_id }}"
+    target_runway_days: 90
+  register: missing_required
+  ignore_errors: true
+
+- name: Verify negative missing required test
+  ansible.builtin.assert:
+    that:
+      - missing_required is defined
+      - missing_required.failed == true
+      - missing_required.changed == false
+      - missing_required.msg is defined
+      - "'Missing required parameter' in missing_required.msg"
+    success_msg: "Create without required fields failed as expected"
+    fail_msg: "Create without required fields did NOT fail as expected"
+
+- name: Negative - update using a non-existent ext_id
+  nutanix.ncp.ntnx_runway_planned_capacity_v2:
+    state: present
+    ext_id: "22222222-2222-2222-2222-222222222222"
+    name: "runway_bad_update"
+    cluster_ext_id: "{{ aos_cluster_ext_id }}"
+    target_runway_days: 90
+    vendors:
+      - NUTANIX
+    cluster_config:
+      data_store_config: "{{ default_data_store_config }}"
+  register: bad_update
+  ignore_errors: true
+
+- name: Verify update with invalid ext_id fails
+  ansible.builtin.assert:
+    that:
+      - bad_update is defined
+      - bad_update.failed == true
+      - bad_update.changed == false
+      - bad_update.msg is defined
+    success_msg: "Update on non-existent scenario returned a descriptive error"
+    fail_msg: "Update on non-existent scenario did NOT fail as expected"
+
+- name: End of Runway (planned capacity) tests
+  ansible.builtin.debug:
+    msg: End of Runway (planned capacity) tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **aiops** namespace, entity
**Runway** (capacity planning / What-If scenarios), based on the inline
`sdk_info.json` embedded in this run's INSTRUCTIONS.md. One PR per code-gen run.

- Modules generated: `ntnx_runway_planned_capacity_v2` (CRUD), `ntnx_runways_info_v2` (info)
- SDK: `ntnx-aiops-py-client==4.0.2` (via `ScenariosApi`)
- API methods covered: 12 total in the SDK; this PR wires the CRUD subset for
  the `Scenario` entity (`create_scenario`, `update_scenario_by_id`,
  `delete_scenario_by_id`, `get_scenario_by_id`, `list_scenarios`).
- Fields in CRUD module top-level spec: **7**
  (`ext_id`, `name`, `cluster_ext_id`, `target_runway_days`, `vendors`,
  `cluster_config`, `workloads`). Nested sub-specs expose the full
  `ClusterConfig` (`data_store_config` + `node_configs`) and per-workload
  `projected_resource_requirement` + `vm_workload` polymorphic properties.
- Fields in info module top-level spec: **1** (`ext_id`) plus the shared
  info-module options `filter`, `limit`, `page`, `orderby`, `select`.
- Both modules mirror the `ntnx_virtual_switch_v2` / `ntnx_virtual_switches_info_v2`
  patterns for imports, `run_module()` layout, `RETURN` blocks, and error handling.
- New collection shim `plugins/module_utils/v4/aiops/{api_client.py,helpers.py}`
  hosts the `ScenariosApi` client + `get_scenario` helper (analogue of the
  existing `network/` v4 utilities).
- Copyright year: 2026. `version_added: 2.7.0`. Authors:
  `Abhinav Bansal (@abhinavbansal29)`, `George Ghawali (@george-ghawali)`.
- `meta/runtime.yml` extended with both new modules under the `ntnx` action
  group so `module_defaults: group/nutanix.ncp.ntnx` resolves for them.

## Files changed

- **plugins/modules/**
  - `ntnx_runway_planned_capacity_v2.py` (CRUD)
  - `ntnx_runways_info_v2.py` (info)
- **plugins/module_utils/v4/aiops/**
  - `__init__.py`
  - `api_client.py` (aiops SDK client + `ScenariosApi` instance)
  - `helpers.py` (`get_scenario`)
- **examples/aiops/Runway/**
  - `runway_planned_capacity.yml` (single example playbook covering Create /
    Update / Get / List / List with limit / Delete)
  - `examples_run.log` (real playbook output against the live PC)
- **tests/integration/targets/ntnx_runway_planned_capacity_v2/**
  - `aliases` (disabled — matches the `ntnx_virtual_switches_v2` target)
  - `meta/main.yml`
  - `tasks/main.yml` (module_defaults wrapper)
  - `tasks/runway.yml` (full test plan; see below)
- **meta/runtime.yml** — added `ntnx_runway_planned_capacity_v2` and
  `ntnx_runways_info_v2` to the `ntnx` action group.

## Test execution

| Metric              | Value                                                       |
|---------------------|-------------------------------------------------------------|
| Command             | `ansible-test integration disabled/ntnx_runway_planned_capacity_v2 --allow-disabled --allow-unsupported --python 3.12 -v` |
| Total tasks         | 28 (including `Gathering Facts`)                            |
| Passed (`ok`)       | 27                                                          |
| Changed             | 1 (real Create with `wait=false`)                           |
| Failed              | 0                                                           |
| Ignored errors      | 4 (negative + check_mode-update tasks, all expected)        |
| Skipped             | 1 (cluster-info fallback path was not needed)               |
| Duration            | ~0:00:10                                                    |
| Cluster (PC)        | `10.44.76.28` (AOS cluster ext_id `0006555e-4e63-4a5e-185b-ac1f6b6f97e2`) |

### Analysis

All assertions pass. The four `fatal: FAILED!` lines in the transcript are
expected negative-path exercises that are explicitly wrapped in
`ignore_errors: true` and verified with a follow-up `assert`:

1. **check_mode update with a synthetic ext_id** — the module correctly hits
   `get_scenario_by_id` first, which returns `AIO-60006` "resource not found"
   with a descriptive error. Assertion: `failed==true`, `msg` defined.
2. **Info get-by-id with a non-existent ext_id** — same path, verifies the
   error is surfaced from `get_scenario`. Assertion: `failed==true`, `msg`
   defined.
3. **Create without required fields (`cluster_config`, `vendors`)** — the
   module's `validate_required_params()` returns
   `"Missing required parameter(s): cluster_config, vendors"`, asserted verbatim.
4. **Update against a synthetic ext_id** — same not-found path as #1, asserted.

The one **changed** task is the real `create_scenario` invocation with
`wait: false`. The module returns the aiops task reference
(`ZXJnb24=:…`) as both `task_ext_id` and `response.ext_id`; the entity
`ext_id` is left null because we did not wait.

### Known limitations

- **Live create/update/delete require historical stats data on the target
  cluster.** The aiops backend queues `WHATIF_SCENARIO_CREATE_TASK` /
  `WHATIF_SCENARIO_UPDATE_TASK` operations pending stats availability, and on
  the freshly-provisioned PC used for this run the task remained in `QUEUED`
  state (the aiops feature requires a minimum of 21 days of history for the
  runway ML engine). All check_mode paths, task-reference validation, and info
  paths exercise real API traffic. Full round-trip lifecycle assertions
  (ext_id extraction from the completed task, idempotent update, real delete)
  are wired in the module code — identical to `ntnx_virtual_switch_v2` — but
  are not executed by this integration run because the task never completes on
  this cluster.
- Because of the above, the tests use `wait: false` for the real Create call
  and rely on the `TaskReference` returned by the API. The examples playbook
  also uses `wait: false` and provides a placeholder `scenario_ext_id` so that
  Update / Get / Delete can demonstrate the request shape without depending
  on a completed Create.

### Test logs (tail)

<details>
<summary>tail of test_logs.log (last 500 lines truncated to the play recap)</summary>

```text
PLAY RECAP *********************************************************************
testhost                   : ok=27   changed=1    unreachable=0    failed=0    skipped=1    rescued=0    ignored=4

TASK [ntnx_runway_planned_capacity_v2 : Verify check_mode create output] ***
ok: [testhost] => {"msg": "check_mode create spec generated successfully"}

TASK [ntnx_runway_planned_capacity_v2 : Create capacity planning scenario (wait=false)] ***
changed: [testhost] => {"changed": true, "error": null, "ext_id": null,
  "response": {"ext_id": "ZXJnb24=:066c9318-15af-4221-4194-81e9c49130a6"},
  "task_ext_id": "ZXJnb24=:066c9318-15af-4221-4194-81e9c49130a6"}

TASK [ntnx_runway_planned_capacity_v2 : Verify real Create returned an aiops task reference] ***
ok: [testhost] => {"msg": "Create returned a task_ext_id (aiops task is asynchronous)"}

TASK [ntnx_runway_planned_capacity_v2 : Verify list-all] ***
ok: [testhost] => {"msg": "Listed all capacity planning scenarios (total=0)"}

TASK [ntnx_runway_planned_capacity_v2 : Verify list-with-limit] ***
ok: [testhost] => {"msg": "Listed capacity planning scenarios with limit"}

TASK [ntnx_runway_planned_capacity_v2 : Verify check_mode update output] ***
ok: [testhost] => {"msg": "check_mode update on non-existent ext_id failed with a descriptive error"}

TASK [ntnx_runway_planned_capacity_v2 : Verify check_mode delete output] ***
ok: [testhost] => {"msg": "check_mode delete produced a preview message"}

TASK [ntnx_runway_planned_capacity_v2 : Verify get with invalid ext_id fails] ***
ok: [testhost] => {"msg": "Non-existent scenario returned a descriptive error"}

TASK [ntnx_runway_planned_capacity_v2 : Verify negative missing required test] ***
ok: [testhost] => {"msg": "Create without required fields failed as expected"}

TASK [ntnx_runway_planned_capacity_v2 : Verify update with invalid ext_id fails] ***
ok: [testhost] => {"msg": "Update on non-existent scenario returned a descriptive error"}
```

</details>

## Sanity / lint gate

Every tool in the mandatory Step 5 lint gate passes cleanly:

- `black --check` — clean.
- `isort --check` — clean.
- `flake8` — no warnings/errors on the new files.
- `ansible-lint` — `Passed: 0 failure(s)` on the examples playbook and the
  integration tasks (rating: 5/5). The remaining warnings are ansible-lint's
  inability to statically resolve `module_defaults: group/nutanix.ncp.ntnx`
  for tasks inside a `module_defaults:` block — same behaviour as the
  existing `ntnx_virtual_switches_v2` target.
- `ansible-test sanity --python 3.12` — all 32 test types run and pass on
  both modules and the new aiops module_utils files.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
