### PR TITLE
RecalculateColdData Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/examples/files/RecalculateColdData/examples_run.log
+++ b/examples/files/RecalculateColdData/examples_run.log
@@ -1,0 +1,24 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [RecalculateColdData playbook] ********************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"file_server_ext_id": "b2c3d4e5-6789-4abc-9def-0123456789ab"}, "changed": false}
+
+TASK [Recalculate cold data for a file server] *********************************
+[ERROR]: Task failed: Module failed: Api Exception raised while recalculating cold data for file server
+Origin: /tmp/codegen-artifacts.QDRmWg/run_example.yml:20:7
+
+18         file_server_ext_id: "b2c3d4e5-6789-4abc-9def-0123456789ab"
+19
+20     - name: Recalculate cold data for a file server
+         ^ column 7
+
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while recalculating cold data for file server", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
+

--- a/examples/files/RecalculateColdData/recalculate_cold_data_v2.yml
+++ b/examples/files/RecalculateColdData/recalculate_cold_data_v2.yml
@@ -1,0 +1,29 @@
+---
+# Summary:
+# This playbook will do:
+# 1. Recalculate cold data eligible for tiering on a Nutanix Files file server
+
+- name: RecalculateColdData playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        file_server_ext_id: "b2c3d4e5-6789-4abc-9def-0123456789ab"
+
+    - name: Recalculate cold data for a file server
+      nutanix.ncp.ntnx_files_recalculate_cold_data_v2:
+        ext_id: "{{ file_server_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    # Response sample:
+    # <Need to add sample - the Nutanix Files service (minerva, port 7509) was
+    #  unavailable on the target Prism Central during the run, so a live sample
+    #  could not be captured. See the PR body for details.>

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_files_recalculate_cold_data_v2

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,112 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details.
+    Args:
+        module (object): Ansible module object
+    return:
+        client (object): api client object
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    # Setup API logging if debug is enabled
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    return:
+        etag (str): etag value
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_tier_api_instance(module):
+    """
+    This method will return TierApi instance.
+    The Tier API exposes tiering configurations, object store profiles and the
+    tiering action endpoints (recalculate cold data, tier data, recall tiered files).
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Tier api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.TierApi(api_client=api_client)
+
+
+def get_file_server_api_instance(module):
+    """
+    This method will return FileServersApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): File Servers api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.FileServersApi(api_client=api_client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,53 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception
+
+
+def get_file_server(module, api_instance, ext_id):
+    """
+    Get file server by ext_id.
+    Args:
+        module: Ansible module
+        api_instance: FileServersApi instance from ntnx_files_py_client sdk
+        ext_id: ext_id of the file server
+    Returns:
+        file_server (obj): file server info object
+    """
+    try:
+        return api_instance.get_file_server_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching file server info using ext_id",
+        )
+
+
+def normalize_response_data(data):
+    """
+    Normalize the ``data`` field of a v4 API response into a JSON-serializable
+    structure.
+
+    Some action endpoints (for example, recalculate cold data) return a
+    ``OneOf`` payload that may resolve to a single SDK model object, a list of
+    application messages, an empty list, or an empty map. This helper converts
+    any of those shapes into plain dicts/lists so they can be returned as
+    module output.
+
+    Args:
+        data (object): The ``data`` attribute of a v4 SDK API response.
+    Returns:
+        The normalized data as a dict, list, or None.
+    """
+    if data is None:
+        return None
+    if isinstance(data, list):
+        return [item.to_dict() if hasattr(item, "to_dict") else item for item in data]
+    if hasattr(data, "to_dict"):
+        return data.to_dict()
+    return data

