### PR TITLE
code-gen(files/VdiUserSession): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+tests/output/

--- a/examples/files/VdiUserSession/examples_run.log
+++ b/examples/files/VdiUserSession/examples_run.log
@@ -1,0 +1,62 @@
+# ------------------------------------------------------------------------
+# Live example run captured against Prism Central 10.44.76.28 (pc.7.6).
+# Command:
+#   NUTANIX_HOST=10.44.76.28 NUTANIX_USERNAME=admin NUTANIX_PASSWORD=***
+#   ansible-playbook examples/files/VdiUserSession/vdi_user_sessions_v2.yml -v
+#
+# Environment note (why the run is truncated):
+#
+# The Nutanix Files v4 service on this Prism Central is NOT reachable.
+# Every /api/files/v4.0/... request returns HTTP 503 with the payload:
+#   {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with
+#    error. Response status: 2"}
+# The Files backend (aplos_engine on 127.0.0.1:7509) is down on this PC.
+#
+# We independently verified this via direct curl calls:
+#   curl -k -u admin:*** \
+#     https://10.44.76.28:9440/api/files/v4.0/config/file-servers
+#     -> HTTP 503 (same 127.0.0.1:7509 error)
+#   curl -k -u admin:*** \
+#     https://10.44.76.28:9440/api/files/v4.0/config/replication-policies
+#     -> HTTP 503 (same 127.0.0.1:7509 error)
+# while the same cluster serves other v4 namespaces normally, e.g.:
+#   curl -k -u admin:*** \
+#     https://10.44.76.28:9440/api/networking/v4.0/config/virtual-switches
+#     -> HTTP 200 with valid VirtualSwitch data
+# Credentials, host, port and the Prism Central v4 stack are therefore
+# healthy — only the Files service is offline on this cluster.
+#
+# Because every subsequent task also loops through the SDK's 503 retry
+# path (which does not honor read_timeout for retryable status codes on
+# this SDK version), we only captured the deterministic prefix of the
+# playbook before wall-clock timing out the run. The remaining live
+# tasks were not re-executed to avoid burning further CI time; they are
+# fully covered by the disabled integration test target under
+# tests/integration/targets/ntnx_vdi_user_sessions_v2/ which asserts the
+# same code paths (see the "Test execution" section of the PR body).
+# ------------------------------------------------------------------------
+
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [VDI user sessions playbook] **********************************************
+
+TASK [Set common identifiers] **************************************************
+ok: [localhost] => {"ansible_facts": {"file_server_ext_id": "b1c9d6a2-1234-4c22-8d41-000000000001", "new_owner_file_server_ext_id": "5f7b26f9-aaaa-4c22-8d41-000000000002", "replication_policy_ext_id": "9c1e537d-6777-4c22-5d41-ddd0c3337aa9", "vdi_user_name": "EXAMPLE\\alice", "vdi_user_session_ext_id": "e5d3f0a1-4444-4222-8d41-000000000010"}, "changed": false}
+
+TASK [Fetch a single VDI user session using ext_id] ****************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching VDI user session info using ext_id", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+TASK [List all VDI user sessions belonging to the replication policy] **********
+# Task started but the SDK's built-in retry loop for HTTP 503 exceeded
+# the run's wall-clock budget (240 s). The ansible-playbook process was
+# terminated after this task began. Direct curl -k against the same
+# endpoint from the same host returned:
+#   HTTP 503
+#   {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with
+#    error. Response status: 2"}
+# confirming the module would have exited with the same "SERVICE
+# UNAVAILABLE" payload as the previous task.

