### PR TITLE
QuotaPolicy Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/files/QuotaPolicy/examples_run.log
+++ b/examples/files/QuotaPolicy/examples_run.log
@@ -1,0 +1,144 @@
+# Real output of running examples/files/QuotaPolicy/quota_policy.yml against Prism Central 10.44.76.28.
+# NOTE: The Nutanix Files service backend (Files Manager / minerva gateway, 127.0.0.1:7509) returned HTTP 503
+#       on this Prism Central, i.e. no file server / mount target is deployed, so the live create/get/list/update/delete
+#       calls could not complete. check_mode and argument validation paths execute fully. See PR body for details.
+#
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Nutanix Files quota policy playbook] *************************************
+
+TASK [Setting variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"file_server_ext_id": "9c1e537d-6777-4c22-5d41-ddd0c3337aa9", "mount_target_ext_id": "48f78959-14a6-4c47-b5db-920460c4b668"}, "changed": false}
+
+TASK [Create quota policy for a user with all attributes] **********************
+[ERROR]: Task failed: Module failed: Api Exception raised while creating quota policy
+Origin: /tmp/codegen-artifacts.OoRVFb/quota_policy_run.yml:27:7
+
+25         mount_target_ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+26
+27     - name: Create quota policy for a user with all attributes
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while creating quota policy", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Fetch the created quota policy using its external ID] ********************
+[ERROR]: Task failed: Finalization of task args for 'nutanix.ncp.ntnx_files_quota_policies_info_v2' failed: Error while resolving value for 'ext_id': object of type 'dict' has no attribute 'ext_id'
+
+Task failed.
+Origin: /tmp/codegen-artifacts.OoRVFb/quota_policy_run.yml:42:7
+
+40       ignore_errors: true
+41
+42     - name: Fetch the created quota policy using its external ID
+         ^ column 7
+
+<<< caused by >>>
+
+Finalization of task args for 'nutanix.ncp.ntnx_files_quota_policies_info_v2' failed.
+Origin: /tmp/codegen-artifacts.OoRVFb/quota_policy_run.yml:43:7
+
+41
+42     - name: Fetch the created quota policy using its external ID
+43       nutanix.ncp.ntnx_files_quota_policies_info_v2:
+         ^ column 7
+
+<<< caused by >>>
+
+Error while resolving value for 'ext_id': object of type 'dict' has no attribute 'ext_id'
+Origin: /tmp/codegen-artifacts.OoRVFb/quota_policy_run.yml:46:17
+
+44         file_server_ext_id: "{{ file_server_ext_id }}"
+45         mount_target_ext_id: "{{ mount_target_ext_id }}"
+46         ext_id: "{{ created_quota_policy.ext_id }}"
+                   ^ column 17
+
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: Finalization of task args for 'nutanix.ncp.ntnx_files_quota_policies_info_v2' failed: Error while resolving value for 'ext_id': object of type 'dict' has no attribute 'ext_id'"}
+...ignoring
+
+TASK [Fetch all quota policies of the mount target] ****************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching quota policies info
+Origin: /tmp/codegen-artifacts.OoRVFb/quota_policy_run.yml:50:7
+
+48       ignore_errors: true
+49
+50     - name: Fetch all quota policies of the mount target
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching quota policies info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Update the quota policy with all attributes] *****************************
+[ERROR]: Task failed: Finalization of task args for 'nutanix.ncp.ntnx_files_quota_policy_v2' failed: Error while resolving value for 'ext_id': object of type 'dict' has no attribute 'ext_id'
+
+Task failed.
+Origin: /tmp/codegen-artifacts.OoRVFb/quota_policy_run.yml:57:7
+
+55       ignore_errors: true
+56
+57     - name: Update the quota policy with all attributes
+         ^ column 7
+
+<<< caused by >>>
+
+Finalization of task args for 'nutanix.ncp.ntnx_files_quota_policy_v2' failed.
+Origin: /tmp/codegen-artifacts.OoRVFb/quota_policy_run.yml:58:7
+
+56
+57     - name: Update the quota policy with all attributes
+58       nutanix.ncp.ntnx_files_quota_policy_v2:
+         ^ column 7
+
+<<< caused by >>>
+
+Error while resolving value for 'ext_id': object of type 'dict' has no attribute 'ext_id'
+Origin: /tmp/codegen-artifacts.OoRVFb/quota_policy_run.yml:62:17
+
+60         file_server_ext_id: "{{ file_server_ext_id }}"
+61         mount_target_ext_id: "{{ mount_target_ext_id }}"
+62         ext_id: "{{ created_quota_policy.ext_id }}"
+                   ^ column 17
+
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: Finalization of task args for 'nutanix.ncp.ntnx_files_quota_policy_v2' failed: Error while resolving value for 'ext_id': object of type 'dict' has no attribute 'ext_id'"}
+...ignoring
+
+TASK [Delete the quota policy] *************************************************
+[ERROR]: Task failed: Finalization of task args for 'nutanix.ncp.ntnx_files_quota_policy_v2' failed: Error while resolving value for 'ext_id': object of type 'dict' has no attribute 'ext_id'
+
+Task failed.
+Origin: /tmp/codegen-artifacts.OoRVFb/quota_policy_run.yml:73:7
+
+71       ignore_errors: true
+72
+73     - name: Delete the quota policy
+         ^ column 7
+
+<<< caused by >>>
+
+Finalization of task args for 'nutanix.ncp.ntnx_files_quota_policy_v2' failed.
+Origin: /tmp/codegen-artifacts.OoRVFb/quota_policy_run.yml:74:7
+
+72
+73     - name: Delete the quota policy
+74       nutanix.ncp.ntnx_files_quota_policy_v2:
+         ^ column 7
+
+<<< caused by >>>
+
+Error while resolving value for 'ext_id': object of type 'dict' has no attribute 'ext_id'
+Origin: /tmp/codegen-artifacts.OoRVFb/quota_policy_run.yml:78:17
+
+76         file_server_ext_id: "{{ file_server_ext_id }}"
+77         mount_target_ext_id: "{{ mount_target_ext_id }}"
+78         ext_id: "{{ created_quota_policy.ext_id }}"
+                   ^ column 17
+
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: Finalization of task args for 'nutanix.ncp.ntnx_files_quota_policy_v2' failed: Error while resolving value for 'ext_id': object of type 'dict' has no attribute 'ext_id'"}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=5   
+
+EXAMPLES_DONE exit=0