--- a/plugins/modules/ntnx_files_recalculate_cold_data_v2.py
+++ b/plugins/modules/ntnx_files_recalculate_cold_data_v2.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_recalculate_cold_data_v2
+short_description: Recalculate cold data eligible for tiering on a Nutanix Files file server
+version_added: 2.7.0
+description:
+    - Trigger a recalculation of the storage size of cold data that is eligible for tiering on a file server.
+    - This action schedules a background scan on the file server that recomputes the cold data
+      statistics (number and size of files that meet the tiering eligibility criteria).
+    - This action only estimates and calculates the cold data size, it does not move or tier any data.
+    - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Recalculate cold data.) -
+      Required Roles: Files Administrator, Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+    state:
+        description:
+            - State of the module.
+            - If C(state) is C(present), the module will trigger recalculation of cold data for the file server.
+        type: str
+        choices:
+            - present
+        default: present
+    ext_id:
+        description:
+            - The external ID of the file server on which to recalculate cold data.
+        type: str
+        required: true
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+    - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Recalculate cold data for a file server
+  nutanix.ncp.ntnx_files_recalculate_cold_data_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    ext_id: "b2c3d4e5-6789-4abc-9def-0123456789ab"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for recalculating cold data on the file server.
+        - Returns the application messages returned by the recalculate cold data action.
+    returned: always
+    type: dict
+    sample:
+        [
+            {
+                "code": "FILES-10000",
+                "locale": "en_US",
+                "message": "Recalculate cold data request has been accepted.",
+                "severity": "INFO"
+            }
+        ]
+
+changed:
+    description: This indicates whether the task resulted in any changes
+    returned: always
+    type: bool
+    sample: true
+
+msg:
+    description: This indicates the message if any message occurred
+    returned: When there is an error or in check mode
+    type: str
+    sample: "File server with ext_id:b2c3d4e5-6789-4abc-9def-0123456789ab will be triggered to recalculate cold data."
+
+error:
+    description: This field typically holds information about if the task have errors that occurred during the task execution
+    returned: when an error occurs
+    type: str
+    sample: "Api Exception raised while recalculating cold data for file server"
+
+failed:
+    description: This field typically holds information about if the task have failed
+    returned: always
+    type: bool
+    sample: false
+
+task_ext_id:
+    description: The external ID of the task, if the operation created a task.
+    returned: always
+    type: str
+    sample: "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1"
+
+ext_id:
+    description: The external ID of the file server
+    returned: always
+    type: str
+    sample: "b2c3d4e5-6789-4abc-9def-0123456789ab"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.files.api_client import get_tier_api_instance  # noqa: E402
+from ..module_utils.v4.files.helpers import normalize_response_data  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        ext_id=dict(type="str", required=True),
+    )
+
+    return module_args
+
+
+def recalculate_cold_data(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "File server with ext_id:{0} will be triggered to recalculate cold data.".format(
+                ext_id
+            )
+        )
+        return
+
+    resp = None
+    try:
+        resp = api_instance.recalculate_cold_data(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while recalculating cold data for file server",
+        )
+
+    data = getattr(resp, "data", None)
+    result["response"] = strip_internal_attributes(normalize_response_data(data))
+
+    task_ext_id = getattr(data, "ext_id", None)
+    if task_ext_id:
+        result["task_ext_id"] = task_ext_id
+        if module.params.get("wait"):
+            task = wait_for_completion(module, task_ext_id)
+            result["response"] = strip_internal_attributes(task.to_dict())
+
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    api_instance = get_tier_api_instance(module)
+    recalculate_cold_data(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_files_recalculate_cold_data_v2/aliases
+++ b/tests/integration/targets/ntnx_files_recalculate_cold_data_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_files_recalculate_cold_data_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_files_recalculate_cold_data_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_files_recalculate_cold_data_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_files_recalculate_cold_data_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import recalculate_cold_data.yml
+      ansible.builtin.import_tasks: recalculate_cold_data.yml

--- a/tests/integration/targets/ntnx_files_recalculate_cold_data_v2/tasks/recalculate_cold_data.yml
+++ b/tests/integration/targets/ntnx_files_recalculate_cold_data_v2/tasks/recalculate_cold_data.yml
@@ -1,0 +1,154 @@
+---
+##############################################################################
+# Test plan for ntnx_files_recalculate_cold_data_v2
+#
+# RecalculateColdData is an ACTION module. It triggers a background scan on a
+# Nutanix Files file server that recomputes the size of cold data eligible for
+# tiering. It has a single input (ext_id = file server external id) and does
+# NOT create an Ergon task; the API returns application messages immediately
+# once the scan is scheduled.
+#
+# Scenarios covered:
+#   1. check_mode: trigger with ext_id -> no API call, predicted message.
+#   2. Negative  : ext_id omitted -> argument-spec validation failure.
+#   3. Negative  : invalid state value -> argument-spec validation failure.
+#   4. Live      : (gated on `file_server_ext_id`) trigger recalculate against a
+#                  real file server, re-run to prove the action is repeatable,
+#                  and trigger against a non-existent ext_id for the error path.
+#
+# Every assertion block checks `changed` and `failed` first, then the rest.
+##############################################################################
+
+- name: Start ntnx_files_recalculate_cold_data_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_files_recalculate_cold_data_v2 tests
+
+- name: Set a non-existent file server ext_id for negative tests
+  ansible.builtin.set_fact:
+    non_existent_ext_id: "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+########################################################################
+# 1. check_mode
+########################################################################
+
+- name: Recalculate cold data in check mode
+  nutanix.ncp.ntnx_files_recalculate_cold_data_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Recalculate cold data in check mode - status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == "00000000-0000-0000-0000-000000000000"
+      - result.msg is defined
+      - "'will be triggered to recalculate cold data' in result.msg"
+    success_msg: "check_mode returned the predicted message without calling the API"
+    fail_msg: "check_mode did not behave as expected"
+
+########################################################################
+# 2. Negative - missing required ext_id
+########################################################################
+
+- name: Recalculate cold data without ext_id (should fail)
+  nutanix.ncp.ntnx_files_recalculate_cold_data_v2:
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: Recalculate cold data without ext_id - status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - "'ext_id' in result.msg"
+    success_msg: "Module correctly rejected the request when ext_id was missing"
+    fail_msg: "Module did not fail when the required ext_id was missing"
+
+########################################################################
+# 3. Negative - invalid state value
+########################################################################
+
+- name: Recalculate cold data with invalid state (should fail)
+  nutanix.ncp.ntnx_files_recalculate_cold_data_v2:
+    state: absent
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Recalculate cold data with invalid state - status
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == true
+      - "'state' in result.msg"
+    success_msg: "Module correctly rejected the unsupported state value"
+    fail_msg: "Module did not fail for an unsupported state value"
+
+########################################################################
+# 4. Live tests - require a real file server (gated)
+#    Provide `file_server_ext_id` in integration_config.yml to enable.
+########################################################################
+
+- name: Skip live tests when no file server is available
+  ansible.builtin.debug:
+    msg: >-
+      Skipping live RecalculateColdData tests because `file_server_ext_id`
+      is not defined. Define it in integration_config.yml to run them against
+      a file server that has a tiering configuration.
+  when: file_server_ext_id is not defined or (file_server_ext_id | length == 0)
+
+- name: Live RecalculateColdData tests
+  when: file_server_ext_id is defined and (file_server_ext_id | length > 0)
+  block:
+    - name: Recalculate cold data for the file server
+      nutanix.ncp.ntnx_files_recalculate_cold_data_v2:
+        ext_id: "{{ file_server_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Recalculate cold data for the file server - status
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+          - result.failed == false
+          - result.ext_id == file_server_ext_id
+          - result.response is defined
+        success_msg: "Recalculate cold data was triggered successfully"
+        fail_msg: "Recalculate cold data trigger failed"
+
+    - name: Recalculate cold data again (action is repeatable, not idempotent)
+      nutanix.ncp.ntnx_files_recalculate_cold_data_v2:
+        ext_id: "{{ file_server_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Recalculate cold data again - status
+      ansible.builtin.assert:
+        that:
+          - result.changed == true
+          - result.failed == false
+          - result.ext_id == file_server_ext_id
+        success_msg: "Recalculate cold data can be triggered repeatedly"
+        fail_msg: "Re-running recalculate cold data did not behave as expected"
+
+    - name: Recalculate cold data for a non-existent file server (should fail)
+      nutanix.ncp.ntnx_files_recalculate_cold_data_v2:
+        ext_id: "{{ non_existent_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Recalculate cold data for a non-existent file server - status
+      ansible.builtin.assert:
+        that:
+          - result.changed == false
+          - result.failed == true
+        success_msg: "Module correctly failed for a non-existent file server"
+        fail_msg: "Module did not fail for a non-existent file server"
+
+- name: Finish ntnx_files_recalculate_cold_data_v2 tests
+  ansible.builtin.debug:
+    msg: Finish ntnx_files_recalculate_cold_data_v2 tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection module for the **files** namespace, entity
**RecalculateColdData**.

`RecalculateColdData` is an **action** endpoint
(`POST /api/files/v4.0/config/file-servers/{extId}/$actions/recalculate-cold-data`),
so this change ships a single action module. The info module
(`ntnx_recalculate_cold_datas_info_v2`) is intentionally **not** generated
because the entity exposes no GET/LIST endpoint (there is nothing to fetch).

- Module generated: `ntnx_files_recalculate_cold_data_v2` (action type)
- API methods covered: `1` (`RecalculateColdData` on `TierApi`)
- Fields in module spec: `2` (`state`, `ext_id`)
- New shared helpers: `plugins/module_utils/v4/files/api_client.py`,
  `plugins/module_utils/v4/files/helpers.py` (first modules for the `files`
  SDK namespace in this collection)

The module mirrors the action-module reference `ntnx_vm_revert_v2` for its
structure, error handling and `RETURN` block.

## Domain knowledge (from Glean)

Domain context for this feature was gathered up front via Glean and used to
drive the implementation, examples and tests. Summary (no internal links
included, per repo policy):

- **What it is:** `RecalculateColdData` (formerly "refresh cold data") triggers
  a file server to recalculate the storage size of cold data that is eligible
  for tiering. It only **estimates/calculates** cold-data statistics — it does
  **not** move or tier any data (actual movement is handled by the separate
  tier-data / recall-tiered-files actions).
- **How it works:** It schedules a background scan on the File Server VM
  metadata database, which counts files that are both large enough and old
  enough (per the tiering policy's minimum file size and cool-off time) and
  publishes eligibility metrics (cold file count / bytes, total file count /
  bytes) to the insights datastore.
- **Interface:** An empty HTTP `POST` to the file server action endpoint,
  identified only by the file server external identifier (`extId`). No request
  body is required.
- **Behavioral details:** The call returns as soon as the scan is *scheduled*
  (not when it finishes), and it does **not** create an Ergon task. Repeated
  calls simply re-schedule the scan; if a scan is already running the duplicate
  trigger is dropped, but the API still returns success.
- **Prerequisites:** The file server must already have a tiering configuration /
  default tiering policy, and the shares of interest must be included in that
  policy; otherwise the computed metrics are zero.
- **RBAC:** Requires the file-server cold-data recalculation permission,
  typically granted to Files Administrator / Prism Admin roles.

These behaviors shaped the module design: the module takes only `ext_id`,
supports `check_mode`, handles the "no task returned" response shape defensively
(the response `data` is a `OneOf` of an empty list/map or a list of application
messages), and treats the action as repeatable (not idempotent).

## Files changed

- `plugins/modules/`
  - `ntnx_files_recalculate_cold_data_v2.py` (new action module)
- `plugins/module_utils/v4/files/`
  - `api_client.py` (new — files SDK client + `TierApi`/`FileServersApi` instances + `get_etag`)
  - `helpers.py` (new — `get_file_server`, `normalize_response_data`)
- `meta/runtime.yml`
  - registered `ntnx_files_recalculate_cold_data_v2` in the `ntnx` action group
- `examples/files/RecalculateColdData/`
  - `recalculate_cold_data_v2.yml` (example playbook)
  - `examples_run.log` (real output captured from running the example against the live PC)
- `tests/integration/targets/ntnx_files_recalculate_cold_data_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/recalculate_cold_data.yml`

## Test execution

| Metric        | Value                                                                                      |
|---------------|--------------------------------------------------------------------------------------------|
| Command       | `ansible-test integration ntnx_files_recalculate_cold_data_v2 --local --allow-disabled --allow-unsupported -v` |
| Validations   | 3 executed / 3 passed (check_mode, missing-required, invalid-enum)                          |
| Passed        | 3                                                                                          |
| Failed        | 0                                                                                          |
| Skipped       | 3 live validations (require a file server with tiering config)                              |
| PLAY RECAP    | `ok=11 changed=0 unreachable=0 failed=0 skipped=6 rescued=0 ignored=2`                      |
| Cluster (PC)  | `10.44.76.28`                                                                              |

Additionally, `ansible-test sanity` (34 tests: black/pep8, pylint, validate-modules,
runtime-metadata, import, compile, yamllint, etc.) passes for all new/changed files,
and `black`, `isort`, `flake8` and `ansible-lint` all pass.

### Analysis

- **check_mode**, **missing required `ext_id`** and **invalid `state`** validations
  ran and passed. These exercise the argument spec and the check-mode short-circuit
  without contacting the Files service.
- The **live** validations (real trigger, repeat trigger, non-existent file server)
  are gated on a `file_server_ext_id` variable and were **skipped**: the target
  Prism Central (`10.44.76.28`) has an **unhealthy Files (minerva) service** — every
  `/api/files/...` endpoint returns `HTTP 503` (`Http request to endpoint
  0:127.0.0.1:7509 failed`), while `prism`/`clustermgmt` v4 endpoints return `200`.
  No file server could be listed or created, so a live tiering scenario could not
  be exercised. This is an **environment limitation**, not a module defect.
- End-to-end proof against the live PC: running the example playbook shows the module
  authenticating, building the request and **correctly handling the 503** —
  `{"error": "SERVICE UNAVAILABLE", "status": 503, "msg": "Api Exception raised while
  recalculating cold data for file server"}`. This validates the module's request and
  error-handling path against the real cluster. See `examples/files/RecalculateColdData/examples_run.log`.
- Because a successful live response could not be captured, the example response
  `sample:` is left as a documented `<Need to add sample>` and the module `RETURN`
  `response` sample uses a representative application-message shape derived from the SDK.

### Test logs (tail)

<details>
<summary>tail test_logs.log</summary>

```text
TASK [ntnx_files_recalculate_cold_data_v2 : Recalculate cold data in check mode - status] ***
ok: [testhost] => { "changed": false, "msg": "check_mode returned the predicted message without calling the API" }

TASK [... : Recalculate cold data without ext_id - status] ***
ok: [testhost] => { "changed": false, "msg": "Module correctly rejected the request when ext_id was missing" }

TASK [... : Recalculate cold data with invalid state - status] ***
ok: [testhost] => { "changed": false, "msg": "Module correctly rejected the unsupported state value" }

TASK [... : Skip live tests when no file server is available] ***
ok: [testhost] => { "msg": "Skipping live RecalculateColdData tests because `file_server_ext_id` is not defined ..." }

PLAY RECAP *********************************************************************
testhost : ok=11  changed=0  unreachable=0  failed=0  skipped=6  rescued=0  ignored=2
```

</details>

<details>
<summary>examples_run.log (live PC)</summary>

```text
TASK [Recalculate cold data for a file server] *********************************
fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE",
"msg": "Api Exception raised while recalculating cold data for file server",
"response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"},
"status": 503}
...ignoring
PLAY RECAP: localhost : ok=2 changed=0 unreachable=0 failed=0 ignored=1
```

</details>

## How this was generated

- Generated by the Cursor agent for namespace=files, entity=RecalculateColdData,
  using the inline SDK information provided for this run.
- Field mappings, import paths and response shapes were taken from the pinned
  `ntnx-files-py-client` SDK.
