### PR TITLE
feat(vmm): add legacy VM-VM anti-affinity policy v2 modules

### DIFF
--- a/examples/virtual_machine_management/LegacyVmAntiAffinityPolicy/examples_run.log
+++ b/examples/virtual_machine_management/LegacyVmAntiAffinityPolicy/examples_run.log
@@ -1,0 +1,30 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Legacy VM-VM anti-affinity policy playbook] ******************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"legacy_policy_ext_id": "3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f"}, "changed": false}
+
+TASK [List all legacy VM-VM anti-affinity policies] ****************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List legacy VM-VM anti-affinity policies with an OData filter] ***********
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List legacy VM-VM anti-affinity policies with a limit] *******************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Fetch a specific legacy VM-VM anti-affinity policy using ext_id] *********
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Legacy VM-VM anti-affinity policy with ext_id '3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f' was not found."}
+...ignoring
+
+TASK [Delete a legacy VM-VM anti-affinity policy by ext_id] ********************
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T09:03:36.487335+00:00", "completion_details": null, "created_time": "2026-07-21T09:03:36.462429+00:00", "entities_affected": [{"ext_id": "3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f", "name": null, "rel": "vmm:ahv:policies:legacy-vm-anti-affinity-policy"}], "error_messages": [{"arguments_map": {"policy_uuid": "3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f"}, "code": "VMM-34060", "error_group": "POLICY_NOT_FOUND", "locale": "en_US", "message": "Failed to perform the operation on the policy with UUID '3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f', because it is not found.", "severity": "ERROR"}], "ext_id": "ZXJnb24=:7fa839a6-61d8-597a-b863-52de10812acc", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T09:03:36.487333+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "DeleteLegacyVmAntiAffinityPolicyById", "operation_description": "Delete the Legacy VM Anti-Affinity Policy", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T09:03:36.472945+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": null, "warnings": null}}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=2   
+

