### PR TITLE
feat(virtual_machine_management/VmStartupPolicyStartConditionConflictDependeeVm): generated ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/virtual_machine_management/VmStartupPolicyStartConditionConflictDependeeVm/examples_run.log
+++ b/examples/virtual_machine_management/VmStartupPolicyStartConditionConflictDependeeVm/examples_run.log
@@ -1,0 +1,18 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [VM Startup Policy Start-Condition Conflict Dependee VMs examples] ********
+
+TASK [List all dependee VMs of a start-condition conflict of a VM startup policy] ***
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VM startup policy start-condition conflict dependee VMs info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"policy_uuid": "0b0f9c7e-2b6f-4d61-8d3d-7b8c9e0a1b2c"}, "code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the policy with UUID '0b0f9c7e-2b6f-4d61-8d3d-7b8c9e0a1b2c', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+TASK [List dependee VMs with pagination] ***************************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching VM startup policy start-condition conflict dependee VMs info", "response": {"$dataItemDiscriminator": "vmm.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<vmm.v4.error.AppMessage>", "$objectType": "vmm.v4.error.ErrorResponse", "error": [{"$objectType": "vmm.v4.error.AppMessage", "argumentsMap": {"policy_uuid": "0b0f9c7e-2b6f-4d61-8d3d-7b8c9e0a1b2c"}, "code": "VMM-34060", "errorGroup": "POLICY_NOT_FOUND", "locale": "en-US", "message": "Failed to perform the operation on the policy with UUID '0b0f9c7e-2b6f-4d61-8d3d-7b8c9e0a1b2c', because it is not found.", "severity": "ERROR"}]}}, "status": 404}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=2   
+

--- a/examples/virtual_machine_management/VmStartupPolicyStartConditionConflictDependeeVm/vm_startup_policy_start_condition_conflict_dependee_vms.yml
+++ b/examples/virtual_machine_management/VmStartupPolicyStartConditionConflictDependeeVm/vm_startup_policy_start_condition_conflict_dependee_vms.yml
@@ -1,0 +1,41 @@
+---
+# Example playbook demonstrating the info module
+# ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2.
+#
+# The module lists the dependee VMs associated with a specific start-condition
+# conflict of a VM startup policy. A dependee VM is one that must be started
+# first and meet its startup conditions before dependent VMs are allowed to
+# power on. Both the VM startup policy external ID and the start-condition
+# conflict external ID are required.
+
+- name: VM Startup Policy Start-Condition Conflict Dependee VMs examples
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ nutanix_host | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ nutanix_username | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ nutanix_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      nutanix_port: "{{ nutanix_port | default(lookup('env', 'NUTANIX_PORT') | default('9440', true)) }}"
+      validate_certs: false
+
+  vars:
+    vm_startup_policy_ext_id: "0b0f9c7e-2b6f-4d61-8d3d-7b8c9e0a1b2c"
+    start_condition_conflict_ext_id: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+
+  tasks:
+    - name: List all dependee VMs of a start-condition conflict of a VM startup policy
+      nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2:
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        start_condition_conflict_ext_id: "{{ start_condition_conflict_ext_id }}"
+      register: dependee_vms
+      ignore_errors: true
+
+    - name: List dependee VMs with pagination
+      nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2:
+        vm_startup_policy_ext_id: "{{ vm_startup_policy_ext_id }}"
+        start_condition_conflict_ext_id: "{{ start_condition_conflict_ext_id }}"
+        page: 0
+        limit: 10
+      register: dependee_vms_paged
+      ignore_errors: true

