### PR TITLE
ObjectStoreProfile Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+__pycache__/
+*.py[cod]

--- a/examples/files/ObjectStoreProfile/examples_run.log
+++ b/examples/files/ObjectStoreProfile/examples_run.log
@@ -1,0 +1,86 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+
+PLAY [Object Store Profiles playbook] ******************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost]
+
+TASK [Create AWS object store profile] *****************************************
+[ERROR]: Task failed: Module failed: Api Exception raised while creating object store profile
+Origin: /tmp/codegen-artifacts.B21VD9/example_run/object_store_profiles_v2.yml:31:7
+
+29         object_store_profile_ext_id: ""
+30
+31     - name: Create AWS object store profile
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while creating object store profile", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [Set object store profile ext_id] *****************************************
+ok: [localhost]
+
+TASK [Update object store profile] *********************************************
+[ERROR]: Task failed: Module failed: Invalid value for `ext_id`, must be a follow pattern or equal to `/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/`
+Origin: /tmp/codegen-artifacts.B21VD9/example_run/object_store_profiles_v2.yml:63:7
+
+61         object_store_profile_ext_id: "{{ result.ext_id | default(object_store_profile_ext_id) }}"
+62
+63     - name: Update object store profile
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: Module failed: Invalid value for `ext_id`, must be a follow pattern or equal to `/^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$/`"}
+...ignoring
+
+TASK [Get object store profile using ext_id] ***********************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching object store profiles info
+Origin: /tmp/codegen-artifacts.B21VD9/example_run/object_store_profiles_v2.yml:86:7
+
+84       ignore_errors: true
+85
+86     - name: Get object store profile using ext_id
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching object store profiles info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List all object store profiles for the file server] **********************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching object store profiles info
+Origin: /tmp/codegen-artifacts.B21VD9/example_run/object_store_profiles_v2.yml:93:7
+
+91       ignore_errors: true
+92
+93     - name: List all object store profiles for the file server
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching object store profiles info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List object store profiles with filter] **********************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching object store profiles info
+Origin: /tmp/codegen-artifacts.B21VD9/example_run/object_store_profiles_v2.yml:99:7
+
+97       ignore_errors: true
+98
+99     - name: List object store profiles with filter
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching object store profiles info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List object store profiles with limit] ***********************************
+[ERROR]: Task failed: Module failed: Api Exception raised while fetching object store profiles info
+Origin: /tmp/codegen-artifacts.B21VD9/example_run/object_store_profiles_v2.yml:106:7
+
+104       ignore_errors: true
+105
+106     - name: List object store profiles with limit
+          ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching object store profiles info", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=8    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=6   
+