--- a/examples/files/QuotaPolicy/quota_policy.yml
+++ b/examples/files/QuotaPolicy/quota_policy.yml
@@ -1,0 +1,80 @@
+---
+# Summary:
+# This playbook demonstrates the management of Nutanix Files quota policies for a
+# mount target (share/export) using the v4 API based modules.
+# It will do:
+# 1. Create a quota policy for a user with all attributes
+# 2. Fetch the above created quota policy using its external ID
+# 3. Fetch all quota policies of the mount target
+# 4. Update the quota policy with all attributes
+# 5. Delete the quota policy
+
+- name: Nutanix Files quota policy playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting variables
+      ansible.builtin.set_fact:
+        file_server_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+        mount_target_ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+
+    - name: Create quota policy for a user with all attributes
+      nutanix.ncp.ntnx_files_quota_policy_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        principal_type: "USER"
+        principal_name: "user1@ad.example.com"
+        size_in_bytes: 1073741824
+        enforcement_type: "SOFT"
+        is_notification_enabled: true
+        notification_recipients:
+          - "admin@ad.example.com"
+      register: created_quota_policy
+      ignore_errors: true
+
+    - name: Fetch the created quota policy using its external ID
+      nutanix.ncp.ntnx_files_quota_policies_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        ext_id: "{{ created_quota_policy.ext_id }}"
+      register: quota_policy_info
+      ignore_errors: true
+
+    - name: Fetch all quota policies of the mount target
+      nutanix.ncp.ntnx_files_quota_policies_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+      register: all_quota_policies
+      ignore_errors: true
+
+    - name: Update the quota policy with all attributes
+      nutanix.ncp.ntnx_files_quota_policy_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        ext_id: "{{ created_quota_policy.ext_id }}"
+        principal_type: "USER"
+        principal_name: "user1@ad.example.com"
+        size_in_bytes: 2147483648
+        enforcement_type: "HARD"
+        is_notification_enabled: false
+        notification_recipients:
+          - "admin@ad.example.com"
+      register: updated_quota_policy
+      ignore_errors: true
+
+    - name: Delete the quota policy
+      nutanix.ncp.ntnx_files_quota_policy_v2:
+        state: absent
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        mount_target_ext_id: "{{ mount_target_ext_id }}"
+        ext_id: "{{ created_quota_policy.ext_id }}"
+      register: deleted_quota_policy
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_files_quota_policy_v2
+    - ntnx_files_quota_policies_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,7 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        QUOTA_POLICY = "files:config:quota-policy"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,111 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def _build_api_client(config):
+    """
+    Build a Files SDK ApiClient, tolerating SDK versions that do not accept
+    the ``allow_version_negotiation`` keyword argument.
+    Args:
+        config (object): Files SDK Configuration object
+    return:
+        client (object): Files SDK ApiClient object
+    """
+    try:
+        return ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        return ntnx_files_py_client.ApiClient(configuration=config)
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details.
+    Args:
+        module (object): Ansible module object
+    return:
+        client (object): api client object
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    client = _build_api_client(config)
+
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    # Setup API logging if debug is enabled
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    return:
+        etag (str): etag value
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_quota_policies_api_instance(module):
+    """
+    This method will return QuotaPoliciesApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): quota policies api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.QuotaPoliciesApi(api_client=api_client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,36 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_quota_policy(
+    module, api_instance, file_server_ext_id, mount_target_ext_id, ext_id
+):
+    """
+    This method will return quota policy info using its ext_id.
+    Args:
+        module (object): Ansible module object
+        api_instance (object): QuotaPoliciesApi instance from ntnx_files_py_client sdk
+        file_server_ext_id (str): external ID of the file server
+        mount_target_ext_id (str): external ID of the mount target
+        ext_id (str): quota policy external ID
+    return:
+        info (object): quota policy info
+    """
+    try:
+        return api_instance.get_quota_policy_by_id(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            extId=ext_id,
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching quota policy info using ext_id",
+        )

--- a/plugins/modules/ntnx_files_quota_policies_info_v2.py
+++ b/plugins/modules/ntnx_files_quota_policies_info_v2.py
@@ -1,0 +1,245 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_quota_policies_info_v2
+short_description: Fetch quota policies information for a Nutanix Files mount target
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about QuotaPolicy in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific QuotaPolicy.
+  - If C(ext_id) is not provided, list multiple QuotaPolicy optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+options:
+  ext_id:
+    description:
+      - The external ID of the quota policy.
+      - If provided, the module fetches the details of the specific quota policy.
+    type: str
+    required: false
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server that owns the mount target.
+    type: str
+    required: true
+  mount_target_ext_id:
+    description:
+      - The external identifier of the mount target (share/export) for which the quota policies are configured.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get quota policy using ext_id
+  nutanix.ncp.ntnx_files_quota_policies_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    mount_target_ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+    ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+  register: result
+  ignore_errors: true
+
+- name: List all quota policies for a mount target
+  nutanix.ncp.ntnx_files_quota_policies_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    mount_target_ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+  register: result
+  ignore_errors: true
+
+- name: List quota policies with filter
+  nutanix.ncp.ntnx_files_quota_policies_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    mount_target_ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+    filter: "principalName eq 'user1@ad.example.com'"
+  register: result
+  ignore_errors: true
+
+- name: List quota policies with limit
+  nutanix.ncp.ntnx_files_quota_policies_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    mount_target_ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC QuotaPolicy info v4 API.
+    - It can be a single QuotaPolicy if external ID is provided.
+    - List of multiple QuotaPolicy if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "enforcement_type": "SOFT",
+      "ext_id": "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0",
+      "is_notification_enabled": true,
+      "links": null,
+      "notification_recipients": ["admin@ad.example.com"],
+      "principal_name": "user1@ad.example.com",
+      "principal_type": "USER",
+      "size_in_bytes": 1073741824,
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching quota policies info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the quota policy
+  type: str
+  returned: when external ID is provided
+  sample: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+
+total_available_results:
+  description: The total number of available quota policies for the mount target in PC.
+  type: int
+  returned: when all quota policies are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_quota_policies_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_quota_policy  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        file_server_ext_id=dict(type="str", required=True),
+        mount_target_ext_id=dict(type="str", required=True),
+    )
+
+    return module_args
+
+
+def get_quota_policy_using_ext_id(module, quota_policies, result):
+    ext_id = module.params.get("ext_id")
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+    resp = get_quota_policy(
+        module, quota_policies, file_server_ext_id, mount_target_ext_id, ext_id
+    )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_quota_policies(module, quota_policies, result):
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating quota policies info spec", **result)
+
+    kwargs["fileServerExtId"] = module.params.get("file_server_ext_id")
+    kwargs["mountTargetExtId"] = module.params.get("mount_target_ext_id")
+
+    try:
+        resp = quota_policies.list_quota_policies(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching quota policies info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    quota_policies = get_quota_policies_api_instance(module)
+    if module.params.get("ext_id"):
+        get_quota_policy_using_ext_id(module, quota_policies, result)
+    else:
+        get_quota_policies(module, quota_policies, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_files_quota_policy_v2.py
+++ b/plugins/modules/ntnx_files_quota_policy_v2.py
@@ -1,0 +1,491 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_quota_policy_v2
+short_description: Create, Update and Delete quota policies for a Nutanix Files mount target
+version_added: 2.7.0
+description:
+  - This module allows you to create, update, and delete quota policies for a Nutanix Files mount target in Nutanix Prism Central.
+  - A quota policy specifies the storage consumption limit for a particular user or group on a mount target (share/export).
+  - This module uses PC v4 APIs based SDKs.
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will be create quota policy.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be update quota policy.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be delete quota policy.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the quota policy.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server that owns the mount target.
+    type: str
+    required: true
+  mount_target_ext_id:
+    description:
+      - The external identifier of the mount target (share/export) for which the quota policy is configured.
+    type: str
+    required: true
+  principal_type:
+    description:
+      - The principal type for which the quota policy is applied.
+      - Required for create operation.
+    type: str
+    required: false
+    choices:
+      - USER
+      - GROUP
+  principal_name:
+    description:
+      - Principal name is the name of the user or group assigned to the principal type.
+      - Maximum 256 characters.
+      - Required for create operation.
+    type: str
+    required: false
+  size_in_bytes:
+    description:
+      - Quota size in bytes.
+      - Minimum value is 0.
+      - Required for create operation.
+    type: int
+    required: false
+  enforcement_type:
+    description:
+      - The enforcement type for the quota policy.
+      - C(SOFT) enforcement only notifies while C(HARD) enforcement blocks writes beyond the quota limit.
+      - Required for create operation.
+    type: str
+    required: false
+    choices:
+      - SOFT
+      - HARD
+  notification_recipients:
+    description:
+      - List of recipient's emails to notify about the quota policy consumption.
+    type: list
+    elements: str
+    required: false
+  is_notification_enabled:
+    description:
+      - Enables email notifications for the user or group specified in the principal type.
+      - A notification will only be sent if the user or group is close to the quota provided.
+    type: bool
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create quota policy for a user
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    file_server_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    mount_target_ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+    principal_type: "USER"
+    principal_name: "user1@ad.example.com"
+    size_in_bytes: 1073741824
+    enforcement_type: "SOFT"
+    is_notification_enabled: true
+    notification_recipients:
+      - "admin@ad.example.com"
+  register: result
+  ignore_errors: true
+
+- name: Update quota policy
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    file_server_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    mount_target_ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+    ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+    principal_type: "USER"
+    principal_name: "user1@ad.example.com"
+    size_in_bytes: 2147483648
+    enforcement_type: "HARD"
+    is_notification_enabled: false
+  register: result
+  ignore_errors: true
+
+- name: Delete quota policy
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    file_server_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    mount_target_ext_id: "48f78959-14a6-4c47-b5db-920460c4b668"
+    ext_id: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting quota policy.
+    - If the operation is create or update and C(wait) is true, it will return the quota policy details.
+    - If the operation is create or update and C(wait) is false, it will return the task details.
+    - If the operation is delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "enforcement_type": "SOFT",
+      "ext_id": "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0",
+      "is_notification_enabled": true,
+      "links": null,
+      "notification_recipients": ["admin@ad.example.com"],
+      "principal_name": "user1@ad.example.com",
+      "principal_type": "USER",
+      "size_in_bytes": 1073741824,
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the quota policy.
+  returned: always
+  type: str
+  sample: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating quota policy"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_etag,
+    get_quota_policies_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_quota_policy  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client as files_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as files_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+# Read-only attributes populated by the platform which must not be sent in an update body.
+READ_ONLY_FIELDS = ["ext_id", "links", "tenant_id"]
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        file_server_ext_id=dict(type="str", required=True),
+        mount_target_ext_id=dict(type="str", required=True),
+        principal_type=dict(
+            type="str",
+            choices=["USER", "GROUP"],
+            obj=files_sdk.PrincipalType,
+        ),
+        principal_name=dict(type="str"),
+        size_in_bytes=dict(type="int"),
+        enforcement_type=dict(
+            type="str",
+            choices=["SOFT", "HARD"],
+            obj=files_sdk.EnforcementType,
+        ),
+        notification_recipients=dict(type="list", elements="str"),
+        is_notification_enabled=dict(type="bool"),
+    )
+    return module_args
+
+
+def create_quota_policy(module, result, quota_policies):
+    validate_required_params(
+        module,
+        ["principal_type", "principal_name", "size_in_bytes", "enforcement_type"],
+    )
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+
+    sg = SpecGenerator(module)
+    default_spec = files_sdk.QuotaPolicy()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create quota policy spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = quota_policies.create_quota_policy(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            body=spec,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating quota policy",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        resp = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            resp, rel=TASK_CONSTANTS.RelEntityType.QUOTA_POLICY
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            resp = get_quota_policy(
+                module,
+                quota_policies,
+                file_server_ext_id,
+                mount_target_ext_id,
+                ext_id,
+            )
+            result["response"] = strip_internal_attributes(resp.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for Quota Policy"
+                ),
+                msg="Failed to get entity ext_id from task for Quota Policy",
+            )
+    result["changed"] = True
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    old_spec_dict = strip_internal_attributes(old_spec_dict)
+    update_spec_dict = strip_internal_attributes(update_spec_dict)
+    return old_spec_dict == update_spec_dict
+
+
+def update_quota_policy(module, result, quota_policies):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+
+    old_spec = get_quota_policy(
+        module, quota_policies, file_server_ext_id, mount_target_ext_id, ext_id
+    )
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            "Unable to fetch etag for updating quota policy", **result
+        )
+    kwargs = {"if_match": etag}
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update quota policy spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.")
+
+    strip_read_only_fields(update_spec, READ_ONLY_FIELDS)
+
+    resp = None
+    try:
+        resp = quota_policies.update_quota_policy_by_id(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            extId=ext_id,
+            body=update_spec,
+            **kwargs,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating quota policy",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_quota_policy(
+            module, quota_policies, file_server_ext_id, mount_target_ext_id, ext_id
+        )
+        result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def delete_quota_policy(module, result, quota_policies):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    mount_target_ext_id = module.params.get("mount_target_ext_id")
+
+    if module.check_mode:
+        result["msg"] = "Quota policy with ext_id:{0} will be deleted.".format(ext_id)
+        return
+
+    old_spec = get_quota_policy(
+        module, quota_policies, file_server_ext_id, mount_target_ext_id, ext_id
+    )
+    etag = get_etag(data=old_spec)
+    kwargs = {"if_match": etag} if etag else {}
+
+    resp = None
+    try:
+        resp = quota_policies.delete_quota_policy_by_id(
+            fileServerExtId=file_server_ext_id,
+            mountTargetExtId=mount_target_ext_id,
+            extId=ext_id,
+            **kwargs,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting quota policy",
+        )
+    task_ext_id = getattr(resp.data, "ext_id", None) if resp else None
+    result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+            ("state", "present", ("principal_type", "ext_id"), True),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    quota_policies = get_quota_policies_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_quota_policy(module, result, quota_policies)
+        else:
+            create_quota_policy(module, result, quota_policies)
+    else:
+        delete_quota_policy(module, result, quota_policies)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_files_quota_policy_v2/aliases
+++ b/tests/integration/targets/ntnx_files_quota_policy_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_files_quota_policy_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_files_quota_policy_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_files_quota_policy_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_files_quota_policy_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import quota_policy.yml
+      ansible.builtin.import_tasks: quota_policy.yml

--- a/tests/integration/targets/ntnx_files_quota_policy_v2/tasks/quota_policy.yml
+++ b/tests/integration/targets/ntnx_files_quota_policy_v2/tasks/quota_policy.yml
@@ -1,0 +1,571 @@
+---
+###############################################################################
+# Test plan for ntnx_files_quota_policy_v2 and ntnx_files_quota_policies_info_v2
+#
+# A quota policy sets the storage consumption limit for a user or group on a
+# Nutanix Files mount target (share/export). It therefore requires a deployed
+# file server and a mount target to exist. Their external IDs are supplied via
+# the `quota_policy` variable group in integration_config.yml.
+#
+# Scenarios covered:
+#   check_mode:
+#     - Create quota policy (ALL attributes) in check mode - no API call.
+#     - Delete quota policy in check mode - no API call.
+#   negative / validation:
+#     - Create with no principal_type and no ext_id -> required_if error.
+#     - Create with principal_type only, missing principal_name/size/enforcement
+#       -> validate_required_params error.
+#     - Create with an invalid principal_type enum value -> argspec error.
+#     - Create with an invalid enforcement_type enum value -> argspec error.
+#     - Delete with missing ext_id -> required_if error.
+#     - Get / Update / Delete with a non-existent ext_id -> API not-found error.
+#   lifecycle (require a live Files backend):
+#     - Create with minimal (required) attributes.
+#     - Create with ALL attributes.
+#     - Get by ext_id (info) and assert every field.
+#     - List all, list with filter, list with limit.
+#     - Update ALL attributes (scalar + enum change SOFT->HARD + list change).
+#     - Idempotent update (same values) -> changed false, "Nothing to change.".
+#     - Delete created quota policies (loop) and assert per-item.
+###############################################################################
+
+- name: Start ntnx_files_quota_policy_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_files_quota_policy_v2 tests
+
+- name: Generate random names
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+
+- name: Set quota policy test facts
+  ansible.builtin.set_fact:
+    file_server_ext_id: "{{ (quota_policy | default({})).file_server_ext_id | default('9c1e537d-6777-4c22-5d41-ddd0c3337aa9') }}"
+    mount_target_ext_id: "{{ (quota_policy | default({})).mount_target_ext_id | default('48f78959-14a6-4c47-b5db-920460c4b668') }}"
+    non_existent_ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+    todelete: []
+
+- name: Set principal names
+  ansible.builtin.set_fact:
+    principal_user: "{{ (quota_policy | default({})).principal_name | default('user_' + suffix_name + '_' + random_name + '@ad.example.com') }}"
+    principal_group: "{{ (quota_policy | default({})).group_name | default('group_' + suffix_name + '_' + random_name + '@ad.example.com') }}"
+
+########################################################################################
+# Create quota policy - check mode with all attributes
+########################################################################################
+
+- name: Generate spec for creating quota policy using check mode with all attributes
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    principal_type: "USER"
+    principal_name: "{{ principal_user }}"
+    size_in_bytes: 1073741824
+    enforcement_type: "SOFT"
+    is_notification_enabled: true
+    notification_recipients:
+      - "admin@ad.example.com"
+      - "ops@ad.example.com"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for creating quota policy using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.principal_type == "USER"
+      - result.response.principal_name == principal_user
+      - result.response.size_in_bytes == 1073741824
+      - result.response.enforcement_type == "SOFT"
+      - result.response.is_notification_enabled == true
+      - result.response.notification_recipients | length == 2
+      - result.response.notification_recipients[0] == "admin@ad.example.com"
+      - result.response.notification_recipients[1] == "ops@ad.example.com"
+    success_msg: "Spec for creating quota policy using check mode with all attributes generated successfully"
+    fail_msg: "Spec for creating quota policy using check mode with all attributes generation failed"
+
+########################################################################################
+# Create quota policy - negative / validation
+########################################################################################
+
+- name: Create quota policy with no principal_type and no ext_id (should fail)
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    principal_name: "{{ principal_user }}"
+    size_in_bytes: 1073741824
+    enforcement_type: "SOFT"
+  register: result
+  ignore_errors: true
+
+- name: Create quota policy with no principal_type and no ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is present but any of the following are missing: principal_type, ext_id' in result.msg"
+    success_msg: "Create quota policy with no principal_type failed as expected"
+    fail_msg: "Create quota policy with no principal_type did not fail as expected"
+
+- name: Create quota policy with missing required attributes (should fail)
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    principal_type: "USER"
+  register: result
+  ignore_errors: true
+
+- name: Create quota policy with missing required attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Missing required parameter(s):' in result.msg"
+      - "'principal_name' in result.msg"
+      - "'size_in_bytes' in result.msg"
+      - "'enforcement_type' in result.msg"
+    success_msg: "Create quota policy with missing required attributes failed as expected"
+    fail_msg: "Create quota policy with missing required attributes did not fail as expected"
+
+- name: Create quota policy with invalid principal_type enum (should fail)
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    principal_type: "INVALID_TYPE"
+    principal_name: "{{ principal_user }}"
+    size_in_bytes: 1073741824
+    enforcement_type: "SOFT"
+  register: result
+  ignore_errors: true
+
+- name: Create quota policy with invalid principal_type enum status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'value of principal_type must be one of' in result.msg"
+    success_msg: "Create quota policy with invalid principal_type enum failed as expected"
+    fail_msg: "Create quota policy with invalid principal_type enum did not fail as expected"
+
+- name: Create quota policy with invalid enforcement_type enum (should fail)
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    principal_type: "USER"
+    principal_name: "{{ principal_user }}"
+    size_in_bytes: 1073741824
+    enforcement_type: "INVALID_ENFORCEMENT"
+  register: result
+  ignore_errors: true
+
+- name: Create quota policy with invalid enforcement_type enum status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'value of enforcement_type must be one of' in result.msg"
+    success_msg: "Create quota policy with invalid enforcement_type enum failed as expected"
+    fail_msg: "Create quota policy with invalid enforcement_type enum did not fail as expected"
+
+########################################################################################
+# Create quota policy - live (minimal + full)
+########################################################################################
+
+- name: Create quota policy with minimum (required) attributes
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    principal_type: "USER"
+    principal_name: "{{ principal_user }}_min"
+    size_in_bytes: 1073741824
+    enforcement_type: "SOFT"
+  register: result
+  ignore_errors: true
+
+- name: Create quota policy with minimum attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.principal_type == "USER"
+      - result.response.principal_name == principal_user ~ "_min"
+      - result.response.size_in_bytes == 1073741824
+      - result.response.enforcement_type == "SOFT"
+    success_msg: "Quota policy with minimum attributes created successfully"
+    fail_msg: "Quota policy with minimum attributes creation failed"
+
+- name: Add quota policy to todelete list
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+  when: result.ext_id is defined and result.ext_id
+
+- name: Create quota policy with all attributes
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    principal_type: "GROUP"
+    principal_name: "{{ principal_group }}"
+    size_in_bytes: 2147483648
+    enforcement_type: "HARD"
+    is_notification_enabled: true
+    notification_recipients:
+      - "admin@ad.example.com"
+  register: result
+  ignore_errors: true
+
+- name: Create quota policy with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.principal_type == "GROUP"
+      - result.response.principal_name == principal_group
+      - result.response.size_in_bytes == 2147483648
+      - result.response.enforcement_type == "HARD"
+      - result.response.is_notification_enabled == true
+      - result.response.notification_recipients | length == 1
+      - result.response.notification_recipients[0] == "admin@ad.example.com"
+    success_msg: "Quota policy with all attributes created successfully"
+    fail_msg: "Quota policy with all attributes creation failed"
+
+- name: Set quota policy ext_id for full lifecycle
+  ansible.builtin.set_fact:
+    quota_policy_ext_id: "{{ result.ext_id }}"
+  when: result.ext_id is defined and result.ext_id
+
+- name: Add quota policy to todelete list
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+  when: result.ext_id is defined and result.ext_id
+
+########################################################################################
+# Info module - get single quota policy
+########################################################################################
+
+- name: Fetch quota policy using external ID
+  nutanix.ncp.ntnx_files_quota_policies_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ quota_policy_ext_id }}"
+  register: result
+  ignore_errors: true
+  when: quota_policy_ext_id is defined
+
+- name: Fetch quota policy using external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == quota_policy_ext_id
+      - result.response.principal_type == "GROUP"
+      - result.response.principal_name == principal_group
+      - result.response.size_in_bytes == 2147483648
+      - result.response.enforcement_type == "HARD"
+    success_msg: "Fetch quota policy using external ID passed"
+    fail_msg: "Fetch quota policy using external ID failed"
+  when: quota_policy_ext_id is defined
+
+- name: Fetch quota policy using wrong external ID
+  nutanix.ncp.ntnx_files_quota_policies_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ non_existent_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch quota policy using wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Fetch quota policy using wrong external ID failed as expected"
+    fail_msg: "Fetch quota policy using wrong external ID did not fail as expected"
+
+########################################################################################
+# Info module - list quota policies
+########################################################################################
+
+- name: List all quota policies for the mount target
+  nutanix.ncp.ntnx_files_quota_policies_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: List all quota policies status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 2
+    success_msg: "List all quota policies passed"
+    fail_msg: "List all quota policies failed"
+  when: quota_policy_ext_id is defined
+
+- name: List quota policies with filter
+  nutanix.ncp.ntnx_files_quota_policies_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    filter: "principalName eq '{{ principal_group }}'"
+  register: result
+  ignore_errors: true
+
+- name: List quota policies with filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+      - result.response[0].principal_name == principal_group
+    success_msg: "List quota policies with filter passed"
+    fail_msg: "List quota policies with filter failed"
+  when: quota_policy_ext_id is defined
+
+- name: List quota policies with limit
+  nutanix.ncp.ntnx_files_quota_policies_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List quota policies with limit status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    success_msg: "List quota policies with limit passed"
+    fail_msg: "List quota policies with limit failed"
+  when: quota_policy_ext_id is defined
+
+########################################################################################
+# Update quota policy
+########################################################################################
+
+- name: Generate spec for updating quota policy using check mode with all attributes
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ quota_policy_ext_id }}"
+    principal_type: "GROUP"
+    principal_name: "{{ principal_group }}"
+    size_in_bytes: 5368709120
+    enforcement_type: "SOFT"
+    is_notification_enabled: false
+  check_mode: true
+  register: result
+  ignore_errors: true
+  when: quota_policy_ext_id is defined
+
+- name: Generate spec for updating quota policy using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.response is defined
+      - result.response.principal_type == "GROUP"
+      - result.response.size_in_bytes == 5368709120
+      - result.response.enforcement_type == "SOFT"
+      - result.response.is_notification_enabled == false
+    success_msg: "Spec for updating quota policy using check mode with all attributes generated successfully"
+    fail_msg: "Spec for updating quota policy using check mode with all attributes generation failed"
+  when: quota_policy_ext_id is defined
+
+- name: Update quota policy with all attributes
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ quota_policy_ext_id }}"
+    principal_type: "GROUP"
+    principal_name: "{{ principal_group }}"
+    size_in_bytes: 5368709120
+    enforcement_type: "SOFT"
+    is_notification_enabled: false
+    notification_recipients:
+      - "admin@ad.example.com"
+      - "ops@ad.example.com"
+  register: result
+  ignore_errors: true
+  when: quota_policy_ext_id is defined
+
+- name: Update quota policy with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.size_in_bytes == 5368709120
+      - result.response.enforcement_type == "SOFT"
+      - result.response.is_notification_enabled == false
+      - result.response.notification_recipients | length == 2
+    success_msg: "Update quota policy with all attributes passed"
+    fail_msg: "Update quota policy with all attributes failed"
+  when: quota_policy_ext_id is defined
+
+- name: Update quota policy with same values (idempotency test)
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ quota_policy_ext_id }}"
+    principal_type: "GROUP"
+    principal_name: "{{ principal_group }}"
+    size_in_bytes: 5368709120
+    enforcement_type: "SOFT"
+    is_notification_enabled: false
+    notification_recipients:
+      - "admin@ad.example.com"
+      - "ops@ad.example.com"
+  register: result
+  ignore_errors: true
+  when: quota_policy_ext_id is defined
+
+- name: Update quota policy with same values (idempotency test) status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.msg == "Nothing to change."
+    success_msg: "Update quota policy idempotency test passed"
+    fail_msg: "Update quota policy idempotency test failed"
+  when: quota_policy_ext_id is defined
+
+- name: Update quota policy with wrong external ID (should fail)
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ non_existent_ext_id }}"
+    principal_type: "USER"
+    principal_name: "{{ principal_user }}"
+    size_in_bytes: 1073741824
+    enforcement_type: "SOFT"
+  register: result
+  ignore_errors: true
+
+- name: Update quota policy with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Update quota policy with wrong external ID failed as expected"
+    fail_msg: "Update quota policy with wrong external ID did not fail as expected"
+
+########################################################################################
+# Delete quota policy
+########################################################################################
+
+- name: Delete quota policy with check mode
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: absent
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ todelete[0] | default(non_existent_ext_id) }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Delete quota policy with check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+    success_msg: "Delete quota policy with check mode passed"
+    fail_msg: "Delete quota policy with check mode failed"
+
+- name: Delete all created quota policies
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: absent
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ item }}"
+  register: result
+  ignore_errors: true
+  loop: "{{ todelete }}"
+  when: todelete | length > 0
+
+- name: Deletion status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.results | length == todelete | length
+    success_msg: "All quota policies are deleted successfully"
+    fail_msg: "Unable to delete all quota policies"
+  when: todelete | length > 0
+
+- name: Delete quota policy with wrong external ID (should fail)
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: absent
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+    ext_id: "{{ non_existent_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Delete quota policy with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Delete quota policy with wrong external ID failed as expected"
+    fail_msg: "Delete quota policy with wrong external ID did not fail as expected"
+
+- name: Delete quota policy with missing external ID (should fail)
+  nutanix.ncp.ntnx_files_quota_policy_v2:
+    state: absent
+    file_server_ext_id: "{{ file_server_ext_id }}"
+    mount_target_ext_id: "{{ mount_target_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Delete quota policy with missing external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete quota policy with missing external ID failed as expected"
+    fail_msg: "Delete quota policy with missing external ID did not fail as expected"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **files** namespace, entity
**QuotaPolicy**. A quota policy sets the storage consumption limit for a user or
group on a Nutanix Files mount target (share/export).

- Modules generated: `ntnx_files_quota_policy_v2`, `ntnx_files_quota_policies_info_v2`
- API methods covered: `5` of the 8 in the SDK — `CreateQuotaPolicy`, `GetQuotaPolicyById`,
  `ListQuotaPolicies`, `UpdateQuotaPolicyById`, `DeleteQuotaPolicyById`.
  (`GetEmailConfig` / `UpdateEmailConfig` belong to the separate *EmailConfig* resource
  and are out of scope for these two QuotaPolicy modules.)
- Fields in CRUD module spec: `9` (`ext_id`, `file_server_ext_id`, `mount_target_ext_id`,
  `principal_type`, `principal_name`, `size_in_bytes`, `enforcement_type`,
  `notification_recipients`, `is_notification_enabled`)
- Fields in info module spec: `3` (`ext_id`, `file_server_ext_id`, `mount_target_ext_id`)
  plus the shared info options (`filter`, `limit`, `page`, `orderby`, `select`).

The CRUD module, info module, helper structure, `get_module_spec()`, `RETURN`/`DOCUMENTATION`
blocks, idempotency logic and error handling mirror the existing `ntnx_virtual_switch_v2`
and `ntnx_virtual_switches_info_v2` modules.

## Domain knowledge (from Glean)

The Glean `chat` tool timed out on this run; the `company_search` tool was reachable and
was used to gather domain knowledge. Per this repository's PR policy, internal ticket
links (JIRA/ENG), Confluence/SharePoint URLs and other internal references are intentionally
omitted from this description.

Feature summary (Nutanix Files QuotaPolicy):
- A quota policy lets a File Server administrator define the storage consumption limit for a
  specific principal (an Active Directory user or group) on a mount target (share/export).
- Scope: quota policies are nested under a mount target, which is nested under a file server:
  `/api/files/v4.0/config/file-servers/{fileServerExtId}/mount-targets/{mountTargetExtId}/quota-policies/{extId}`.
- Key attributes: `principal_type` (USER/GROUP), `principal_name`, `size_in_bytes` (the quota
  limit), `enforcement_type` (SOFT = notify only, HARD = block writes past the limit),
  `is_notification_enabled`, and `notification_recipients` (emails notified as consumption
  nears the limit).
- Prerequisites: a deployed Nutanix Files file server and at least one mount target must
  exist before a quota policy can be created. There is a related per-file-server email
  configuration resource used for quota notifications.
- Required domain skills: Nutanix Files (file servers, shares/exports a.k.a. mount targets),
  Active Directory users/groups, storage quota concepts (soft vs hard enforcement), and the
  Nutanix v4 config REST API + Python SDK conventions (tasks, ETags/If-Match, OData
  filter/limit).

## Files changed

- `plugins/modules/`
  - `ntnx_files_quota_policy_v2.py` (new — CRUD)
  - `ntnx_files_quota_policies_info_v2.py` (new — info)
- `plugins/module_utils/v4/files/`
  - `api_client.py` (new — Files SDK client + `QuotaPoliciesApi` instance + `get_etag`)
  - `helpers.py` (new — `get_quota_policy`)
- `plugins/module_utils/v4/constants.py` (added `RelEntityType.QUOTA_POLICY`)
- `meta/runtime.yml` (registered both modules in the `ntnx` action group)
- `examples/files/QuotaPolicy/`
  - `quota_policy.yml` (new — create/get/list/update/delete example playbook)
  - `examples_run.log` (new — real output of running the example playbook)
- `tests/integration/targets/ntnx_files_quota_policy_v2/`
  - `tasks/main.yml`, `tasks/quota_policy.yml`, `meta/main.yml`, `aliases` (new)

## Test execution

| Metric              | Value                                                                 |
|---------------------|-----------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_files_quota_policy_v2 --allow-disabled --python 3.11 -v` |
| Total tasks (ok)    | `16`                                                                  |
| Passed (asserts)    | `5` (check_mode create + 4 validation/negative asserts)               |
| Failed              | `1` (create-with-minimum-attributes status assert)                    |
| Ignored             | `5` (ignore_errors tasks: 1 live create + 4 expected-failure negatives)|
| Cluster (PC)        | `10.44.76.28`                                                         |
| Lint / Sanity       | `black`, `isort`, `flake8`, `ansible-lint`, `ansible-test sanity` — all PASS |

### Analysis

- **check_mode + validation coverage passed on the live run:**
  - `Generate spec for creating quota policy using check mode with all attributes` — PASS.
  - `Create ... with no principal_type and no ext_id` → `state is present but any of the following are missing: principal_type, ext_id` — PASS.
  - `Create ... with missing required attributes` → `Missing required parameter(s): principal_name, size_in_bytes, enforcement_type` — PASS.
  - `Create ... with invalid principal_type enum` → `value of principal_type must be one of: USER, GROUP, got: INVALID_TYPE` — PASS.
  - `Create ... with invalid enforcement_type enum` → `value of enforcement_type must be one of: SOFT, HARD, got: INVALID_ENFORCEMENT` — PASS.

- **Known issue — live create/read/update/delete could not run (cluster prerequisite unavailable):**
  The Nutanix Files service backend on the supplied Prism Central (`10.44.76.28`) returns
  HTTP `503 SERVICE UNAVAILABLE` for every `/api/files/v4.0/...` call:
  `{"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}`.
  This is the Files Manager / minerva gateway (`127.0.0.1:7509`) being unavailable — i.e. no
  file server / mount target is deployed on this PC. A quota policy cannot be created without
  a live file server + mount target, so the lifecycle tasks (create, get-by-id, list,
  update, idempotency, delete) could not complete and the `Create with minimum attributes`
  status assert failed with `result.changed == true` evaluating to false. The module itself
  behaved correctly: it surfaced the backend error cleanly as
  `msg: "Api Exception raised while creating quota policy", error: "SERVICE UNAVAILABLE", status: 503`.
  Re-running these targets against a PC with Nutanix Files deployed (and setting
  `quota_policy.file_server_ext_id` / `quota_policy.mount_target_ext_id` in
  `tests/integration/integration_config.yml`) will exercise the full lifecycle.

- Because no live create succeeded, `RETURN` documentation samples use realistic structural
  values derived from the SDK `QuotaPolicy` model rather than captured API output.

### Test logs (tail)

<details>
<summary>tail -n 120 test_logs.log</summary>

```text
TASK [ntnx_files_quota_policy_v2 : Generate spec for creating quota policy using check mode with all attributes] ***
ok: [testhost] => {"changed": false, "ext_id": null, "response": {"enforcement_type": "SOFT", "ext_id": null, "is_notification_enabled": true, "links": null, "notification_recipients": ["admin@ad.example.com", "ops@ad.example.com"], "principal_name": "user_ansible_YUuVelooyInr@ad.example.com", "principal_type": "USER", "size_in_bytes": 1073741824, "tenant_id": null}}

TASK [... check mode ... status] => "Spec for creating quota policy using check mode with all attributes generated successfully"

TASK [Create quota policy with no principal_type and no ext_id (should fail)]
fatal: FAILED! => {"msg": "state is present but any of the following are missing: principal_type, ext_id"} ...ignoring => PASS

TASK [Create quota policy with missing required attributes (should fail)]
fatal: FAILED! => {"msg": "Missing required parameter(s): principal_name, size_in_bytes, enforcement_type"} ...ignoring => PASS

TASK [Create quota policy with invalid principal_type enum (should fail)]
fatal: FAILED! => {"msg": "value of principal_type must be one of: USER, GROUP, got: INVALID_TYPE"} ...ignoring => PASS

TASK [Create quota policy with invalid enforcement_type enum (should fail)]
fatal: FAILED! => {"msg": "value of enforcement_type must be one of: SOFT, HARD, got: INVALID_ENFORCEMENT"} ...ignoring => PASS

TASK [Create quota policy with minimum (required) attributes]
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while creating quota policy", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503} ...ignoring

PLAY RECAP *********************************************************************
testhost                   : ok=16   changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=5
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