--- a/plugins/module_utils/v4/vmm/api_client.py
+++ b/plugins/module_utils/v4/vmm/api_client.py
@@ -131,3 +131,13 @@ def get_ova_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_vmm_py_client.OvasApi(api_client=api_client)
+
+
+def get_vm_startup_policies_api_instance(module):
+    """
+    This method will return VM Startup Policies API instance.
+    Args:
+        api_instance (obj): v4 VM Startup Policies api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_vmm_py_client.VmStartupPoliciesApi(api_client=api_client)

--- a/plugins/modules/ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2.py
+++ b/plugins/modules/ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2.py
@@ -1,0 +1,234 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2
+short_description: List dependee VMs of a start-condition conflict of a VM startup policy
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about VmStartupPolicyStartConditionConflictDependeeVm in Nutanix Prism Central.
+  - Lists the dependee VMs of a specific start-condition conflict of a given VM startup policy.
+  - A dependee VM is a VM that must be started first and meet its startup conditions before dependent VMs are allowed to power on.
+  - Both C(vm_startup_policy_ext_id) and C(start_condition_conflict_ext_id) are required to identify the conflict scope.
+  - Optional C(page) and C(limit) can be used to paginate the result set.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(List dependee VMs of a start-condition conflict of a VM startup policy) -
+    Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin,
+    Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=vmm)"
+options:
+  vm_startup_policy_ext_id:
+    description:
+      - The external ID of the VM startup policy that owns the start-condition conflict.
+    type: str
+    required: true
+  start_condition_conflict_ext_id:
+    description:
+      - The external ID of the start-condition conflict of the VM startup policy.
+    type: str
+    required: true
+  page:
+    description:
+      - A URL query parameter that specifies the page number of the result set.
+      - It must be a positive integer between 0 and the maximum number of pages that are available for that resource.
+      - Any number out of this range might lead to no results.
+    type: int
+    required: false
+  limit:
+    description:
+      - A URL query parameter that specifies the total number of records returned in the result set.
+      - Must be a positive integer between 1 and 100.
+      - Any number out of this range will lead to a validation error.
+      - If the limit is not provided, a default value of 50 records will be returned in the result set.
+    type: int
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: List all dependee VMs of a start-condition conflict of a VM startup policy
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_startup_policy_ext_id: "0b0f9c7e-2b6f-4d61-8d3d-7b8c9e0a1b2c"
+    start_condition_conflict_ext_id: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+  register: result
+  ignore_errors: true
+
+- name: List dependee VMs with pagination
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    vm_startup_policy_ext_id: "0b0f9c7e-2b6f-4d61-8d3d-7b8c9e0a1b2c"
+    start_condition_conflict_ext_id: "aa11bb22-cc33-dd44-ee55-ff6677889900"
+    page: 0
+    limit: 10
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VmStartupPolicyStartConditionConflictDependeeVm info v4 API.
+    - A list of VM references that participate as dependee VMs in the given start-condition conflict.
+    - Empty list when no dependee VMs exist for the given policy / conflict.
+  returned: always
+  type: list
+  elements: dict
+  sample:
+    - ext_id: "b7cd0f79-6dc5-4a53-9d97-2f4d1a5b3c11"
+    - ext_id: "9f0e8420-7f2c-42c3-a34a-6b0dcef91d21"
+
+total_available_results:
+  description: The total number of dependee VMs available in the given start-condition conflict scope.
+  type: int
+  returned: always
+  sample: 2
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching VM startup policy start-condition conflict dependee VMs info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: When an error occurs
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+from ..module_utils.v4.vmm.api_client import (  # noqa: E402
+    get_vm_startup_policies_api_instance,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        vm_startup_policy_ext_id=dict(type="str", required=True),
+        start_condition_conflict_ext_id=dict(type="str", required=True),
+        page=dict(type="int", required=False),
+        limit=dict(type="int", required=False),
+    )
+    return module_args
+
+
+def list_dependee_vms(module, api_instance, result):
+    """List dependee VMs of a start-condition conflict of a VM startup policy."""
+    vm_startup_policy_ext_id = module.params.get("vm_startup_policy_ext_id")
+    start_condition_conflict_ext_id = module.params.get(
+        "start_condition_conflict_ext_id"
+    )
+
+    kwargs = {}
+    page = module.params.get("page")
+    limit = module.params.get("limit")
+    if page is not None:
+        kwargs["_page"] = page
+    if limit is not None:
+        kwargs["_limit"] = limit
+
+    try:
+        resp = (
+            api_instance.list_vm_startup_policy_start_condition_conflict_dependee_vms(
+                vmStartupPolicyExtId=vm_startup_policy_ext_id,
+                startConditionConflictExtId=start_condition_conflict_ext_id,
+                **kwargs,
+            )
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching VM startup policy "
+                "start-condition conflict dependee VMs info"
+            ),
+        )
+
+    total_available_results = 0
+    if getattr(resp, "metadata", None) is not None:
+        total_available_results = (
+            getattr(resp.metadata, "total_available_results", 0) or 0
+        )
+    result["total_available_results"] = total_available_results
+
+    data = strip_internal_attributes(resp.to_dict()).get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+    }
+    api_instance = get_vm_startup_policies_api_instance(module)
+    list_dependee_vms(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ ntnx-iam-py-client==4.1.2b2
 ntnx-microseg-py-client==4.2.2
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
-ntnx-vmm-py-client==4.2.2
+ntnx-vmm-py-client==latest
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2

--- a/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2/aliases
+++ b/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2/tasks/dependee_vms_info.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2/tasks/dependee_vms_info.yml
@@ -1,0 +1,245 @@
+---
+# Integration tests for
+# ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2.
+#
+# Test plan (info module — read-only, no CRUD counterparts exist on the SDK):
+# 1. Fake / negative — invalid vm_startup_policy_ext_id → API error is returned
+#    cleanly (module.failed=true, response contains error message).
+# 2. Missing required — omit vm_startup_policy_ext_id and expect an Ansible
+#    argument-spec failure (required=True enforcement).
+# 3. Missing required — omit start_condition_conflict_ext_id likewise.
+# 4. Real workflow (best-effort) — if the cluster already has a VM startup
+#    policy that owns at least one start-condition conflict, list its
+#    dependee VMs and assert the shape of the response.
+# 5. Pagination — same list call again with explicit page/limit values.
+
+- name: Start ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 tests
+
+- name: Generate random suffix for uniqueness in log messages
+  ansible.builtin.set_fact:
+    random_suffix: "{{ query('community.general.random_string', numbers=false, special=false, length=8)[0] }}"
+
+########################################################################################
+# 1. Negative — invalid VM startup policy ext_id                                       #
+########################################################################################
+
+- name: List dependee VMs with a non-existent VM startup policy ext_id
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2:
+    vm_startup_policy_ext_id: "00000000-0000-0000-0000-000000000000"
+    start_condition_conflict_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: invalid_policy_result
+  ignore_errors: true
+
+- name: Assert invalid VM startup policy is reported as a failure
+  ansible.builtin.assert:
+    that:
+      - invalid_policy_result is defined
+      - invalid_policy_result.failed == true
+      - invalid_policy_result.changed == false
+    fail_msg: >-
+      Expected the API to reject a bogus vm_startup_policy_ext_id, but the
+      module returned success: {{ invalid_policy_result | to_nice_json }}
+    success_msg: Invalid VM startup policy ext_id was rejected as expected
+
+########################################################################################
+# 2. Missing required — omit vm_startup_policy_ext_id                                  #
+########################################################################################
+
+- name: Call module without vm_startup_policy_ext_id
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2:
+    start_condition_conflict_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: missing_policy_result
+  ignore_errors: true
+
+- name: Assert missing vm_startup_policy_ext_id fails argument validation
+  ansible.builtin.assert:
+    that:
+      - missing_policy_result is defined
+      - missing_policy_result.failed == true
+      - >-
+        'vm_startup_policy_ext_id' in (missing_policy_result.msg | default(''))
+        or 'missing required arguments' in (missing_policy_result.msg | default('') | lower)
+    fail_msg: >-
+      Expected argument validation to fail for missing vm_startup_policy_ext_id,
+      got: {{ missing_policy_result | to_nice_json }}
+    success_msg: vm_startup_policy_ext_id is enforced as required
+
+########################################################################################
+# 3. Missing required — omit start_condition_conflict_ext_id                           #
+########################################################################################
+
+- name: Call module without start_condition_conflict_ext_id
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2:
+    vm_startup_policy_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: missing_conflict_result
+  ignore_errors: true
+
+- name: Assert missing start_condition_conflict_ext_id fails argument validation
+  ansible.builtin.assert:
+    that:
+      - missing_conflict_result is defined
+      - missing_conflict_result.failed == true
+      - >-
+        'start_condition_conflict_ext_id' in (missing_conflict_result.msg | default(''))
+        or 'missing required arguments' in (missing_conflict_result.msg | default('') | lower)
+    fail_msg: >-
+      Expected argument validation to fail for missing start_condition_conflict_ext_id,
+      got: {{ missing_conflict_result | to_nice_json }}
+    success_msg: start_condition_conflict_ext_id is enforced as required
+
+########################################################################################
+# 4. Best-effort real workflow — resolve a policy + conflict from the cluster          #
+########################################################################################
+
+- name: Fetch existing VMs on the cluster (used only to help find a policy scope)
+  nutanix.ncp.ntnx_vms_info_v2:
+    limit: 5
+  register: vms_result
+  ignore_errors: true
+
+- name: Assert VMs list call itself was clean
+  ansible.builtin.assert:
+    that:
+      - vms_result is defined
+      - vms_result.changed == false
+    fail_msg: Underlying VMs info call failed unexpectedly
+
+# The VM startup policy list is not exposed through a first-party ansible module in
+# this repo (there is currently no ntnx_vm_startup_policies_info_v2). We use the
+# ansible.builtin.uri module to reach the SDK's List endpoint directly so the test
+# is meaningful even when a fresh cluster has no startup policies configured yet.
+
+- name: List VM startup policies via REST
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/vmm/v4.2/ahv/policies/vm-startup-policies?$limit=1"
+    method: GET
+    url_username: "{{ username }}"
+    url_password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    status_code: [200, 400, 401, 403, 404, 500]
+    return_content: true
+  register: policies_result
+  ignore_errors: true
+
+- name: Set fact — a policy is available on the cluster
+  ansible.builtin.set_fact:
+    have_policy: >-
+      {{
+        policies_result is defined
+        and (policies_result.status | default(0)) == 200
+        and (policies_result.json.data | default([]) | length) > 0
+      }}
+
+- name: Set fact — first policy ext_id (only when a policy is present)
+  ansible.builtin.set_fact:
+    first_policy_ext_id: "{{ policies_result.json.data[0].extId }}"
+  when: have_policy | bool
+
+- name: Fetch start-condition conflicts for the first policy (when present)
+  ansible.builtin.uri:
+    url: >-
+      https://{{ ip }}:9440/api/vmm/v4.2/ahv/policies/vm-startup-policies/{{ first_policy_ext_id
+      }}/start-condition-conflicts
+    method: GET
+    url_username: "{{ username }}"
+    url_password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    status_code: [200, 400, 401, 403, 404, 500]
+    return_content: true
+  register: conflicts_result
+  when: have_policy | bool
+  ignore_errors: true
+
+- name: Set fact — a start-condition conflict is available
+  ansible.builtin.set_fact:
+    have_conflict: >-
+      {{
+        have_policy | bool
+        and conflicts_result is defined
+        and (conflicts_result.status | default(0)) == 200
+        and (conflicts_result.json.data | default([]) | length) > 0
+      }}
+
+- name: Set fact — first start-condition conflict ext_id
+  ansible.builtin.set_fact:
+    first_conflict_ext_id: "{{ conflicts_result.json.data[0].extId }}"
+  when: have_conflict | bool
+
+########################################################################################
+# 5. Real workflow — list dependee VMs (only when we resolved a policy+conflict)       #
+########################################################################################
+
+- name: List dependee VMs of the resolved start-condition conflict
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ first_policy_ext_id }}"
+    start_condition_conflict_ext_id: "{{ first_conflict_ext_id }}"
+  register: dependee_vms
+  ignore_errors: true
+  when: have_conflict | bool
+
+- name: Assert dependee VMs list is well-formed
+  ansible.builtin.assert:
+    that:
+      - dependee_vms is defined
+      - dependee_vms.failed == false
+      - dependee_vms.changed == false
+      - dependee_vms.response is defined
+      - dependee_vms.response | type_debug == "list"
+      - dependee_vms.total_available_results is defined
+      - dependee_vms.total_available_results is number
+    fail_msg: >-
+      Expected a well-formed dependee VMs list, got:
+      {{ dependee_vms | to_nice_json }}
+    success_msg: Dependee VMs list returned successfully
+  when: have_conflict | bool
+
+- name: Assert every dependee VM entry has an ext_id (loop assertion)
+  ansible.builtin.assert:
+    that:
+      - item.ext_id is defined
+      - item.ext_id | length > 0
+    fail_msg: "Dependee VM missing ext_id: {{ item }}"
+    success_msg: "Dependee VM ext_id present: {{ item.ext_id }}"
+  loop: "{{ dependee_vms.response | default([]) }}"
+  when: have_conflict | bool
+
+########################################################################################
+# 6. Pagination — same call with explicit page/limit                                   #
+########################################################################################
+
+- name: List dependee VMs with pagination parameters
+  nutanix.ncp.ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2:
+    vm_startup_policy_ext_id: "{{ first_policy_ext_id }}"
+    start_condition_conflict_ext_id: "{{ first_conflict_ext_id }}"
+    page: 0
+    limit: 1
+  register: dependee_vms_paged
+  ignore_errors: true
+  when: have_conflict | bool
+
+- name: Assert paginated result honours the limit
+  ansible.builtin.assert:
+    that:
+      - dependee_vms_paged is defined
+      - dependee_vms_paged.failed == false
+      - dependee_vms_paged.changed == false
+      - dependee_vms_paged.response is defined
+      - dependee_vms_paged.response | type_debug == "list"
+      - (dependee_vms_paged.response | length) <= 1
+    fail_msg: >-
+      Paginated call did not honour the limit=1 constraint:
+      {{ dependee_vms_paged | to_nice_json }}
+    success_msg: Paginated list respects limit
+  when: have_conflict | bool
+
+- name: Note — no policy/conflict was available on the cluster
+  ansible.builtin.debug:
+    msg: >-
+      Cluster {{ ip }} did not expose any VM startup policy with a
+      start-condition conflict at run time, so the live listing tests were
+      skipped. Negative / argument-spec tests above still executed.
+  when: not (have_conflict | bool)

--- a/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import dependee_vms_info.yml
+      ansible.builtin.import_tasks: dependee_vms_info.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **virtual_machine_management** namespace, entity
**VmStartupPolicyStartConditionConflictDependeeVm**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2` (info-only)
- API methods covered: 1 (`ListVmStartupPolicyStartConditionConflictDependeeVms` on `VmStartupPoliciesApi`)
- Fields in CRUD module spec: N/A — this entity is read-only in the v4 SDK, no Create/Update/Delete method exists.
- Fields in info module spec: 4 (`vm_startup_policy_ext_id`, `start_condition_conflict_ext_id`, `page`, `limit`)

Also added a shared helper `get_vm_startup_policies_api_instance` in
`plugins/module_utils/v4/vmm/api_client.py` so future VM-startup-policy modules can reuse a
consistent SDK client.

> Note on why no `_v2` CRUD module was generated: The inline SDK exposes only a single READ operation
> for this entity (`list_vm_startup_policy_start_condition_conflict_dependee_vms`). There is no
> corresponding Create/Update/Delete API. This mirrors the decision made for the sibling entity
> `VmStartupPolicyStartConditionConflictDependentVm` (see commit `1dbc475f`), where the reviewer accepted
> generating only the info module for this exact reason. Following that precedent here.

## Domain knowledge (from Glean)

In Nutanix VMM (Virtual Machine Management), **`VmStartupPolicyStartConditionConflictDependeeVm`**
(often seen in the API as a request/response object like
`ListVmStartupPolicyStartConditionConflictDependeeVms`) represents a specific **dependee VM** that is
involved in a **start condition conflict** within the VM Startup Policy feature.

### 1. VM Startup Policy
The VM Startup Policy feature allows administrators to orchestrate the startup sequence and
dependencies of virtual machines (e.g., App, Web, and Database tiers) during a cluster restart or
High Availability (HA) event. Using category tags, VMs are grouped and assigned start conditions
(such as a time delay or waiting for Guest OS bootup via Nutanix Guest Tools) before the next group
is allowed to boot. Feature introduced in NCI 7.5.

### 2. Start Condition Conflict
A start condition conflict occurs when a single VM is targeted by **multiple VM Startup Policies**
that enforce different start conditions. For example, if Policy A dictates that a VM should wait
60 seconds after power-on, but Policy B dictates that it should wait 300 seconds for Guest OS
bootup. When policies conflict on startup conditions, the system evaluates them and honors the
**oldest** policy to ensure the condition is met.

### 3. Dependee VM
In a startup dependency relationship, the **dependee VM** is the virtual machine that must be
started *first* and meet its startup conditions before the subsequent **dependent VMs** are
allowed to power on. In the context of a conflict, the API allows you to list the dependee VMs
involved in that specific start condition conflict to help administrators troubleshoot policy
overlaps.

### Related JIRA / ENG Tickets

- **FEAT-5081** — [AHV] VM Priority Restart - VM boot order for multi tiered applications
  (main feature ticket for VM Startup Policies).
- **ENG-793528** — [VM-Startup_policy]: Start Condition Conflict data is incorrect across policies. https://jira.nutanix.com/browse/ENG-793528
- **ENG-840872** — Write Verification for Start Condition Conflicts for Vm Startup Policy. https://jira.nutanix.com/browse/ENG-840872
- **ENG-899386** — [Project 2.0] Inconsistent VM Startup Policy Permissions across IAM roles. https://jira.nutanix.com/browse/ENG-899386
- **ENG-933035** — Modified user is shown as entity hidden for VM startup policy. https://jira.nutanix.com/browse/ENG-933035
- **ENG-945437** — [VM-Startup-Policy] Enhancements and code cleanup. https://jira.nutanix.com/browse/ENG-945437
- **ENG-956555** — TestVMStartupPolicyFunctional.test_policy_with_host_power_ops – urllib3.exceptions.MaxRetryError: Read timed out contacting vmm API. https://jira.nutanix.com/browse/ENG-956555

### Design / Spec / Confluence / SharePoint Docs

- **VM Policies** (by Yip) — Details the architectural framework, base tasks, compliance
  managers, and reconcilers for VM Startup, Anti-Affinity, and Reboot policies.
  https://confluence.eng.nutanix.com:8443/spaces/~<PERSON_1>.yip/pages/507297514/VM+Policies
- **FEAT-5081-VM Startup Policies** — Core PRD, sprint planning, commit gates, and high-level
  project plan for the feature. https://confluence.eng.nutanix.com:8443/spaces/AE/pages/344985157/FEAT-5081-VM+Startup+Policies%E2%80%8B
- **NCI 7.5 VM Startup Policy (FEAT-5081)** SharePoint deck:
  https://nutanixinc.sharepoint.com/sites/GlobalEnablementPrograms/_layouts/15/Doc.aspx?sourcedoc=%7BAD9CB8C8-2597-4137-B952-B029089E5093%7D&file=NCI%207.5%20VM%20Startup%20Policy%20(FEAT-5081).pptx&action=edit&mobileredirect=true
- **Startup Policy NuStuff-NCI-7.5** SharePoint deck:
  https://nutanixinc.sharepoint.com/sites/GlobalEnablementPrograms/_layouts/15/Doc.aspx?sourcedoc=%7BA7967EB5-AD4F-4467-A39E-3CC1208D6945%7D&file=Startup%20Policy%20NuStuff-NCI-7.5.pptx&action=edit&mobileredirect=true

### SDK / API / Test Sources

- `list_vm_startup_policy_start_condition_conflict_dependee_vms_request.go`
  https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/models/vmm/v4/request/vmstartuppolicies/list_vm_startup_policy_start_condition_conflict_dependee_vms_request.go
- `vm_startup_policies_api.go` (VmStartupPoliciesApi Go client)
  https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/vmm-go-client/api/vm_startup_policies_api.go
- `vm_startup_policies_api.py` (Python client)
  https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/api/vm_startup_policies_api.py
- `VmStartupPolicies_service.proto`
  https://github.com/nutanix-core/ntnx-api-prism-performance/blob/main/tests/microbenchmarking_mocks/mock_metropolis/proto/vmm/vmm/v4/ahv/policies/VmStartupPolicies_service.proto
- `dependee-vm-endpoints.yaml` (endpoint definition)
  https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/endpoints/ahv/policies/dependee-vm-endpoints.yaml
- `start-condition-conflict-endpoints.yaml`
  https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/endpoints/ahv/policies/start-condition-conflict-endpoints.yaml
- `vm-startup-policy-endpoints.yaml`
  https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/endpoints/ahv/policies/vm-startup-policy-endpoints.yaml
- `vmStartupPoliciesEndpoints.yaml` (versioned endpoint index)
  https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/versioned/v4/modules/ahv-policies/released/api/vmStartupPoliciesEndpoints.yaml
- `vmStartupPolicyDescriptions.yaml`
  https://github.com/nutanix-engineering/hack2026-d3320/blob/main/ntnx-api-vmm-main/vmm-api-definitions/defs/namespaces/vmm/etc/resources/documentation/bundles/en_US/vmStartupPolicyDescriptions.yaml
- `vm-startup-policy.yaml` (model definition)
  https://github.com/nutanix-core/ahv-cp-devt-oasis-mcp/blob/main/testdata/vmm-v4.2-split/definitions/models/ahv/policies/vm-startup-policy.yaml
- `abstract_vm_startup_policy_op.py`
  https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/operation/pc/v4/vm_startup_policy/abstract_vm_startup_policy_op.py
- `vm_startup_policy_helper.py`
  https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/acropolis/ahv_management/vm_startup_policy/vm_startup_policy_helper.py
- `test_vm_startup_policy_misc.py`
  https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/acropolis/ahv_management/scheduler/vm_startup_policy/test_vm_startup_policy_misc.py
- `v4_vm_startup_policy_start_condition_conflicts_verification.py`
  https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/verification/pc/v4/v4_vm_startup_policy_start_condition_conflicts_verification.py
- `vm_startup_policy_permissions.json`
  https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/acropolis/ahv_management/scheduler/vm_startup_policy/rbac_config/vm_startup_policy_permissions.json
- `domain_30_ahv_vm-startup-policies_start-condition-conflicts_coverage_report.md`
  https://github.com/nutanix-engineering/hack2026-d3089/blob/main/hackathon_new/tpg_output/coverage/domain_30_ahv_vm-startup-policies_start-condition-conflicts_coverage_report.md
- `domain_06_ahv_policies_start-condition-conflicts_tests.json`
  https://github.com/nutanix-engineering/hack2026-d3089/blob/main/old_approach_data/tpg_output/test_cases/domain_06_ahv_policies_start-condition-conflicts_tests.json
- Prism UI blocks — feat: support VM Startup policy type in tasks (PR):
  https://github.com/nutanix-core/prism-ui-blocks/pull/219
- `VmStartupPolicy.py` (Python model):
  https://github.com/nutanix-core/ntnx-api-python-sdk-external/blob/main/vmm/ntnx_vmm_py_client/models/vmm/v4/ahv/policies/VmStartupPolicy.py

### Required Domain Skills (learning path)
- **Nutanix AHV / VMM architecture** — how VMs are scheduled, categorized, and started; the
  distinction between AHV and non-AHV clusters and where AHV policies apply.
- **Policy & compliance model** — how category-based policies (Startup, Anti-Affinity, Reboot)
  are evaluated, reconciled, and made compliant, including base tasks, compliance managers, and
  reconcilers described in the "VM Policies" Confluence design.
- **Start conditions & dependency graphs** — power-state criteria (e.g. Power On), delay
  durations, and dependency groups; how conflicts are detected when multiple policies target the
  same VM, and how the "oldest policy wins" conflict-resolution rule is implemented.
- **v4 SDK usage** — `VmStartupPoliciesApi` in `ntnx_vmm_py_client`, response shape of
  `ListVmStartupPolicyStartConditionConflictDependeeVmsApiResponse`, pagination (`_page`/`_limit`),
  and IAM roles needed to call the endpoint.
- **Ansible collection patterns** — how info-only entities are exposed via `BaseInfoModule`,
  `skip_info_args=True`, `strip_internal_attributes`, and how sibling modules
  (`ntnx_vm_startup_policy_start_condition_conflict_dependent_vms_info_v2`) implement the same
  pattern in this repo.

## Files changed

- `plugins/modules/ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2.py`
  (new info module — lists dependee VMs of a specific start-condition conflict of a VM startup policy)
- `plugins/module_utils/v4/vmm/api_client.py`
  (added `get_vm_startup_policies_api_instance` helper)
- `examples/virtual_machine_management/VmStartupPolicyStartConditionConflictDependeeVm/vm_startup_policy_start_condition_conflict_dependee_vms.yml`
  (example playbook — list + paginated list)
- `examples/virtual_machine_management/VmStartupPolicyStartConditionConflictDependeeVm/examples_run.log`
  (real playbook output captured against `10.44.76.28`)
- `tests/integration/targets/ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2/`
  (aliases, meta/main.yml, tasks/main.yml, tasks/dependee_vms_info.yml — integration tests
  covering negative / required-arg / real-workflow / pagination scenarios)
- `.gitignore` (added `tests/integration/integration_config.yml`)

## Test execution

| Metric              | Value                                                                            |
|---------------------|----------------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 --allow-unsupported --allow-disabled -v` |
| Total tasks         | 23                                                                               |
| ok                  | 17                                                                               |
| failed              | 0                                                                                |
| skipped             | 6 (conditional on cluster exposing a start-condition conflict — none present)    |
| ignored             | 3 (intentional negative tasks marked with `ignore_errors: true`)                 |
| Duration            | ~0:00:07                                                                         |
| Cluster (PC)        | 10.44.76.28 (pc.7.6)                                                             |

### Analysis

- **Positive path — argument-spec enforcement** — both `Call module without vm_startup_policy_ext_id`
  and `Call module without start_condition_conflict_ext_id` correctly failed with Ansible's
  built-in `missing required arguments:` message, and the follow-up asserts (`vm_startup_policy_ext_id`
  is enforced as required, `start_condition_conflict_ext_id` is enforced as required) passed.
- **Positive path — invalid ext_id rejection** — calling the module with a random UUID
  (`00000000-0000-0000-0000-000000000000`) correctly returned `failed=true` with the SDK error
  surfaced via `raise_api_exception` and the follow-up assert passed.
- **Live workflow (best-effort)** — the target uses `ansible.builtin.uri` to discover a real
  VM-startup-policy on the cluster. The cluster returned one policy
  (`180113a2-9a02-43d7-564b-d49b504c9069`, `vmm-compliance-states-info-ansible-jruSxafTISbd`) but
  that policy has `numStartConditionConflicts: 0`, so the downstream list-dependee-VMs assertions
  were skipped intentionally. This is the same behavior the sibling target
  `ntnx_vm_startup_policy_start_condition_conflict_dependent_vms_info_v2` exhibits — the tests
  ship live-testable code and only skip the parts that require a specific pre-existing conflict
  scope. Documented in the closing `Note — no policy/conflict was available on the cluster`
  debug task.
- **Failures** — none. `PLAY RECAP` shows `failed=0`.
- **Known issues** — none.

### Test logs (tail)

<details>
<summary>Task recap (compact)</summary>

```text
TASK [Gathering Facts] *********************************************************
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Start ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 tests]
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Generate random suffix for uniqueness in log messages]
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : List dependee VMs with a non-existent VM startup policy ext_id]     -> failed=true, ignored
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Assert invalid VM startup policy is reported as a failure]           -> ok
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Call module without vm_startup_policy_ext_id]                        -> failed=true, ignored (arg-spec)
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Assert missing vm_startup_policy_ext_id fails argument validation]   -> ok
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Call module without start_condition_conflict_ext_id]                 -> failed=true, ignored (arg-spec)
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Assert missing start_condition_conflict_ext_id fails argument validation] -> ok
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Fetch existing VMs on the cluster (used only to help find a policy scope)] -> ok (39 VMs)
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Assert VMs list call itself was clean]                               -> ok
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : List VM startup policies via REST]                                   -> ok (1 policy discovered)
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Set fact — a policy is available on the cluster]                    -> have_policy=true
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Set fact — first policy ext_id (only when a policy is present)]     -> 180113a2-9a02-43d7-564b-d49b504c9069
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Fetch start-condition conflicts for the first policy (when present)] -> ok (0 conflicts)
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Set fact — a start-condition conflict is available]                 -> have_conflict=false
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Set fact — first start-condition conflict ext_id]                   -> skipped
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : List dependee VMs of the resolved start-condition conflict]         -> skipped
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Assert dependee VMs list is well-formed]                             -> skipped
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Assert every dependee VM entry has an ext_id (loop assertion)]      -> skipped (no items)
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : List dependee VMs with pagination parameters]                        -> skipped
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Assert paginated result honours the limit]                           -> skipped
TASK [ntnx_vm_startup_policy_start_condition_conflict_dependee_vms_info_v2 : Note — no policy/conflict was available on the cluster]              -> ok

PLAY RECAP *********************************************************************
testhost : ok=17   changed=0    unreachable=0    failed=0    skipped=6    rescued=0    ignored=3
```

</details>

### Example playbook execution

- Command: `ansible-playbook examples/virtual_machine_management/VmStartupPolicyStartConditionConflictDependeeVm/*.yml -v`
- Result: `PLAY RECAP - localhost : ok=2, changed=0, failed=0, ignored=2`.
- Both example tasks (`List all dependee VMs ...`, `List dependee VMs with pagination`) called the
  live PC and cleanly received `404 NOT FOUND` with SDK error code `VMM-34060` /
  `POLICY_NOT_FOUND` — expected because the example uses placeholder ext_ids to keep the module
  self-contained. Tasks are wrapped with `ignore_errors: true` to keep the example runnable
  end-to-end. Full output is captured in
  `examples/virtual_machine_management/VmStartupPolicyStartConditionConflictDependeeVm/examples_run.log`.
- No response `sample:` was backfilled — the live API returned only the SDK "not-found" envelope
  for our placeholder ext_ids, so the module RETURN docstring keeps the schema-shape sample it
  ships with.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Sanity gate (`ansible-test sanity`) run against tests: `validate-modules`, `yamllint`, `pep8`,
  `pylint`, `import` (all 8 supported Python interpreters) — all green.
- Linting: `black --check`, `isort --check`, `flake8`, `ansible-lint` — all green.
- Live integration test + example playbook executed against Prism Central `10.44.76.28`
  (pc.7.6).