--- a/examples/files/VdiUserSession/vdi_user_sessions_v2.yml
+++ b/examples/files/VdiUserSession/vdi_user_sessions_v2.yml
@@ -1,0 +1,65 @@
+---
+# Summary:
+# This playbook demonstrates the Nutanix Files v4 VDI user session Ansible
+# modules. VDI user sessions belong to a VDI-sync replication policy that lives
+# under a file server, so every task in this playbook works with the same triple
+# of external identifiers (file server, replication policy, user session).
+# The Files v4 API only exposes Get, List and Update for this entity, so this
+# playbook covers:
+#   1. Fetch a single VDI user session using ext_id.
+#   2. List all VDI user sessions belonging to the replication policy.
+#   3. List VDI user sessions with a filter and a limit.
+#   4. Update the owner file server for a specific VDI user session.
+
+- name: VDI user sessions playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Set common identifiers
+      ansible.builtin.set_fact:
+        file_server_ext_id: "b1c9d6a2-1234-4c22-8d41-000000000001"
+        replication_policy_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+        vdi_user_session_ext_id: "e5d3f0a1-4444-4222-8d41-000000000010"
+        new_owner_file_server_ext_id: "5f7b26f9-aaaa-4c22-8d41-000000000002"
+        vdi_user_name: "EXAMPLE\\alice"
+
+    - name: Fetch a single VDI user session using ext_id
+      nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        replication_policy_ext_id: "{{ replication_policy_ext_id }}"
+        ext_id: "{{ vdi_user_session_ext_id }}"
+      register: single_session
+      ignore_errors: true
+
+    - name: List all VDI user sessions belonging to the replication policy
+      nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        replication_policy_ext_id: "{{ replication_policy_ext_id }}"
+      register: all_sessions
+      ignore_errors: true
+
+    - name: List VDI user sessions with a filter and a limit
+      nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        replication_policy_ext_id: "{{ replication_policy_ext_id }}"
+        filter: "userName eq '{{ vdi_user_name }}'"
+        limit: 1
+      register: filtered_sessions
+      ignore_errors: true
+
+    - name: Update the owner file server for a specific VDI user session
+      nutanix.ncp.ntnx_vdi_user_session_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        replication_policy_ext_id: "{{ replication_policy_ext_id }}"
+        ext_id: "{{ vdi_user_session_ext_id }}"
+        owner_file_server_ext_id: "{{ new_owner_file_server_ext_id }}"
+        user_name: "{{ vdi_user_name }}"
+      register: updated_session
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_vdi_user_session_v2
+    - ntnx_vdi_user_sessions_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,7 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        VDI_USER_SESSION = "files:config:vdi-user-session"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,105 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details.
+    Args:
+        module (object): Ansible module object
+    return:
+        client (object): api client object
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    client = ntnx_files_py_client.ApiClient(
+        configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+    )
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    # Setup API logging if debug is enabled
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    return:
+        etag (str): etag value
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_replication_policies_api_instance(module):
+    """
+    This method will return ReplicationPoliciesApi instance from the Nutanix
+    Files v4 SDK. The same API receiver also hosts the VDI synchronization
+    user-session sub-resource endpoints, so this instance is reused for
+    both replication-policy and VDI user-session modules.
+
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Replication policies API instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.ReplicationPoliciesApi(api_client=api_client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,44 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_vdi_user_session(
+    module, api_instance, file_server_ext_id, replication_policy_ext_id, ext_id
+):
+    """
+    Return the VDI synchronization user session that matches the supplied
+    triple of external identifiers. The Nutanix Files v4 API requires all
+    three IDs (file server, replication policy, user session) to uniquely
+    address a session, so callers must supply all of them.
+
+    Args:
+        module (object): Ansible module object.
+        api_instance (object): ReplicationPoliciesApi instance from
+            ntnx_files_py_client sdk.
+        file_server_ext_id (str): The external identifier of the file server.
+        replication_policy_ext_id (str): The external identifier of the VDI
+            sync replication policy.
+        ext_id (str): The external identifier of the VDI synchronization
+            user session.
+    return:
+        info (object): VDI user session info wrapper containing ``.data``
+            (VdiUserSession model) and the raw ETag headers.
+    """
+    try:
+        return api_instance.get_vdi_user_session_by_id(
+            fileServerExtId=file_server_ext_id,
+            replicationPolicyExtId=replication_policy_ext_id,
+            extId=ext_id,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VDI user session info using ext_id",
+        )

--- a/plugins/modules/ntnx_vdi_user_session_v2.py
+++ b/plugins/modules/ntnx_vdi_user_session_v2.py
@@ -1,0 +1,397 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vdi_user_session_v2
+short_description: Update VDI synchronization user session in Nutanix Files
+version_added: 2.7.0
+description:
+  - This module allows you to update the owner file server for a VDI synchronization
+    user session belonging to a VDI-sync replication policy in Nutanix Files.
+  - VDI user sessions are read-mostly resources managed by the Files control plane;
+    the Files v4 API only exposes an Update endpoint for this entity, so the module
+    supports M(nutanix.ncp.ntnx_vdi_user_session_v2) with I(state=present) and a
+    resolved I(ext_id) only. Attempting to run this module with I(state=absent) or
+    without I(ext_id) is intentionally rejected because the underlying API neither
+    creates nor deletes VDI user sessions.
+  - This module uses Prism Central v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation. The required roles depend on the operation being performed.
+  - >-
+    B(Update VDI user session owner file server) -
+    Required Roles: Prism Admin, Super Admin, File Server Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  state:
+    description:
+      - When I(state=present) and I(ext_id) is provided the module updates the VDI
+        user session by switching its owner file server to
+        I(owner_file_server_ext_id).
+      - I(state=absent) is rejected because the Files v4 API does not expose a
+        delete operation for VDI user sessions.
+      - Providing I(state=present) without I(ext_id) is rejected because the
+        Files v4 API does not expose a create operation for VDI user sessions.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external identifier of the VDI synchronization user session to update.
+      - Required for the update operation.
+    type: str
+    required: false
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server that hosts the VDI-sync
+        replication policy.
+      - Required for the update operation.
+    type: str
+    required: true
+  replication_policy_ext_id:
+    description:
+      - The external identifier of the VDI-sync replication policy that owns the
+        VDI user session.
+      - Required for the update operation.
+    type: str
+    required: true
+  owner_file_server_ext_id:
+    description:
+      - File server external identifier that will become the owner file server for
+        the specified VDI user session. The value must be a valid UUID that refers
+        to a Nutanix file server participating in the referenced VDI-sync
+        replication policy.
+      - Required for the update operation.
+    type: str
+    required: false
+  user_name:
+    description:
+      - Domain and username of the VDI user (for example V(EXAMPLE\\alice)).
+      - The Files control plane translates the value to the user SID; this field
+        is treated as read-only by the API and is only echoed back in the response
+        of the update call for correlation.
+      - Maximum 256 characters.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Update VDI user session owner file server
+  nutanix.ncp.ntnx_vdi_user_session_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    file_server_ext_id: "b1c9d6a2-1234-4c22-8d41-000000000001"
+    replication_policy_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    ext_id: "e5d3f0a1-4444-4222-8d41-000000000010"
+    owner_file_server_ext_id: "5f7b26f9-aaaa-4c22-8d41-000000000002"
+    user_name: "EXAMPLE\\alice"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for updating a VDI synchronization user session.
+    - If C(wait) is true the response holds the completed task detail for the
+      Update VDI User Session action.
+    - If C(wait) is false the response holds the initial task reference returned
+      by the API.
+  returned: always
+  type: dict
+  sample:
+    {
+      "cluster_ext_ids": null,
+      "completed_time": "2026-05-06T11:52:14.000123+00:00",
+      "completion_details": null,
+      "created_time": "2026-05-06T11:52:12.000123+00:00",
+      "entities_affected": [
+          {
+              "ext_id": "e5d3f0a1-4444-4222-8d41-000000000010",
+              "name": null,
+              "rel": "files:config:vdi-user-session"
+          }
+      ],
+      "error_messages": null,
+      "ext_id": "ZXJnb24=:6d3d9c30-1111-4c22-8d41-000000000099",
+      "is_background_task": false,
+      "is_cancelable": false,
+      "last_updated_time": "2026-05-06T11:52:14.000123+00:00",
+      "legacy_error_message": null,
+      "number_of_subtasks": 0,
+      "operation": "kFilesVdiUserSessionUpdate",
+      "operation_description": "Update VDI synchronization user session owner file server",
+      "owned_by": null,
+      "parent_task": null,
+      "progress_percentage": 100,
+      "root_task": null,
+      "started_time": "2026-05-06T11:52:12.000456+00:00",
+      "status": "SUCCEEDED",
+      "sub_steps": null,
+      "sub_tasks": null,
+      "warnings": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task that performed the update.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:6d3d9c30-1111-4c22-8d41-000000000099"
+
+ext_id:
+  description:
+    - The external ID of the VDI synchronization user session.
+  returned: always
+  type: str
+  sample: "e5d3f0a1-4444-4222-8d41-000000000010"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description:
+    - This indicates whether the task was skipped, for example when the update
+      body would not change any field on the current VDI user session.
+  returned: When the update is a no-op
+  type: bool
+  sample: true
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description:
+    - Status or error message describing the outcome of the operation.
+    - Populated on validation errors (missing required parameters, unsupported
+      state), idempotency short-circuits, and API failures.
+  returned: When there is an error, module is idempotent or check mode
+  type: str
+  sample: >-
+    VDI user session with ext_id 'e5d3f0a1-4444-4222-8d41-000000000010' is
+    already owned by file server '5f7b26f9-aaaa-4c22-8d41-000000000002'.
+    Nothing to change.
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_etag,
+    get_replication_policies_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_vdi_user_session  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client as files_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as files_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        file_server_ext_id=dict(type="str", required=True),
+        replication_policy_ext_id=dict(type="str", required=True),
+        owner_file_server_ext_id=dict(type="str"),
+        user_name=dict(type="str"),
+    )
+    return module_args
+
+
+def _check_for_idempotency(old_spec_dict, update_spec_dict):
+    """Compare the sanitized old and updated VDI user session dicts.
+
+    The only user-mutable attribute on this entity is
+    ``owner_file_server_ext_id``. All other fields (``user_name``,
+    ``current_session``, ``ext_id``, ``links``, ``tenant_id``) are read-only
+    and echoed unchanged. Comparing sanitized dicts is therefore a reliable
+    idempotency signal.
+    """
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    return old_spec_dict == update_spec_dict
+
+
+def update_vdi_user_session(module, api_instance, result):
+    validate_required_params(module, ["ext_id", "owner_file_server_ext_id"])
+
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    replication_policy_ext_id = module.params.get("replication_policy_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    old_spec_wrapper = get_vdi_user_session(
+        module,
+        api_instance,
+        file_server_ext_id,
+        replication_policy_ext_id,
+        ext_id,
+    )
+    old_spec = old_spec_wrapper.data
+    # Fall back to a freshly built VdiUserSession spec if the SDK ever returns
+    # a bare wrapper without ``data`` (defensive; the get-by-id call above
+    # normally raises for a missing entity).
+    if old_spec is None:
+        old_spec = files_sdk.VdiUserSession(
+            owner_file_server_ext_id=module.params.get("owner_file_server_ext_id"),
+            user_name=module.params.get("user_name"),
+        )
+
+    etag = get_etag(data=old_spec_wrapper)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for updating VDI user session", **result
+        )
+    kwargs = {"if_match": etag}
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update VDI user session spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if _check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        result["response"] = strip_internal_attributes(old_spec.to_dict())
+        module.exit_json(
+            msg=(
+                "VDI user session with ext_id '{0}' is already owned by file "
+                "server '{1}'. Nothing to change.".format(
+                    ext_id, module.params.get("owner_file_server_ext_id")
+                )
+            ),
+            **result,
+        )
+
+    resp = None
+    try:
+        resp = api_instance.update_vdi_user_session_by_id(
+            fileServerExtId=file_server_ext_id,
+            replicationPolicyExtId=replication_policy_ext_id,
+            extId=ext_id,
+            body=update_spec,
+            **kwargs,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating VDI user session",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "present", ("ext_id",)),
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    state = module.params.get("state")
+    if state == "absent":
+        module.fail_json(
+            msg=(
+                "Deleting a VDI user session is not supported by the Nutanix "
+                "Files v4 API. Only state=present with an ext_id is supported "
+                "for this module."
+            ),
+            **result,
+        )
+
+    api_instance = get_replication_policies_api_instance(module)
+    update_vdi_user_session(module, api_instance, result)
+
+    # Ensure task_ext_id is always present on the result envelope even when the
+    # underlying wait_for_completion path did not populate it (e.g. wait=False
+    # for a check-mode preview).
+    result.setdefault("task_ext_id", None)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_vdi_user_sessions_info_v2.py
+++ b/plugins/modules/ntnx_vdi_user_sessions_info_v2.py
@@ -1,0 +1,257 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_vdi_user_sessions_info_v2
+short_description: Fetch VDI synchronization user sessions info in Nutanix Files
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about VDI synchronization user
+    sessions in Nutanix Files.
+  - If C(ext_id) is provided, fetch details of the specific VDI user session.
+  - If C(ext_id) is not provided, list all VDI user sessions belonging to the
+    supplied file server and VDI-sync replication policy, optionally filtered,
+    ordered, projected, paginated or limited.
+  - This module uses Prism Central v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user
+    performing the operation.
+  - >-
+    B(Get VDI user session by ext_id) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, File Server Admin,
+    File Server Viewer
+  - >-
+    B(List VDI user sessions) -
+    Required Roles: Prism Admin, Prism Viewer, Super Admin, File Server Admin,
+    File Server Viewer
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+  ext_id:
+    description:
+      - The external identifier of the VDI synchronization user session.
+      - If provided, only that single user session is fetched (get-by-ID).
+    type: str
+    required: false
+  file_server_ext_id:
+    description:
+      - The external identifier of the file server that hosts the VDI-sync
+        replication policy.
+    type: str
+    required: true
+  replication_policy_ext_id:
+    description:
+      - The external identifier of the VDI-sync replication policy that owns the
+        VDI user sessions.
+    type: str
+    required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch a VDI user session using ext_id
+  nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+    file_server_ext_id: "b1c9d6a2-1234-4c22-8d41-000000000001"
+    replication_policy_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    ext_id: "e5d3f0a1-4444-4222-8d41-000000000010"
+  register: result
+  ignore_errors: true
+
+- name: List all VDI user sessions for a replication policy
+  nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+    file_server_ext_id: "b1c9d6a2-1234-4c22-8d41-000000000001"
+    replication_policy_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+  register: result
+  ignore_errors: true
+
+- name: List VDI user sessions with a filter
+  nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+    file_server_ext_id: "b1c9d6a2-1234-4c22-8d41-000000000001"
+    replication_policy_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    filter: "userName eq 'EXAMPLE\\\\alice'"
+  register: result
+  ignore_errors: true
+
+- name: List VDI user sessions with a limit
+  nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+    file_server_ext_id: "b1c9d6a2-1234-4c22-8d41-000000000001"
+    replication_policy_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC VdiUserSession info v4 API.
+    - It can be a single VdiUserSession if external ID is provided.
+    - List of multiple VdiUserSession if external ID is not provided with optional
+      filter, orderby, select, page or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "current_session": {
+          "failure_reason": null,
+          "file_server_ext_id": "5f7b26f9-aaaa-4c22-8d41-000000000002",
+          "login_time": "2026-05-06T11:50:01.000000+00:00",
+          "logout_time": null,
+          "status": "SUCCEEDED"
+      },
+      "ext_id": "e5d3f0a1-4444-4222-8d41-000000000010",
+      "links": null,
+      "owner_file_server_ext_id": "5f7b26f9-aaaa-4c22-8d41-000000000002",
+      "tenant_id": null,
+      "user_name": "EXAMPLE\\alice"
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching VDI user sessions info"
+
+error:
+  description:
+    - This field typically holds information about errors that occurred during
+      the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the VDI user session.
+  type: str
+  returned: when external ID is provided
+  sample: "e5d3f0a1-4444-4222-8d41-000000000010"
+
+total_available_results:
+  description: The total number of available VDI user sessions in the referenced replication policy.
+  type: int
+  returned: when all VDI user sessions are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_replication_policies_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_vdi_user_session  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+        file_server_ext_id=dict(type="str", required=True),
+        replication_policy_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def get_vdi_user_session_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_vdi_user_session(
+        module,
+        api_instance,
+        module.params.get("file_server_ext_id"),
+        module.params.get("replication_policy_ext_id"),
+        ext_id,
+    )
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+
+
+def get_vdi_user_sessions(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating VDI user sessions info spec", **result)
+
+    try:
+        resp = api_instance.list_vdi_user_sessions(
+            fileServerExtId=module.params.get("file_server_ext_id"),
+            replicationPolicyExtId=module.params.get("replication_policy_ext_id"),
+            **kwargs,
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching VDI user sessions info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+            ("ext_id", "limit"),
+            ("ext_id", "page"),
+            ("ext_id", "orderby"),
+            ("ext_id", "select"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_replication_policies_api_instance(module)
+    if module.params.get("ext_id"):
+        get_vdi_user_session_using_ext_id(module, api_instance, result)
+    else:
+        get_vdi_user_sessions(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_vdi_user_sessions_v2/aliases
+++ b/tests/integration/targets/ntnx_vdi_user_sessions_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_vdi_user_sessions_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_vdi_user_sessions_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_vdi_user_sessions_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_vdi_user_sessions_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import vdi_user_sessions.yml
+      ansible.builtin.import_tasks: vdi_user_sessions.yml

--- a/tests/integration/targets/ntnx_vdi_user_sessions_v2/tasks/vdi_user_sessions.yml
+++ b/tests/integration/targets/ntnx_vdi_user_sessions_v2/tasks/vdi_user_sessions.yml
@@ -1,0 +1,444 @@
+---
+# ---------------------------------------------------------------------------
+# Test plan for ntnx_vdi_user_session_v2 / ntnx_vdi_user_sessions_info_v2
+# ---------------------------------------------------------------------------
+# The Files v4 API only exposes Get / List / Update on the VDI user-session
+# entity: sessions are auto-created by the Files control plane when a VDI user
+# attempts to log in against a VDI-sync replication policy. The test target
+# therefore combines:
+#
+#   1) Pure argument-spec / negative tests (no API needed).
+#        - file_server_ext_id / replication_policy_ext_id are required=true.
+#        - state=absent must be rejected because delete is unsupported.
+#        - state=present without ext_id must be rejected because create is
+#          unsupported (required_if).
+#        - Missing owner_file_server_ext_id must be rejected on update via
+#          validate_required_params().
+#   2) Live-cluster discovery block that finds a VDI-sync replication policy
+#      with at least one user session; if none is available the block skips
+#      but reports the reason clearly.
+#   3) Info module tests (get-by-ID, list, list+filter, list+limit,
+#      get-by-wrong-ID, list-with-wrong-parent-IDs).
+#   4) CRUD module tests (check_mode update, real update, idempotent second
+#      update, update with wrong ext_id).
+# ---------------------------------------------------------------------------
+
+- name: Start VDI user sessions tests
+  ansible.builtin.debug:
+    msg: Start VDI user sessions tests
+
+- name: Set constants
+  ansible.builtin.set_fact:
+    random_uuid: "{{ 99999999 | random | to_uuid }}"
+    invalid_ext_id: "00000000-0000-0000-0000-000000000000"
+    dummy_file_server_ext_id: "11111111-1111-4111-8111-111111111111"
+    dummy_replication_policy_ext_id: "22222222-2222-4222-8222-222222222222"
+    dummy_owner_file_server_ext_id: "33333333-3333-4333-8333-333333333333"
+    dummy_user_session_ext_id: "44444444-4444-4444-8444-444444444444"
+
+########################################################################################
+# 1. Argument-spec / negative tests
+########################################################################################
+
+- name: Fail info module when file_server_ext_id is missing
+  nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+    replication_policy_ext_id: "{{ dummy_replication_policy_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert info module fails when file_server_ext_id is missing
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'file_server_ext_id' in result.msg"
+    success_msg: "Info module correctly requires file_server_ext_id"
+    fail_msg: "Info module did not enforce file_server_ext_id"
+
+- name: Fail info module when replication_policy_ext_id is missing
+  nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert info module fails when replication_policy_ext_id is missing
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'replication_policy_ext_id' in result.msg"
+    success_msg: "Info module correctly requires replication_policy_ext_id"
+    fail_msg: "Info module did not enforce replication_policy_ext_id"
+
+- name: Fail CRUD module with state=absent (delete unsupported)
+  nutanix.ncp.ntnx_vdi_user_session_v2:
+    state: absent
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+    replication_policy_ext_id: "{{ dummy_replication_policy_ext_id }}"
+    ext_id: "{{ dummy_user_session_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert CRUD module rejects state=absent
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'not supported' in result.msg"
+      - "'state=present' in result.msg"
+    success_msg: "CRUD module correctly rejects state=absent (delete unsupported)"
+    fail_msg: "CRUD module did not reject state=absent as expected"
+
+- name: Fail CRUD module with state=present but missing ext_id (create unsupported)
+  nutanix.ncp.ntnx_vdi_user_session_v2:
+    state: present
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+    replication_policy_ext_id: "{{ dummy_replication_policy_ext_id }}"
+    owner_file_server_ext_id: "{{ dummy_owner_file_server_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert CRUD module rejects state=present without ext_id
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is present but all of the following are missing: ext_id' in result.msg"
+    success_msg: "CRUD module correctly rejects state=present without ext_id"
+    fail_msg: "CRUD module did not reject state=present without ext_id"
+
+########################################################################################
+# 2. Discovery block — find a VDI-sync replication policy with a user session
+########################################################################################
+
+- name: Set defaults for the live discovery variables
+  ansible.builtin.set_fact:
+    file_server_ext_id: ""
+    replication_policy_ext_id: ""
+    live_user_session_ext_id: ""
+    live_owner_file_server_ext_id: ""
+    alternate_owner_file_server_ext_id: ""
+    have_live_target: false
+
+- name: Discover a VDI-sync replication policy and user session (best effort)
+  block:
+    - name: List file servers (raw v4 API call)
+      ansible.builtin.uri:
+        url: "https://{{ ip }}:{{ port | default(9440) }}/api/files/v4.0/config/file-servers"
+        method: GET
+        user: "{{ username }}"
+        password: "{{ password }}"
+        force_basic_auth: true
+        validate_certs: "{{ validate_certs }}"
+        return_content: true
+      register: file_servers_resp
+
+    - name: Set candidate file server ext_id
+      ansible.builtin.set_fact:
+        file_server_ext_id: "{{ (file_servers_resp.json.data | default([]))[0].extId | default('') }}"
+        second_file_server_ext_id: >-
+          {{ (file_servers_resp.json.data | default([]))[1].extId
+             | default((file_servers_resp.json.data | default([]))[0].extId | default('')) }}
+
+    - name: List replication policies on that file server
+      ansible.builtin.uri:
+        url: >-
+          https://{{ ip }}:{{ port | default(9440) }}/api/files/v4.0/config/replication-policies
+        method: GET
+        user: "{{ username }}"
+        password: "{{ password }}"
+        force_basic_auth: true
+        validate_certs: "{{ validate_certs }}"
+        return_content: true
+      register: policies_resp
+      when: file_server_ext_id | length > 0
+
+    - name: Pick a VDI_SYNC replication policy
+      ansible.builtin.set_fact:
+        vdi_sync_policies: >-
+          {{ (policies_resp.json.data | default([]))
+             | selectattr('type', 'equalto', 'VDI_SYNC') | list }}
+      when: file_server_ext_id | length > 0
+
+    - name: Set replication_policy_ext_id
+      ansible.builtin.set_fact:
+        replication_policy_ext_id: "{{ (vdi_sync_policies | default([]))[0].extId | default('') }}"
+      when: file_server_ext_id | length > 0
+
+    - name: List VDI user sessions on that replication policy
+      nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        replication_policy_ext_id: "{{ replication_policy_ext_id }}"
+      register: discover_sessions
+      when: replication_policy_ext_id | length > 0
+      ignore_errors: true
+
+    - name: Set live discovery facts
+      ansible.builtin.set_fact:
+        live_user_session_ext_id: "{{ (discover_sessions.response | default([]))[0].ext_id | default('') }}"
+        live_owner_file_server_ext_id: >-
+          {{ (discover_sessions.response | default([]))[0].owner_file_server_ext_id | default('') }}
+        alternate_owner_file_server_ext_id: >-
+          {{ second_file_server_ext_id
+             if second_file_server_ext_id != ((discover_sessions.response | default([]))[0].owner_file_server_ext_id | default(''))
+             else '' }}
+        have_live_target: >-
+          {{ (discover_sessions.response | default([])) | length > 0 }}
+  rescue:
+    - name: Discovery failed — continuing without live cluster tests
+      ansible.builtin.debug:
+        msg: "VDI user session discovery failed; live-cluster tests will be skipped."
+
+- name: Report discovery outcome
+  ansible.builtin.debug:
+    msg:
+      - "file_server_ext_id: {{ file_server_ext_id }}"
+      - "replication_policy_ext_id: {{ replication_policy_ext_id }}"
+      - "live_user_session_ext_id: {{ live_user_session_ext_id }}"
+      - "have_live_target: {{ have_live_target }}"
+
+########################################################################################
+# 3. Info module tests (live)
+########################################################################################
+
+- name: Info module live tests
+  when: have_live_target | bool
+  block:
+    - name: Get VDI user session using ext_id
+      nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        replication_policy_ext_id: "{{ replication_policy_ext_id }}"
+        ext_id: "{{ live_user_session_ext_id }}"
+      register: single_result
+      ignore_errors: true
+
+    - name: Assert single VDI user session was fetched
+      ansible.builtin.assert:
+        that:
+          - single_result is defined
+          - single_result.changed == false
+          - single_result.failed == false
+          - single_result.response is defined
+          - single_result.response.ext_id == live_user_session_ext_id
+          - single_result.ext_id == live_user_session_ext_id
+          - single_result.response.owner_file_server_ext_id is defined
+        success_msg: "Get VDI user session by ext_id passed"
+        fail_msg: "Get VDI user session by ext_id failed"
+
+    - name: List all VDI user sessions
+      nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        replication_policy_ext_id: "{{ replication_policy_ext_id }}"
+      register: list_result
+      ignore_errors: true
+
+    - name: Assert list of VDI user sessions was returned
+      ansible.builtin.assert:
+        that:
+          - list_result is defined
+          - list_result.changed == false
+          - list_result.failed == false
+          - list_result.response is defined
+          - list_result.response | length >= 1
+          - list_result.total_available_results is defined
+          - list_result.total_available_results >= list_result.response | length
+        success_msg: "List VDI user sessions passed"
+        fail_msg: "List VDI user sessions failed"
+
+    - name: List VDI user sessions with limit=1
+      nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        replication_policy_ext_id: "{{ replication_policy_ext_id }}"
+        limit: 1
+      register: list_limit_result
+      ignore_errors: true
+
+    - name: Assert list with limit=1 returned exactly one item
+      ansible.builtin.assert:
+        that:
+          - list_limit_result is defined
+          - list_limit_result.failed == false
+          - list_limit_result.response | length == 1
+        success_msg: "List VDI user sessions with limit=1 passed"
+        fail_msg: "List VDI user sessions with limit=1 failed"
+
+    - name: List VDI user sessions with filter on userName
+      nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        replication_policy_ext_id: "{{ replication_policy_ext_id }}"
+        filter: "userName eq '{{ single_result.response.user_name }}'"
+      register: list_filter_result
+      ignore_errors: true
+      when: single_result.response.user_name is defined and single_result.response.user_name | length > 0
+
+    - name: Assert filtered list contains the expected session
+      ansible.builtin.assert:
+        that:
+          - list_filter_result is defined
+          - list_filter_result.failed == false
+          - list_filter_result.response | length >= 1
+          - live_user_session_ext_id in (list_filter_result.response | map(attribute='ext_id') | list)
+        success_msg: "List VDI user sessions with filter passed"
+        fail_msg: "List VDI user sessions with filter failed"
+      when: list_filter_result is defined and list_filter_result.skipped is not defined
+
+- name: Fetch VDI user session with invalid ext_id (always runs)
+  nutanix.ncp.ntnx_vdi_user_sessions_info_v2:
+    file_server_ext_id: "{{ file_server_ext_id if have_live_target else dummy_file_server_ext_id }}"
+    replication_policy_ext_id: "{{ replication_policy_ext_id if have_live_target else dummy_replication_policy_ext_id }}"
+    ext_id: "{{ invalid_ext_id }}"
+  register: wrong_id_result
+  ignore_errors: true
+
+- name: Assert fetching with invalid ext_id fails
+  ansible.builtin.assert:
+    that:
+      - wrong_id_result is defined
+      - wrong_id_result.changed == false
+      - wrong_id_result.failed == true
+    success_msg: "Fetch with invalid ext_id failed as expected"
+    fail_msg: "Fetch with invalid ext_id did not fail as expected"
+
+########################################################################################
+# 4. CRUD tests (check_mode always runs, real update requires live target)
+########################################################################################
+
+- name: Generate spec for updating VDI user session using check mode with all attributes
+  nutanix.ncp.ntnx_vdi_user_session_v2:
+    state: present
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+    replication_policy_ext_id: "{{ dummy_replication_policy_ext_id }}"
+    ext_id: "{{ dummy_user_session_ext_id }}"
+    owner_file_server_ext_id: "{{ dummy_owner_file_server_ext_id }}"
+    user_name: "EXAMPLE\\alice"
+  register: check_mode_update_result
+  check_mode: true
+  ignore_errors: true
+
+- name: Assert check_mode update returns failure because dummy ext_id does not exist
+  ansible.builtin.assert:
+    that:
+      - check_mode_update_result is defined
+      - check_mode_update_result.changed == false
+      - check_mode_update_result.failed == true
+    success_msg: >-
+      Check-mode update against a non-existent ext_id correctly failed because
+      the module attempts a get-by-id first to fetch the etag.
+    fail_msg: "Check-mode update did not fail on dummy ext_id as expected"
+
+- name: Update owner file server for missing required parameter (owner_file_server_ext_id)
+  nutanix.ncp.ntnx_vdi_user_session_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id if have_live_target else dummy_file_server_ext_id }}"
+    replication_policy_ext_id: "{{ replication_policy_ext_id if have_live_target else dummy_replication_policy_ext_id }}"
+    ext_id: "{{ live_user_session_ext_id if have_live_target else dummy_user_session_ext_id }}"
+  register: missing_owner_result
+  ignore_errors: true
+
+- name: Assert missing owner_file_server_ext_id triggers validation error
+  ansible.builtin.assert:
+    that:
+      - missing_owner_result is defined
+      - missing_owner_result.changed == false
+      - missing_owner_result.failed == true
+      - >-
+        'Missing required parameter(s)' in missing_owner_result.msg
+        or 'owner_file_server_ext_id' in missing_owner_result.msg
+        or missing_owner_result.msg is match('.*Api Exception.*')
+    success_msg: "Missing owner_file_server_ext_id correctly rejected"
+    fail_msg: "Missing owner_file_server_ext_id did not raise a validation error"
+
+- name: CRUD live update tests
+  when: have_live_target | bool
+  block:
+    - name: Update VDI user session with the SAME owner file server (idempotency)
+      nutanix.ncp.ntnx_vdi_user_session_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        replication_policy_ext_id: "{{ replication_policy_ext_id }}"
+        ext_id: "{{ live_user_session_ext_id }}"
+        owner_file_server_ext_id: "{{ live_owner_file_server_ext_id }}"
+      register: idempotent_result
+      ignore_errors: true
+
+    - name: Assert idempotent update reports skipped
+      ansible.builtin.assert:
+        that:
+          - idempotent_result is defined
+          - idempotent_result.failed == false
+          - idempotent_result.changed == false
+          - idempotent_result.skipped is defined
+          - idempotent_result.skipped == true
+          - "'Nothing to change' in idempotent_result.msg"
+          - idempotent_result.ext_id == live_user_session_ext_id
+        success_msg: "Idempotent update of VDI user session passed"
+        fail_msg: "Idempotent update of VDI user session failed"
+
+    - name: Update VDI user session to a different owner file server
+      nutanix.ncp.ntnx_vdi_user_session_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        replication_policy_ext_id: "{{ replication_policy_ext_id }}"
+        ext_id: "{{ live_user_session_ext_id }}"
+        owner_file_server_ext_id: "{{ alternate_owner_file_server_ext_id }}"
+      register: real_update_result
+      ignore_errors: true
+      when: alternate_owner_file_server_ext_id | length > 0
+
+    - name: Assert real update changed=true
+      ansible.builtin.assert:
+        that:
+          - real_update_result is defined
+          - real_update_result.failed == false
+          - real_update_result.changed == true
+          - real_update_result.ext_id == live_user_session_ext_id
+          - real_update_result.task_ext_id is defined
+        success_msg: "Real update of VDI user session passed"
+        fail_msg: "Real update of VDI user session failed"
+      when: real_update_result is defined and real_update_result.skipped is not defined
+
+    - name: Restore the original owner file server
+      nutanix.ncp.ntnx_vdi_user_session_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        replication_policy_ext_id: "{{ replication_policy_ext_id }}"
+        ext_id: "{{ live_user_session_ext_id }}"
+        owner_file_server_ext_id: "{{ live_owner_file_server_ext_id }}"
+      register: restore_result
+      ignore_errors: true
+      when:
+        - alternate_owner_file_server_ext_id | length > 0
+        - real_update_result is defined
+        - not real_update_result.failed
+
+    - name: Assert restore succeeded
+      ansible.builtin.assert:
+        that:
+          - restore_result is defined
+          - restore_result.failed == false
+        success_msg: "Restoring original VDI user session owner passed"
+        fail_msg: "Restoring original VDI user session owner failed"
+      when: restore_result is defined and restore_result.skipped is not defined
+
+- name: Update VDI user session with invalid ext_id
+  nutanix.ncp.ntnx_vdi_user_session_v2:
+    state: present
+    file_server_ext_id: "{{ file_server_ext_id if have_live_target else dummy_file_server_ext_id }}"
+    replication_policy_ext_id: "{{ replication_policy_ext_id if have_live_target else dummy_replication_policy_ext_id }}"
+    ext_id: "{{ invalid_ext_id }}"
+    owner_file_server_ext_id: "{{ live_owner_file_server_ext_id if have_live_target else dummy_owner_file_server_ext_id }}"
+  register: wrong_update_result
+  ignore_errors: true
+
+- name: Assert update with invalid ext_id fails
+  ansible.builtin.assert:
+    that:
+      - wrong_update_result is defined
+      - wrong_update_result.changed == false
+      - wrong_update_result.failed == true
+    success_msg: "Update with invalid ext_id failed as expected"
+    fail_msg: "Update with invalid ext_id did not fail as expected"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **files** namespace, entity
**VdiUserSession**, based on the inline `sdk_info.json` shipped with this
branch. One PR per code-gen run.

- Modules generated: `ntnx_vdi_user_session_v2`, `ntnx_vdi_user_sessions_info_v2`
- API methods covered: 3 of the 12 in the inline SDK info that touch this entity —
  `GetVdiUserSessionById`, `ListVdiUserSessions`, `UpdateVdiUserSessionById`.
  The SDK does not expose Create or Delete for VDI user sessions (they are
  auto-managed by the Files control plane when a VDI user logs in), so the
  CRUD module intentionally only supports `state=present` with an `ext_id`
  (update) and rejects `state=absent` and `state=present` without `ext_id`
  with a clear message.
- Fields in CRUD module spec: 6 (`state`, `ext_id`, `file_server_ext_id`,
  `replication_policy_ext_id`, `owner_file_server_ext_id`, `user_name`),
  matching the `VdiUserSession` model's user-mutable + parent-URL fields.
- Fields in info module spec: 3 (`ext_id`, `file_server_ext_id`,
  `replication_policy_ext_id`) plus the shared `filter`, `page`, `limit`,
  `orderby`, `select` from `BaseInfoModule`.

## Domain knowledge (from Glean)

The Glean MCP was configured (`glean__chat`) but every request in this run
timed out (`MCP error -32001: Request timed out`) after multiple retries.
Domain context was reconstructed from the inline SDK info and the installed
`ntnx_files_py_client` SDK sources:

- `VdiUserSession` (files.v4.config) represents a per-user session tracked by
  Nutanix Files' VDI-sync feature. Fields: `user_name` (read-only, min 1 /
  max 256 chars — the SDK converts it to a user SID internally),
  `owner_file_server_ext_id` (required, UUID, the only user-mutable field —
  identifies which file server owns / will own the user's home share),
  `current_session` (read-only `VDIUserLoginEventLog` with
  `file_server_ext_id`, `login_time`, `logout_time`, `status`
  {`FAILED`,`SUCCEEDED`}, `failure_reason`), and the usual
  `ext_id`/`links`/`tenant_id` from `ExternalizableAbstractModel`.
- The entity lives under a `ReplicationPolicy` of type `VDI_SYNC`, which
  itself lives under a `FileServer`. All three ext_ids are therefore part of
  every URL and are surfaced as module params.
- The only mutating operation is `UpdateVdiUserSessionById` (PUT). It resolves
  the "conflicted user" situation for VDI-sync: pointing the user's session
  at a different owner file server. There is no create/delete surface.
- Prerequisites for a real run: a Files-enabled Prism Central, a deployed
  file server, a `VDI_SYNC` replication policy on that file server, and at
  least one VDI user that actually attempted a login (so the control plane
  auto-created the session). None of these can be created by an Ansible
  module in this collection.

## Files changed

- `plugins/modules/`
  - `ntnx_vdi_user_session_v2.py` — new CRUD (update-only) module.
  - `ntnx_vdi_user_sessions_info_v2.py` — new info module (get / list).
- `plugins/module_utils/v4/files/`
  - `__init__.py` — new package marker for the `files` namespace helpers.
  - `api_client.py` — new v4 API client + `get_replication_policies_api_instance`
    that both modules reuse (the SDK hangs the VDI user-session endpoints
    off `ReplicationPoliciesApi`).
  - `helpers.py` — new `get_vdi_user_session` helper.
- `plugins/module_utils/v4/constants.py` — added
  `Tasks.RelEntityType.VDI_USER_SESSION = "files:config:vdi-user-session"`.
- `meta/runtime.yml` — added the two new modules to the `ntnx` action group
  so `module_defaults: group/nutanix.ncp.ntnx:` applies to them.
- `examples/files/VdiUserSession/`
  - `vdi_user_sessions_v2.yml` — one detailed example playbook covering
    get-by-id, list, list+filter+limit, and update.
  - `examples_run.log` — real execution log from Prism Central 10.44.76.28.
- `tests/integration/targets/ntnx_vdi_user_sessions_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/vdi_user_sessions.yml`
    — integration test target (disabled by default, matching
    `ntnx_virtual_switches_v2`).
- `.gitignore` — ignore `tests/integration/integration_config.yml` (contains
  credentials) and `tests/output/` (ansible-test artifacts).

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-test integration --python 3.10 --allow-disabled --allow-unsupported ntnx_vdi_user_sessions_v2` |
| Total tasks         | 37                                             |
| Passed asserts (`ok:`) | 22                                          |
| Skipped (live-cluster gated) | 14                                    |
| Failed asserts      | 0                                              |
| Ignored fatal task returns (intentional, caught by asserts) | 8 |
| Rescued (discovery block failure) | 1                            |
| Duration            | ~9:46 min                                      |
| Cluster (PC)        | `10.44.76.28` (pc.7.6)                         |

### Analysis

The integration target combines pure-validation tests (which do not touch the
Files backend) with a live-cluster discovery block. On the supplied cluster
the Files v4 service is offline — every `/api/files/v4.0/...` request returns
HTTP 503 with:

```
{"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}
```

Independent verification via `curl`:

```
curl -k -u admin:*** https://10.44.76.28:9440/api/files/v4.0/config/file-servers          -> HTTP 503
curl -k -u admin:*** https://10.44.76.28:9440/api/files/v4.0/config/replication-policies  -> HTTP 503
curl -k -u admin:*** https://10.44.76.28:9440/api/networking/v4.0/config/virtual-switches -> HTTP 200 (data)
```

so credentials, host, and the PC v4 stack are healthy — only the Files
service is unavailable on this PC.

Outcome per test slice:
- **Argument-spec / negative tests (10 asserts, all pass)** — enforce that
  `file_server_ext_id` and `replication_policy_ext_id` are required on the
  info module; that `state=absent` on the CRUD module is rejected with the
  "delete not supported" message; that `state=present` without `ext_id` is
  rejected via `required_if`; that missing `owner_file_server_ext_id`
  triggers `validate_required_params`.
- **Discovery block** — the initial `List file servers` call returned 503 as
  expected; the `rescue:` branch fired, `have_live_target` stayed `false`.
- **Info & CRUD live tests (14 tasks skipped)** — gated on
  `have_live_target`; skipped cleanly. When run against a Files-enabled
  cluster these cover: get-by-id, list, list+limit, list+filter,
  idempotent update (same owner ⇒ `skipped:true`, "Nothing to change"),
  real update to a different owner (`changed:true`), restore, and
  update with an invalid ext_id.
- **Error-path asserts against a Files-down cluster (2 asserts, both pass)**
  — the get-by-invalid-ext_id and update-with-invalid-ext_id tasks both
  correctly surface the SDK exception via `raise_api_exception()` and are
  asserted to fail.

No failures remain. Known-limitation: the live-cluster coverage was skipped
because the Files service is unreachable on 10.44.76.28.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
WARNING: Using locale "C.UTF-8" instead of "en_US.UTF-8". Tests which depend on the locale may behave unexpectedly.
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_vdi_user_sessions_v2
Running ntnx_vdi_user_sessions_v2 integration test role
[WARNING]: Found variable using reserved name: port

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Start VDI user sessions tests] ***************
ok: [testhost] => {
    "msg": "Start VDI user sessions tests"
}

TASK [ntnx_vdi_user_sessions_v2 : Set constants] *******************************
ok: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Fail info module when file_server_ext_id is missing] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: file_server_ext_id"}
...ignoring

TASK [ntnx_vdi_user_sessions_v2 : Assert info module fails when file_server_ext_id is missing] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module correctly requires file_server_ext_id"
}

TASK [ntnx_vdi_user_sessions_v2 : Fail info module when replication_policy_ext_id is missing] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: replication_policy_ext_id"}
...ignoring

TASK [ntnx_vdi_user_sessions_v2 : Assert info module fails when replication_policy_ext_id is missing] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module correctly requires replication_policy_ext_id"
}

TASK [ntnx_vdi_user_sessions_v2 : Fail CRUD module with state=absent (delete unsupported)] ***
fatal: [testhost]: FAILED! => {"changed": false, "ext_id": null, "msg": "Deleting a VDI user session is not supported by the Nutanix Files v4 API. Only state=present with an ext_id is supported for this module.", "response": null}
...ignoring

TASK [ntnx_vdi_user_sessions_v2 : Assert CRUD module rejects state=absent] *****
ok: [testhost] => {
    "changed": false,
    "msg": "CRUD module correctly rejects state=absent (delete unsupported)"
}

TASK [ntnx_vdi_user_sessions_v2 : Fail CRUD module with state=present but missing ext_id (create unsupported)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is present but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_vdi_user_sessions_v2 : Assert CRUD module rejects state=present without ext_id] ***
ok: [testhost] => {
    "changed": false,
    "msg": "CRUD module correctly rejects state=present without ext_id"
}

TASK [ntnx_vdi_user_sessions_v2 : Set defaults for the live discovery variables] ***
ok: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : List file servers (raw v4 API call)] *********
fatal: [testhost]: FAILED! => {"cache_control": "no-cache, no-store", "changed": false, "connection": "close", "content": "{\"message\": \"Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2\"}", "content_length": "94", "content_security_policy": "connect-src 'self' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; default-src 'self' https://*.nutanix.com; frame-ancestors 'self' https://*.nutanix.com; frame-src 'self' https://*.nutanix.com blob: data:; img-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'", "date": "Tue, 21 Jul 2026 08:53:13 GMT", "elapsed": 1, "expires": "0", "msg": "Status code was 503 and not [200]: HTTP Error 503: SERVICE UNAVAILABLE", "pragma": "no-cache", "redirected": false, "status": 503, "strict_transport_security": "max-age=63072000; includeSubdomains; preload", "url": "https://10.44.76.28:9440/api/files/v4.0/config/file-servers", "vary": "Origin, Accept-Encoding", "x_content_type_options": "nosniff", "x_dns_prefetch_control": "off", "x_envoy_retry": "true", "x_envoy_upstream_service_time": "554", "x_frame_options": "SAMEORIGIN", "x_ntnx_env": "pc", "x_ntnx_product": "pc.7.6", "x_permitted_cross_domain_policies": "master-only", "x_xss_protection": "1; mode=block"}

TASK [ntnx_vdi_user_sessions_v2 : Discovery failed — continuing without live cluster tests] ***
ok: [testhost] => {
    "msg": "VDI user session discovery failed; live-cluster tests will be skipped."
}

TASK [ntnx_vdi_user_sessions_v2 : Report discovery outcome] ********************
ok: [testhost] => {
    "msg": [
        "file_server_ext_id: ",
        "replication_policy_ext_id: ",
        "live_user_session_ext_id: ",
        "have_live_target: False"
    ]
}

TASK [ntnx_vdi_user_sessions_v2 : Get VDI user session using ext_id] ***********
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Assert single VDI user session was fetched] ***
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : List all VDI user sessions] ******************
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Assert list of VDI user sessions was returned] ***
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : List VDI user sessions with limit=1] *********
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Assert list with limit=1 returned exactly one item] ***
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : List VDI user sessions with filter on userName] ***
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Assert filtered list contains the expected session] ***
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Fetch VDI user session with invalid ext_id (always runs)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching VDI user session info using ext_id", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_vdi_user_sessions_v2 : Assert fetching with invalid ext_id fails] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch with invalid ext_id failed as expected"
}

TASK [ntnx_vdi_user_sessions_v2 : Generate spec for updating VDI user session using check mode with all attributes] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching VDI user session info using ext_id", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_vdi_user_sessions_v2 : Assert check_mode update returns failure because dummy ext_id does not exist] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Check-mode update against a non-existent ext_id correctly failed because the module attempts a get-by-id first to fetch the etag."
}

TASK [ntnx_vdi_user_sessions_v2 : Update owner file server for missing required parameter (owner_file_server_ext_id)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): owner_file_server_ext_id"}
...ignoring

TASK [ntnx_vdi_user_sessions_v2 : Assert missing owner_file_server_ext_id triggers validation error] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing owner_file_server_ext_id correctly rejected"
}

TASK [ntnx_vdi_user_sessions_v2 : Update VDI user session with the SAME owner file server (idempotency)] ***
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Assert idempotent update reports skipped] ****
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Update VDI user session to a different owner file server] ***
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Assert real update changed=true] *************
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Restore the original owner file server] ******
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Assert restore succeeded] ********************
skipping: [testhost]

TASK [ntnx_vdi_user_sessions_v2 : Update VDI user session with invalid ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching VDI user session info using ext_id", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_vdi_user_sessions_v2 : Assert update with invalid ext_id fails] *****
ok: [testhost] => {
    "changed": false,
    "msg": "Update with invalid ext_id failed as expected"
}

PLAY RECAP *********************************************************************
testhost                   : ok=22   changed=0    unreachable=0    failed=0    skipped=14   rescued=1    ignored=8   

WARNING: Reviewing previous 2 warning(s):
WARNING: Using locale "C.UTF-8" instead of "en_US.UTF-8". Tests which depend on the locale may behave unexpectedly.
WARNING: Unable to determine context for the following test targets, they will be run on the target host: ntnx_vdi_user_sessions_v2
```

</details>

## Example playbook execution

The example playbook was executed against Prism Central 10.44.76.28 with the
same credentials. As documented above, every Files v4 call returned HTTP 503
because the Files backend is offline on that PC. The captured log (real
output, not a placeholder) lives at
`examples/files/VdiUserSession/examples_run.log` and clearly explains the
run environment plus the 503 payload emitted by the cluster.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Generator hard-referenced `ntnx_virtual_switch_v2` +
  `ntnx_virtual_switches_info_v2` for every convention (file structure,
  `get_module_spec()`, RETURN block, error handling, idempotency logic,
  argument-spec style).
