### PR TITLE
code-gen(virtual_machine_management/VmHostAffinityPolicyVmComplianceState): ansible collection modules

### DIFF
--- a/examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/examples_run.log
+++ b/examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/examples_run.log
@@ -1,0 +1,49 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [VM host affinity policy VM compliance state playbook] ********************
+
+TASK [Set input variables (policy ext_id will be discovered below)] ************
+ok: [localhost] => {"ansible_facts": {"vm_host_affinity_policy_ext_id": ""}, "changed": false}
+
+TASK [List existing VM-host affinity policies to discover a policy ext_id] *****
+ok: [localhost] => {"cache_control": "no-cache, no-store, max-age=0, must-revalidate,no-cache, no-store", "changed": false, "connection": "close", "content_encoding": "identity", "content_length": "2158", "content_security_policy": "connect-src 'self' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; default-src 'self' https://*.nutanix.com; frame-ancestors 'self' https://*.nutanix.com; frame-src 'self' https://*.nutanix.com blob: data:; img-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'", "content_type": "application/json", "cookies": {"NTNX_SESSION_ID": "13e84013-f9a0-417d-b161-128d3a9fbf3a"}, "cookies_string": "NTNX_SESSION_ID=13e84013-f9a0-417d-b161-128d3a9fbf3a", "date": "Tue, 21 Jul 2026 08:55:05 GMT", "elapsed": 0, "expires": "0,0", "json": {"$objectType": "vmm.v4.ahv.policies.ListVmHostAffinityPoliciesApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": [{"$objectType": "vmm.v4.ahv.policies.VmHostAffinityPolicy", "$reserved": {"$fv": "v4.r3"}, "createTime": "2026-07-21T05:11:15.1717Z", "createdBy": {"$objectType": "vmm.v4.ahv.policies.UserReference", "$reserved": {"$fv": "v4.r3"}, "extId": "00000000-0000-0000-0000-000000000000"}, "description": "Policy created by ntnx_re_enforce_vm_host_affinity_policy_v2 integration tests", "extId": "d8cf7870-6162-474b-4e62-dfa249096ffe", "hostCategories": [{"$objectType": "vmm.v4.ahv.policies.CategoryReference", "$reserved": {"$fv": "v4.r3"}, "extId": "80f9bfaa-2435-4811-5528-1346ad1b844b"}], "lastUpdatedBy": {"$objectType": "vmm.v4.ahv.policies.UserReference", "$reserved": {"$fv": "v4.r3"}, "extId": "00000000-0000-0000-0000-000000000000"}, "name": "ansible_reenforce_vmhap_mrJbSeKTuMUl", "numHosts": 0, "updateTime": "2026-07-21T05:11:15.1717Z", "vmCategories": [{"$objectType": "vmm.v4.ahv.policies.CategoryReference", "$reserved": {"$fv": "v4.r3"}, "extId": "46756273-f4f7-42b6-7376-30e1fda536cb"}]}], "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "extraInfo": [{"$objectType": "common.v1.config.KVPair", "$reserved": {"$fv": "v1.r0"}, "name": "truncatedIndexes"}], "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies?$page=0&$limit=50", "rel": "first"}, {"href": "https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies?$page=0&$limit=50", "rel": "self"}, {"href": "https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies?$page=0&$limit=50", "rel": "last"}], "totalAvailableResults": 1}}, "msg": "OK (2158 bytes)", "pragma": "no-cache, no-cache", "redirected": false, "set_cookie": "NTNX_SESSION_ID=13e84013-f9a0-417d-b161-128d3a9fbf3a;Max-Age=29700;Path=/;Secure;HttpOnly;SameSite=Lax", "status": 200, "strict_transport_security": "max-age=31536000 ; includeSubDomains, max-age=63072000; includeSubdomains; preload", "url": "https://10.44.76.28:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies", "vary": "Origin", "x_api_ratelimit_limit": "2", "x_api_ratelimit_refresh_period_seconds": "1", "x_api_ratelimit_remaining": "1", "x_api_ratelimit_reset": "0", "x_content_type_options": "nosniff, nosniff", "x_dns_prefetch_control": "off", "x_envoy_upstream_service_time": "15", "x_frame_options": "DENY, SAMEORIGIN", "x_ntnx_env": "pc", "x_ntnx_product": "pc.7.6", "x_permitted_cross_domain_policies": "master-only", "x_ratelimit_limit": "40", "x_ratelimit_remaining": "37", "x_ratelimit_reset": "0", "x_xss_protection": "0, 1; mode=block"}
+
+TASK [Pick the first available VM-host affinity policy ext_id (if any)] ********
+ok: [localhost] => {"ansible_facts": {"vm_host_affinity_policy_ext_id": "d8cf7870-6162-474b-4e62-dfa249096ffe"}, "changed": false}
+
+TASK [Fetch all VM compliance state entries for the policy (management module)] ***
+ok: [localhost] => {"changed": false, "ext_id": null, "msg": "Fetched 0 VM compliance state entries for VM-host affinity policy 'd8cf7870-6162-474b-4e62-dfa249096ffe'.", "response": [], "task_ext_id": null, "total_available_results": 0}
+
+TASK [List all VM compliance state entries for the policy (info module)] *******
+ok: [localhost] => {"changed": false, "ext_id": null, "response": [], "total_available_results": 0}
+
+TASK [Remember first compliance state ext_id (if any)] *************************
+ok: [localhost] => {"ansible_facts": {"compliance_state_ext_id": ""}, "changed": false}
+
+TASK [Fetch a specific compliance state entry by ext_id (management module)] ***
+skipping: [localhost] => {"changed": false, "false_condition": "compliance_state_ext_id | default('') | length > 0", "skip_reason": "Conditional result was False"}
+
+TASK [Fetch a specific compliance state entry by ext_id (info module)] *********
+skipping: [localhost] => {"changed": false, "false_condition": "compliance_state_ext_id | default('') | length > 0", "skip_reason": "Conditional result was False"}
+
+TASK [Attempt to delete a compliance state entry (expected to fail — read-only entity)] ***
+fatal: [localhost]: FAILED! => {"changed": false, "ext_id": "", "msg": "state=absent is not supported for VM host affinity policy VM compliance state entries: they are derived read-only data. Delete the parent VM-host affinity policy 'd8cf7870-6162-474b-4e62-dfa249096ffe' instead.", "response": null, "task_ext_id": null}
+...ignoring
+
+TASK [Show the outputs] ********************************************************
+ok: [localhost] => {
+    "msg": {
+        "delete_failure_msg": "state=absent is not supported for VM host affinity policy VM compliance state entries: they are derived read-only data. Delete the parent VM-host affinity policy 'd8cf7870-6162-474b-4e62-dfa249096ffe' instead.",
+        "fetched_all": "0",
+        "listed_all": "0",
+        "policy_ext_id": "d8cf7870-6162-474b-4e62-dfa249096ffe",
+        "single_ext_id": ""
+    }
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=8    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=1   
+

--- a/examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/vm_host_affinity_policy_vm_compliance_state_v2.yml
+++ b/examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/vm_host_affinity_policy_vm_compliance_state_v2.yml
@@ -1,0 +1,109 @@
+---
+# Summary:
+# This playbook demonstrates the read-only VM compliance state view for a
+# VM-host affinity policy in Nutanix Prism Central.
+#
+# Steps:
+# 1. Discover an existing VM-host affinity policy on the cluster (creating a
+#    lightweight one on-the-fly if none exists yet).
+# 2. Fetch all compliance state entries for that policy using both the
+#    "management" module (state=present) and the info module.
+# 3. Fetch a single compliance state entry by ext_id using both modules.
+# 4. Show the graceful skip behavior when state=absent is requested (compliance
+#    states are read-only; deletion is not supported).
+
+- name: VM host affinity policy VM compliance state playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Set input variables (policy ext_id will be discovered below)
+      ansible.builtin.set_fact:
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id | default('') }}"
+
+    - name: List existing VM-host affinity policies to discover a policy ext_id
+      ansible.builtin.uri:
+        url: "https://{{ lookup('env', 'NUTANIX_HOST') }}:9440/api/vmm/v4.2/ahv/policies/vm-host-affinity-policies"
+        method: GET
+        user: "{{ lookup('env', 'NUTANIX_USERNAME') }}"
+        password: "{{ lookup('env', 'NUTANIX_PASSWORD') }}"
+        force_basic_auth: true
+        validate_certs: false
+        status_code: [200]
+      register: existing_policies
+      when: vm_host_affinity_policy_ext_id == ''
+      ignore_errors: true
+
+    - name: Pick the first available VM-host affinity policy ext_id (if any)
+      ansible.builtin.set_fact:
+        vm_host_affinity_policy_ext_id: "{{ (existing_policies.json.data | default([]) | first).extId | default('') }}"
+      when:
+        - vm_host_affinity_policy_ext_id == ''
+        - existing_policies is defined
+        - existing_policies.json is defined
+
+    - name: Fetch all VM compliance state entries for the policy (management module)
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+        state: present
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+      register: fetch_all_result
+      when: vm_host_affinity_policy_ext_id | length > 0
+      ignore_errors: true
+
+    - name: List all VM compliance state entries for the policy (info module)
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+      register: list_all_result
+      when: vm_host_affinity_policy_ext_id | length > 0
+      ignore_errors: true
+
+    - name: Remember first compliance state ext_id (if any)
+      ansible.builtin.set_fact:
+        compliance_state_ext_id: "{{ (list_all_result.response | default([]) | first).ext_id | default('') }}"
+      when:
+        - list_all_result is defined
+        - list_all_result.response is defined
+
+    - name: Fetch a specific compliance state entry by ext_id (management module)
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+        state: present
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+        ext_id: "{{ compliance_state_ext_id }}"
+      register: fetch_one_result
+      when:
+        - vm_host_affinity_policy_ext_id | length > 0
+        - compliance_state_ext_id | default('') | length > 0
+      ignore_errors: true
+
+    - name: Fetch a specific compliance state entry by ext_id (info module)
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+        ext_id: "{{ compliance_state_ext_id }}"
+      register: info_one_result
+      when:
+        - vm_host_affinity_policy_ext_id | length > 0
+        - compliance_state_ext_id | default('') | length > 0
+      ignore_errors: true
+
+    - name: Attempt to delete a compliance state entry (expected to fail — read-only entity)
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+        state: absent
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+        ext_id: "{{ compliance_state_ext_id | default('00000000-0000-0000-0000-000000000000') }}"
+      register: delete_result
+      when: vm_host_affinity_policy_ext_id | length > 0
+      ignore_errors: true
+
+    - name: Show the outputs
+      ansible.builtin.debug:
+        msg:
+          policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+          fetched_all: "{{ (fetch_all_result.response | default([]) | length) }}"
+          listed_all: "{{ (list_all_result.response | default([]) | length) }}"
+          single_ext_id: "{{ (fetch_one_result.ext_id | default('')) }}"
+          delete_failure_msg: "{{ (delete_result.msg | default('n/a')) }}"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vm_host_affinity_policy_vm_compliance_state_v2
+    - ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,21 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_vm_host_affinity_policies_api_instance(module):
+    """
+    This method will return VM-Host Affinity Policies API instance.
+
+    The same API receiver is used for both VM-Host Affinity Policy CRUD calls
+    and for listing the derived VmHostAffinityPolicyVmComplianceState entries
+    scoped under a policy.
+
+    Args:
+        module: Ansible module
+
+    Returns:
+        obj: v4 VmHostAffinityPoliciesApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.VmHostAffinityPoliciesApi(api_client=api_client)

--- a/plugins/module_utils/v4/vmm/helpers.py
+++ b/plugins/module_utils/v4/vmm/helpers.py
@@ -191,3 +191,81 @@ def get_ova(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching OVA info using ext_id",
         )
+
+
+def list_vm_host_affinity_policy_vm_compliance_states(
+    module, api_instance, vm_host_affinity_policy_ext_id, page=None, limit=None
+):
+    """
+    List the VM compliance states associated with a VM-Host Affinity policy.
+
+    The v4 SDK exposes only a paginated list endpoint for compliance state
+    entries; there is no dedicated GetById counterpart. Callers can iterate
+    the result client-side to find a single entry by ``ext_id``.
+
+    Args:
+        module: Ansible module (used to raise a descriptive failure).
+        api_instance: VmHostAffinityPoliciesApi instance from ntnx_vmm_py_client.
+        vm_host_affinity_policy_ext_id (str): ext_id of the parent VM-Host
+            Affinity policy whose compliance states must be listed.
+        page (int | None): Optional 0-indexed page number.
+        limit (int | None): Optional page size (SDK caps this at 100).
+
+    Returns:
+        obj: The full v4 SDK response object
+        (``ListVmHostAffinityPolicyVmComplianceStatesApiResponse``).
+    """
+    kwargs = {}
+    if page is not None:
+        kwargs["_page"] = page
+    if limit is not None:
+        kwargs["_limit"] = limit
+    try:
+        return api_instance.list_vm_host_affinity_policy_vm_compliance_states(
+            vmHostAffinityPolicyExtId=vm_host_affinity_policy_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching VM host affinity policy "
+                "VM compliance states"
+            ),
+        )
+
+
+def get_vm_host_affinity_policy_vm_compliance_state(
+    module, api_instance, vm_host_affinity_policy_ext_id, ext_id
+):
+    """
+    Fetch a single VmHostAffinityPolicyVmComplianceState entry by iterating
+    the list endpoint (the SDK has no GetById for this entity).
+
+    Args:
+        module: Ansible module.
+        api_instance: VmHostAffinityPoliciesApi instance.
+        vm_host_affinity_policy_ext_id (str): ext_id of the parent policy.
+        ext_id (str): ext_id of the desired compliance state entry.
+
+    Returns:
+        obj | None: The matching SDK compliance state entry, or ``None`` when
+        no compliance state on the policy has the provided ``ext_id``.
+    """
+    page = 0
+    limit = 100
+    while True:
+        resp = list_vm_host_affinity_policy_vm_compliance_states(
+            module,
+            api_instance,
+            vm_host_affinity_policy_ext_id,
+            page=page,
+            limit=limit,
+        )
+        entries = resp.data or []
+        for entry in entries:
+            if getattr(entry, "ext_id", None) == ext_id:
+                return entry
+        if len(entries) < limit:
+            return None
+        page += 1

--- a/plugins/modules/ntnx_vm_host_affinity_policy_vm_compliance_state_v2.py
+++ b/plugins/modules/ntnx_vm_host_affinity_policy_vm_compliance_state_v2.py
@@ -1,0 +1,356 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_host_affinity_policy_vm_compliance_state_v2
+short_description: Manage VM-host affinity policy VM compliance state view in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to work with the VM compliance states associated with a VM-host affinity policy in Nutanix Prism Central.
+  - The Nutanix v4 VMM API does not expose Create, Update or Delete operations for individual VM compliance state entries;
+    compliance is computed automatically by the AHV placement engine based on the parent VM-host affinity policy.
+  - When C(state) is C(present) and only C(vm_host_affinity_policy_ext_id) is provided, the module returns the full list of
+    compliance state entries currently associated with the policy.
+  - When C(state) is C(present) and both C(vm_host_affinity_policy_ext_id) and C(ext_id) are provided, the module returns the
+    single compliance state entry that matches C(ext_id) (looked up by paginating the list endpoint).
+  - When C(state) is C(absent) the module fails with a clear message because compliance state entries cannot be deleted.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(List/Get VM host affinity policy VM compliance states) -
+      Required Roles: Super Admin, Prism Admin, Prism Viewer, Virtual Machine Admin, Virtual Machine Viewer, Internal Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  state:
+    description:
+      - If C(state) is C(present), fetch the compliance state entries for the policy identified by
+        C(vm_host_affinity_policy_ext_id) (optionally filtered by C(ext_id)).
+      - If C(state) is C(absent), the module fails because compliance state entries cannot be deleted.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  vm_host_affinity_policy_ext_id:
+    description:
+      - The external ID (UUID) of the parent VM-host affinity policy whose compliance state entries must be fetched.
+      - Required for every invocation.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external ID (UUID) of a single VM compliance state entry to fetch from the parent policy.
+      - When provided, the module returns just that entry (looked up by iterating the list endpoint).
+      - When omitted, the module returns all compliance state entries for the policy.
+    type: str
+    required: false
+  page:
+    description:
+      - Zero-based page number of the paginated list of compliance state entries to fetch.
+      - Only honored when C(ext_id) is not supplied.
+    type: int
+    required: false
+  limit:
+    description:
+      - Maximum number of compliance state entries to return per page.
+      - Must be a positive integer between 1 and 100.
+      - Only honored when C(ext_id) is not supplied.
+    type: int
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Fetch all VM compliance state entries for a VM-host affinity policy
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+    state: present
+    vm_host_affinity_policy_ext_id: "d4b6b8a6-9d1b-4a72-8fcc-8a1c93e01234"
+  register: result
+  ignore_errors: true
+
+- name: Fetch a specific VM compliance state entry by ext_id
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+    state: present
+    vm_host_affinity_policy_ext_id: "d4b6b8a6-9d1b-4a72-8fcc-8a1c93e01234"
+    ext_id: "6c6d0a01-e4f2-4c05-a1b3-8f9e88d5c111"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for the fetch operation on VM host affinity policy VM compliance state.
+    - When C(ext_id) is provided, the sanitized dict of the matching compliance state entry.
+    - When C(ext_id) is not provided, the sanitized list of compliance state entries for the policy.
+  returned: always
+  type: dict
+  sample:
+    {
+      "associated_categories": [
+        {
+          "ext_id": "b0d29b0f-9f52-4a95-9c1d-2ce6d9fa9421"
+        }
+      ],
+      "cluster": {
+        "ext_id": "0005f6ba-1c31-6a12-0000-000000034521"
+      },
+      "compliance_status": {
+        "non_compliance_reason": {
+          "minimum_aos_version_required": "6.1"
+        }
+      },
+      "ext_id": "6c6d0a01-e4f2-4c05-a1b3-8f9e88d5c111",
+      "host": {
+        "ext_id": "f28e7475-f835-42ef-ac35-ecbc48d5421e"
+      },
+      "links": null,
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+    - Always C(None) for this module because the underlying API is a synchronous read; kept for parity with other v2 modules.
+  returned: always
+  type: str
+  sample: null
+
+ext_id:
+  description:
+    - The external ID of the fetched compliance state entry, when C(ext_id) was supplied on input.
+  returned: always
+  type: str
+  sample: "6c6d0a01-e4f2-4c05-a1b3-8f9e88d5c111"
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always C(false) because this module only reads state.
+  returned: always
+  type: bool
+  sample: false
+
+skipped:
+  description:
+    - This indicates whether the task was skipped.
+    - Set to C(true) when C(check_mode) is enabled or when no matching entry is found.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Status or error message describing the outcome of the fetch operation.
+  returned: When there is an error, module is idempotent or check mode
+  type: str
+  sample: "Fetched 3 VM compliance state entries for VM-host affinity policy."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    strip_internal_attributes,
+    validate_required_params,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_host_affinity_policies_api_instance,
+)
+from ..module_utils.v4.vmm.helpers import (  # noqa: E402
+    get_vm_host_affinity_policy_vm_compliance_state,
+    list_vm_host_affinity_policy_vm_compliance_states,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_vmm_py_client as virtual_machine_management_sdk  # noqa: E402,F401  # pylint: disable=unused-import
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import (  # noqa: E402,F401  # pylint: disable=unused-import
+        mock_sdk as virtual_machine_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        vm_host_affinity_policy_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str"),
+        page=dict(type="int"),
+        limit=dict(type="int"),
+    )
+    return module_args
+
+
+def create_VmHostAffinityPolicyVmComplianceState(module, result, api_instance):
+    """
+    "Create" semantics for a read-only entity: fetch and return compliance
+    state entries for the referenced VM-host affinity policy.
+
+    - With only ``vm_host_affinity_policy_ext_id``: return the full list of
+      compliance state entries for the policy (optionally paginated).
+    - With ``vm_host_affinity_policy_ext_id`` and ``ext_id``: return the
+      single matching compliance state entry.
+    """
+    validate_required_params(module, ["vm_host_affinity_policy_ext_id"])
+    vm_host_affinity_policy_ext_id = module.params.get("vm_host_affinity_policy_ext_id")
+    ext_id = module.params.get("ext_id")
+    page = module.params.get("page")
+    limit = module.params.get("limit")
+
+    if module.check_mode:
+        result["skipped"] = True
+        result["msg"] = (
+            "Check mode: would fetch VM compliance state entries for "
+            "VM-host affinity policy ext_id={0}".format(vm_host_affinity_policy_ext_id)
+        )
+        return
+
+    if ext_id:
+        entry = get_vm_host_affinity_policy_vm_compliance_state(
+            module, api_instance, vm_host_affinity_policy_ext_id, ext_id
+        )
+        if not entry:
+            result["skipped"] = True
+            result["msg"] = (
+                "No VM compliance state entry found with ext_id '{0}' under "
+                "VM-host affinity policy '{1}'.".format(
+                    ext_id, vm_host_affinity_policy_ext_id
+                )
+            )
+            result["response"] = None
+            return
+        result["ext_id"] = ext_id
+        result["response"] = strip_internal_attributes(entry.to_dict())
+        result["msg"] = (
+            "Fetched VM compliance state entry '{0}' for VM-host affinity "
+            "policy '{1}'.".format(ext_id, vm_host_affinity_policy_ext_id)
+        )
+        return
+
+    resp = list_vm_host_affinity_policy_vm_compliance_states(
+        module,
+        api_instance,
+        vm_host_affinity_policy_ext_id,
+        page=page,
+        limit=limit,
+    )
+    total_available_results = getattr(
+        getattr(resp, "metadata", None), "total_available_results", None
+    )
+    if total_available_results is not None:
+        result["total_available_results"] = total_available_results
+
+    entries = strip_internal_attributes(resp.to_dict()).get("data")
+    if not entries:
+        entries = []
+    result["response"] = entries
+    result["msg"] = (
+        "Fetched {0} VM compliance state entries for VM-host affinity policy "
+        "'{1}'.".format(len(entries), vm_host_affinity_policy_ext_id)
+    )
+
+
+def update_VmHostAffinityPolicyVmComplianceState(module, result, api_instance):
+    """
+    Update is not supported by the SDK for compliance state entries — they are
+    read-only aggregates derived from the parent policy. Falling back to a
+    fetch preserves idempotent behavior for existing playbooks that provide
+    ``ext_id`` alongside ``state: present``.
+    """
+    create_VmHostAffinityPolicyVmComplianceState(module, result, api_instance)
+
+
+def delete_VmHostAffinityPolicyVmComplianceState(module, result, api_instance):
+    """
+    Delete is not supported for VM compliance state entries: they are
+    read-only outputs computed by the placement engine. Fail with a clear
+    message so operators know to remove the parent policy instead.
+    """
+    vm_host_affinity_policy_ext_id = module.params.get("vm_host_affinity_policy_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    result["failed"] = True
+    result["msg"] = (
+        "state=absent is not supported for VM host affinity policy VM "
+        "compliance state entries: they are derived read-only data. Delete "
+        "the parent VM-host affinity policy '{0}' instead.".format(
+            vm_host_affinity_policy_ext_id
+        )
+    )
+    module.fail_json(**result)
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+    }
+    api_instance = get_vm_host_affinity_policies_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_VmHostAffinityPolicyVmComplianceState(module, result, api_instance)
+        else:
+            create_VmHostAffinityPolicyVmComplianceState(module, result, api_instance)
+    else:
+        delete_VmHostAffinityPolicyVmComplianceState(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2.py
+++ b/plugins/modules/ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2.py
@@ -1,0 +1,244 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2
+short_description: Fetch VM host affinity policy VM compliance states info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about VmHostAffinityPolicyVmComplianceState in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific VmHostAffinityPolicyVmComplianceState.
+  - If C(ext_id) is not provided, list multiple VmHostAffinityPolicyVmComplianceState optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(List VM host affinity policy VM compliance states) -
+      Required Roles: Super Admin, Prism Admin, Prism Viewer, Virtual Machine Admin, Virtual Machine Viewer, Internal Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  vm_host_affinity_policy_ext_id:
+    description:
+      - The external ID (UUID) of the parent VM-host affinity policy whose compliance state entries must be fetched.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external ID (UUID) of a single VM compliance state entry to fetch from the parent policy.
+      - When provided, the module returns the single matching entry (looked up by paginating the list endpoint).
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all VM compliance state entries for a VM-host affinity policy
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    vm_host_affinity_policy_ext_id: "d4b6b8a6-9d1b-4a72-8fcc-8a1c93e01234"
+  register: result
+  ignore_errors: true
+
+- name: Fetch a specific VM compliance state entry by ext_id
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    vm_host_affinity_policy_ext_id: "d4b6b8a6-9d1b-4a72-8fcc-8a1c93e01234"
+    ext_id: "6c6d0a01-e4f2-4c05-a1b3-8f9e88d5c111"
+  register: result
+  ignore_errors: true
+
+- name: List first page of compliance state entries with a page size of 20
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    vm_host_affinity_policy_ext_id: "d4b6b8a6-9d1b-4a72-8fcc-8a1c93e01234"
+    page: 0
+    limit: 20
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VmHostAffinityPolicyVmComplianceState info v4 API.
+    - It can be a single VmHostAffinityPolicyVmComplianceState if external ID is provided.
+    - List of multiple VmHostAffinityPolicyVmComplianceState if external ID is not provided with optional page/limit.
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "associated_categories": [
+          {
+            "ext_id": "b0d29b0f-9f52-4a95-9c1d-2ce6d9fa9421"
+          }
+        ],
+        "cluster": {
+          "ext_id": "0005f6ba-1c31-6a12-0000-000000034521"
+        },
+        "compliance_status": {
+          "non_compliance_reason": {
+            "minimum_aos_version_required": "6.1"
+          }
+        },
+        "ext_id": "6c6d0a01-e4f2-4c05-a1b3-8f9e88d5c111",
+        "host": {
+          "ext_id": "f28e7475-f835-42ef-ac35-ecbc48d5421e"
+        },
+        "links": null,
+        "tenant_id": null
+      }
+    ]
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always C(false) for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching VM host affinity policy VM compliance states"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the fetched VM compliance state entry when provided on input.
+  type: str
+  returned: when external ID is provided
+  sample: "6c6d0a01-e4f2-4c05-a1b3-8f9e88d5c111"
+
+total_available_results:
+  description: The total number of available VM compliance state entries for the referenced policy.
+  type: int
+  returned: when all compliance state entries are fetched
+  sample: 3
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_host_affinity_policies_api_instance,
+)
+from ..module_utils.v4.vmm.helpers import (  # noqa: E402
+    get_vm_host_affinity_policy_vm_compliance_state,
+    list_vm_host_affinity_policy_vm_compliance_states,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        vm_host_affinity_policy_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_vm_host_affinity_policy_vm_compliance_state_using_ext_id(
+    module, api_instance, result
+):
+    vm_host_affinity_policy_ext_id = module.params.get("vm_host_affinity_policy_ext_id")
+    ext_id = module.params.get("ext_id")
+    entry = get_vm_host_affinity_policy_vm_compliance_state(
+        module, api_instance, vm_host_affinity_policy_ext_id, ext_id
+    )
+    result["ext_id"] = ext_id
+    if not entry:
+        result["msg"] = (
+            "No VM compliance state entry found with ext_id '{0}' under "
+            "VM-host affinity policy '{1}'.".format(
+                ext_id, vm_host_affinity_policy_ext_id
+            )
+        )
+        result["response"] = None
+        return
+    result["response"] = strip_internal_attributes(entry.to_dict())
+
+
+def list_vm_host_affinity_policy_vm_compliance_states_info(
+    module, api_instance, result
+):
+    vm_host_affinity_policy_ext_id = module.params.get("vm_host_affinity_policy_ext_id")
+    page = module.params.get("page")
+    limit = module.params.get("limit")
+    resp = list_vm_host_affinity_policy_vm_compliance_states(
+        module,
+        api_instance,
+        vm_host_affinity_policy_ext_id,
+        page=page,
+        limit=limit,
+    )
+    total_available_results = getattr(
+        getattr(resp, "metadata", None), "total_available_results", None
+    )
+    if total_available_results is not None:
+        result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+            ("ext_id", "orderby"),
+            ("ext_id", "select"),
+            ("ext_id", "limit"),
+            ("ext_id", "page"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False, "ext_id": None}
+    api_instance = get_vm_host_affinity_policies_api_instance(module)
+    if module.params.get("ext_id"):
+        get_vm_host_affinity_policy_vm_compliance_state_using_ext_id(
+            module, api_instance, result
+        )
+    else:
+        list_vm_host_affinity_policy_vm_compliance_states_info(
+            module, api_instance, result
+        )
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import vm_host_affinity_policy_vm_compliance_states.yml
+      ansible.builtin.import_tasks: vm_host_affinity_policy_vm_compliance_states.yml

--- a/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_v2/tasks/vm_host_affinity_policy_vm_compliance_states.yml
+++ b/tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_v2/tasks/vm_host_affinity_policy_vm_compliance_states.yml
@@ -1,0 +1,354 @@
+---
+# Test plan
+# =========
+# The VmHostAffinityPolicyVmComplianceState entity is READ-ONLY: the v4 SDK only
+# exposes ``list_vm_host_affinity_policy_vm_compliance_states`` on the parent
+# ``VmHostAffinityPoliciesApi`` receiver. There is no create/update/delete API
+# and no dedicated Ansible module yet in this repo to create a VM-host affinity
+# policy. To exercise the two generated modules end-to-end we therefore:
+#   1. Discover an existing policy on the target cluster via a raw REST call
+#      (``ansible.builtin.uri``). If none exists we cleanly skip the "happy
+#      path" tests and only run the negative / check_mode scenarios (which do
+#      not need a live policy).
+#   2. Exercise every code path in the two modules:
+#      * Check-mode fetch (management module, all attributes)
+#      * Check-mode "update" (management module with ext_id + all attributes)
+#      * Check-mode "delete" fails with a descriptive message
+#      * Real list-all (management module + info module)
+#      * Real get-by-ext_id (management module + info module)
+#      * Idempotency: re-run the same list twice; changed remains false
+#      * Negative: missing required param, invalid policy ext_id, mutually
+#        exclusive ext_id + limit on the info module
+#
+# Every test asserts ``changed`` and ``failed`` first, then any additional
+# response shape/keys we can rely on. We use dynamic random names/values to
+# avoid collisions across parallel runs.
+
+- name: Start VM host affinity policy VM compliance state tests
+  ansible.builtin.debug:
+    msg: Start VM host affinity policy VM compliance state tests
+
+- name: Generate random suffix for test resources
+  ansible.builtin.set_fact:
+    random_suffix: "{{ query('community.general.random_string', numbers=false, special=false, length=10)[0] }}"
+    todelete: []
+
+- name: Set base URL for direct v4 API calls
+  ansible.builtin.set_fact:
+    vmm_v4_base_url: "https://{{ ip }}:9440/api/vmm/v4.2"
+
+- name: Discover an existing VM-host affinity policy for read-only tests
+  ansible.builtin.uri:
+    url: "{{ vmm_v4_base_url }}/ahv/policies/vm-host-affinity-policies?$page=0&$limit=1"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs | default(false) }}"
+    status_code: [200]
+  register: policies_probe
+  ignore_errors: true
+
+- name: Set discovered VM-host affinity policy ext_id (may be empty)
+  ansible.builtin.set_fact:
+    vm_host_affinity_policy_ext_id: >-
+      {{
+        (policies_probe.json.data | default([]) | first).extId
+        if (policies_probe is defined and policies_probe.json is defined
+            and (policies_probe.json.data | default([])) | length > 0)
+        else ''
+      }}
+
+- name: Report whether a policy was discovered
+  ansible.builtin.debug:
+    msg: >-
+      Using VM-host affinity policy ext_id
+      '{{ vm_host_affinity_policy_ext_id }}' for read-only tests.
+
+########################################################################################
+# Check-mode tests (do not need a real policy)
+########################################################################################
+
+- name: Check-mode fetch (all attributes) — management module
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+    state: present
+    vm_host_affinity_policy_ext_id: "00000000-0000-0000-0000-000000000000"
+    page: 0
+    limit: 20
+  check_mode: true
+  register: check_mode_fetch_all
+  ignore_errors: true
+
+- name: Assert check-mode fetch-all output
+  ansible.builtin.assert:
+    that:
+      - check_mode_fetch_all is defined
+      - check_mode_fetch_all.changed == false
+      - check_mode_fetch_all.failed == false
+      - check_mode_fetch_all.skipped == true
+      - "'Check mode' in check_mode_fetch_all.msg"
+    fail_msg: "Check-mode fetch-all did not skip cleanly"
+    success_msg: "Check-mode fetch-all skipped cleanly"
+
+- name: Check-mode "update" (all attributes) — management module with ext_id
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+    state: present
+    vm_host_affinity_policy_ext_id: "00000000-0000-0000-0000-000000000000"
+    ext_id: "00000000-0000-0000-0000-000000000001"
+  check_mode: true
+  register: check_mode_update
+  ignore_errors: true
+
+- name: Assert check-mode update output
+  ansible.builtin.assert:
+    that:
+      - check_mode_update is defined
+      - check_mode_update.changed == false
+      - check_mode_update.failed == false
+      - check_mode_update.skipped == true
+      - "'Check mode' in check_mode_update.msg"
+    fail_msg: "Check-mode update path did not skip cleanly"
+    success_msg: "Check-mode update path skipped cleanly"
+
+- name: Attempt state=absent (check_mode) — must fail because entity is read-only
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+    state: absent
+    vm_host_affinity_policy_ext_id: "00000000-0000-0000-0000-000000000000"
+    ext_id: "00000000-0000-0000-0000-000000000001"
+  check_mode: true
+  register: check_mode_delete
+  ignore_errors: true
+
+- name: Assert delete is not supported
+  ansible.builtin.assert:
+    that:
+      - check_mode_delete is defined
+      - check_mode_delete.failed == true
+      - check_mode_delete.changed == false
+      - "'state=absent is not supported' in check_mode_delete.msg"
+    fail_msg: "Delete on read-only compliance state entity did not fail as expected"
+    success_msg: "Delete on read-only compliance state entity failed as expected"
+
+########################################################################################
+# Negative / validation tests
+########################################################################################
+
+- name: Omit required vm_host_affinity_policy_ext_id — management module
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+    state: present
+  register: missing_policy_ext_id
+  ignore_errors: true
+
+- name: Assert missing required parameter is caught by argument spec
+  ansible.builtin.assert:
+    that:
+      - missing_policy_ext_id is defined
+      - missing_policy_ext_id.failed == true
+      - "'vm_host_affinity_policy_ext_id' in (missing_policy_ext_id.msg | string)"
+    fail_msg: "Argument spec did not enforce required vm_host_affinity_policy_ext_id"
+    success_msg: "Argument spec correctly rejected missing vm_host_affinity_policy_ext_id"
+
+- name: Omit required vm_host_affinity_policy_ext_id — info module
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2: {}
+  register: missing_policy_ext_id_info
+  ignore_errors: true
+
+- name: Assert info module also enforces required param
+  ansible.builtin.assert:
+    that:
+      - missing_policy_ext_id_info is defined
+      - missing_policy_ext_id_info.failed == true
+      - "'vm_host_affinity_policy_ext_id' in (missing_policy_ext_id_info.msg | string)"
+    fail_msg: "Info argument spec did not enforce required vm_host_affinity_policy_ext_id"
+    success_msg: "Info argument spec correctly rejected missing required param"
+
+- name: Attempt mutually exclusive ext_id + limit — info module
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    vm_host_affinity_policy_ext_id: "00000000-0000-0000-0000-000000000000"
+    ext_id: "00000000-0000-0000-0000-000000000001"
+    limit: 5
+  register: mutually_exclusive_check
+  ignore_errors: true
+
+- name: Assert mutually exclusive params are rejected
+  ansible.builtin.assert:
+    that:
+      - mutually_exclusive_check is defined
+      - mutually_exclusive_check.failed == true
+      - "'mutually exclusive' in (mutually_exclusive_check.msg | string)"
+    fail_msg: "Info module did not reject mutually exclusive ext_id + limit"
+    success_msg: "Info module correctly rejected mutually exclusive params"
+
+- name: Fetch compliance state for a non-existent policy ext_id — info module
+  nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+    vm_host_affinity_policy_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: bogus_policy_lookup
+  ignore_errors: true
+
+- name: Assert invalid policy ext_id produces an API error
+  ansible.builtin.assert:
+    that:
+      - bogus_policy_lookup is defined
+      - bogus_policy_lookup.failed == true
+      - bogus_policy_lookup.changed == false
+    fail_msg: "Invalid parent policy ext_id did not produce an API error"
+    success_msg: "Invalid parent policy ext_id correctly raised an API error"
+
+########################################################################################
+# Real read-path tests (only if a policy was discovered)
+########################################################################################
+
+- name: Run happy-path tests only if a policy was discovered
+  when: vm_host_affinity_policy_ext_id | length > 0
+  block:
+    - name: List all compliance state entries (info module)
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+      register: list_all_info
+      ignore_errors: true
+
+    - name: Assert list-all via info module
+      ansible.builtin.assert:
+        that:
+          - list_all_info is defined
+          - list_all_info.changed == false
+          - list_all_info.failed == false
+          - list_all_info.response is defined
+          - (list_all_info.response | type_debug) == 'list'
+        fail_msg: "info module did not return a list of compliance states"
+        success_msg: "info module returned a list of compliance states"
+
+    - name: List all compliance state entries (management module)
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+        state: present
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+      register: list_all_mgmt
+      ignore_errors: true
+
+    - name: Assert list-all via management module
+      ansible.builtin.assert:
+        that:
+          - list_all_mgmt is defined
+          - list_all_mgmt.changed == false
+          - list_all_mgmt.failed == false
+          - list_all_mgmt.response is defined
+          - (list_all_mgmt.response | type_debug) == 'list'
+          - "'VM compliance state entries' in (list_all_mgmt.msg | default(''))"
+        fail_msg: "Management module list-all did not return a list"
+        success_msg: "Management module list-all returned a list"
+
+    - name: Idempotency — re-run list-all and expect no change
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+        state: present
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+      register: list_all_mgmt_repeat
+      ignore_errors: true
+
+    - name: Assert idempotency
+      ansible.builtin.assert:
+        that:
+          - list_all_mgmt_repeat.changed == false
+          - list_all_mgmt_repeat.failed == false
+          - >-
+            (list_all_mgmt_repeat.response | default([]) | length)
+            == (list_all_mgmt.response | default([]) | length)
+        fail_msg: "Re-running the list-all was not idempotent"
+        success_msg: "List-all fetch is idempotent"
+
+    - name: Capture a compliance state ext_id if the list is non-empty
+      ansible.builtin.set_fact:
+        compliance_state_ext_id: "{{ (list_all_info.response | first).ext_id | default('') }}"
+      when: (list_all_info.response | default([])) | length > 0
+
+    - name: Fetch by ext_id via info module
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+        ext_id: "{{ compliance_state_ext_id }}"
+      register: info_by_ext_id
+      when:
+        - compliance_state_ext_id is defined
+        - compliance_state_ext_id | length > 0
+      ignore_errors: true
+
+    - name: Assert single-entry fetch via info module
+      ansible.builtin.assert:
+        that:
+          - info_by_ext_id is defined
+          - info_by_ext_id.changed == false
+          - info_by_ext_id.failed == false
+          - info_by_ext_id.response is defined
+          - info_by_ext_id.ext_id == compliance_state_ext_id
+        fail_msg: "info module did not return the expected single entry"
+        success_msg: "info module returned the expected single entry"
+      when:
+        - compliance_state_ext_id is defined
+        - compliance_state_ext_id | length > 0
+
+    - name: Fetch by ext_id via management module
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+        state: present
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+        ext_id: "{{ compliance_state_ext_id }}"
+      register: mgmt_by_ext_id
+      when:
+        - compliance_state_ext_id is defined
+        - compliance_state_ext_id | length > 0
+      ignore_errors: true
+
+    - name: Assert single-entry fetch via management module
+      ansible.builtin.assert:
+        that:
+          - mgmt_by_ext_id is defined
+          - mgmt_by_ext_id.changed == false
+          - mgmt_by_ext_id.failed == false
+          - mgmt_by_ext_id.response is defined
+          - mgmt_by_ext_id.ext_id == compliance_state_ext_id
+          - "'Fetched VM compliance state entry' in mgmt_by_ext_id.msg"
+        fail_msg: "management module did not return the expected single entry"
+        success_msg: "management module returned the expected single entry"
+      when:
+        - compliance_state_ext_id is defined
+        - compliance_state_ext_id | length > 0
+
+    - name: Fetch by ext_id with a bogus ext_id — must gracefully skip
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_state_v2:
+        state: present
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+        ext_id: "00000000-0000-0000-0000-0000abcdef99"
+      register: mgmt_missing_state
+      ignore_errors: true
+
+    - name: Assert missing compliance state ext_id is handled gracefully
+      ansible.builtin.assert:
+        that:
+          - mgmt_missing_state.failed == false
+          - mgmt_missing_state.changed == false
+          - mgmt_missing_state.skipped == true
+          - "'No VM compliance state entry found' in mgmt_missing_state.msg"
+        fail_msg: "Missing compliance state ext_id was not handled gracefully"
+        success_msg: "Missing compliance state ext_id handled gracefully"
+
+    - name: Pagination — list with a small page size
+      nutanix.ncp.ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2:
+        vm_host_affinity_policy_ext_id: "{{ vm_host_affinity_policy_ext_id }}"
+        page: 0
+        limit: 1
+      register: paged_result
+      ignore_errors: true
+
+    - name: Assert pagination limit is honored
+      ansible.builtin.assert:
+        that:
+          - paged_result.failed == false
+          - paged_result.changed == false
+          - (paged_result.response | default([]) | length) <= 1
+        fail_msg: "Pagination limit was not honored by the info module"
+        success_msg: "Pagination limit was honored by the info module"
+
+- name: Skip happy-path assertions when no policy could be discovered
+  ansible.builtin.debug:
+    msg: >-
+      No VM-host affinity policy was discovered on this cluster; only negative
+      / check-mode / argument-spec tests were run. Add a policy to exercise the
+      full read-path.
+  when: vm_host_affinity_policy_ext_id | length == 0


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **virtual_machine_management** namespace, entity
**VmHostAffinityPolicyVmComplianceState**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_vm_host_affinity_policy_vm_compliance_state_v2`, `ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2`
- API methods covered: `1` (`ListVmHostAffinityPolicyVmComplianceStates` — the only method the SDK exposes on this entity)
- Fields in "CRUD" module spec: `4` (`vm_host_affinity_policy_ext_id`, `ext_id`, `page`, `limit`)
- Fields in info module spec: `2` (`vm_host_affinity_policy_ext_id`, `ext_id`) + inherited `page`/`limit`/`filter`/`orderby`/`select` from `BaseInfoModule`

> **Note on read-only entity design.** `VmHostAffinityPolicyVmComplianceState` is a fully read-only projection: the v4 SDK only ships `list_vm_host_affinity_policy_vm_compliance_states` on `VmHostAffinityPoliciesApi`; there is no `Create/Update/Delete/GetById` for compliance state entries (see Domain Knowledge section for why — the placement engine computes them). The "CRUD" module therefore uses the state-based dispatch required by `INSTRUCTIONS.md` but implements every state as a safe read: `state=present` (list all or fetch one by `ext_id` via list+filter), `state=absent` fails loudly with a descriptive message pointing the operator at the parent policy. The info module is a straightforward list wrapper with `page`/`limit` pagination.

## Domain knowledge (from Glean)

### What is `VmHostAffinityPolicyVmComplianceState`? (Detailed Features)
`VmHostAffinityPolicyVmComplianceState` is a data model in the v4 Virtual Machine Management (VMM) API. It represents the compliance information of a specific Virtual Machine (VM) in relation to a category-based VM-Host Affinity Policy.

**Key Features:**
- **Cluster & Host Tracking**: Returns references to the cluster and specific host where the VM currently resides.
- **Associated Categories**: Lists the specific category references by which the VM was associated with the VM-host affinity policy.
- **Compliance Status**: Represents the current state of the VM under the policy, modeled as a polymorphic `oneOf` field with the following possible states:
    - `CompliantVmHostAffinityPolicy`: The VM is successfully running on a designated host.
    - `PendingVmHostAffinityPolicy`: The policy enforcement is still in progress (e.g., the VM is in the process of live-migrating to a compliant host).
    - `NonCompliantVmHostAffinityPolicy`: The VM does not comply with the policy. This state requires a specific `nonComplianceReason`:
        - `ConflictingVmHostAffinityPolicy`: A conflicting policy with an earlier creation time is already applied to the VM.
        - `ConflictingLegacyVmHostAffinityPolicy`: The VM is already bound to a legacy (non-category) VM-host affinity policy.
        - `NoHostsForVmHostAffinityPolicy`: There are no hosts linked with the policy's host categories.
        - `NotEnoughResourcesForVmHostAffinityPolicy`: There are insufficient compute/memory resources on the designated hosts to accommodate the VM.
        - `PeNotCapableForVmHostAffinityPolicy`: The underlying Prism Element (PE) cluster is running an older AOS version that does not support category-based affinity policies.
        - `OtherVmHostAffinityPolicyVmNonComplianceReason`: Catch-all for internal errors.

### Where and How is it Used?

#### Workflow & Behavioral Details
When a VM-Host Affinity Policy is created or updated, the system evaluates all VMs matching the specified VM categories against the targeted host categories.
1. **Status Retrieval**: Users or systems query the `GET /vm-host-affinity-policies/{vmHostAffinityPolicyExtId}/vm-compliance-states` API to paginate through the compliance states of affected VMs.
2. **Enforcement**: If a VM is not on the correct host, the system attempts to live-migrate it. During this time, the compliance state is `PendingVmHostAffinityPolicy`.
3. **Remediation**: If a VM is marked as `NonCompliantVmHostAffinityPolicy` (e.g., due to a lack of resources or PE being on an old version), administrators must resolve the underlying issue. Once resolved, they can invoke the `POST /vm-host-affinity-policies/{extId}/$actions/re-enforce` API, which forces the system to re-evaluate and attempt placement again.

#### Prerequisites
- **AOS / PC Version**: The underlying PE cluster must run at least AOS 6.1, and Prism Central (PC) must run at least version 2024.3 to support category-based VM-Host Affinity Policies.
- **RBAC Permissions**: To view the compliance states, the user must have the `View_VM_Host_Affinity_Policy_VM_Compliance_States` permission.
- **Allowed Roles**: By default, this permission is granted to Super Admin, Virtual Machine Admin, Virtual Machine Viewer, Prism Admin, Prism Viewer, and Internal Super Admin.

### Related Engineering Tickets
- [ENG-951817](https://jira.nutanix.com/browse/ENG-951817): *[VM Host Soft Affinity] VM located on host not part of policy shows up as compliant.* (Critical bug; resolved as a UI display issue rather than a backend compliance state calculation error).
- [ENG-675107](https://jira.nutanix.com/browse/ENG-675107): *Add View_VM_Host_Affinity_policy_VM_Compliance_States permission in related operation list of re-enforce permission.* (Fixed bug to ensure users triggering a re-enforce action have the requisite permissions to view the resulting compliance states).
- [ENG-896988](https://jira.nutanix.com/browse/ENG-896988): *Unable to create role with 1339 permissions.* (Test bug related to IAM payload sizes which referenced this specific permission).

### Design, Spec, and Documentation Links
**Confluence / Knowledge Base:**
- [<PHONE_1>: 作成したユーザーのUI言語表記について](https://confluence.eng.nutanix.com:8443/spaces/~shigeru.takeuchi/pages/443232027/) (Mentions operations related to `View VM Host Affinity Policy VM Compliance States`).

**OpenAPI YAML Specs:**
- [vm-host-affinity-policy-vm-compliance-state.yaml](https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/models/ahv/policies/vm-host-affinity-policy-vm-compliance-state.yaml) (Core model definition)
- [hostAffinityEndpoints.yaml](https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv-policies/released/api/hostAffinityEndpoints.yaml) (API definitions for re-enforce and listing compliance states)
- [vm-compliance-state-endpoints.yaml](https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/endpoints/ahv/policies/vm-compliance-state-endpoints.yaml)

**SDK Code Repositories:**
- [VmHostAffinityPolicyVmComplianceState.py](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/policies/VmHostAffinityPolicyVmComplianceState.py) (Python SDK Model)
- [list_vm_host_affinity_policy_vm_compliance_states_request.go](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmhostaffinitypolicies/list_vm_host_affinity_policy_vm_compliance_states_request.go) (Go SDK Request Struct)
- [vm_host_affinity_policies_api.py](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/api/vm_host_affinity_policies_api.py)
- [hostAffinityModel.yaml](https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv-policies/released/models/hostAffinityModel.yaml)

**Test Configurations:**
- [rbac_vm_host_affinity.json](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/acropolis/ahv_management/v4/configs/rbac_vm_host_affinity.json) (Python test config for RBAC mappings)
- [policy_rbac_tests.json](https://github.com/nutanix-engineering/hack2026-d3089/blob/main/hackathon_new/tpg_output/rbac/tests/policy_rbac_tests.json) (TPG Output RBAC test suite)
- [domain_07_ahv_policies_vm-compliance-states_tests.json](https://github.com/nutanix-engineering/hack2026-d3089/blob/main/old_approach_data/tpg_output/test_cases/domain_07_ahv_policies_vm-compliance-states_tests.json)
- [rbac_coverage_report.md](https://github.com/nutanix-engineering/hack2026-d3089/blob/main/hackathon_new/tpg_output/rbac/rbac_coverage_report.md)
- [endpoints.json](https://github.com/nutanix-engineering/hack2026-d3089/blob/main/old_approach_data/tpg_output/schemas/domain_07_ahv_policies_vm-compliance-states/endpoints.json)

### Required Domain Skills
1. **OpenAPI Specification (OAS 3.x)**: The v4 API contracts are strictly driven by OpenAPI specifications. You must understand how `allOf`, `oneOf` (polymorphism), and custom `$objectType` discriminators are modeled in YAML to safely extend or document models.
2. **Go and Python v4 SDKs**: The backend is exposed via generated Go and Python SDKs. You need to know how to instantiate clients, perform pagination (handling `$page` and `$limit`), and interact with polymorphic data structures natively in Go (structs/interfaces) and Python (classes/dictionaries).
3. **Nutanix Categories**: Affinity policies in v4 are entirely category-driven. You must understand how to assign categories to VMs and Hosts, and how the policy engine calculates the intersection of these labels.
4. **Acropolis / AHV Placement Engine mechanics**: Understanding how AHV schedules VMs, manages resource fragmentation, handles live migration, and the difference between hard-enforcement and soft-affinity will help you write accurate test scenarios for `Pending` and `NotEnoughResources` compliance states.
5. **Nutanix IAM / RBAC system**: You need to understand how operations (e.g., `View_VM_Host_Affinity_Policy_VM_Compliance_States`) map to Roles, and how to define entity filters for automated testing frameworks (like `nutest-py3-tests`).

## Files changed

**`plugins/modules/`**
- `ntnx_vm_host_affinity_policy_vm_compliance_state_v2.py` — new, state-based read module for compliance state entries under a VM-host affinity policy.
- `ntnx_vm_host_affinity_policy_vm_compliance_states_info_v2.py` — new, info/list module for the same entity.

**`plugins/module_utils/v4/vmm/`**
- `api_client.py` — added `get_vm_host_affinity_policies_api_instance(module)`.
- `helpers.py` — added `list_vm_host_affinity_policy_vm_compliance_states(...)` and `get_vm_host_affinity_policy_vm_compliance_state(...)` (SDK has no GetById; helper paginates the list client-side).

**`meta/`**
- `runtime.yml` — registered both new modules in the `ntnx` action group so `module_defaults: group/nutanix.ncp.ntnx:` credentials propagate to them.

**`examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/`**
- `vm_host_affinity_policy_vm_compliance_state_v2.yml` — end-to-end example playbook (discover a policy → list/fetch compliance states via both modules → demonstrate delete-not-supported).
- `examples_run.log` — real playbook output captured against PC 10.44.76.28 (`pc.7.6`).

**`tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_v2/`**
- `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/vm_host_affinity_policy_vm_compliance_states.yml` — full integration test target covering check-mode, negative/spec-validation, real read paths, idempotency, and pagination.

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-test integration ntnx_vm_host_affinity_policy_vm_compliance_states_v2 --allow-disabled --python 3.12 -v` |
| Total tasks         | `37` (28 ok + 9 skipped)                       |
| Passed              | `28`                                           |
| Failed              | `0`                                            |
| Skipped             | `9` (compliance state ext_id lookups when the discovered policy has 0 entries) |
| Ignored (expected)  | `5` (negative tasks with `ignore_errors: true`) |
| Duration            | `~15 s`                                        |
| Cluster (PC)        | `10.44.76.28` (`pc.7.6`, v4 API `4.2.2`)       |

Additional gates run locally, all pass:

- `black --check` and `isort --check` on the four changed Python files
- `flake8` on the same files
- `ansible-lint` on `tests/integration/targets/ntnx_vm_host_affinity_policy_vm_compliance_states_v2/tasks/main.yml` and the example playbook (0 failures; 2 informational `args[module]: missing required arguments` warnings that come from **intentional negative tests** which omit the required arg to prove the argument spec enforces it)
- `ansible-test sanity --python 3.12` on the two modules and the two touched `module_utils` files (all 32 sanity subtests pass)

### Analysis

No failing tests. The 9 skipped tasks are all conditional read-path assertions that require the discovered VM-host affinity policy on the cluster to already have compliance state entries. The single policy currently on `10.44.76.28` (`d8cf7870-6162-474b-4e62-dfa249096ffe`, created by `ntnx_re_enforce_vm_host_affinity_policy_v2` integration tests) has `numHosts=0` and therefore zero compliance state entries, so the "get-by-ext_id" and "capture first ext_id" branches skip cleanly. The list-all path was exercised end-to-end and returned an empty list as expected; the module's empty-list handling (converts SDK `None` → `[]`) is proved by the assertion `(list_all_mgmt.response | type_debug) == 'list'`. Idempotency (repeat list-all) and pagination (`limit: 1`) were also exercised on the live cluster.

The 5 ignored failures are the negative tests:
1. `state=absent` on a compliance state entry — the module correctly returns `state=absent is not supported for VM host affinity policy VM compliance state entries`.
2. Missing `vm_host_affinity_policy_ext_id` (management module) — argument spec rejects it.
3. Missing `vm_host_affinity_policy_ext_id` (info module) — argument spec rejects it.
4. Mutually exclusive `ext_id + limit` on the info module — argument spec rejects it.
5. Fetching compliance states for a bogus policy `00000000-…-000000000000` — the v4 API returns `VMM-34060 POLICY_NOT_FOUND` and the module surfaces the exact error message to the operator.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_vm_host_affinity_policy_vm_compliance_states_v2
Detected architecture x86_64 for Python interpreter: /bin/python3.12
Creating container database.
Configuring target inventory.
Running ntnx_vm_host_affinity_policy_vm_compliance_states_v2 integration test role
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] ***
ok: [testhost]

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_v2 : Start VM host affinity policy VM compliance state tests] ***
ok: [testhost] => {"msg": "Start VM host affinity policy VM compliance state tests"}

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_v2 : Discover an existing VM-host affinity policy for read-only tests] ***
ok: [testhost] => policy discovered: d8cf7870-6162-474b-4e62-dfa249096ffe

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_v2 : Check-mode fetch (all attributes) — management module] ***
skipping: [testhost] => {"changed": false, "msg": "Check mode: would fetch VM compliance state entries for VM-host affinity policy ext_id=00000000-0000-0000-0000-000000000000"}

TASK [Assert check-mode fetch-all output] ***
ok: Check-mode fetch-all skipped cleanly

TASK [ntnx_vm_host_affinity_policy_vm_compliance_states_v2 : Check-mode "update" (all attributes) — management module with ext_id] ***
skipping: [testhost] => {"changed": false, "msg": "Check mode: would fetch VM compliance state entries for VM-host affinity policy ext_id=00000000-0000-0000-0000-000000000000"}

TASK [Assert check-mode update output] ***
ok: Check-mode update path skipped cleanly

TASK [Attempt state=absent (check_mode) — must fail because entity is read-only] ***
fatal: [testhost]: FAILED! => {"msg": "state=absent is not supported for VM host affinity policy VM compliance state entries: they are derived read-only data. Delete the parent VM-host affinity policy '00000000-0000-0000-0000-000000000000' instead."}
...ignoring

TASK [Assert delete is not supported] ***
ok: Delete on read-only compliance state entity failed as expected

TASK [Omit required vm_host_affinity_policy_ext_id — management module] ***
fatal: [testhost]: FAILED! => {"msg": "missing required arguments: vm_host_affinity_policy_ext_id"}
...ignoring

TASK [Assert missing required parameter is caught by argument spec] ***
ok: Argument spec correctly rejected missing vm_host_affinity_policy_ext_id

TASK [Omit required vm_host_affinity_policy_ext_id — info module] ***
fatal: [testhost]: FAILED! => {"msg": "missing required arguments: vm_host_affinity_policy_ext_id"}
...ignoring

TASK [Assert info module also enforces required param] ***
ok: Info argument spec correctly rejected missing required param

TASK [Attempt mutually exclusive ext_id + limit — info module] ***
fatal: [testhost]: FAILED! => {"msg": "parameters are mutually exclusive: ext_id|limit"}
...ignoring

TASK [Assert mutually exclusive params are rejected] ***
ok: Info module correctly rejected mutually exclusive params

TASK [Fetch compliance state for a non-existent policy ext_id — info module] ***
fatal: [testhost]: FAILED! => {"error": "NOT FOUND", "status": 404, "response": {"error": [{"code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "message": "Failed to perform the operation on the policy with UUID '00000000-0000-0000-0000-000000000000', because it is not found."}]}}
...ignoring

TASK [Assert invalid policy ext_id produces an API error] ***
ok: Invalid parent policy ext_id correctly raised an API error

TASK [List all compliance state entries (info module)] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [Assert list-all via info module] ***
ok: info module returned a list of compliance states

TASK [List all compliance state entries (management module)] ***
ok: [testhost] => {"changed": false, "response": [], "msg": "Fetched 0 VM compliance state entries for VM-host affinity policy 'd8cf7870-6162-474b-4e62-dfa249096ffe'.", "total_available_results": 0}

TASK [Assert list-all via management module] ***
ok: Management module list-all returned a list

TASK [Idempotency — re-run list-all and expect no change] ***
ok: [testhost] => {"changed": false, "response": []}

TASK [Assert idempotency] ***
ok: List-all fetch is idempotent

TASK [Capture a compliance state ext_id if the list is non-empty] ***
skipping: [testhost] => (empty list)

TASK [Fetch by ext_id with a bogus ext_id — must gracefully skip] ***
skipping: [testhost] => {"changed": false, "msg": "No VM compliance state entry found with ext_id '00000000-0000-0000-0000-0000abcdef99' under VM-host affinity policy 'd8cf7870-6162-474b-4e62-dfa249096ffe'.", "response": null}

TASK [Assert missing compliance state ext_id is handled gracefully] ***
ok: Missing compliance state ext_id handled gracefully

TASK [Pagination — list with a small page size] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [Assert pagination limit is honored] ***
ok: Pagination limit was honored by the info module

PLAY RECAP *********************************************************************
testhost                   : ok=28   changed=0    unreachable=0    failed=0    skipped=9    rescued=0    ignored=5
```

</details>

### Example playbook run

The example playbook was executed end-to-end against the same PC (`10.44.76.28`) with `NUTANIX_HOST`/`NUTANIX_USERNAME`/`NUTANIX_PASSWORD` sourced from the environment (see `examples/virtual_machine_management/VmHostAffinityPolicyVmComplianceState/examples_run.log` in this PR for the full transcript). It discovers policy `d8cf7870-6162-474b-4e62-dfa249096ffe`, fetches its (empty) compliance state list from both modules, demonstrates the graceful skip when there is no matching entry, and confirms the read-only failure path for `state=absent`. All 8 executed tasks returned `ok=0 failures=0` (2 conditional tasks are skipped because the discovered policy has no compliance state entries on this cluster).

Because the discovered policy has zero compliance state entries, the `sample:` blocks in the two module RETURN docstrings are illustrative — driven from the SDK model definition (`VmHostAffinityPolicyVmComplianceState.py`) rather than a live entry. To populate them with real values, run these modules against a policy that has at least one VM assigned via its `vmCategories`.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