--- a/examples/virtual_machine_management/LegacyVmAntiAffinityPolicy/legacy_vm_anti_affinity_policy_v2.yml
+++ b/examples/virtual_machine_management/LegacyVmAntiAffinityPolicy/legacy_vm_anti_affinity_policy_v2.yml
@@ -1,0 +1,55 @@
+---
+# Summary:
+# This playbook demonstrates end-to-end usage of the legacy VM-VM anti-affinity
+# policy v4 modules against a Prism Central. Because the v4 API for legacy
+# policies only exposes list and delete operations, the playbook:
+#   1. Lists all legacy VM-VM anti-affinity policies on the target PC.
+#   2. Optionally fetches a single legacy policy by external ID.
+#   3. Deletes a specific legacy policy by external ID.
+#
+# The playbook uses play-level module_defaults so connection parameters are
+# defined once and inherited by every task.
+
+- name: Legacy VM-VM anti-affinity policy playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        legacy_policy_ext_id: "3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f"
+
+    - name: List all legacy VM-VM anti-affinity policies
+      nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+      register: legacy_policies_list
+      ignore_errors: true
+
+    - name: List legacy VM-VM anti-affinity policies with an OData filter
+      nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+        filter: "name eq 'legacy_aaf_policy'"
+      register: legacy_policies_filtered
+      ignore_errors: true
+
+    - name: List legacy VM-VM anti-affinity policies with a limit
+      nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+        limit: 1
+      register: legacy_policies_limited
+      ignore_errors: true
+
+    - name: Fetch a specific legacy VM-VM anti-affinity policy using ext_id
+      nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+        ext_id: "{{ legacy_policy_ext_id }}"
+      register: legacy_policy_detail
+      ignore_errors: true
+
+    - name: Delete a legacy VM-VM anti-affinity policy by ext_id
+      nutanix.ncp.ntnx_legacy_vm_anti_affinity_policy_v2:
+        state: absent
+        ext_id: "{{ legacy_policy_ext_id }}"
+      register: legacy_policy_delete
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_legacy_vm_anti_affinity_policy_v2
+    - ntnx_legacy_vm_anti_affinity_policies_info_v2

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,13 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_vm_anti_affinity_policies_api_instance(module):
+    """
+    This method will return VM Anti-Affinity Policies API instance.
+    Args:
+        api_instance (obj): v4 VmAntiAffinityPoliciesApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.VmAntiAffinityPoliciesApi(api_client=api_client)

--- a/plugins/module_utils/v4/vmm/helpers.py
+++ b/plugins/module_utils/v4/vmm/helpers.py
@@ -191,3 +191,42 @@ def get_ova(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching OVA info using ext_id",
         )
+
+
+def get_legacy_vm_anti_affinity_policy(module, api_instance, ext_id):
+    """
+    Get legacy VM-VM anti-affinity policy by ext_id.
+
+    Legacy VM-VM anti-affinity policies do not expose a GET-by-ID API in the
+    v4 SDK. This helper implements the equivalent lookup by listing legacy
+    policies with an OData filter on ``extId`` and returning the single
+    matching entity, or failing the module when the entity does not exist.
+
+    Args:
+        module: Ansible module
+        api_instance: VmAntiAffinityPoliciesApi instance from ntnx_vmm_py_client sdk
+        ext_id: ext_id of the legacy VM-VM anti-affinity policy
+
+    Returns:
+        obj: The matching LegacyVmAntiAffinityPolicy SDK model instance.
+    """
+    try:
+        resp = api_instance.list_legacy_vm_anti_affinity_policies(
+            _filter="extId eq '{0}'".format(ext_id)
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching legacy VM-VM anti-affinity policy using ext_id",
+        )
+
+    data = getattr(resp, "data", None)
+    if not data:
+        module.fail_json(
+            msg=(
+                "Legacy VM-VM anti-affinity policy with ext_id "
+                "'{0}' was not found.".format(ext_id)
+            )
+        )
+    return data[0]

--- a/plugins/modules/ntnx_legacy_vm_anti_affinity_policies_info_v2.py
+++ b/plugins/modules/ntnx_legacy_vm_anti_affinity_policies_info_v2.py
@@ -1,0 +1,233 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_legacy_vm_anti_affinity_policies_info_v2
+short_description: Fetch legacy VM-VM anti-affinity policies info from Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about LegacyVmAntiAffinityPolicy in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific LegacyVmAntiAffinityPolicy.
+  - If C(ext_id) is not provided, list multiple LegacyVmAntiAffinityPolicy optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get / List Legacy VM-VM Anti-Affinity Policies) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin, Cluster Admin.
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=virtual_machine_management)"
+options:
+  ext_id:
+    description:
+      - The external ID (UUID) of the legacy VM-VM anti-affinity policy.
+      - When provided, a single policy is fetched. When omitted, the module lists all legacy policies.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch a legacy VM-VM anti-affinity policy using ext_id
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f"
+  register: result
+  ignore_errors: true
+
+- name: List all legacy VM-VM anti-affinity policies
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+  register: result
+  ignore_errors: true
+
+- name: List legacy VM-VM anti-affinity policies with an OData filter
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    filter: "name eq 'legacy_aaf_policy'"
+  register: result
+  ignore_errors: true
+
+- name: List legacy VM-VM anti-affinity policies with a limit
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC LegacyVmAntiAffinityPolicy info v4 API.
+    - It can be a single LegacyVmAntiAffinityPolicy if external ID is provided.
+    - List of multiple LegacyVmAntiAffinityPolicy if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster": {
+          "ext_id": "000647b8-ddb3-6bbb-0000-000000028f57"
+      },
+      "ext_id": "3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f",
+      "links": null,
+      "name": "legacy_aaf_policy",
+      "tenant_id": null,
+      "vms": [
+          {
+              "ext_id": "a1b2c3d4-e5f6-7890-1234-56789abcdef0"
+          },
+          {
+              "ext_id": "b2c3d4e5-f6a7-8901-2345-6789abcdef01"
+          }
+      ]
+    }
+
+changed:
+  description: Whether the operation resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Contextual status or error message.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching legacy VM-VM anti-affinity policies info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: When an error occurs
+
+failed:
+  description: Whether the module invocation failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: The external ID of the legacy VM-VM anti-affinity policy that was fetched.
+  type: str
+  returned: When an external ID is provided
+  sample: "3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f"
+
+total_available_results:
+  description: The total number of legacy VM-VM anti-affinity policies available on the Prism Central.
+  type: int
+  returned: When all legacy VM-VM anti-affinity policies are listed
+  sample: 3
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_anti_affinity_policies_api_instance,
+)
+from ..module_utils.v4.vmm.helpers import (  # noqa: E402
+    get_legacy_vm_anti_affinity_policy,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def get_legacy_vm_anti_affinity_policy_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_legacy_vm_anti_affinity_policy(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_legacy_vm_anti_affinity_policies(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating legacy VM-VM anti-affinity policies info spec",
+            **result,
+        )
+
+    try:
+        resp = api_instance.list_legacy_vm_anti_affinity_policies(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching legacy VM-VM anti-affinity policies info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_vm_anti_affinity_policies_api_instance(module)
+    if module.params.get("ext_id"):
+        get_legacy_vm_anti_affinity_policy_using_ext_id(module, api_instance, result)
+    else:
+        get_legacy_vm_anti_affinity_policies(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_legacy_vm_anti_affinity_policy_v2.py
+++ b/plugins/modules/ntnx_legacy_vm_anti_affinity_policy_v2.py
@@ -1,0 +1,315 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_legacy_vm_anti_affinity_policy_v2
+short_description: Delete legacy VM-VM anti-affinity policies in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to manage the lifecycle of a legacy VM-VM anti-affinity policy in Nutanix Prism Central.
+  - Legacy VM-VM anti-affinity policies were originally configured on Prism Element using VM groups (via acli or Prism Element APIs).
+  - The Prism Central v4 API exposes these legacy policies as read-only entities that can only be deleted to make room for the
+    modern category-based VM-VM anti-affinity policies.
+  - This module therefore supports the delete operation only. Attempting create (C(state=present) without C(ext_id))
+    or update (C(state=present) with C(ext_id)) will fail with a descriptive error, because the underlying v4 SDK does
+    not expose create or update endpoints for legacy policies.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Delete a Legacy VM-VM Anti-Affinity Policy) -
+      Required Roles: Prism Admin, Super Admin, Cluster Admin.
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=virtual_machine_management)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the legacy VM-VM anti-affinity policy will be deleted.
+      - C(state=present) is not supported by the underlying v4 API for legacy policies and will fail with a descriptive error.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID (UUID) of the legacy VM-VM anti-affinity policy.
+      - Required for the delete operation.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Delete legacy VM-VM anti-affinity policy
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policy_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for deleting a legacy VM-VM anti-affinity policy.
+    - When C(wait) is C(true), it contains the completed delete task details.
+    - When C(wait) is C(false), it contains the task reference returned by the API.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_ids": null,
+      "completed_time": "2026-07-21T09:12:45.000000+00:00",
+      "completion_details": null,
+      "created_time": "2026-07-21T09:12:43.000000+00:00",
+      "entities_affected": [
+          {
+              "ext_id": "3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f",
+              "name": null,
+              "rel": "vmm:ahv:policies:legacy-vm-anti-affinity-policy"
+          }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-07-21T09:12:45.000000+00:00",
+      "legacy_error_message": null,
+      "operation": "DeleteLegacyVmAntiAffinityPolicy",
+      "operation_description": "Delete legacy VM-VM anti-affinity policy",
+      "owned_by": null,
+      "parent_task": null,
+      "progress_percentage": 100,
+      "root_task": null,
+      "started_time": "2026-07-21T09:12:43.000000+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the asynchronous task returned by the delete API.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d"
+
+ext_id:
+  description:
+    - The external ID of the legacy VM-VM anti-affinity policy that was acted upon.
+  returned: always
+  type: str
+  sample: "3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f"
+
+changed:
+  description: Whether the operation resulted in any changes on the target Prism Central.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: Whether the operation was skipped (for example, when running in check mode).
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: The error message, if any, when the operation failed.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: Whether the module invocation failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: Contextual status or error message emitted by the module.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Legacy VM-VM anti-affinity policy with ext_id: 3f6a1c5c-4b7f-4a5f-8e2e-6a1e5b9c2d3f will be deleted."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_anti_affinity_policies_api_instance,
+)
+
+# The SDK is not referenced directly in this module (no spec object building is
+# required for a delete-only entity), but a guarded import is still kept to
+# match the convention used by the other v4 modules in this collection and to
+# produce a clean ``missing_required_lib`` failure at run time if the wheel is
+# absent. The imports below are intentionally unused at import time.
+SDK_IMP_ERROR = None
+try:
+    # pylint: disable=unused-import
+    import ntnx_vmm_py_client as virtual_machine_management_sdk  # noqa: F401,E402
+except ImportError:
+
+    # pylint: disable=unused-import
+    from ..module_utils.v4.sdk_mock import (  # noqa: F401,E402
+        mock_sdk as virtual_machine_management_sdk,
+    )
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def create_LegacyVmAntiAffinityPolicy(module, result, api_instance):
+    """Create is not supported for legacy VM-VM anti-affinity policies.
+
+    The v4 SDK does not expose a create endpoint for legacy policies — they
+    are strictly read-only/delete-only carry-overs from PE. Fail loudly with
+    a descriptive message so operators are directed to the modern
+    category-based VM-VM anti-affinity policy APIs instead.
+    """
+    module.fail_json(
+        msg=(
+            "Create is not supported for legacy VM-VM anti-affinity policies. "
+            "The Nutanix v4 VMM API only allows listing and deleting legacy "
+            "policies. Use the modern VM-VM anti-affinity policy APIs to "
+            "create new anti-affinity rules."
+        ),
+        **result,
+    )
+
+
+def update_LegacyVmAntiAffinityPolicy(module, result, api_instance):
+    """Update is not supported for legacy VM-VM anti-affinity policies.
+
+    The v4 SDK does not expose an update endpoint for legacy policies. Fail
+    loudly with a descriptive message rather than silently no-op'ing.
+    """
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    module.fail_json(
+        msg=(
+            "Update is not supported for legacy VM-VM anti-affinity policies "
+            "(ext_id: {0}). The Nutanix v4 VMM API only allows listing and "
+            "deleting legacy policies. Delete the legacy policy and re-create "
+            "the equivalent rule using the modern VM-VM anti-affinity policy "
+            "APIs instead.".format(ext_id)
+        ),
+        **result,
+    )
+
+
+def delete_LegacyVmAntiAffinityPolicy(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    validate_required_params(module, ["ext_id"])
+
+    if module.check_mode:
+        result["msg"] = (
+            "Legacy VM-VM anti-affinity policy with ext_id: "
+            "{0} will be deleted.".format(ext_id)
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.delete_legacy_vm_anti_affinity_policy_by_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while deleting legacy VM-VM "
+                "anti-affinity policy with ext_id: {0}".format(ext_id)
+            ),
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_vmm_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_vm_anti_affinity_policies_api_instance(module)
+    state = module.params.get("state")
+
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_LegacyVmAntiAffinityPolicy(module, result, api_instance)
+        else:
+            create_LegacyVmAntiAffinityPolicy(module, result, api_instance)
+    else:
+        delete_LegacyVmAntiAffinityPolicy(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_legacy_vm_anti_affinity_policies_v2/aliases
+++ b/tests/integration/targets/ntnx_legacy_vm_anti_affinity_policies_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_legacy_vm_anti_affinity_policies_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_legacy_vm_anti_affinity_policies_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_legacy_vm_anti_affinity_policies_v2/tasks/legacy_vm_anti_affinity_policies.yml
+++ b/tests/integration/targets/ntnx_legacy_vm_anti_affinity_policies_v2/tasks/legacy_vm_anti_affinity_policies.yml
@@ -1,0 +1,292 @@
+---
+# =============================================================================
+# Integration tests for Nutanix Ansible modules:
+#   - ntnx_legacy_vm_anti_affinity_policy_v2      (CRUD — delete only)
+#   - ntnx_legacy_vm_anti_affinity_policies_info_v2 (info — get by id / list)
+#
+# Design notes:
+# - The Nutanix v4 VMM SDK exposes ONLY list + delete for legacy VM-VM
+#   anti-affinity policies. There is no create/update endpoint, so the CRUD
+#   module intentionally fails when state=present.
+# - Legacy policies are the ones originally configured on Prism Element via
+#   VM groups (acli). They are surfaced in PC v4 API purely for read + delete
+#   migration workflows. Because Ansible cannot create them, the tests cover:
+#     * list-all / list-with-filter / list-with-limit
+#     * get-by-id happy path (only when at least one legacy policy exists on
+#       the target Prism Central) and non-existent ext_id error path
+#     * state=present create-attempt error path
+#     * state=present + ext_id update-attempt error path
+#     * state=absent missing ext_id error path
+#     * state=absent non-existent ext_id error path
+#     * state=absent check_mode dry-run
+#     * state=absent delete flow (only when at least one legacy policy exists
+#       on the target Prism Central)
+# =============================================================================
+
+- name: Start Legacy VM-VM anti-affinity policies tests
+  ansible.builtin.debug:
+    msg: Start Legacy VM-VM anti-affinity policies tests
+
+- name: Generate random suffix for test data
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    fake_ext_id: "00000000-0000-0000-0000-{{ query('community.general.random_string', numbers=true, upper=false, lower=false, special=false, length=12)[0] }}"
+
+# ============================================================================
+# Info module: LIST scenarios
+# ============================================================================
+
+- name: List all legacy VM-VM anti-affinity policies
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+  register: list_result
+  ignore_errors: true
+
+- name: List all legacy VM-VM anti-affinity policies status
+  ansible.builtin.assert:
+    that:
+      - list_result is defined
+      - list_result.changed == false
+      - list_result.failed == false
+      - list_result.response is defined
+      - list_result.response is iterable
+      - list_result.total_available_results is defined
+      - list_result.total_available_results is number
+    success_msg: "List all legacy VM-VM anti-affinity policies passed"
+    fail_msg: "List all legacy VM-VM anti-affinity policies failed"
+
+- name: Capture the first legacy policy ext_id (if any exist) for later tests
+  ansible.builtin.set_fact:
+    existing_legacy_policy_ext_id: >-
+      {{ (list_result.response | default([]) | length > 0) | ternary(list_result.response[0].ext_id, '') }}
+    existing_legacy_policy_name: >-
+      {{ (list_result.response | default([]) | length > 0) | ternary(list_result.response[0].name, '') }}
+
+- name: List legacy VM-VM anti-affinity policies with a small limit
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+    limit: 1
+  register: list_limited_result
+  ignore_errors: true
+
+- name: List legacy VM-VM anti-affinity policies with a small limit status
+  ansible.builtin.assert:
+    that:
+      - list_limited_result is defined
+      - list_limited_result.changed == false
+      - list_limited_result.failed == false
+      - list_limited_result.response is defined
+      - (list_limited_result.response | length) <= 1
+    success_msg: "List legacy VM-VM anti-affinity policies with limit passed"
+    fail_msg: "List legacy VM-VM anti-affinity policies with limit failed"
+
+- name: List legacy VM-VM anti-affinity policies with a bogus filter
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+    filter: "name eq 'nonexistent_policy_{{ random_name }}'"
+  register: list_filter_result
+  ignore_errors: true
+
+- name: List legacy VM-VM anti-affinity policies with a bogus filter status
+  ansible.builtin.assert:
+    that:
+      - list_filter_result is defined
+      - list_filter_result.changed == false
+      - list_filter_result.failed == false
+      - list_filter_result.response is defined
+      - (list_filter_result.response | length) == 0
+    success_msg: "Filtering by a non-existent name returned an empty list as expected"
+    fail_msg: "Filtering by a non-existent name did not return an empty list"
+
+# ============================================================================
+# Info module: GET-by-ID scenarios (happy path only if any legacy policy exists)
+# ============================================================================
+
+- name: Fetch a specific legacy VM-VM anti-affinity policy by ext_id (happy path)
+  when: existing_legacy_policy_ext_id | length > 0
+  block:
+    - name: Fetch legacy policy by ext_id
+      nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+        ext_id: "{{ existing_legacy_policy_ext_id }}"
+      register: get_result
+      ignore_errors: true
+
+    - name: Fetch legacy policy by ext_id status
+      ansible.builtin.assert:
+        that:
+          - get_result is defined
+          - get_result.changed == false
+          - get_result.failed == false
+          - get_result.response is defined
+          - get_result.response.ext_id == existing_legacy_policy_ext_id
+          - get_result.ext_id == existing_legacy_policy_ext_id
+          - get_result.response.name == existing_legacy_policy_name
+        success_msg: "Fetch legacy policy by ext_id passed"
+        fail_msg: "Fetch legacy policy by ext_id failed"
+
+- name: Fetch legacy policy by non-existent ext_id (should fail)
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+    ext_id: "{{ fake_ext_id }}"
+  register: get_not_found_result
+  ignore_errors: true
+
+- name: Fetch legacy policy by non-existent ext_id status
+  ansible.builtin.assert:
+    that:
+      - get_not_found_result is defined
+      - get_not_found_result.failed == true
+      - "'was not found' in get_not_found_result.msg or 'not found' in (get_not_found_result.msg | lower)"
+    success_msg: "Fetching a non-existent legacy policy failed as expected"
+    fail_msg: "Fetching a non-existent legacy policy did not fail as expected"
+
+# ============================================================================
+# CRUD module: state=present must fail because create/update is unsupported
+# ============================================================================
+
+- name: Attempt to create a legacy policy (state=present without ext_id) should fail
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policy_v2:
+    state: present
+  register: create_attempt
+  ignore_errors: true
+
+- name: Attempt to create a legacy policy status
+  ansible.builtin.assert:
+    that:
+      - create_attempt is defined
+      - create_attempt.changed == false
+      - create_attempt.failed == true
+      - "'Create is not supported for legacy VM-VM anti-affinity policies' in create_attempt.msg"
+    success_msg: "Create attempt correctly failed with a descriptive message"
+    fail_msg: "Create attempt did not fail with the expected message"
+
+- name: Attempt to update a legacy policy (state=present with ext_id) should fail
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policy_v2:
+    state: present
+    ext_id: "{{ fake_ext_id }}"
+  register: update_attempt
+  ignore_errors: true
+
+- name: Attempt to update a legacy policy status
+  ansible.builtin.assert:
+    that:
+      - update_attempt is defined
+      - update_attempt.changed == false
+      - update_attempt.failed == true
+      - "'Update is not supported for legacy VM-VM anti-affinity policies' in update_attempt.msg"
+      - update_attempt.ext_id == fake_ext_id
+    success_msg: "Update attempt correctly failed with a descriptive message"
+    fail_msg: "Update attempt did not fail with the expected message"
+
+# ============================================================================
+# CRUD module: state=absent negative paths
+# ============================================================================
+
+- name: Attempt delete without ext_id should fail
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policy_v2:
+    state: absent
+  register: delete_missing_ext_id
+  ignore_errors: true
+
+- name: Attempt delete without ext_id status
+  ansible.builtin.assert:
+    that:
+      - delete_missing_ext_id is defined
+      - delete_missing_ext_id.changed == false
+      - delete_missing_ext_id.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in delete_missing_ext_id.msg"
+    success_msg: "Delete without ext_id failed as expected"
+    fail_msg: "Delete without ext_id did not fail as expected"
+
+- name: Delete a legacy policy using a non-existent ext_id should fail
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policy_v2:
+    state: absent
+    ext_id: "{{ fake_ext_id }}"
+  register: delete_not_found
+  ignore_errors: true
+
+- name: Delete a legacy policy using a non-existent ext_id status
+  ansible.builtin.assert:
+    that:
+      - delete_not_found is defined
+      - delete_not_found.changed == false
+      - delete_not_found.failed == true
+      # When the task fails, the message comes from wait_for_completion — this
+      # code path does not preserve the module-local ``result`` fields (e.g.
+      # ``ext_id``), so we only assert on the fail reason and the task body.
+      - delete_not_found.msg == "Task Failed"
+      - delete_not_found.response is defined
+      - delete_not_found.response.status == "FAILED"
+      - delete_not_found.response.error_messages | length > 0
+      - delete_not_found.response.error_messages[0].code == "VMM-34060"
+    success_msg: "Delete of non-existent legacy policy failed as expected"
+    fail_msg: "Delete of non-existent legacy policy did not fail as expected"
+
+# ============================================================================
+# CRUD module: state=absent check_mode dry-run
+# ============================================================================
+
+- name: Delete a legacy policy in check_mode
+  nutanix.ncp.ntnx_legacy_vm_anti_affinity_policy_v2:
+    state: absent
+    ext_id: "{{ fake_ext_id }}"
+  check_mode: true
+  register: delete_check_mode
+  ignore_errors: true
+
+- name: Delete a legacy policy in check_mode status
+  ansible.builtin.assert:
+    that:
+      - delete_check_mode is defined
+      - delete_check_mode.changed == false
+      - delete_check_mode.failed == false
+      - delete_check_mode.ext_id == fake_ext_id
+      - "'will be deleted' in delete_check_mode.msg"
+    success_msg: "Delete in check_mode returned the expected dry-run message"
+    fail_msg: "Delete in check_mode did not return the expected dry-run message"
+
+# ============================================================================
+# CRUD module: real delete (only when a legacy policy exists on the cluster)
+# ============================================================================
+
+- name: Delete an existing legacy VM-VM anti-affinity policy (happy path)
+  when: existing_legacy_policy_ext_id | length > 0
+  block:
+    - name: Delete existing legacy policy
+      nutanix.ncp.ntnx_legacy_vm_anti_affinity_policy_v2:
+        state: absent
+        ext_id: "{{ existing_legacy_policy_ext_id }}"
+      register: delete_result
+      ignore_errors: true
+
+    - name: Delete existing legacy policy status
+      ansible.builtin.assert:
+        that:
+          - delete_result is defined
+          - delete_result.changed == true
+          - delete_result.failed == false
+          - delete_result.ext_id == existing_legacy_policy_ext_id
+          - delete_result.task_ext_id is defined
+          - delete_result.response is defined
+          - delete_result.response.status == "SUCCEEDED"
+        success_msg: "Delete of existing legacy VM-VM anti-affinity policy passed"
+        fail_msg: "Delete of existing legacy VM-VM anti-affinity policy failed"
+
+    - name: Verify the deleted legacy policy no longer exists
+      nutanix.ncp.ntnx_legacy_vm_anti_affinity_policies_info_v2:
+        ext_id: "{{ existing_legacy_policy_ext_id }}"
+      register: verify_deleted
+      ignore_errors: true
+
+    - name: Verify the deleted legacy policy no longer exists status
+      ansible.builtin.assert:
+        that:
+          - verify_deleted is defined
+          - verify_deleted.failed == true
+        success_msg: "Deleted legacy policy is no longer reachable as expected"
+        fail_msg: "Deleted legacy policy was unexpectedly still reachable"
+
+- name: Note that no legacy policies existed on this Prism Central
+  when: existing_legacy_policy_ext_id | length == 0
+  ansible.builtin.debug:
+    msg: >-
+      No legacy VM-VM anti-affinity policies were found on the target Prism Central.
+      The delete happy-path and get-by-id happy-path tests were skipped because
+      legacy policies cannot be created via the v4 API — they only exist as
+      carry-overs from PE-based VM group configurations.

--- a/tests/integration/targets/ntnx_legacy_vm_anti_affinity_policies_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_legacy_vm_anti_affinity_policies_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import legacy_vm_anti_affinity_policies.yml
+      ansible.builtin.import_tasks: legacy_vm_anti_affinity_policies.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **virtual_machine_management** namespace, entity
**LegacyVmAntiAffinityPolicy**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_legacy_vm_anti_affinity_policy_v2` (CRUD — delete-only, per SDK surface), `ntnx_legacy_vm_anti_affinity_policies_info_v2` (info)
- API methods covered from `sdk_info.api_request_response_struct` (2 of the 8 methods explicitly for legacy policies): `delete_legacy_vm_anti_affinity_policy_by_id`, `list_legacy_vm_anti_affinity_policies`. The other 6 methods in the SDK apply to the modern (non-legacy) VM-VM anti-affinity entity and are out of scope for this PR
- Fields in CRUD module spec: 1 (`ext_id`) — the underlying v4 API does not expose create/update endpoints for legacy policies
- Fields in info module spec: 1 (`ext_id`) — plus the base info-module parameters (`filter`, `limit`, `page`, `orderby`, `select`)

## Domain knowledge (from Glean)

### Overview of LegacyVmAntiAffinityPolicy in Nutanix AHV VMM v4 API
The **`LegacyVmAntiAffinityPolicy`** in the Nutanix Virtual Machine Management (VMM) v4 API represents the legacy VM-VM anti-affinity policies that were historically configured using VM groups through aCLI directly in Prism Element (PE).

With the introduction of Prism Central (PC) category-based policies in newer releases, this legacy entity is primarily exposed in the PC v4 API to allow administrators to view and clean up old PE-based configurations as they migrate to the new PC-based framework.

---

### Features
* **Migration Support**: Provides a way to read and delete old PE-based anti-affinity groups from PC so that they can be replaced by the new category-based PC VM-VM anti-affinity policies.
* **Read and Delete Only**: The API strictly provides `GET` (list and view) and `DELETE` operations for legacy policies. You cannot create or update legacy policies via the v4 API.
* **Soft Enforcement (General Anti-Affinity)**: The underlying VM-VM anti-affinity scheduler logic evaluates these policies as "soft-enforced" during failover. The policy is honored as long as there are sufficient independent nodes available; if not, VMs may power on together to prioritize availability over strict separation.
* **RBAC Integration**: It is integrated with Nutanix IAMv2. Support includes built-in roles and permissions like `View_Legacy_VM_Anti_Affinity_Policy` and `Delete_Legacy_VM_Anti_Affinity_Policy`.

### Prerequisites
* **Prism Central**: Requires PC version 2024.3 or newer.
* **Prism Element / AOS**: Requires AHV and AOS version 6.9 or 7.0+ on the clusters managing the VMs.
* **Role Permissions**: The user must have a role with explicit permissions to view or delete the policies (e.g., Prism Admin, Super Admin, Cluster Admin).

### Workflow
1. **Discovery**: Administrators call the `GET /vmm/v4.2/ahv/policies/legacy-vm-anti-affinity-policies` API to retrieve a list of all existing PE-based VM anti-affinity groups mapped as `LegacyVmAntiAffinityPolicy` objects.
2. **Review & Audit**: The response returns the policy UUIDs, names, the clusters they belong to, and the list of VM references attached to them.
3. **Cleanup/Migration**: When migrating to the new PC-based categories, administrators call the `DELETE /vmm/v4.2/ahv/policies/legacy-vm-anti-affinity-policies/{extId}` endpoint to remove the legacy policy from PE.
4. **Re-creation (Modern)**: Administrators then use the standard `VmAntiAffinityPolicy` endpoints to create the new rules using PC categories.

---

### Related Engineering Tickets (JIRA / ENG)
* **[FEAT-4595](https://jira.nutanix.com/browse/FEAT-4595)** — [ahv][mgmt] VM-VM Anti-Affinity: The primary Epic tracking the implementation of VM-VM Anti-Affinity in PC/AHV.
* **[FEAT-11078](https://jira.nutanix.com/browse/FEAT-11078)** — VM-VM Affinity.
* **[ENG-514728](https://jira.nutanix.com/browse/ENG-514728)** — [vm-vm-anti-affinity] PG readiness for FEAT-4595.
* **[ENG-866733](https://github.com/nutanix-core/ntnx-api-vmm/pull/1415)** — RBAC updates mapping VM Anti Affinity policy permissions (Removed vm_host_affinity_policy for tenant users).
* **[ENG-729037](https://github.com/nutanix-core/iam-ui/pull/1186)** — Addressed an IAM UI issue filtering the `LEGACY_VM_ANTI_AFFINITY_POLICY` entity type in ACP view mode.
* **[SOL-935](https://jira.nutanix.com/browse/SOL-935)** — Tracker story for Solutions & Performance Engineering validation of VM-VM Anti-Affinity.
* **[ENG-928891](https://jira.nutanix.com/browse/ENG-928891)** — [FEAT ADOPTION] FEAT table cleanup.
* **[ENG-945408](https://jira.nutanix.com/browse/ENG-945408)** — [PROD UPDATE][FEAT ADOPTION] Update FEAT status in FEAT table.

### Related Confluence Pages & Design Docs
* **[FEAT-4595 - VM-VM Anti-Affinity (Main Status Page)](https://confluence.eng.nutanix.com:8443/spaces/AE/pages/190193743/FEAT-4595+-+VM-VM+Anti-Affinity)** — Includes project timelines, contributors, QA status, and links to backend PRDs and ERDs.
* **[AHV VMM VM-VM Anti-affinity policies - RBAC P0 requirements](https://confluence.eng.nutanix.com:8443/spaces/AE/pages/327128427/AHV+VMM+VM-VM+Anti-affinity+policies+-+RBAC+P0+requirements)** — Discusses the registration of `legacy_vm_anti_affinity_policy` as an IAM entity and its permissions.
* **[FEAT-4595 VM-VM Anti-affinity policies Serviceability checklist](https://confluence.eng.nutanix.com:8443/spaces/AE/pages/332860977/FEAT-4595+VM-VM+Anti-affinity+policies+Serviceability+checklist)** — Details on telemetry, log collection, and troubleshooting guides for the feature.
* **[6.9 FEAT-4595 VM-VM Anti-Affinity (Support Readiness)](https://confluence.eng.nutanix.com:8443/spaces/STK/pages/338573689/6.9+FEAT-4595+VM-VM+Anti-Affinity)** — Includes troubleshooting, notification audits (e.g., `kVmGroupAntiAffinityViolation`), and Acropolis/Lazan log signatures.
* **[FEAT-4595 Serviceability PG checklist](https://confluence.eng.nutanix.com:8443/spaces/AE/pages/338576740/FEAT-4595+Serviceability+PG+checklist)**.
* **[Pegasus - AOS 7.0 and PC 2024.3](https://confluence.eng.nutanix.com:8443/spaces/~bella.goldenberg/pages/560089612/Pegasus+-+AOS+7.0+and+PC+2024.3)**.
* **[7.0 New Feature Tests](https://confluence.eng.nutanix.com:8443/spaces/QA/pages/561045542/7.0_New_Feature_Tests)**.
* **[AOS 6.9/PC2024.x(AOS 7.0/Pegasus)](https://confluence.eng.nutanix.com:8443/spaces/CER/pages/276675253/AOS+6.9+PC2024.x+AOS+7.0+Pegasus)**.
* **[Q4FY24 - Tracker - EMEA](https://confluence.eng.nutanix.com:8443/spaces/SW/pages/327124389/Q4FY24+-+Tracker+-+EMEA)**.

### Related SharePoint / eLearning
* **[FEAT-4595 (SharePoint)](https://nutanixinc.sharepoint.com/sites/GlobalEnablementPrograms/ELearning%20Repository/nuStuff/AOS%20Releases/NCI%207.0/NCI%207.0%20Core,%20AHV,%20BCDR%20-%20200%20-%20nuStuff/FEAT-4595)**.

### Related Code / API Definitions
* **[legacy-vm-anti-affinity-policy.yaml (OpenAPI model)](https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/models/ahv/policies/legacy-vm-anti-affinity-policy.yaml)**.
* **[legacy-vm-anti-affinity-policy-endpoints.yaml (OpenAPI endpoints)](https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split-module-tree/definitions/endpoints/ahv/policies/legacy-vm-anti-affinity-policy-endpoints.yaml)**.
* **[LegacyVmAntiAffinityPolicy.py (Python SDK model)](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/policies/LegacyVmAntiAffinityPolicy.py)**.
* **[ConflictingLegacyVmAntiAffinityPolicy.py (Python SDK model)](https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/policies/ConflictingLegacyVmAntiAffinityPolicy.py)**.
* **[list_legacy_vm_anti_affinity_policies_request.go (Go SDK)](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmantiaffinitypolicies/list_legacy_vm_anti_affinity_policies_request.go)**.
* **[delete_legacy_vm_anti_affinity_policy_by_id_request.go (Go SDK)](https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmantiaffinitypolicies/delete_legacy_vm_anti_affinity_policy_by_id_request.go)**.
* **[antiAffinityEndpoints.yaml (hack2026-d3320)](https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv-policies/released/api/antiAffinityEndpoints.yaml)**.
* **[antiAffinityModel.yaml (hack2026-d3320)](https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv-policies/released/models/antiAffinityModel.yaml)**.
* **[VmAntiAffinityPolicies_service.proto](https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/tests/microbenchmarking_mocks/mock_metropolis/proto/vmm/vmm/v4/ahv/policies/VmAntiAffinityPolicies_service.proto)**.

### Related Test Sources
* **[test_vm_vm_anti_affinity_policy.py (nutest)](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/systest/acropolis/pc/test_vm_vm_anti_affinity_policy.py)**.
* **[test_aaf_permissions.py (nutest)](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/acropolis/ahv_management/anti_affinity_policy_based/test_aaf_permissions.py)**.
* **[pc_aaf_rbac.json (RBAC config)](https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/enhanced_pc_rbac/config/pc_aaf_rbac.json)**.
* **[domain_03_ahv_policies_core_delete_tests.json (TPG)](https://github.com/nutanix-engineering/hack2026-d3089/blob/main/old_approach_data/tpg_output/test_cases/domain_03_ahv_policies_core_delete_tests.json)**.

### Required domain skills for this feature
* Ansible module development (v4 patterns used across the `nutanix.ncp` collection).
* Nutanix Prism Central v4 REST API, especially `/vmm/v4.2/ahv/policies/*`.
* `ntnx_vmm_py_client` Python SDK (models: `LegacyVmAntiAffinityPolicy`, `VmAntiAffinityPoliciesApi`, `TaskReference`).
* Nutanix IAM v2 concepts (roles, permissions, entity types) — specifically `View_Legacy_VM_Anti_Affinity_Policy` and `Delete_Legacy_VM_Anti_Affinity_Policy`.
* AHV / Acropolis scheduler behaviour for VM-VM anti-affinity ("soft" enforcement, `kVmGroupAntiAffinityViolation` notification, Lazan/Acropolis log signatures).
* Historical PE-side VM group configuration (`acli vm.affinity_set`) so you understand what a "legacy" policy is and why customers migrate.

## Files changed

- `plugins/modules/`:
  - `ntnx_legacy_vm_anti_affinity_policy_v2.py` — new CRUD module (`state=absent` supported; `state=present` fails with a descriptive message because the v4 SDK does not expose create/update for legacy policies).
  - `ntnx_legacy_vm_anti_affinity_policies_info_v2.py` — new info module (`ext_id`, `filter`, `limit`, `page`, `orderby`, `select`).
- `plugins/module_utils/v4/vmm/api_client.py` — added `get_vm_anti_affinity_policies_api_instance` helper.
- `plugins/module_utils/v4/vmm/helpers.py` — added `get_legacy_vm_anti_affinity_policy` helper (list-with-`extId` filter as a stand-in for the missing `GET-by-id` endpoint).
- `meta/runtime.yml` — registered both new modules in the `ntnx` action group.
- `examples/virtual_machine_management/LegacyVmAntiAffinityPolicy/legacy_vm_anti_affinity_policy_v2.yml` — new playbook covering list-all, list-with-filter, list-with-limit, get-by-id, and delete.
- `examples/virtual_machine_management/LegacyVmAntiAffinityPolicy/examples_run.log` — captured output from running the example playbook against the live Prism Central.
- `tests/integration/targets/ntnx_legacy_vm_anti_affinity_policies_v2/{aliases,meta/main.yml,tasks/main.yml,tasks/legacy_vm_anti_affinity_policies.yml}` — new integration test target.

## Test execution

| Metric              | Value                                                                     |
|---------------------|---------------------------------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 --allow-disabled ntnx_legacy_vm_anti_affinity_policies_v2 -v` |
| Total tasks         | 34 (Ansible tasks in the target playbook, including asserts and skips)    |
| Passed              | 23 (`ok`)                                                                 |
| Ignored             | 5 (module returned `failed=true` on purpose; assertion of that failure passed) |
| Skipped             | 6 (get-by-id happy path + delete happy path require an existing legacy policy on the cluster; none present on the target PC) |
| Failed              | 0                                                                         |
| Duration            | ~0:00:11                                                                  |
| Cluster (PC)        | `10.44.76.28` (PC 2024.3 / Pegasus)                                       |
| Sanity (`ansible-test sanity --python 3.12`) | All 32 sanity tests passed on the new modules + updated helpers |

### Analysis

- All negative-path tests (missing `ext_id`, invalid `state=present`, non-existent policy delete/get) triggered the exact expected error/task-failed messages surfaced by both the module code and the live cluster's `POLICY_NOT_FOUND` (`VMM-34060`) error group.
- The two happy-path tests (fetch-by-id and delete an existing legacy policy) were **skipped** because the target Prism Central had zero legacy VM-VM anti-affinity policies (`total_available_results: 0`). Legacy policies can only be created from PE via `acli vm.affinity_set`; the v4 API cannot create them, so we cannot seed one from Ansible. The test file guards these tasks with a `when` clause and emits a debug message explaining the skip.
- `state=present` (both create and update forms) is intentionally rejected in the module because the SDK provides no `create_legacy_vm_anti_affinity_policy` / `update_legacy_vm_anti_affinity_policy` endpoint — only `list_legacy_vm_anti_affinity_policies` and `delete_legacy_vm_anti_affinity_policy_by_id`.

### Known issues

- Happy-path fetch-by-id and delete tests cannot run automatically until a PE-managed cluster hosting the target PC has an existing legacy VM group configured via `acli vm.affinity_set`. Reviewers running this test suite on a cluster that DOES have legacy policies will automatically exercise those paths.

### Test logs (tail)

<details>
<summary>tail -n 100 test_logs.log</summary>

```text
TASK [ntnx_legacy_vm_anti_affinity_policies_v2 : List all legacy VM-VM anti-affinity policies] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_legacy_vm_anti_affinity_policies_v2 : List legacy VM-VM anti-affinity policies with a small limit] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_legacy_vm_anti_affinity_policies_v2 : List legacy VM-VM anti-affinity policies with a bogus filter] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_legacy_vm_anti_affinity_policies_v2 : Fetch legacy policy by non-existent ext_id (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Legacy VM-VM anti-affinity policy with ext_id '00000000-0000-0000-0000-044188479216' was not found."}
...ignoring

TASK [ntnx_legacy_vm_anti_affinity_policies_v2 : Attempt to create a legacy policy (state=present without ext_id) should fail] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": null, "msg": "Create is not supported for legacy VM-VM anti-affinity policies. The Nutanix v4 VMM API only allows listing and deleting legacy policies. Use the modern VM-VM anti-affinity policy APIs to create new anti-affinity rules.", "response": null}
...ignoring

TASK [ntnx_legacy_vm_anti_affinity_policies_v2 : Attempt to update a legacy policy (state=present with ext_id) should fail] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": "00000000-0000-0000-0000-044188479216", "msg": "Update is not supported for legacy VM-VM anti-affinity policies (ext_id: 00000000-0000-0000-0000-044188479216). ..."}
...ignoring

TASK [ntnx_legacy_vm_anti_affinity_policies_v2 : Attempt delete without ext_id should fail] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_legacy_vm_anti_affinity_policies_v2 : Delete a legacy policy using a non-existent ext_id should fail] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"error_messages": [{"code": "VMM-34060", "error_group": "POLICY_NOT_FOUND", "message": "Failed to perform the operation on the policy with UUID '00000000-0000-0000-0000-044188479216', because it is not found."}], "status": "FAILED"}}
...ignoring

TASK [ntnx_legacy_vm_anti_affinity_policies_v2 : Delete a legacy policy in check_mode] ***
ok: [testhost] => {"changed": false, "ext_id": "00000000-0000-0000-0000-044188479216", "msg": "Legacy VM-VM anti-affinity policy with ext_id: 00000000-0000-0000-0000-044188479216 will be deleted.", "response": null}

TASK [ntnx_legacy_vm_anti_affinity_policies_v2 : Note that no legacy policies existed on this Prism Central] ***
ok: [testhost] => {"msg": "No legacy VM-VM anti-affinity policies were found on the target Prism Central. The delete happy-path and get-by-id happy-path tests were skipped because legacy policies cannot be created via the v4 API — they only exist as carry-overs from PE-based VM group configurations."}

PLAY RECAP *********************************************************************
testhost                   : ok=23   changed=0    unreachable=0    failed=0    skipped=6    rescued=0    ignored=5
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Domain knowledge sourced live from Glean (`glean__chat` MCP tool) during the run.
- Integration tests executed against Prism Central `10.44.76.28`.
- Example playbook executed against the same Prism Central; captured output committed to `examples/virtual_machine_management/LegacyVmAntiAffinityPolicy/examples_run.log`.