--- a/examples/files/ObjectStoreProfile/object_store_profiles_v2.yml
+++ b/examples/files/ObjectStoreProfile/object_store_profiles_v2.yml
@@ -1,0 +1,111 @@
+---
+# Summary:
+# This playbook will do:
+# 1. Create an object store profile (tiering profile) for a file server
+# 2. Update the object store profile
+# 3. Get the object store profile using ext_id
+# 4. List all object store profiles for the file server
+# 5. List object store profiles with a filter
+# 6. List object store profiles with a limit
+#
+# Note: The Nutanix Files v4 API does not expose a delete operation for object
+# store profiles, so this playbook does not include a delete example.
+
+- name: Object Store Profiles playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        file_server_ext_id: "0006abcd-1111-2222-3333-444455556666"
+        mount_target_ext_id: "b0df3e22-a3a3-4b86-8f09-ec9e1f3e8dc2"
+        profile_name: "tiering_profile_ansible"
+        object_store_profile_ext_id: ""
+
+    - name: Create AWS object store profile
+      nutanix.ncp.ntnx_files_object_store_profile_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        name: "{{ profile_name }}"
+        object_store_type: "AWS"
+        mount_targets_enablement_type: "ALL_CURRENT_MOUNT_TARGETS"
+        mount_target_ext_ids:
+          - "{{ mount_target_ext_id }}"
+        retention_period_days: 1825
+        is_ssl_peer_verfication_enabled: true
+        object_store_config:
+          base_url: "https://s3.us-east-1.amazonaws.com/"
+          ca_cert_content: "-----BEGIN CERTIFICATE-----\nMIIC...\n-----END CERTIFICATE-----"
+          proxy_server:
+            url: "http://proxy.example.com:8080/"
+            credential:
+              username: "proxy_user"
+              password: "proxy_password"
+          configuration:
+            aws:
+              access_key: "AKIAEXAMPLEACCESSKEY"
+              secret_key: "wJalrXUtnFEMIEXAMPLESECRETKEY"
+              bucket_name: "files-tiering-bucket"
+              bucket_location: "us-east-1"
+      register: result
+      ignore_errors: true
+
+    - name: Set object store profile ext_id
+      ansible.builtin.set_fact:
+        object_store_profile_ext_id: "{{ result.ext_id | default(object_store_profile_ext_id) }}"
+
+    - name: Update object store profile
+      nutanix.ncp.ntnx_files_object_store_profile_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ object_store_profile_ext_id }}"
+        name: "{{ profile_name }}_updated"
+        object_store_type: "AWS"
+        mount_targets_enablement_type: "ALL_CURRENT_FUTURE_MOUNT_TARGETS"
+        mount_target_ext_ids:
+          - "{{ mount_target_ext_id }}"
+        retention_period_days: 3650
+        is_ssl_peer_verfication_enabled: false
+        object_store_config:
+          base_url: "https://s3.us-east-1.amazonaws.com/"
+          configuration:
+            aws:
+              access_key: "AKIAEXAMPLEACCESSKEY"
+              secret_key: "wJalrXUtnFEMIEXAMPLESECRETKEY"
+              bucket_name: "files-tiering-bucket"
+              bucket_location: "us-east-1"
+      register: result
+      ignore_errors: true
+
+    - name: Get object store profile using ext_id
+      nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ object_store_profile_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: List all object store profiles for the file server
+      nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: List object store profiles with filter
+      nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        filter: "name eq '{{ profile_name }}_updated'"
+      register: result
+      ignore_errors: true
+
+    - name: List object store profiles with limit
+      nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        limit: 1
+      register: result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_files_object_store_profile_v2
+    - ntnx_files_object_store_profiles_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,7 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        OBJECT_STORE_PROFILE = "files:config:object-store-profile"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/files/__init__.py
+++ b/plugins/module_utils/v4/files/__init__.py
@@ -1,0 +1,6 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,111 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+files_SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    files_SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details.
+    Args:
+        module (object): Ansible module object
+    return:
+        client (object): ApiClient instance
+    """
+    if files_SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=files_SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    # Setup API logging if debug is enabled
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    return:
+        etag (str): etag value
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_tier_api_instance(module):
+    """
+    This method will return TierApi instance.
+    The TierApi hosts the object store profile and tiering configuration APIs.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): TierApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.TierApi(api_client=api_client)
+
+
+def get_file_servers_api_instance(module):
+    """
+    This method will return FileServersApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): FileServersApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.FileServersApi(api_client=api_client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,31 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_object_store_profile(module, api_instance, file_server_ext_id, ext_id):
+    """
+    This method will return an object store profile using its external ID.
+    Args:
+        module: Ansible module
+        api_instance: TierApi instance from ntnx_files_py_client sdk
+        file_server_ext_id (str): external ID of the parent file server
+        ext_id (str): object store profile external ID
+    return:
+        object_store_profile (object): object store profile info
+    """
+    try:
+        return api_instance.get_object_store_profile_by_id(
+            fileServerExtId=file_server_ext_id, extId=ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching object store profile using ext_id",
+        )

--- a/plugins/modules/ntnx_files_object_store_profile_v2.py
+++ b/plugins/modules/ntnx_files_object_store_profile_v2.py
@@ -1,0 +1,755 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_object_store_profile_v2
+short_description: Create and update object store profiles for a Nutanix Files file server
+version_added: 2.6.0
+description:
+  - This module allows you to create and update object store profiles (tiering profiles) for a Nutanix Files file server in Nutanix Prism Central.
+  - An object store profile defines the S3/Azure object store backend used by Nutanix Files Smart Tiering.
+  - If C(ext_id) is not provided, a new object store profile is created.
+  - If C(ext_id) is provided, the existing object store profile is updated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - This module does not support deletion because the Nutanix Files v4 API does not expose a delete operation for object store profiles.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  state:
+    description:
+      - State of the object store profile.
+      - If C(state) is C(present) and C(ext_id) is not provided, a new object store profile is created.
+      - If C(state) is C(present) and C(ext_id) is provided, the existing object store profile is updated.
+    type: str
+    choices:
+      - present
+    default: present
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server that owns the object store profile.
+      - Required for all operations.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external identifier of the object store profile.
+      - Required for the update operation.
+    type: str
+    required: false
+  name:
+    description:
+      - Object store cloud profile name.
+      - Required for the create operation.
+      - Maximum 80 characters.
+    type: str
+    required: false
+  object_store_type:
+    description:
+      - Type of the object store backend used for tiering.
+      - Required for the create operation.
+    type: str
+    required: false
+    choices:
+      - AWS
+      - AWS_GLACIER_IR
+      - AWS_STANDARD_IA
+      - AZURE
+      - AZURE_COOL
+      - GCP
+      - NUTANIX
+      - OTHER
+  mount_target_ext_ids:
+    description:
+      - List of mount target (share) external identifiers that should be included in the tiering profile.
+    type: list
+    elements: str
+    required: false
+  mount_targets_enablement_type:
+    description:
+      - Controls which mount targets of the file server are enabled for tiering with this profile.
+    type: str
+    required: false
+    choices:
+      - ALL_CURRENT_FUTURE_MOUNT_TARGETS
+      - ALL_CURRENT_MOUNT_TARGETS
+      - ALL_FUTURE_MOUNT_TARGETS
+      - NONE
+  retention_period_days:
+    description:
+      - Indicates time in days for which the data will be maintained in the cloud after it is deleted from the local storage on the file server.
+      - Minimum value is 0. The API default is 1825 days.
+    type: int
+    required: false
+  is_ssl_peer_verfication_enabled:
+    description:
+      - Enable SSL verify peer certificate for the object store connection.
+    type: bool
+    required: false
+  object_store_config:
+    description:
+      - Object store connection and credential configuration for the tiering profile.
+      - Required for the create operation.
+    type: dict
+    required: false
+    suboptions:
+      base_url:
+        description:
+          - Base URL of the object store endpoint.
+          - Required when C(object_store_config) is provided.
+        type: str
+        required: false
+      ca_cert_content:
+        description:
+          - CA certificate content used to validate the object store endpoint.
+        type: str
+        required: false
+      proxy_server:
+        description:
+          - HTTP proxy server configuration used to reach the object store.
+        type: dict
+        required: false
+        suboptions:
+          url:
+            description:
+              - HTTP proxy server URL.
+            type: str
+            required: false
+          credential:
+            description:
+              - Credentials used to authenticate with the proxy server.
+            type: dict
+            required: false
+            suboptions:
+              username:
+                description:
+                  - Name of the user for the proxy server.
+                  - Maximum 256 characters.
+                type: str
+                required: false
+              password:
+                description:
+                  - Password of the user for the proxy server.
+                type: str
+                required: false
+      configuration:
+        description:
+          - AWS/Azure configuration for the tiering profile.
+          - Provide C(aws) for AWS/NUTANIX/GCP/OTHER object store types and C(azure) for Azure object store types.
+          - Required when C(object_store_config) is provided.
+        type: dict
+        required: false
+        suboptions:
+          aws:
+            description:
+              - AWS (or S3-compatible) configuration for the tiering profile.
+            type: dict
+            required: false
+            suboptions:
+              access_key:
+                description:
+                  - Access key for the object store.
+                  - Required when C(aws) is provided.
+                  - Maximum 1024 characters.
+                type: str
+                required: false
+              secret_key:
+                description:
+                  - Secret key for the object store.
+                  - Maximum 1024 characters.
+                type: str
+                required: false
+              bucket_name:
+                description:
+                  - Bucket name.
+                  - Minimum 3 and maximum 63 characters.
+                type: str
+                required: false
+              bucket_location:
+                description:
+                  - Bucket location (region).
+                  - Maximum 2048 characters.
+                type: str
+                required: false
+          azure:
+            description:
+              - Azure configuration for the tiering profile.
+            type: dict
+            required: false
+            suboptions:
+              storage_account_name:
+                description:
+                  - Storage account name for Azure.
+                  - Required when C(azure) is provided.
+                  - Minimum 3 and maximum 24 characters.
+                type: str
+                required: false
+              storage_account_key:
+                description:
+                  - Storage account key for Azure.
+                  - Maximum 1024 characters.
+                type: str
+                required: false
+              container_name:
+                description:
+                  - Container name for Azure.
+                  - Minimum 3 and maximum 63 characters.
+                type: str
+                required: false
+  recovery_object_store_config:
+    description:
+      - Recovery object store connection and credential configuration for the tiering profile.
+      - This has the same structure as C(object_store_config).
+    type: dict
+    required: false
+    suboptions:
+      base_url:
+        description:
+          - Base URL of the recovery object store endpoint.
+          - Required when C(recovery_object_store_config) is provided.
+        type: str
+        required: false
+      ca_cert_content:
+        description:
+          - CA certificate content used to validate the recovery object store endpoint.
+        type: str
+        required: false
+      proxy_server:
+        description:
+          - HTTP proxy server configuration used to reach the recovery object store.
+        type: dict
+        required: false
+        suboptions:
+          url:
+            description:
+              - HTTP proxy server URL.
+            type: str
+            required: false
+          credential:
+            description:
+              - Credentials used to authenticate with the proxy server.
+            type: dict
+            required: false
+            suboptions:
+              username:
+                description:
+                  - Name of the user for the proxy server.
+                  - Maximum 256 characters.
+                type: str
+                required: false
+              password:
+                description:
+                  - Password of the user for the proxy server.
+                type: str
+                required: false
+      configuration:
+        description:
+          - AWS/Azure configuration for the recovery object store.
+          - Provide C(aws) for AWS/NUTANIX/GCP/OTHER object store types and C(azure) for Azure object store types.
+          - Required when C(recovery_object_store_config) is provided.
+        type: dict
+        required: false
+        suboptions:
+          aws:
+            description:
+              - AWS (or S3-compatible) configuration for the recovery object store.
+            type: dict
+            required: false
+            suboptions:
+              access_key:
+                description:
+                  - Access key for the recovery object store.
+                  - Required when C(aws) is provided.
+                  - Maximum 1024 characters.
+                type: str
+                required: false
+              secret_key:
+                description:
+                  - Secret key for the recovery object store.
+                  - Maximum 1024 characters.
+                type: str
+                required: false
+              bucket_name:
+                description:
+                  - Bucket name.
+                  - Minimum 3 and maximum 63 characters.
+                type: str
+                required: false
+              bucket_location:
+                description:
+                  - Bucket location (region).
+                  - Maximum 2048 characters.
+                type: str
+                required: false
+          azure:
+            description:
+              - Azure configuration for the recovery object store.
+            type: dict
+            required: false
+            suboptions:
+              storage_account_name:
+                description:
+                  - Storage account name for Azure.
+                  - Required when C(azure) is provided.
+                  - Minimum 3 and maximum 24 characters.
+                type: str
+                required: false
+              storage_account_key:
+                description:
+                  - Storage account key for Azure.
+                  - Maximum 1024 characters.
+                type: str
+                required: false
+              container_name:
+                description:
+                  - Container name for Azure.
+                  - Minimum 3 and maximum 63 characters.
+                type: str
+                required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Nutanix (@nutanix)
+"""
+
+EXAMPLES = r"""
+- name: Create AWS object store profile
+  nutanix.ncp.ntnx_files_object_store_profile_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    file_server_ext_id: "0006abcd-1111-2222-3333-444455556666"
+    name: "tiering_profile_ansible"
+    object_store_type: "AWS"
+    mount_targets_enablement_type: "ALL_CURRENT_MOUNT_TARGETS"
+    mount_target_ext_ids:
+      - "b0df3e22-a3a3-4b86-8f09-ec9e1f3e8dc2"
+    retention_period_days: 1825
+    is_ssl_peer_verfication_enabled: true
+    object_store_config:
+      base_url: "https://s3.us-east-1.amazonaws.com/"
+      configuration:
+        aws:
+          access_key: "AKIAEXAMPLEACCESSKEY"
+          secret_key: "wJalrXUtnFEMIEXAMPLESECRETKEY"
+          bucket_name: "files-tiering-bucket"
+          bucket_location: "us-east-1"
+  register: result
+  ignore_errors: true
+
+- name: Update object store profile
+  nutanix.ncp.ntnx_files_object_store_profile_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    file_server_ext_id: "0006abcd-1111-2222-3333-444455556666"
+    ext_id: "1e4e557e-a53e-4d2f-b2d6-a1da4ccf2430"
+    name: "tiering_profile_ansible_updated"
+    object_store_type: "AWS"
+    mount_targets_enablement_type: "ALL_CURRENT_FUTURE_MOUNT_TARGETS"
+    retention_period_days: 3650
+    is_ssl_peer_verfication_enabled: false
+    object_store_config:
+      base_url: "https://s3.us-east-1.amazonaws.com/"
+      configuration:
+        aws:
+          access_key: "AKIAEXAMPLEACCESSKEY"
+          secret_key: "wJalrXUtnFEMIEXAMPLESECRETKEY"
+          bucket_name: "files-tiering-bucket"
+          bucket_location: "us-east-1"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating or updating the object store profile.
+    - If the operation is create or update and C(wait) is true, it will return the object store profile details.
+    - If the operation is create or update and C(wait) is false, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "1e4e557e-a53e-4d2f-b2d6-a1da4ccf2430",
+      "name": "tiering_profile_ansible",
+      "object_store_type": "AWS",
+      "mount_targets_enablement_type": "ALL_CURRENT_MOUNT_TARGETS",
+      "mount_target_ext_ids": ["b0df3e22-a3a3-4b86-8f09-ec9e1f3e8dc2"],
+      "retention_period_days": 1825,
+      "is_ssl_peer_verfication_enabled": true,
+      "object_store_config": {
+          "base_url": "https://s3.us-east-1.amazonaws.com/",
+          "ca_cert_content": null,
+          "configuration": {
+              "access_key": "AKIAEXAMPLEACCESSKEY",
+              "bucket_location": "us-east-1",
+              "bucket_name": "files-tiering-bucket"
+          },
+          "proxy_server": null
+      },
+      "recovery_object_store_config": null,
+      "links": null,
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the object store profile.
+  returned: always
+  type: str
+  sample: "1e4e557e-a53e-4d2f-b2d6-a1da4ccf2430"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped due to idempotency
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error, module is idempotent or check mode
+  type: str
+  sample: "Nothing to change."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_etag,
+    get_tier_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_object_store_profile  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client as files_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as files_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+# Read-only attributes populated by the platform that must not be sent back on update.
+READ_ONLY_FIELDS = ["ext_id", "links", "tenant_id"]
+
+
+def get_object_store_config_spec():
+    """Build the argument spec for an object store configuration block."""
+
+    credential_spec = dict(
+        username=dict(type="str"),
+        password=dict(type="str", no_log=True),
+    )
+
+    proxy_server_spec = dict(
+        url=dict(type="str"),
+        credential=dict(
+            type="dict",
+            options=credential_spec,
+            obj=files_sdk.Credential,
+        ),
+    )
+
+    aws_config_spec = dict(
+        access_key=dict(type="str", no_log=True),
+        secret_key=dict(type="str", no_log=True),
+        bucket_name=dict(type="str"),
+        bucket_location=dict(type="str"),
+    )
+
+    azure_config_spec = dict(
+        storage_account_name=dict(type="str"),
+        storage_account_key=dict(type="str", no_log=True),
+        container_name=dict(type="str"),
+    )
+
+    configuration_obj_map = {
+        "aws": files_sdk.AWSConfig,
+        "azure": files_sdk.AzureConfig,
+    }
+
+    configuration_spec = dict(
+        aws=dict(type="dict", options=aws_config_spec),
+        azure=dict(type="dict", options=azure_config_spec),
+    )
+
+    object_store_config_spec = dict(
+        base_url=dict(type="str"),
+        ca_cert_content=dict(type="str"),
+        proxy_server=dict(
+            type="dict",
+            options=proxy_server_spec,
+            obj=files_sdk.ProxyServer,
+        ),
+        configuration=dict(
+            type="dict",
+            options=configuration_spec,
+            obj=configuration_obj_map,
+            mutually_exclusive=[("aws", "azure")],
+        ),
+    )
+    return object_store_config_spec
+
+
+def get_module_spec():
+    object_store_config_spec = get_object_store_config_spec()
+
+    module_args = dict(
+        state=dict(type="str", choices=["present"], default="present"),
+        file_server_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        object_store_type=dict(
+            type="str",
+            choices=[
+                "AWS",
+                "AWS_GLACIER_IR",
+                "AWS_STANDARD_IA",
+                "AZURE",
+                "AZURE_COOL",
+                "GCP",
+                "NUTANIX",
+                "OTHER",
+            ],
+            obj=files_sdk.ObjectStoreType,
+        ),
+        mount_target_ext_ids=dict(type="list", elements="str"),
+        mount_targets_enablement_type=dict(
+            type="str",
+            choices=[
+                "ALL_CURRENT_FUTURE_MOUNT_TARGETS",
+                "ALL_CURRENT_MOUNT_TARGETS",
+                "ALL_FUTURE_MOUNT_TARGETS",
+                "NONE",
+            ],
+            obj=files_sdk.MountTargetsEnablementType,
+        ),
+        retention_period_days=dict(type="int"),
+        is_ssl_peer_verfication_enabled=dict(type="bool"),
+        object_store_config=dict(
+            type="dict",
+            options=object_store_config_spec,
+            obj=files_sdk.ObjectStoreConfig,
+        ),
+        recovery_object_store_config=dict(
+            type="dict",
+            options=deepcopy(object_store_config_spec),
+            obj=files_sdk.ObjectStoreConfig,
+        ),
+    )
+    return module_args
+
+
+def create_object_store_profile(module, result, tier_api):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    validate_required_params(
+        module, ["name", "object_store_type", "object_store_config"]
+    )
+
+    sg = SpecGenerator(module)
+    default_spec = files_sdk.ObjectStoreProfile()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating create object store profile spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = tier_api.create_object_store_profile(
+            fileServerExtId=file_server_ext_id, body=spec
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating object store profile",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task_status, rel=TASK_CONSTANTS.RelEntityType.OBJECT_STORE_PROFILE
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            resp = get_object_store_profile(
+                module, tier_api, file_server_ext_id, ext_id
+            )
+            result["response"] = strip_internal_attributes(resp.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get object store profile ext_id from task"
+                ),
+                msg="Failed to get object store profile ext_id from task",
+            )
+    result["changed"] = True
+
+
+def check_object_store_profile_idempotency(old_spec, update_spec):
+    old_spec = strip_internal_attributes(old_spec)
+    update_spec = strip_internal_attributes(update_spec)
+    return old_spec == update_spec
+
+
+def update_object_store_profile(module, result, tier_api):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    old_spec = get_object_store_profile(module, tier_api, file_server_ext_id, ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for updating object store profile", **result
+        )
+    kwargs = {"if_match": etag}
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating update object store profile spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_object_store_profile_idempotency(
+        old_spec.to_dict(), update_spec.to_dict()
+    ):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    strip_read_only_fields(update_spec, fields=READ_ONLY_FIELDS)
+
+    resp = None
+    try:
+        resp = tier_api.update_object_store_profile_by_id(
+            fileServerExtId=file_server_ext_id, extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating object store profile",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_object_store_profile(module, tier_api, file_server_ext_id, ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    tier_api = get_tier_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_object_store_profile(module, result, tier_api)
+        else:
+            create_object_store_profile(module, result, tier_api)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_files_object_store_profiles_info_v2.py
+++ b/plugins/modules/ntnx_files_object_store_profiles_info_v2.py
@@ -1,0 +1,242 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_object_store_profiles_info_v2
+short_description: Fetch object store profiles for a Nutanix Files file server
+version_added: 2.6.0
+description:
+  - This module allows you to fetch information about ObjectStoreProfile in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific ObjectStoreProfile.
+  - If C(ext_id) is not provided, list multiple ObjectStoreProfile optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server that owns the object store profiles.
+      - Required for both get-by-id and list operations.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The external identifier of the object store profile.
+      - If provided, fetch the specific object store profile.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Nutanix (@nutanix)
+"""
+
+EXAMPLES = r"""
+- name: Fetch object store profile using ext_id
+  nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "0006abcd-1111-2222-3333-444455556666"
+    ext_id: "1e4e557e-a53e-4d2f-b2d6-a1da4ccf2430"
+  register: result
+  ignore_errors: true
+
+- name: List all object store profiles for a file server
+  nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "0006abcd-1111-2222-3333-444455556666"
+  register: result
+  ignore_errors: true
+
+- name: List object store profiles with filter
+  nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "0006abcd-1111-2222-3333-444455556666"
+    filter: "name eq 'tiering_profile_ansible'"
+  register: result
+  ignore_errors: true
+
+- name: List object store profiles with limit
+  nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "0006abcd-1111-2222-3333-444455556666"
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC ObjectStoreProfile info v4 API.
+    - It can be a single ObjectStoreProfile if external ID is provided.
+    - List of multiple ObjectStoreProfile if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "1e4e557e-a53e-4d2f-b2d6-a1da4ccf2430",
+      "name": "tiering_profile_ansible",
+      "object_store_type": "AWS",
+      "mount_targets_enablement_type": "ALL_CURRENT_MOUNT_TARGETS",
+      "mount_target_ext_ids": ["b0df3e22-a3a3-4b86-8f09-ec9e1f3e8dc2"],
+      "retention_period_days": 1825,
+      "is_ssl_peer_verfication_enabled": true,
+      "object_store_config": {
+          "base_url": "https://s3.us-east-1.amazonaws.com/",
+          "ca_cert_content": null,
+          "configuration": {
+              "access_key": "AKIAEXAMPLEACCESSKEY",
+              "bucket_location": "us-east-1",
+              "bucket_name": "files-tiering-bucket"
+          },
+          "proxy_server": null
+      },
+      "recovery_object_store_config": null,
+      "links": null,
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: The external ID of the object store profile.
+  returned: when external ID is provided
+  type: str
+  sample: "1e4e557e-a53e-4d2f-b2d6-a1da4ccf2430"
+
+total_available_results:
+  description: The total number of available object store profiles for the file server.
+  returned: when all object store profiles are fetched
+  type: int
+  sample: 1
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching object store profiles info"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import get_tier_api_instance  # noqa: E402
+from ..module_utils.v4.files.helpers import get_object_store_profile  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        file_server_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def get_object_store_profile_using_ext_id(module, tier_api, result):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    ext_id = module.params.get("ext_id")
+    resp = get_object_store_profile(module, tier_api, file_server_ext_id, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_object_store_profiles(module, tier_api, result):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating object store profiles info spec", **result
+        )
+
+    try:
+        resp = tier_api.list_object_store_profiles(
+            fileServerExtId=file_server_ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching object store profiles info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    tier_api = get_tier_api_instance(module)
+    if module.params.get("ext_id"):
+        get_object_store_profile_using_ext_id(module, tier_api, result)
+    else:
+        get_object_store_profiles(module, tier_api, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_files_object_store_profile_v2/aliases
+++ b/tests/integration/targets/ntnx_files_object_store_profile_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_files_object_store_profile_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_files_object_store_profile_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_files_object_store_profile_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_files_object_store_profile_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import object_store_profiles.yml
+      ansible.builtin.import_tasks: object_store_profiles.yml

--- a/tests/integration/targets/ntnx_files_object_store_profile_v2/tasks/object_store_profiles.yml
+++ b/tests/integration/targets/ntnx_files_object_store_profile_v2/tasks/object_store_profiles.yml
@@ -1,0 +1,598 @@
+---
+###############################################################################
+# Test plan for ntnx_files_object_store_profile_v2 /
+# ntnx_files_object_store_profiles_info_v2
+#
+# An object store profile ("tiering profile") describes the S3/Azure object
+# store backend used by Nutanix Files Smart Tiering. It is scoped to a file
+# server (fileServerExtId path param) and supports Create / Update / Get /
+# List. The v4 API does NOT expose a Delete operation, so there is no delete
+# test.
+#
+# Scenarios covered:
+#   Argument / spec validation (do NOT need a live Files service):
+#     1.  check_mode Create with ALL attributes (AWS/S3 backend, OneOf branch)
+#     2.  check_mode Create with ALL attributes (Azure backend, OneOf branch)
+#     3.  Negative: missing required `name`
+#     4.  Negative: missing required `object_store_type`
+#     5.  Negative: missing required `object_store_config`
+#     6.  Negative: invalid enum for `object_store_type`
+#     7.  Negative: invalid enum for `mount_targets_enablement_type`
+#     8.  Negative: mutually exclusive `aws` + `azure` under configuration
+#     9.  Negative (info): missing required `file_server_ext_id`
+#
+#   Full lifecycle (need a live Files service + an existing file server; run
+#   only when `file_server_ext_id` is provided via integration_config.yml):
+#     10. check_mode Create (minimal required attributes)
+#     11. Create with minimal required attributes
+#     12. Create with ALL attributes -> capture ext_id
+#     13. Info: get by ext_id (single entity)
+#     14. Info: list all (list of entities)
+#     15. Info: list with filter
+#     16. Info: list with limit
+#     17. check_mode Update with ALL attributes
+#     18. Update with ALL attributes (state transitions)
+#     19. Update idempotency (Nothing to change)
+#     20. Negative: get by invalid ext_id
+###############################################################################
+
+- name: Start ntnx_files_object_store_profile_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_files_object_store_profile_v2 tests
+
+- name: Generate random names
+  ansible.builtin.set_fact:
+    random_name: "{{ 999999999999 | random | string }}"
+    suffix_name: "ansible"
+
+- name: Set profile names and file server ext_id
+  ansible.builtin.set_fact:
+    profile_name: "osp_{{ suffix_name }}_{{ random_name }}"
+    # `file_server_ext_id` is expected to be provided by integration_config.yml
+    # when a Nutanix Files file server exists on the target cluster.
+    fs_ext_id: "{{ file_server_ext_id | default('') }}"
+
+###############################################################################
+# Argument / spec validation tests (no live Files service required)
+###############################################################################
+
+- name: Generate spec for creating AWS object store profile using check mode with all attributes
+  nutanix.ncp.ntnx_files_object_store_profile_v2:
+    state: present
+    file_server_ext_id: "check_mode_fs"
+    name: "check_mode_osp_aws"
+    object_store_type: "AWS"
+    mount_targets_enablement_type: "ALL_CURRENT_MOUNT_TARGETS"
+    mount_target_ext_ids:
+      - "mt-1"
+      - "mt-2"
+    retention_period_days: 1825
+    is_ssl_peer_verfication_enabled: true
+    object_store_config:
+      base_url: "https://s3.us-east-1.amazonaws.com/"
+      ca_cert_content: "CERTDATA"
+      proxy_server:
+        url: "http://proxy.local:8080/"
+        credential:
+          username: "proxy_user"
+          password: "proxy_password"
+      configuration:
+        aws:
+          access_key: "AKIAEXAMPLEACCESSKEY"
+          secret_key: "wJalrXUtnFEMIEXAMPLESECRETKEY"
+          bucket_name: "files-tiering-bucket"
+          bucket_location: "us-east-1"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for creating AWS object store profile using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_osp_aws"
+      - result.response.object_store_type == "AWS"
+      - result.response.mount_targets_enablement_type == "ALL_CURRENT_MOUNT_TARGETS"
+      - result.response.mount_target_ext_ids | length == 2
+      - result.response.mount_target_ext_ids[0] == "mt-1"
+      - result.response.mount_target_ext_ids[1] == "mt-2"
+      - result.response.retention_period_days == 1825
+      - result.response.is_ssl_peer_verfication_enabled == true
+      - result.response.object_store_config.base_url == "https://s3.us-east-1.amazonaws.com/"
+      - result.response.object_store_config.ca_cert_content == "CERTDATA"
+      - result.response.object_store_config.proxy_server.url == "http://proxy.local:8080/"
+      - result.response.object_store_config.proxy_server.credential.username == "proxy_user"
+      - result.response.object_store_config.configuration.bucket_name == "files-tiering-bucket"
+      - result.response.object_store_config.configuration.bucket_location == "us-east-1"
+    success_msg: "Spec for creating AWS object store profile using check mode with all attributes generated successfully"
+    fail_msg: "Spec for creating AWS object store profile using check mode with all attributes generation failed"
+
+- name: Generate spec for creating Azure object store profile using check mode with all attributes
+  nutanix.ncp.ntnx_files_object_store_profile_v2:
+    state: present
+    file_server_ext_id: "check_mode_fs"
+    name: "check_mode_osp_azure"
+    object_store_type: "AZURE"
+    mount_targets_enablement_type: "ALL_CURRENT_FUTURE_MOUNT_TARGETS"
+    retention_period_days: 3650
+    is_ssl_peer_verfication_enabled: false
+    object_store_config:
+      base_url: "https://myaccount.blob.core.windows.net/"
+      configuration:
+        azure:
+          storage_account_name: "myaccount"
+          storage_account_key: "azurestoragekey"
+          container_name: "mycontainer"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for creating Azure object store profile using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_osp_azure"
+      - result.response.object_store_type == "AZURE"
+      - result.response.mount_targets_enablement_type == "ALL_CURRENT_FUTURE_MOUNT_TARGETS"
+      - result.response.retention_period_days == 3650
+      - result.response.is_ssl_peer_verfication_enabled == false
+      - result.response.object_store_config.base_url == "https://myaccount.blob.core.windows.net/"
+      - result.response.object_store_config.configuration.storage_account_name == "myaccount"
+      - result.response.object_store_config.configuration.container_name == "mycontainer"
+    success_msg: "Spec for creating Azure object store profile using check mode with all attributes generated successfully"
+    fail_msg: "Spec for creating Azure object store profile using check mode with all attributes generation failed"
+
+- name: Create object store profile with missing name (should fail)
+  nutanix.ncp.ntnx_files_object_store_profile_v2:
+    state: present
+    file_server_ext_id: "check_mode_fs"
+    object_store_type: "AWS"
+    object_store_config:
+      base_url: "https://s3.us-east-1.amazonaws.com/"
+      configuration:
+        aws:
+          access_key: "AKIAEXAMPLEACCESSKEY"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Create object store profile with missing name status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - 'result.msg == "Missing required parameter(s): name"'
+    success_msg: "Create object store profile with missing name failed as expected"
+    fail_msg: "Create object store profile with missing name did not fail as expected"
+
+- name: Create object store profile with missing object_store_type (should fail)
+  nutanix.ncp.ntnx_files_object_store_profile_v2:
+    state: present
+    file_server_ext_id: "check_mode_fs"
+    name: "missing_type"
+    object_store_config:
+      base_url: "https://s3.us-east-1.amazonaws.com/"
+      configuration:
+        aws:
+          access_key: "AKIAEXAMPLEACCESSKEY"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Create object store profile with missing object_store_type status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - 'result.msg == "Missing required parameter(s): object_store_type"'
+    success_msg: "Create object store profile with missing object_store_type failed as expected"
+    fail_msg: "Create object store profile with missing object_store_type did not fail as expected"
+
+- name: Create object store profile with missing object_store_config (should fail)
+  nutanix.ncp.ntnx_files_object_store_profile_v2:
+    state: present
+    file_server_ext_id: "check_mode_fs"
+    name: "missing_config"
+    object_store_type: "AWS"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Create object store profile with missing object_store_config status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - 'result.msg == "Missing required parameter(s): object_store_config"'
+    success_msg: "Create object store profile with missing object_store_config failed as expected"
+    fail_msg: "Create object store profile with missing object_store_config did not fail as expected"
+
+- name: Create object store profile with invalid object_store_type enum (should fail) # noqa: args[module]
+  nutanix.ncp.ntnx_files_object_store_profile_v2:
+    state: present
+    file_server_ext_id: "check_mode_fs"
+    name: "invalid_enum"
+    object_store_type: "INVALID_TYPE"
+    object_store_config:
+      base_url: "https://s3.us-east-1.amazonaws.com/"
+      configuration:
+        aws:
+          access_key: "AKIAEXAMPLEACCESSKEY"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Create object store profile with invalid object_store_type enum status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'value of object_store_type must be one of' in result.msg"
+    success_msg: "Create object store profile with invalid object_store_type enum failed as expected"
+    fail_msg: "Create object store profile with invalid object_store_type enum did not fail as expected"
+
+- name: Create object store profile with invalid mount_targets_enablement_type enum (should fail) # noqa: args[module]
+  nutanix.ncp.ntnx_files_object_store_profile_v2:
+    state: present
+    file_server_ext_id: "check_mode_fs"
+    name: "invalid_enablement"
+    object_store_type: "AWS"
+    mount_targets_enablement_type: "INVALID_ENABLEMENT"
+    object_store_config:
+      base_url: "https://s3.us-east-1.amazonaws.com/"
+      configuration:
+        aws:
+          access_key: "AKIAEXAMPLEACCESSKEY"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Create object store profile with invalid mount_targets_enablement_type enum status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'value of mount_targets_enablement_type must be one of' in result.msg"
+    success_msg: "Create object store profile with invalid mount_targets_enablement_type enum failed as expected"
+    fail_msg: "Create object store profile with invalid mount_targets_enablement_type enum did not fail as expected"
+
+- name: Create object store profile with mutually exclusive aws and azure (should fail)
+  nutanix.ncp.ntnx_files_object_store_profile_v2:
+    state: present
+    file_server_ext_id: "check_mode_fs"
+    name: "mutually_exclusive"
+    object_store_type: "AWS"
+    object_store_config:
+      base_url: "https://s3.us-east-1.amazonaws.com/"
+      configuration:
+        aws:
+          access_key: "AKIAEXAMPLEACCESSKEY"
+        azure:
+          storage_account_name: "myaccount"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Create object store profile with mutually exclusive aws and azure status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'aws|azure' in result.msg"
+    success_msg: "Create object store profile with mutually exclusive aws and azure failed as expected"
+    fail_msg: "Create object store profile with mutually exclusive aws and azure did not fail as expected"
+
+- name: Fetch object store profiles info with missing file_server_ext_id (should fail) # noqa: args[module]
+  nutanix.ncp.ntnx_files_object_store_profiles_info_v2: {}
+  register: result
+  ignore_errors: true
+
+- name: Fetch object store profiles info with missing file_server_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - "'missing required arguments: file_server_ext_id' in result.msg"
+    success_msg: "Fetch object store profiles info with missing file_server_ext_id failed as expected"
+    fail_msg: "Fetch object store profiles info with missing file_server_ext_id did not fail as expected"
+
+###############################################################################
+# Full lifecycle tests (require a live Files service and an existing file
+# server). These run only when `file_server_ext_id` is supplied via
+# integration_config.yml. See the PR body for why they are skipped on a
+# cluster without Nutanix Files deployed.
+###############################################################################
+
+- name: Full lifecycle tests
+  when: fs_ext_id | length > 0
+  block:
+    - name: Generate spec for creating object store profile using check mode with minimal attributes
+      nutanix.ncp.ntnx_files_object_store_profile_v2:
+        state: present
+        file_server_ext_id: "{{ fs_ext_id }}"
+        name: "{{ profile_name }}_cm"
+        object_store_type: "AWS"
+        object_store_config:
+          base_url: "https://s3.us-east-1.amazonaws.com/"
+          configuration:
+            aws:
+              access_key: "AKIAEXAMPLEACCESSKEY"
+      check_mode: true
+      register: result
+      ignore_errors: true
+
+    - name: Generate spec for creating object store profile using check mode with minimal attributes status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response.name == "{{ profile_name }}_cm"
+          - result.response.object_store_type == "AWS"
+        success_msg: "check mode create with minimal attributes passed"
+        fail_msg: "check mode create with minimal attributes failed"
+
+    - name: Create object store profile with minimal attributes
+      nutanix.ncp.ntnx_files_object_store_profile_v2:
+        state: present
+        file_server_ext_id: "{{ fs_ext_id }}"
+        name: "{{ profile_name }}_min"
+        object_store_type: "AWS"
+        object_store_config:
+          base_url: "https://s3.us-east-1.amazonaws.com/"
+          configuration:
+            aws:
+              access_key: "AKIAEXAMPLEACCESSKEY"
+              secret_key: "wJalrXUtnFEMIEXAMPLESECRETKEY"
+              bucket_name: "files-tiering-bucket"
+              bucket_location: "us-east-1"
+      register: result
+      ignore_errors: true
+
+    - name: Create object store profile with minimal attributes status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.ext_id is defined
+          - result.task_ext_id is defined
+          - result.response.name == "{{ profile_name }}_min"
+          - result.response.object_store_type == "AWS"
+        success_msg: "Create object store profile with minimal attributes passed"
+        fail_msg: "Create object store profile with minimal attributes failed"
+
+    - name: Create object store profile with all attributes
+      nutanix.ncp.ntnx_files_object_store_profile_v2:
+        state: present
+        file_server_ext_id: "{{ fs_ext_id }}"
+        name: "{{ profile_name }}_all"
+        object_store_type: "AWS"
+        mount_targets_enablement_type: "ALL_CURRENT_MOUNT_TARGETS"
+        retention_period_days: 1825
+        is_ssl_peer_verfication_enabled: true
+        object_store_config:
+          base_url: "https://s3.us-east-1.amazonaws.com/"
+          configuration:
+            aws:
+              access_key: "AKIAEXAMPLEACCESSKEY"
+              secret_key: "wJalrXUtnFEMIEXAMPLESECRETKEY"
+              bucket_name: "files-tiering-bucket"
+              bucket_location: "us-east-1"
+      register: result
+      ignore_errors: true
+
+    - name: Create object store profile with all attributes status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.ext_id is defined
+          - result.task_ext_id is defined
+          - result.response.name == "{{ profile_name }}_all"
+          - result.response.object_store_type == "AWS"
+          - result.response.mount_targets_enablement_type == "ALL_CURRENT_MOUNT_TARGETS"
+          - result.response.retention_period_days == 1825
+          - result.response.is_ssl_peer_verfication_enabled == true
+        success_msg: "Create object store profile with all attributes passed"
+        fail_msg: "Create object store profile with all attributes failed"
+
+    - name: Set object store profile ext_id
+      ansible.builtin.set_fact:
+        osp_ext_id: "{{ result.ext_id }}"
+
+    - name: Fetch object store profile using ext_id
+      nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+        file_server_ext_id: "{{ fs_ext_id }}"
+        ext_id: "{{ osp_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Fetch object store profile using ext_id status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.ext_id == "{{ osp_ext_id }}"
+          - result.response.name == "{{ profile_name }}_all"
+          - result.response.object_store_type == "AWS"
+        success_msg: "Fetch object store profile using ext_id passed"
+        fail_msg: "Fetch object store profile using ext_id failed"
+
+    - name: List all object store profiles
+      nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+        file_server_ext_id: "{{ fs_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: List all object store profiles status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response is defined
+          - result.response | length >= 2
+        success_msg: "List all object store profiles passed"
+        fail_msg: "List all object store profiles failed"
+
+    - name: List object store profiles with filter
+      nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+        file_server_ext_id: "{{ fs_ext_id }}"
+        filter: "name eq '{{ profile_name }}_all'"
+      register: result
+      ignore_errors: true
+
+    - name: List object store profiles with filter status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response | length == 1
+          - result.response[0].name == "{{ profile_name }}_all"
+        success_msg: "List object store profiles with filter passed"
+        fail_msg: "List object store profiles with filter failed"
+
+    - name: List object store profiles with limit
+      nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+        file_server_ext_id: "{{ fs_ext_id }}"
+        limit: 1
+      register: result
+      ignore_errors: true
+
+    - name: List object store profiles with limit status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.response | length == 1
+        success_msg: "List object store profiles with limit passed"
+        fail_msg: "List object store profiles with limit failed"
+
+    - name: Generate spec for updating object store profile using check mode with all attributes
+      nutanix.ncp.ntnx_files_object_store_profile_v2:
+        state: present
+        file_server_ext_id: "{{ fs_ext_id }}"
+        ext_id: "{{ osp_ext_id }}"
+        name: "{{ profile_name }}_updated"
+        object_store_type: "AWS"
+        mount_targets_enablement_type: "ALL_CURRENT_FUTURE_MOUNT_TARGETS"
+        retention_period_days: 3650
+        is_ssl_peer_verfication_enabled: false
+        object_store_config:
+          base_url: "https://s3.us-east-1.amazonaws.com/"
+          configuration:
+            aws:
+              access_key: "AKIAEXAMPLEACCESSKEY"
+              secret_key: "wJalrXUtnFEMIEXAMPLESECRETKEY"
+              bucket_name: "files-tiering-bucket"
+              bucket_location: "us-east-1"
+      check_mode: true
+      register: result
+      ignore_errors: true
+
+    - name: Generate spec for updating object store profile using check mode with all attributes status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.failed == false
+          - result.response.name == "{{ profile_name }}_updated"
+          - result.response.retention_period_days == 3650
+          - result.response.is_ssl_peer_verfication_enabled == false
+          - result.response.mount_targets_enablement_type == "ALL_CURRENT_FUTURE_MOUNT_TARGETS"
+        success_msg: "check mode update with all attributes passed"
+        fail_msg: "check mode update with all attributes failed"
+
+    - name: Update object store profile with all attributes
+      nutanix.ncp.ntnx_files_object_store_profile_v2:
+        state: present
+        file_server_ext_id: "{{ fs_ext_id }}"
+        ext_id: "{{ osp_ext_id }}"
+        name: "{{ profile_name }}_updated"
+        object_store_type: "AWS"
+        mount_targets_enablement_type: "ALL_CURRENT_FUTURE_MOUNT_TARGETS"
+        retention_period_days: 3650
+        is_ssl_peer_verfication_enabled: false
+        object_store_config:
+          base_url: "https://s3.us-east-1.amazonaws.com/"
+          configuration:
+            aws:
+              access_key: "AKIAEXAMPLEACCESSKEY"
+              secret_key: "wJalrXUtnFEMIEXAMPLESECRETKEY"
+              bucket_name: "files-tiering-bucket"
+              bucket_location: "us-east-1"
+      register: result
+      ignore_errors: true
+
+    - name: Update object store profile with all attributes status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.response.name == "{{ profile_name }}_updated"
+          - result.response.retention_period_days == 3650
+          - result.response.is_ssl_peer_verfication_enabled == false
+          - result.response.mount_targets_enablement_type == "ALL_CURRENT_FUTURE_MOUNT_TARGETS"
+        success_msg: "Update object store profile with all attributes passed"
+        fail_msg: "Update object store profile with all attributes failed"
+
+    - name: Update object store profile with same values (idempotency)
+      nutanix.ncp.ntnx_files_object_store_profile_v2:
+        state: present
+        file_server_ext_id: "{{ fs_ext_id }}"
+        ext_id: "{{ osp_ext_id }}"
+        name: "{{ profile_name }}_updated"
+        object_store_type: "AWS"
+        mount_targets_enablement_type: "ALL_CURRENT_FUTURE_MOUNT_TARGETS"
+        retention_period_days: 3650
+        is_ssl_peer_verfication_enabled: false
+        object_store_config:
+          base_url: "https://s3.us-east-1.amazonaws.com/"
+          configuration:
+            aws:
+              access_key: "AKIAEXAMPLEACCESSKEY"
+              bucket_name: "files-tiering-bucket"
+              bucket_location: "us-east-1"
+      register: result
+      ignore_errors: true
+
+    - name: Update object store profile with same values (idempotency) status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.msg == "Nothing to change."
+          - result.skipped == true
+        success_msg: "Update object store profile idempotency passed"
+        fail_msg: "Update object store profile idempotency failed"
+
+    - name: Fetch object store profile using wrong external ID (should fail)
+      nutanix.ncp.ntnx_files_object_store_profiles_info_v2:
+        file_server_ext_id: "{{ fs_ext_id }}"
+        ext_id: "00000000-0000-0000-0000-000000000000"
+      register: result
+      ignore_errors: true
+
+    - name: Fetch object store profile using wrong external ID status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == true
+        success_msg: "Fetch object store profile using wrong external ID failed as expected"
+        fail_msg: "Fetch object store profile using wrong external ID did not fail as expected"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **files** namespace, entity
**ObjectStoreProfile** (Nutanix Files v4 tiering / object-store profile), based on the
inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_files_object_store_profile_v2` (CRUD), `ntnx_files_object_store_profiles_info_v2` (info)
- API methods covered: **4** — `create_object_store_profile`, `get_object_store_profile_by_id`, `list_object_store_profiles`, `update_object_store_profile_by_id`
- **No delete**: the Files v4 SDK exposes no delete operation for `ObjectStoreProfile`, so the CRUD module restricts `state` to `present` only (no `absent`). This mirrors the existing `ntnx_users_v2` precedent.
- Fields in CRUD module spec: **11** top-level parameters (`state`, `file_server_ext_id`, `ext_id`, `name`, `object_store_type`, `mount_target_ext_ids`, `mount_targets_enablement_type`, `retention_period_days`, `is_ssl_peer_verfication_enabled`, `object_store_config`, `recovery_object_store_config`) plus nested `object_store_config` (`base_url`, `ca_cert_content`, `proxy_server{url, credential{username, password}}`, and the polymorphic `configuration` → `aws{access_key, secret_key, bucket_name, bucket_location}` / `azure{storage_account_name, storage_account_key, container_name}`).
- Fields in info module spec: **7** — `file_server_ext_id` (required), `ext_id`, plus the standard info args (`filter`, `limit`, `page`, `orderby`, `select`) injected by `BaseInfoModule`.
- All operations are scoped under a parent file server via the required `file_server_ext_id` (maps to the SDK `fileServerExtId` path parameter).
- The polymorphic `configuration` field (OneOf `AWSConfig`/`AzureConfig`) is modelled as a `mutually_exclusive` dict so the correct `$objectType` is emitted by the spec generator.

## Domain knowledge (from Glean)

Per this repository's PR policy, internal Glean references (Jira/ENG tickets, Confluence/
SharePoint links, and other internal source material) are intentionally **omitted** from
this public PR description. Functional behaviour implemented here was derived from the
inline `sdk_info.json` schema shipped with the code-gen request.

Functional summary (schema-derived, no internal links): an `ObjectStoreProfile` defines a
tiering configuration attached to a Nutanix Files file server. It targets an external
object store (AWS S3 / S3-compatible, Azure Blob, GCP, Nutanix Objects, or Other),
selects which mount targets are tiered (`mount_targets_enablement_type`), sets a data
`retention_period_days`, optionally routes through an HTTP `proxy_server` with
credentials, optionally supplies a CA certificate for SSL peer verification, and carries
provider-specific credentials/bucket settings in the polymorphic `configuration`
(`AWSConfig` or `AzureConfig`). A `recovery_object_store_config` may be supplied for
recovery scenarios.

## Files changed

- `plugins/modules/`
  - `ntnx_files_object_store_profile_v2.py` (new — CRUD, `state: present` create/update)
  - `ntnx_files_object_store_profiles_info_v2.py` (new — get-by-id + list with filter/limit/page)
- `plugins/module_utils/v4/files/`
  - `__init__.py` (new — package marker)
  - `api_client.py` (new — `get_api_client`, `get_etag`, `get_tier_api_instance`, `get_file_servers_api_instance`)
  - `helpers.py` (new — `get_object_store_profile`)
- `plugins/module_utils/v4/constants.py` (added `Tasks.RelEntityType.OBJECT_STORE_PROFILE`)
- `meta/runtime.yml` (registered both modules in the `ntnx` action group)
- `examples/files/ObjectStoreProfile/`
  - `object_store_profiles_v2.yml` (new — create AWS, update, get-by-id, list, list+filter, list+limit)
  - `examples_run.log` (new — real playbook output from the live PC run)
- `tests/integration/targets/ntnx_files_object_store_profile_v2/` (new — meta, aliases, tasks)
- `.gitignore` (ignore `integration_config.yml` credentials + Python bytecode)

## Test execution

| Metric        | Value                                                                                  |
|---------------|----------------------------------------------------------------------------------------|
| Command       | `ansible-test integration ntnx_files_object_store_profile_v2 --allow-disabled --python 3.11` |
| Tasks OK      | `22`                                                                                   |
| Failed        | `0`                                                                                    |
| Ignored       | `7` (intentional negative tests — module fails as designed, verified by asserts)       |
| Skipped       | `23` (live CRUD block — requires a deployed Files server, see Known issues)            |
| Duration      | `~0:00:08`                                                                             |
| Cluster (PC)  | `10.44.76.28`                                                                          |

Additional quality gates (all green):

- `black --check` / `isort --check` / `flake8`: clean on all new Python.
- `ansible-test sanity` (24 tests incl. `validate-modules`, `pep8`, `pylint`, `import`, `ansible-doc`, `yamllint`): passed.
- `ansible-lint` (production profile): `0 failure(s), 0 warning(s)`, rating 5/5.

### Analysis

No test failures. Coverage exercised without a live Files service:

- **Positive (check_mode spec generation):** AWS and Azure create specs are generated and
  validated with all attributes — proves the argument spec, nested `object_store_config`,
  proxy, and polymorphic `configuration` all serialize correctly.
- **Negative (intentional, shown as "ignored"):** missing `name` / `object_store_type` /
  `object_store_config`; invalid `object_store_type` enum; invalid
  `mount_targets_enablement_type` enum; mutually-exclusive `aws`|`azure`; and info module
  missing required `file_server_ext_id`. Each fails with the exact expected message and is
  verified by a following `assert` task (all asserts OK).
- **Live CRUD block (skipped):** create/get/list/update/idempotency/negative-get run only
  when a real `file_server_ext_id` is supplied in `integration_config.yml`. The target PC
  has no deployed Nutanix Files service (see Known issues), so these were skipped rather
  than failed.

### Test logs (tail)

<details>
<summary>tail of test_logs.log</summary>

```text
TASK [ntnx_files_object_store_profile_v2 : Create object store profile with mutually exclusive aws and azure status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Create object store profile with mutually exclusive aws and azure failed as expected"
}

TASK [ntnx_files_object_store_profile_v2 : Fetch object store profiles info with missing file_server_ext_id (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: file_server_ext_id"}
...ignoring

TASK [ntnx_files_object_store_profile_v2 : Fetch object store profiles info with missing file_server_ext_id status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch object store profiles info with missing file_server_ext_id failed as expected"
}

TASK [ntnx_files_object_store_profile_v2 : Create object store profile with minimal attributes] ***
skipping: [testhost]

... (live CRUD block skipped — no deployed Files server) ...

TASK [ntnx_files_object_store_profile_v2 : Fetch object store profile using wrong external ID status] ***
skipping: [testhost]

PLAY RECAP *********************************************************************
testhost                   : ok=22   changed=0    unreachable=0    failed=0    skipped=23   rescued=0    ignored=7
```

</details>

## Example execution

The example playbook was run end-to-end against the same PC (`10.44.76.28`):

- Command: `ansible-playbook examples/files/ObjectStoreProfile/object_store_profiles_v2.yml`
- PLAY RECAP: `ok=8  changed=0  failed=0  ignored=6`
- The 6 API-calling tasks (create/update/get/list×3) returned **HTTP 503 SERVICE UNAVAILABLE**
  because the Nutanix Files service is not deployed on this PC. The play authenticates to
  Prism Central successfully and completes cleanly (errors are ignored per-task), and the
  full real output is committed to `examples/files/ObjectStoreProfile/examples_run.log`.

## Known issues / cluster prerequisites

- **Nutanix Files service not deployed on the target PC.** Prism Central (`10.44.76.28`) is
  reachable and healthy, but the Files/tiering API returns `503 SERVICE UNAVAILABLE`. As a
  result: (a) the live-cluster integration block was skipped (no real `file_server_ext_id`
  to supply), and (b) the example playbook's API calls returned 503. Both were exercised
  offline via check_mode + negative tests. Re-running with a deployed file server and a
  real `file_server_ext_id` in `integration_config.yml` will enable the live CRUD path.
- **No delete API.** The Files v4 SDK provides no delete for `ObjectStoreProfile`; the CRUD
  module therefore supports only `state: present` (create/update) and ships no delete
  example or test. Documented in the module `DOCUMENTATION` block.
- Because live create did not run, example `sample:` blocks retain schema-derived samples
  rather than real API responses.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Generated modules follow the existing `ntnx_virtual_switch_v2` / `ntnx_virtual_switches_info_v2`
  patterns for structure, argument spec, task handling, idempotency, and return docs.
