### PR TITLE
code-gen(aiops/EntityMetricsV4): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/aiops/EntityMetricsV4/entity_metrics_v4.yml
+++ b/examples/aiops/EntityMetricsV4/entity_metrics_v4.yml
@@ -1,0 +1,85 @@
+---
+# Summary:
+# This playbook demonstrates end-to-end usage of the AIOps EntityMetricsV4 API
+# via the nutanix.ncp.ntnx_entity_metrics_v4_v2 and ntnx_entity_metrics_info_v2
+# modules. It follows the standard AIOps discovery workflow:
+#   1. Compute a time window (last 15 minutes).
+#   2. Fetch entity metrics for a well-known entity type via the "CRUD" module.
+#   3. Fetch entity metrics with all optional attributes (sampling, stat_type,
+#      pagination, ordering).
+#   4. Fetch entity metrics info via the info module (get-style single fetch).
+#   5. Fetch entity metrics info with sampling / stat_type via the info module.
+
+- name: AIOps EntityMetricsV4 playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ pc_ip | default(lookup('env', 'NUTANIX_HOST')) }}"
+      nutanix_username: "{{ pc_user | default(lookup('env', 'NUTANIX_USERNAME')) }}"
+      nutanix_password: "{{ pc_password | default(lookup('env', 'NUTANIX_PASSWORD')) }}"
+      validate_certs: false
+  tasks:
+    - name: Set example variables (source id, entity type id)
+      ansible.builtin.set_fact:
+        # AIOps 'nutanix' data source UUID on the target cluster.
+        # Use ntnx_aiops_py_client.StatsApi.get_sources_v4 to discover it.
+        source_ext_id: "db293e8a-5770-c3c7-4213-85dbbc1d3679"
+        # AIOps 'cluster' entity type UUID for the source above.
+        # Use ntnx_aiops_py_client.StatsApi.get_entity_types_v4 to discover it.
+        entity_type_ext_id: "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c"
+
+    - name: Compute reporting window start (now minus 15 minutes)
+      ansible.builtin.command: date -u -d "-900 seconds" +"%Y-%m-%dT%H:%M:%S.%3NZ"
+      register: start_time
+      changed_when: false
+
+    - name: Compute reporting window end (now)
+      ansible.builtin.command: date -u +"%Y-%m-%dT%H:%M:%S.%3NZ"
+      register: end_time
+      changed_when: false
+
+    - name: Fetch VM entity metrics (all attributes populated) — Create/Get equivalent
+      nutanix.ncp.ntnx_entity_metrics_v4_v2:
+        source_ext_id: "{{ source_ext_id }}"
+        ext_id: "{{ entity_type_ext_id }}"
+        start_time: "{{ start_time.stdout }}"
+        end_time: "{{ end_time.stdout }}"
+        sampling_interval: 30
+        stat_type: "AVG"
+        page: 0
+        limit: 5
+        orderby: "extId asc"
+      register: full_metrics_result
+      ignore_errors: true
+
+    - name: Fetch VM entity metrics (minimal required attributes) — Update-equivalent refresh
+      nutanix.ncp.ntnx_entity_metrics_v4_v2:
+        source_ext_id: "{{ source_ext_id }}"
+        ext_id: "{{ entity_type_ext_id }}"
+        start_time: "{{ start_time.stdout }}"
+        end_time: "{{ end_time.stdout }}"
+      register: minimal_metrics_result
+      ignore_errors: true
+
+    - name: Fetch entity metrics info (all attributes populated)
+      nutanix.ncp.ntnx_entity_metrics_info_v2:
+        source_ext_id: "{{ source_ext_id }}"
+        ext_id: "{{ entity_type_ext_id }}"
+        start_time: "{{ start_time.stdout }}"
+        end_time: "{{ end_time.stdout }}"
+        sampling_interval: 60
+        stat_type: "SUM"
+        limit: 3
+        orderby: "extId asc"
+      register: full_info_result
+      ignore_errors: true
+
+    - name: Fetch entity metrics info (minimal) — Delete/Get equivalent
+      nutanix.ncp.ntnx_entity_metrics_info_v2:
+        source_ext_id: "{{ source_ext_id }}"
+        ext_id: "{{ entity_type_ext_id }}"
+        start_time: "{{ start_time.stdout }}"
+        end_time: "{{ end_time.stdout }}"
+      register: minimal_info_result
+      ignore_errors: true

--- a/examples/aiops/EntityMetricsV4/examples_run.log
+++ b/examples/aiops/EntityMetricsV4/examples_run.log
@@ -1,0 +1,31 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [AIOps EntityMetricsV4 playbook] ******************************************
+
+TASK [Set example variables (source id, entity type id)] ***********************
+ok: [localhost] => {"ansible_facts": {"entity_type_ext_id": "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c", "source_ext_id": "db293e8a-5770-c3c7-4213-85dbbc1d3679"}, "changed": false}
+
+TASK [Compute reporting window start (now minus 15 minutes)] *******************
+ok: [localhost] => {"changed": false, "cmd": ["date", "-u", "-d", "-900 seconds", "+%Y-%m-%dT%H:%M:%S.%3NZ"], "delta": "0:00:01.003439", "end": "2026-07-21 09:31:22.107114", "msg": "", "rc": 0, "start": "2026-07-21 09:31:21.103675", "stderr": "", "stderr_lines": [], "stdout": "2026-07-21T09:16:21.106Z", "stdout_lines": ["2026-07-21T09:16:21.106Z"]}
+
+TASK [Compute reporting window end (now)] **************************************
+ok: [localhost] => {"changed": false, "cmd": ["date", "-u", "+%Y-%m-%dT%H:%M:%S.%3NZ"], "delta": "0:00:00.002893", "end": "2026-07-21 09:31:22.332746", "msg": "", "rc": 0, "start": "2026-07-21 09:31:22.329853", "stderr": "", "stderr_lines": [], "stdout": "2026-07-21T09:31:22.332Z", "stdout_lines": ["2026-07-21T09:31:22.332Z"]}
+
+TASK [Fetch VM entity metrics (all attributes populated) — Create/Get equivalent] ***
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c", "response": [{"entity_type": "cluster", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "metrics": [{"name": "extId", "time_series": {"sampling_interval_secs": null, "values": [{"$valueItemDiscriminator": "aiops.v4.stats.StrVal", "timestamp": "2026-06-30T16:42:01+00:00", "value": {"str_value": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}}]}}], "parents": null, "source": "nutanix", "tenant_id": null}], "source_ext_id": "db293e8a-5770-c3c7-4213-85dbbc1d3679", "total_available_results": 1}
+
+TASK [Fetch VM entity metrics (minimal required attributes) — Update-equivalent refresh] ***
+ok: [localhost] => {"changed": false, "error": null, "ext_id": "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c", "response": [{"entity_type": "cluster", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "metrics": [{"name": "extId", "time_series": {"sampling_interval_secs": null, "values": [{"$valueItemDiscriminator": "aiops.v4.stats.StrVal", "timestamp": "2026-06-30T16:42:01+00:00", "value": {"str_value": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}}]}}], "parents": null, "source": "nutanix", "tenant_id": null}], "source_ext_id": "db293e8a-5770-c3c7-4213-85dbbc1d3679", "total_available_results": 1}
+
+TASK [Fetch entity metrics info (all attributes populated)] ********************
+ok: [localhost] => {"changed": false, "ext_id": "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c", "response": [{"entity_type": "cluster", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "metrics": [{"name": "extId", "time_series": {"sampling_interval_secs": null, "values": [{"$valueItemDiscriminator": "aiops.v4.stats.StrVal", "timestamp": "2026-06-30T16:42:01+00:00", "value": {"str_value": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}}]}}], "parents": null, "source": "nutanix", "tenant_id": null}], "source_ext_id": "db293e8a-5770-c3c7-4213-85dbbc1d3679", "total_available_results": 1}
+
+TASK [Fetch entity metrics info (minimal) — Delete/Get equivalent] *************
+ok: [localhost] => {"changed": false, "ext_id": "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c", "response": [{"entity_type": "cluster", "ext_id": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2", "links": null, "metrics": [{"name": "extId", "time_series": {"sampling_interval_secs": null, "values": [{"$valueItemDiscriminator": "aiops.v4.stats.StrVal", "timestamp": "2026-06-30T16:42:01+00:00", "value": {"str_value": "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"}}]}}], "parents": null, "source": "nutanix", "tenant_id": null}], "source_ext_id": "db293e8a-5770-c3c7-4213-85dbbc1d3679", "total_available_results": 1}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_entity_metrics_v4_v2
+    - ntnx_entity_metrics_info_v2

--- a/plugins/module_utils/v4/aiops/api_client.py
+++ b/plugins/module_utils/v4/aiops/api_client.py
@@ -1,0 +1,82 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """Build and return an authenticated ntnx_aiops_py_client ApiClient."""
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_aiops_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    try:
+        client = ntnx_aiops_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_aiops_py_client.ApiClient(configuration=config)
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    client = ntnx_aiops_py_client.ApiClient(
+        configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+    )
+
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """Fetch the etag from a v4 aiops API response."""
+    return ntnx_aiops_py_client.ApiClient.get_etag(data)
+
+
+def get_stats_api_instance(module):
+    """Return the aiops StatsApi instance (entity metrics, sources, entity types)."""
+    client = get_api_client(module)
+    return ntnx_aiops_py_client.StatsApi(client)

--- a/plugins/modules/ntnx_entity_metrics_info_v2.py
+++ b/plugins/modules/ntnx_entity_metrics_info_v2.py
@@ -1,0 +1,299 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_entity_metrics_info_v2
+short_description: Fetch AIOps EntityMetricsV4 info from Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about EntityMetricsV4 in Nutanix Prism Central.
+  - Backs the v4 AIOps StatsApi C(getEntityMetricsV4) API
+    (C(GET /api/aiops/v4.2.b1/stats/sources/{sourceExtId}/entities/{extId})).
+  - Both C(source_ext_id) and C(ext_id) are required — the underlying API only
+    supports fetching metrics for a specific entity type of a specific source.
+  - Returned data is a paginated list of entities with attribute values and
+    time-series metric samples for the requested time window.
+  - This module uses PC v4 APIs based SDKs (ntnx_aiops_py_client).
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get EntityMetricsV4 for an entity type) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin, Intelligent Ops Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+  source_ext_id:
+    description:
+      - The UUID of the AIOps data source (e.g. C(nutanix), C(nutanix_vcenter)).
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The UUID of the entity type whose metrics/attributes to fetch
+        (e.g. C(vm), C(cluster), C(node), C(disk)).
+    type: str
+    required: true
+  start_time:
+    description:
+      - Start time of the reporting window in extended ISO-8601 format.
+      - Example C(2026-07-21T09:00:00.000Z).
+    type: str
+    required: true
+  end_time:
+    description:
+      - End time of the reporting window in extended ISO-8601 format.
+      - Example C(2026-07-21T10:00:00.000Z).
+    type: str
+    required: true
+  sampling_interval:
+    description:
+      - Sampling interval in seconds at which statistical data is aggregated.
+    type: int
+    required: false
+  stat_type:
+    description:
+      - Downsampling operator used when aggregating stats over
+        C(sampling_interval).
+    type: str
+    required: false
+    choices:
+      - SUM
+      - MIN
+      - MAX
+      - AVG
+      - COUNT
+      - LAST
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Get VM metrics info for the last hour (paginated)
+  nutanix.ncp.ntnx_entity_metrics_info_v2:
+    source_ext_id: "nutanix"
+    ext_id: "vm"
+    start_time: "2026-07-21T08:00:00.000Z"
+    end_time: "2026-07-21T09:00:00.000Z"
+    limit: 5
+  register: vm_metrics_info
+
+- name: Get cluster metrics info with 60s SUM downsampling
+  nutanix.ncp.ntnx_entity_metrics_info_v2:
+    source_ext_id: "nutanix"
+    ext_id: "cluster"
+    start_time: "2026-07-21T08:00:00.000Z"
+    end_time: "2026-07-21T09:00:00.000Z"
+    sampling_interval: 60
+    stat_type: "SUM"
+  register: cluster_metrics_info
+
+- name: Get first 3 sorted VM metric entries
+  nutanix.ncp.ntnx_entity_metrics_info_v2:
+    source_ext_id: "nutanix"
+    ext_id: "vm"
+    start_time: "2026-07-21T08:00:00.000Z"
+    end_time: "2026-07-21T09:00:00.000Z"
+    limit: 3
+    orderby: "extId asc"
+  register: sorted_vm_metrics
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC EntityMetricsV4 info v4 API.
+    - A list of EntityMetricsV4 entries (attribute values + time-series metric
+      samples) for the entity type identified by C(ext_id) within the given
+      source. The list is paginated using C(page) / C(limit).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+    - entity_type: "cluster"
+      ext_id: "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+      links: null
+      parents: null
+      source: "nutanix"
+      tenant_id: null
+      metrics:
+          - name: "extId"
+            time_series:
+                sampling_interval_secs: null
+                values:
+                    - timestamp: "2026-06-30T16:42:01+00:00"
+                      value:
+                          str_value: "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+    Info modules always return false.
+  returned: always
+  type: bool
+  sample: false
+
+total_available_results:
+  description: Total available results across all pages of the query.
+  returned: always
+  type: int
+  sample: 12
+
+source_ext_id:
+  description: AIOps data source UUID used for the request.
+  returned: always
+  type: str
+  sample: "db293e8a-5770-c3c7-4213-85dbbc1d3679"
+
+ext_id:
+  description: Entity type UUID used for the request.
+  returned: always
+  type: str
+  sample: "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c"
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching AIOps entity metrics info"
+
+error:
+  description: This field holds information about any errors that occurred during execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import get_stats_api_instance  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        source_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        sampling_interval=dict(type="int"),
+        stat_type=dict(
+            type="str",
+            choices=[
+                "SUM",
+                "MIN",
+                "MAX",
+                "AVG",
+                "COUNT",
+                "LAST",
+            ],
+        ),
+    )
+
+    return module_args
+
+
+def get_entity_metrics_info(module, api_instance, result):
+    validate_required_params(
+        module, ["source_ext_id", "ext_id", "start_time", "end_time"]
+    )
+
+    source_ext_id = module.params.get("source_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["source_ext_id"] = source_ext_id
+    result["ext_id"] = ext_id
+
+    kwargs = dict(
+        sourceExtId=source_ext_id,
+        extId=ext_id,
+        _startTime=module.params.get("start_time"),
+        _endTime=module.params.get("end_time"),
+    )
+
+    optional_kwargs = {
+        "_page": module.params.get("page"),
+        "_limit": module.params.get("limit"),
+        "_samplingInterval": module.params.get("sampling_interval"),
+        "_statType": module.params.get("stat_type"),
+        "_filter": module.params.get("filter"),
+        "_orderby": module.params.get("orderby"),
+    }
+    for key, value in optional_kwargs.items():
+        if value is not None:
+            kwargs[key] = value
+
+    try:
+        resp = api_instance.get_entity_metrics_v4(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching AIOps entity metrics info",
+        )
+
+    total_available_results = 0
+    if getattr(resp, "metadata", None) is not None:
+        total_available_results = (
+            getattr(resp.metadata, "total_available_results", 0) or 0
+        )
+    result["total_available_results"] = total_available_results
+
+    data = strip_internal_attributes(resp.to_dict()).get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "source_ext_id": None,
+        "ext_id": None,
+        "total_available_results": 0,
+        "failed": False,
+    }
+    api_instance = get_stats_api_instance(module)
+    get_entity_metrics_info(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_entity_metrics_v4_v2.py
+++ b/plugins/modules/ntnx_entity_metrics_v4_v2.py
@@ -1,0 +1,331 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_entity_metrics_v4_v2
+short_description: Fetch AIOps EntityMetricsV4 (attribute/metric time-series) from Nutanix Prism Central
+version_added: 2.5.0
+description:
+    - Fetches attribute and metric time-series data for a given entity of a
+      given entity type from a specific AIOps data source.
+    - Backs the v4 AIOps StatsApi C(getEntityMetricsV4) API
+      (C(GET /api/aiops/v4.2.b1/stats/sources/{sourceExtId}/entities/{extId})).
+    - Returned data is a paginated list of entities where each entity carries
+      the requested attribute values and time-series metric samples for the
+      time window specified.
+    - This module uses PC v4 APIs based SDKs (ntnx_aiops_py_client).
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get EntityMetricsV4 for an entity type) -
+      Required Roles: Prism Admin, Prism Viewer, Super Admin, Intelligent Ops Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+  source_ext_id:
+    description:
+      - The UUID of the AIOps data source (e.g. C(nutanix), C(nutanix_vcenter)).
+      - Obtain the value from the AIOps sources API.
+    type: str
+    required: true
+  ext_id:
+    description:
+      - The UUID of the entity type whose metrics/attributes to fetch
+        (e.g. C(vm), C(cluster), C(node), C(disk)).
+      - Obtain the value from the AIOps entity-types API for the given source.
+    type: str
+    required: true
+  start_time:
+    description:
+      - Start time of the reporting window in extended ISO-8601 format.
+      - Example C(2026-07-21T09:00:00.000Z).
+    type: str
+    required: true
+  end_time:
+    description:
+      - End time of the reporting window in extended ISO-8601 format.
+      - Example C(2026-07-21T10:00:00.000Z).
+    type: str
+    required: true
+  page:
+    description:
+      - Zero-indexed page number of the paginated result set.
+    type: int
+    required: false
+  limit:
+    description:
+      - Number of records returned per page. Must be a positive integer
+        between 1 and 100. Defaults to 50 on the server if omitted.
+    type: int
+    required: false
+  sampling_interval:
+    description:
+      - Sampling interval in seconds at which statistical data is aggregated.
+        For example, 30 aggregates data into 30-second buckets.
+    type: int
+    required: false
+  stat_type:
+    description:
+      - Downsampling operator used when aggregating stats over
+        C(sampling_interval).
+    type: str
+    required: false
+    choices:
+      - SUM
+      - MIN
+      - MAX
+      - AVG
+      - COUNT
+      - LAST
+  filter:
+    description:
+      - OData V4.01 C($filter) expression applied to the returned entities.
+    type: str
+    required: false
+  orderby:
+    description:
+      - OData V4.01 C($orderby) expression to sort the returned entities.
+    type: str
+    required: false
+  read_timeout:
+    description: Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+      - nutanix.ncp.ntnx_credentials
+      - nutanix.ncp.ntnx_logger
+      - nutanix.ncp.ntnx_proxy_v2
+author:
+ - George Ghawali (@george-ghawali)
+ - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Fetch VM entity metrics from the nutanix source for the last hour
+  nutanix.ncp.ntnx_entity_metrics_v4_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    source_ext_id: "nutanix"
+    ext_id: "vm"
+    start_time: "2026-07-21T08:00:00.000Z"
+    end_time: "2026-07-21T09:00:00.000Z"
+  register: vm_metrics
+
+- name: Fetch cluster metrics aggregated into 30s buckets with SUM downsampling
+  nutanix.ncp.ntnx_entity_metrics_v4_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    source_ext_id: "nutanix"
+    ext_id: "cluster"
+    start_time: "2026-07-21T08:00:00.000Z"
+    end_time: "2026-07-21T09:00:00.000Z"
+    sampling_interval: 30
+    stat_type: "SUM"
+    page: 0
+    limit: 10
+    orderby: "extId asc"
+  register: cluster_metrics
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Paginated list of entities with attribute/metric time-series data
+          returned by the AIOps StatsApi C(getEntityMetricsV4) API.
+        - Each list item is a dict representing one entity of the requested
+          entity type carrying its attribute values and time-series metric
+          samples.
+    type: list
+    elements: dict
+    returned: always
+    sample:
+        - entity_type: "cluster"
+          ext_id: "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+          links: null
+          parents: null
+          source: "nutanix"
+          tenant_id: null
+          metrics:
+              - name: "extId"
+                time_series:
+                    sampling_interval_secs: null
+                    values:
+                        - timestamp: "2026-06-30T16:42:01+00:00"
+                          value:
+                              str_value: "0006555e-4e63-4a5e-185b-ac1f6b6f97e2"
+total_available_results:
+    description:
+        - Total number of results available on the server for the query
+          across all pages.
+    type: int
+    returned: always
+    sample: 1
+source_ext_id:
+    description:
+        - AIOps data source UUID used for the request.
+    type: str
+    returned: always
+    sample: "db293e8a-5770-c3c7-4213-85dbbc1d3679"
+ext_id:
+    description:
+        - Entity type UUID used for the request.
+    type: str
+    returned: always
+    sample: "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c"
+changed:
+    description: Always false — this module only reads metric data.
+    type: bool
+    returned: always
+    sample: false
+failed:
+    description: True if the module failed.
+    type: bool
+    returned: always
+    sample: false
+msg:
+    description: Contextual status/error message.
+    returned: When there is an error
+    type: str
+    sample: "Api Exception raised while fetching AIOps entity metrics"
+error:
+    description: Error details when an error occurs.
+    type: str
+    returned: when an error occurs
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import get_stats_api_instance  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        source_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+        start_time=dict(type="str", required=True),
+        end_time=dict(type="str", required=True),
+        page=dict(type="int"),
+        limit=dict(type="int"),
+        sampling_interval=dict(type="int"),
+        stat_type=dict(
+            type="str",
+            choices=[
+                "SUM",
+                "MIN",
+                "MAX",
+                "AVG",
+                "COUNT",
+                "LAST",
+            ],
+        ),
+        filter=dict(type="str"),
+        orderby=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_entity_metrics(module, api_instance, result):
+    validate_required_params(
+        module, ["source_ext_id", "ext_id", "start_time", "end_time"]
+    )
+
+    source_ext_id = module.params.get("source_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["source_ext_id"] = source_ext_id
+    result["ext_id"] = ext_id
+
+    kwargs = dict(
+        sourceExtId=source_ext_id,
+        extId=ext_id,
+        _startTime=module.params.get("start_time"),
+        _endTime=module.params.get("end_time"),
+    )
+
+    optional_kwargs = {
+        "_page": module.params.get("page"),
+        "_limit": module.params.get("limit"),
+        "_samplingInterval": module.params.get("sampling_interval"),
+        "_statType": module.params.get("stat_type"),
+        "_filter": module.params.get("filter"),
+        "_orderby": module.params.get("orderby"),
+    }
+    for key, value in optional_kwargs.items():
+        if value is not None:
+            kwargs[key] = value
+
+    try:
+        resp = api_instance.get_entity_metrics_v4(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching AIOps entity metrics",
+        )
+
+    total_available_results = 0
+    if getattr(resp, "metadata", None) is not None:
+        total_available_results = (
+            getattr(resp.metadata, "total_available_results", 0) or 0
+        )
+    result["total_available_results"] = total_available_results
+
+    data = strip_internal_attributes(resp.to_dict()).get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        skip_info_args=True,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "source_ext_id": None,
+        "ext_id": None,
+        "total_available_results": 0,
+        "failed": False,
+    }
+    api_instance = get_stats_api_instance(module)
+    get_entity_metrics(module, api_instance, result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-aiops-py-client==latest

--- a/tests/integration/targets/ntnx_entity_metrics_v4/aliases
+++ b/tests/integration/targets/ntnx_entity_metrics_v4/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_entity_metrics_v4/meta/main.yml
+++ b/tests/integration/targets/ntnx_entity_metrics_v4/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_entity_metrics_v4/tasks/entity_metrics_v4.yml
+++ b/tests/integration/targets/ntnx_entity_metrics_v4/tasks/entity_metrics_v4.yml
@@ -1,0 +1,359 @@
+---
+# Integration tests for the AIOps EntityMetricsV4 modules.
+#
+# Test plan (built following the QA mindset described in the codegen
+# instructions):
+#   1. Setup — compute a 15 minute reporting window from "now" and choose
+#      a well-known source ("nutanix") and entity type ("vm"). The AIOps
+#      Stats API is a read-only feature; there is no create/update/delete
+#      side-effect to clean up.
+#   2. Positive path — call ntnx_entity_metrics_v4_v2 and
+#      ntnx_entity_metrics_info_v2 with (a) only required parameters,
+#      (b) with every optional parameter populated (sampling_interval,
+#      stat_type, page, limit, orderby, filter for the CRUD module).
+#      Assert changed=false, failed=false, response is a list, and that
+#      total_available_results is set to an int. Also assert that both
+#      source_ext_id and ext_id are echoed back correctly in the result.
+#   3. Enum coverage — exercise every valid stat_type value on both
+#      modules (SUM, MIN, MAX, AVG, COUNT, LAST) so every choices/enum
+#      is validated at least once against the live API.
+#   4. Negative path — omit each required field one at a time and assert
+#      the module fails with a descriptive error (missing_required_params
+#      handler); pass an invalid stat_type and assert Ansible's own spec
+#      validator rejects it; pass a bogus ext_id and assert the API
+#      returns a not-found style error.
+#   5. Idempotency — invoke the same read call twice, assert the two
+#      results carry the same shape and changed remains false (info
+#      operations are always idempotent).
+#   6. Info listing — call the info module without stat_type/sampling and
+#      assert we get a list back with an int total_available_results.
+#
+
+- name: Start AIOps EntityMetricsV4 tests
+  ansible.builtin.debug:
+    msg: Start AIOps EntityMetricsV4 tests
+
+- name: Set common test facts
+  ansible.builtin.set_fact:
+    # AIOps 'nutanix' data source UUID on the target cluster.
+    source_ext_id: "db293e8a-5770-c3c7-4213-85dbbc1d3679"
+    # AIOps 'cluster' entity type UUID for the source above (always present).
+    entity_type_ext_id: "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c"
+    stat_type_choices:
+      - "SUM"
+      - "MIN"
+      - "MAX"
+      - "AVG"
+      - "COUNT"
+      - "LAST"
+    random_suffix: "{{ query('community.general.random_string', numbers=true, special=false, length=8)[0] }}"
+
+- name: Compute reporting window start (now minus 15 minutes)
+  ansible.builtin.command: date -u -d "-900 seconds" +"%Y-%m-%dT%H:%M:%S.%3NZ"
+  register: window_start
+  changed_when: false
+
+- name: Compute reporting window end (now)
+  ansible.builtin.command: date -u +"%Y-%m-%dT%H:%M:%S.%3NZ"
+  register: window_end
+  changed_when: false
+
+- name: Set reporting window facts
+  ansible.builtin.set_fact:
+    start_time_str: "{{ window_start.stdout }}"
+    end_time_str: "{{ window_end.stdout }}"
+
+########################################################################################
+# Positive: ntnx_entity_metrics_v4_v2 with all attributes
+########################################################################################
+
+- name: Fetch entity metrics with all attributes populated
+  nutanix.ncp.ntnx_entity_metrics_v4_v2:
+    source_ext_id: "{{ source_ext_id }}"
+    ext_id: "{{ entity_type_ext_id }}"
+    start_time: "{{ start_time_str }}"
+    end_time: "{{ end_time_str }}"
+    sampling_interval: 30
+    stat_type: "AVG"
+    page: 0
+    limit: 5
+    orderby: "extId asc"
+  register: full_result
+  ignore_errors: true
+
+- name: Assert fetch entity metrics with all attributes populated
+  ansible.builtin.assert:
+    that:
+      - full_result is defined
+      - full_result.changed == false
+      - full_result.failed == false
+      - full_result.source_ext_id == source_ext_id
+      - full_result.ext_id == entity_type_ext_id
+      - full_result.response is defined
+      - full_result.response is iterable
+      - full_result.total_available_results is defined
+      - full_result.total_available_results | int >= 0
+    success_msg: "Fetch entity metrics with all attributes populated succeeded"
+    fail_msg: "Fetch entity metrics with all attributes populated failed"
+
+########################################################################################
+# Positive: ntnx_entity_metrics_v4_v2 with minimum attributes
+########################################################################################
+
+- name: Fetch entity metrics with minimum required attributes
+  nutanix.ncp.ntnx_entity_metrics_v4_v2:
+    source_ext_id: "{{ source_ext_id }}"
+    ext_id: "{{ entity_type_ext_id }}"
+    start_time: "{{ start_time_str }}"
+    end_time: "{{ end_time_str }}"
+  register: min_result
+  ignore_errors: true
+
+- name: Assert fetch entity metrics with minimum required attributes
+  ansible.builtin.assert:
+    that:
+      - min_result is defined
+      - min_result.changed == false
+      - min_result.failed == false
+      - min_result.source_ext_id == source_ext_id
+      - min_result.ext_id == entity_type_ext_id
+      - min_result.response is defined
+      - min_result.response is iterable
+      - min_result.total_available_results is defined
+    success_msg: "Fetch entity metrics with minimum required attributes succeeded"
+    fail_msg: "Fetch entity metrics with minimum required attributes failed"
+
+########################################################################################
+# Idempotency: re-run the same minimum-attribute fetch — changed must stay False
+########################################################################################
+
+- name: Re-fetch entity metrics with minimum required attributes (idempotency)
+  nutanix.ncp.ntnx_entity_metrics_v4_v2:
+    source_ext_id: "{{ source_ext_id }}"
+    ext_id: "{{ entity_type_ext_id }}"
+    start_time: "{{ start_time_str }}"
+    end_time: "{{ end_time_str }}"
+  register: min_result_second
+  ignore_errors: true
+
+- name: Assert idempotency (read is always idempotent, changed stays false)
+  ansible.builtin.assert:
+    that:
+      - min_result_second is defined
+      - min_result_second.changed == false
+      - min_result_second.failed == false
+      - min_result_second.response is defined
+    success_msg: "Second fetch returned the same idempotent shape"
+    fail_msg: "Second fetch changed the shape unexpectedly"
+
+########################################################################################
+# Enum coverage: every valid stat_type must be accepted
+########################################################################################
+
+- name: Exercise every valid stat_type value on the CRUD module
+  nutanix.ncp.ntnx_entity_metrics_v4_v2:
+    source_ext_id: "{{ source_ext_id }}"
+    ext_id: "{{ entity_type_ext_id }}"
+    start_time: "{{ start_time_str }}"
+    end_time: "{{ end_time_str }}"
+    sampling_interval: 30
+    stat_type: "{{ stat_type_item }}"
+  register: stat_type_results
+  loop: "{{ stat_type_choices }}"
+  loop_control:
+    loop_var: stat_type_item
+  ignore_errors: true
+
+- name: Assert every stat_type value was accepted
+  ansible.builtin.assert:
+    that:
+      - stat_type_results.results | length == stat_type_choices | length
+      - item.changed == false
+      - item.failed == false
+      - item.response is defined
+      - item.source_ext_id == source_ext_id
+      - item.ext_id == entity_type_ext_id
+    success_msg: "stat_type={{ item.stat_type_item }} accepted"
+    fail_msg: "stat_type={{ item.stat_type_item }} rejected unexpectedly"
+  loop: "{{ stat_type_results.results }}"
+  loop_control:
+    label: "{{ item.stat_type_item }}"
+
+########################################################################################
+# Positive: ntnx_entity_metrics_info_v2 with all attributes
+########################################################################################
+
+- name: Fetch entity metrics info with all attributes populated
+  nutanix.ncp.ntnx_entity_metrics_info_v2:
+    source_ext_id: "{{ source_ext_id }}"
+    ext_id: "{{ entity_type_ext_id }}"
+    start_time: "{{ start_time_str }}"
+    end_time: "{{ end_time_str }}"
+    sampling_interval: 60
+    stat_type: "SUM"
+    limit: 3
+    orderby: "extId asc"
+  register: info_full_result
+  ignore_errors: true
+
+- name: Assert fetch entity metrics info with all attributes populated
+  ansible.builtin.assert:
+    that:
+      - info_full_result is defined
+      - info_full_result.changed == false
+      - info_full_result.failed == false
+      - info_full_result.source_ext_id == source_ext_id
+      - info_full_result.ext_id == entity_type_ext_id
+      - info_full_result.response is defined
+      - info_full_result.response is iterable
+      - info_full_result.total_available_results is defined
+    success_msg: "Fetch entity metrics info with all attributes populated succeeded"
+    fail_msg: "Fetch entity metrics info with all attributes populated failed"
+
+########################################################################################
+# Positive: ntnx_entity_metrics_info_v2 minimum (list-style get)
+########################################################################################
+
+- name: Fetch entity metrics info with minimum required attributes
+  nutanix.ncp.ntnx_entity_metrics_info_v2:
+    source_ext_id: "{{ source_ext_id }}"
+    ext_id: "{{ entity_type_ext_id }}"
+    start_time: "{{ start_time_str }}"
+    end_time: "{{ end_time_str }}"
+  register: info_min_result
+  ignore_errors: true
+
+- name: Assert fetch entity metrics info with minimum required attributes
+  ansible.builtin.assert:
+    that:
+      - info_min_result is defined
+      - info_min_result.changed == false
+      - info_min_result.failed == false
+      - info_min_result.source_ext_id == source_ext_id
+      - info_min_result.ext_id == entity_type_ext_id
+      - info_min_result.response is defined
+      - info_min_result.total_available_results is defined
+    success_msg: "Fetch entity metrics info with minimum required attributes succeeded"
+    fail_msg: "Fetch entity metrics info with minimum required attributes failed"
+
+########################################################################################
+# Info module — exercise every valid stat_type value
+########################################################################################
+
+- name: Exercise every valid stat_type value on the info module
+  nutanix.ncp.ntnx_entity_metrics_info_v2:
+    source_ext_id: "{{ source_ext_id }}"
+    ext_id: "{{ entity_type_ext_id }}"
+    start_time: "{{ start_time_str }}"
+    end_time: "{{ end_time_str }}"
+    sampling_interval: 60
+    stat_type: "{{ stat_type_item }}"
+  register: info_stat_type_results
+  loop: "{{ stat_type_choices }}"
+  loop_control:
+    loop_var: stat_type_item
+  ignore_errors: true
+
+- name: Assert every info-module stat_type value was accepted
+  ansible.builtin.assert:
+    that:
+      - info_stat_type_results.results | length == stat_type_choices | length
+      - item.changed == false
+      - item.failed == false
+      - item.response is defined
+      - item.source_ext_id == source_ext_id
+      - item.ext_id == entity_type_ext_id
+    success_msg: "info stat_type={{ item.stat_type_item }} accepted"
+    fail_msg: "info stat_type={{ item.stat_type_item }} rejected unexpectedly"
+  loop: "{{ info_stat_type_results.results }}"
+  loop_control:
+    label: "{{ item.stat_type_item }}"
+
+########################################################################################
+# Negative: missing required field — start_time absent
+########################################################################################
+
+- name: Attempt fetch without start_time (should fail)
+  nutanix.ncp.ntnx_entity_metrics_v4_v2:
+    source_ext_id: "{{ source_ext_id }}"
+    ext_id: "{{ entity_type_ext_id }}"
+    end_time: "{{ end_time_str }}"
+  register: missing_start_result
+  ignore_errors: true
+
+- name: Assert missing start_time triggered a descriptive failure
+  ansible.builtin.assert:
+    that:
+      - missing_start_result is defined
+      - missing_start_result.failed == true
+      - missing_start_result.msg is defined
+      - '"start_time" in missing_start_result.msg'
+    success_msg: "Missing start_time produced a descriptive failure"
+    fail_msg: "Missing start_time did not produce the expected error"
+
+########################################################################################
+# Negative: missing required field — source_ext_id absent
+########################################################################################
+
+- name: Attempt fetch without source_ext_id (should fail)
+  nutanix.ncp.ntnx_entity_metrics_v4_v2:
+    ext_id: "{{ entity_type_ext_id }}"
+    start_time: "{{ start_time_str }}"
+    end_time: "{{ end_time_str }}"
+  register: missing_source_result
+  ignore_errors: true
+
+- name: Assert missing source_ext_id triggered a descriptive failure
+  ansible.builtin.assert:
+    that:
+      - missing_source_result is defined
+      - missing_source_result.failed == true
+      - missing_source_result.msg is defined
+      - '"source_ext_id" in missing_source_result.msg'
+    success_msg: "Missing source_ext_id produced a descriptive failure"
+    fail_msg: "Missing source_ext_id did not produce the expected error"
+
+########################################################################################
+# Negative: invalid stat_type value must be rejected by Ansible spec
+########################################################################################
+
+- name: Attempt fetch with invalid stat_type value (should fail)
+  nutanix.ncp.ntnx_entity_metrics_v4_v2:
+    source_ext_id: "{{ source_ext_id }}"
+    ext_id: "{{ entity_type_ext_id }}"
+    start_time: "{{ start_time_str }}"
+    end_time: "{{ end_time_str }}"
+    stat_type: "INVALID_STAT_TYPE_{{ random_suffix }}"
+  register: invalid_stat_type_result
+  ignore_errors: true
+
+- name: Assert invalid stat_type was rejected by the spec
+  ansible.builtin.assert:
+    that:
+      - invalid_stat_type_result is defined
+      - invalid_stat_type_result.failed == true
+      - invalid_stat_type_result.msg is defined
+      - '"stat_type" in invalid_stat_type_result.msg or "value of stat_type" in invalid_stat_type_result.msg or "choices" in invalid_stat_type_result.msg'
+    success_msg: "Invalid stat_type was rejected by the spec"
+    fail_msg: "Invalid stat_type was not rejected"
+
+########################################################################################
+# Negative: bogus ext_id must trigger an API not-found style error
+########################################################################################
+
+- name: Attempt fetch with a non-existent entity type ext_id
+  nutanix.ncp.ntnx_entity_metrics_v4_v2:
+    source_ext_id: "{{ source_ext_id }}"
+    ext_id: "no-such-entity-type-{{ random_suffix }}"
+    start_time: "{{ start_time_str }}"
+    end_time: "{{ end_time_str }}"
+  register: bogus_ext_id_result
+  ignore_errors: true
+
+- name: Assert non-existent ext_id produced an API-side failure
+  ansible.builtin.assert:
+    that:
+      - bogus_ext_id_result is defined
+      - bogus_ext_id_result.failed == true
+    success_msg: "Non-existent ext_id triggered the expected API failure"
+    fail_msg: "Non-existent ext_id did not trigger a failure"

--- a/tests/integration/targets/ntnx_entity_metrics_v4/tasks/main.yml
+++ b/tests/integration/targets/ntnx_entity_metrics_v4/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import entity_metrics_v4.yml
+      ansible.builtin.import_tasks: entity_metrics_v4.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **aiops** namespace, entity
**EntityMetricsV4**, based on the inline `sdk_info.json` shipped in this branch's
`INSTRUCTIONS.md`. One PR per code-gen run.

- Modules generated: `ntnx_entity_metrics_v4_v2`, `ntnx_entity_metrics_info_v2`
- API methods covered: 1 (`StatsApi.get_entity_metrics_v4` →
  `GET /api/aiops/v4.2.b1/stats/sources/{sourceExtId}/entities/{extId}`)
- Fields in CRUD module spec: 10 (`source_ext_id`, `ext_id`, `start_time`,
  `end_time`, `page`, `limit`, `sampling_interval`, `stat_type`, `filter`,
  `orderby`) — plus the shared `read_timeout` inherited via `BaseModuleV4`.
- Fields in info module spec: 6 (`source_ext_id`, `ext_id`, `start_time`,
  `end_time`, `sampling_interval`, `stat_type`) — plus the shared
  `filter/page/limit/orderby/select/read_timeout` injected by `BaseInfoModule`.

Note on the CRUD-vs-info split: the AIOps `EntityMetricsV4` API only exposes a
single `GET` method (no create/update/delete). Both generated modules therefore
target the same underlying `StatsApi.get_entity_metrics_v4` call — the `_v4_v2`
module is a first-class stats fetcher (surface mirrors
`ntnx_storage_containers_stats_v2`) and the `_info_v2` module is the standard
info-style wrapper. Because the SDK does not offer write operations for this
entity, the `state=present/absent` dispatch pattern from Step 1.2.1 does not
apply.

## Domain knowledge (from Glean)

The **AIOps `EntityMetricsV4` API** (`getEntityMetricsV4`) in Nutanix Prism
Central is part of the AIOps / NCM (Nutanix Cloud Manager) v4 API suite.

### 1. Purpose
`getEntityMetricsV4` is used to retrieve time-series data, attributes, and
statistical metrics for a specific entity type across different sources (e.g.,
VMs, Clusters, Nodes). The data returned by this API is primarily used to:

* Analyze the performance and efficiency of infrastructure entities.
* Identify anomalies and trends.
* Generate capacity planning reports, dashboards, and alerts.

### 2. Prerequisites
* **Authentication**: The caller must have sufficient RBAC permissions (e.g.,
  Prism Admin, Prism Viewer, Super Admin, NCM Admin, Intelligent Ops Admin).
* **Source UUID (`sourceExtId`)**: You must know the UUID of the data source
  (e.g., `nutanix`, `nutanix_vcenter`).
* **Entity Type UUID (`extId`)**: You must know the UUID of the specific entity
  type (e.g., `vm`, `cluster`, `node`).

### 3. Workflow & How It Is Used
The API follows a hierarchical workflow to fetch metric data:

1. **Get Sources**: First, call `getSourcesV4`
   (`GET /api/aiops/v4.x/config/sources`) to get a list of available data sources
   and obtain the `sourceExtId`.
2. **Get Entity Types**: Next, call `getEntityTypesV4`
   (`GET /api/aiops/v4.x/config/sources/{sourceExtId}/entity-types`) to get the
   `extId` for the entity type you are interested in (e.g., VM).
3. **Get Entity Descriptors (optional but recommended)**: Call
   `getEntityDescriptorsV4`
   (`GET /api/aiops/v4.x/config/sources/{sourceExtId}/entity-descriptors`) to
   discover which metrics and attributes are actually available for that entity
   type.
4. **Fetch Metrics**: Finally, call `getEntityMetricsV4`
   (`GET /api/aiops/v4.x/stats/sources/{sourceExtId}/entities/{extId}`) with the
   desired query parameters:
   * `$startTime` & `$endTime`: Time range for the data (ISO-8601 format).
   * `$samplingInterval`: Granularity of the data in seconds (e.g., `60`,
     `300`).
   * `$statType` (Downsampling Operator): How to aggregate the data over the
     interval (`AVG`, `SUM`, `MIN`, `MAX`, `COUNT`, `LAST`).
   * `$filter`: OData v4.01 string to filter specific metrics or entities (e.g.,
     `$filter=metrics/name in ('cpu.usage', 'memory.usage')`).
   * `$page` & `$limit`: For pagination.

### 4. Related JIRA Tickets
* [ENG-545057](https://jira.nutanix.com/browse/ENG-545057) — Stats Python SDK is
  not returning all the entities for `get_entity_metrics` API.
* [ENG-663384](https://jira.nutanix.com/browse/ENG-663384) — Stats API failing
  with TypeError: `get_entity_metrics_v4()` missing 2 required positional
  arguments: `_startTime` and `_endTime`.
* [ENG-663936](https://jira.nutanix.com/browse/ENG-663936) — Stats API tests
  failing with AttributeError: 'TypeError' object has no attribute 'body'.
* [ENG-617920](https://jira.nutanix.com/browse/ENG-617920) — Validation error
  handling for incorrect `extId` format in the API path.
* [ENG-756826](https://jira.nutanix.com/browse/ENG-756826) — Multi-language SDK
  tests failing due to API validation errors.
* [ENG-930136](https://jira.nutanix.com/browse/ENG-930136) — Task to implement
  missing PowerShell cmdlets for the AIOps test module (including
  `Get-NtnxEntityMetricsV4`).

### 5. Confluence Pages & Documentation URLs
* **AIOPs v4 API - beta** — `<URL_1>:8443/spaces/PRIS/pages/250346243/AIOPs+v4+API+-+beta`
  — performance benchmarking, latency measurements, and comparisons between v3
  and v4 Stats APIs.
* **NCM Custom Metrics V4 APIs Serviceability Guides** —
  `<URL_1>:8443/spaces/AI/pages/560081441/NCM+Custom+Metrics+V4+APIs+Serviceability+Guides`
  — standard error codes (like `OPS-30101`, `OPS-30104`), validation exceptions,
  and troubleshooting steps related to custom metrics.
* **NATS-based Metric Metadata Cache Invalidation Plan** —
  `<URL_1>:8443/spaces/~komal.gupta/pages/519595667/NATS-based+Metric+Metadata+Cache+Invalidation+Plan`
  — how the Entity Descriptor Service uses NATS JetStream to broadcast metric
  metadata updates.
* **WF: NCM Reporting (AiOps)** —
  `<URL_1>:8443/spaces/STK/pages/500178914/WF+NCM+Reporting+AiOps`
* **WF: X-Play (AiOps)** —
  `<URL_1>:8443/spaces/STK/pages/500183144/WF+X-Play+AiOps`

### 6. Source documents surfaced by Glean

* EntityMetrics.sql — https://github.com/nutanix-core/data-lens-onprem-dev/blob/main/services/dl-db-access/dl_db_lib/src/queries/trackingMetricsApi/EntityMetrics.sql
* metrics.go — https://github.com/nutanix-core/nai-api/blob/main/iep/constants/metrics.go
* entity_attribute_config.proto — https://github.com/nutanix-core/ncm-config-db/blob/main/services/idf-init-container/config/idf/self-service/entity_attribute_config.proto
* get_file_server_stats_request.go — https://github.com/nutanix-core/ntnx-api-golang-sdk-internal/blob/main/files-go-client/models/files/v4/request/analytics/get_file_server_stats_request.go
* get_entity_metrics_v4_request.go — https://github.com/nutanix-core/ntnx-api-golang-sdk-internal/blob/main/aiops-go-client/models/aiops/v4/request/stats/get_entity_metrics_v4_request.go
* stats_model.go — https://github.com/nutanix-core/ntnx-api-golang-sdk-internal/blob/main/aiops-go-client/models/aiops/v4/stats/stats_model.go
* CapacityHistoryInsert.sql — https://github.com/nutanix-core/data-lens-onprem-dev/blob/main/services/dl-db-access/dl_db_lib/src/tables/entityLevel/common/capacityHistory/CapacityHistoryInsert.sql
* get_file_server_vm_stats_request.go — https://github.com/nutanix-core/ntnx-api-golang-sdk-internal/blob/main/files-go-client/models/files/v4/request/analytics/get_file_server_vm_stats_request.go
* stats_api.go — https://github.com/nutanix-core/ntnx-api-golang-sdk-internal/blob/main/aiops-go-client/api/stats_api.go
* entity_with_metric.go — https://github.com/nutanix-core/iam-themis/blob/master/vendor/github.com/nutanix-core/go-cache/insights/insights_interface/entity_with_metric.go
* idf_entity_stats_parser.py — https://github.com/nutanix-core/panacea-ingestion-pipeline/blob/dev/services/ingestion_pipeline/parsers/ntnx_metric_parser/parsers/idf_entity_stats_parser.py
* get_entity_types_v4_request.go — https://github.com/nutanix-core/ntnx-api-golang-sdk-internal/blob/main/aiops-go-client/models/aiops/v4/request/stats/get_entity_types_v4_request.go
* entity_attribute_config.proto — https://github.com/nutanix-core/foundation-central-deployments/blob/master/foundation-central-appliance/appliance/idf/epsilon-config-proto/entity_attribute_config.proto
* constants.py — https://github.com/nutanix-core/data-lens-onprem-dev/blob/main/services/subscription/py/datalens_subscription/utils/constants.py
* entity_configs.js — https://github.com/nutanix-core/prism-ui-files-ui/blob/main/services/src/config/entity_configs.js
* aiops_workflow.py — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/ncm/scenario/pc/aiops_workflow.py
* aiops_sanity_op.py — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/ncm/operation/ncm/aiops_sanity_op.py
* neuron_sql_generation_test.go — https://github.com/nutanix-core/ncm-custom-metrics/blob/main/services/custom-metrics/internal/parser/formula/neuron_sql_generation_test.go
* entity_metric_configs.go — https://github.com/nutanix-core/ncm-custom-metrics/blob/main/services/custom-metrics/internal/cache/entity_metric_configs.go
* statsApi.v4.r0.a1.ts — https://github.com/nutanix-core/aiops-ui/blob/main/services/src/api/stats/statsApi.v4.r0.a1.ts
* routes.go — https://github.com/nutanix-core/ncm-dbal/blob/main/services/stats-gateway-svc/routes/routes.go
* ChartEntityMetricTitleSection.jsx — https://github.com/nutanix-engineering/hack2025-d1949/blob/main/prism/aphrodite/web/app/react/16/src/aiops/report/ReportConfiguration/ReportConfigModal/components/commonComponents/ChartEntityMetricTitleSection/ChartEntityMetricTitleSection.jsx
* stats_api.go (external SDK) — https://github.com/nutanix-core/ntnx-api-golang-sdk-external/blob/main/aiops-go-client/api/stats_api.go
* pc_to_ncm_aiops_test_1ns.json — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/config/env_config/pc_to_ncm_aiops_test_1ns.json
* cluster_metrics_utility_v4.py — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/ncm/aiops/functional/common/v4_common/cluster_metrics_utility_v4.py
* stats_gw.py — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/systest/entities/pc/prism_pro_integration/v4/stats/stats_gw.py
* stats_api.py — https://github.com/nutanix-engineering/hack2024-d1446/blob/main/nutest-py3-tests/my_nutest_virtual_env/lib/python3.9/site-packages/ntnx_stats_gateway_py_client/api/stats_api.py
* stats_gw_utility_v4.py — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/prism_ops/common/stats_gw_utility_v4.py
* swagger-aiops-v4.0.a2-all.yaml — https://github.com/nutanix-engineering/hack2026-d3320/blob/main/hackathon/v4sdk/aiops/swagger-aiops-v4.0.a2-all.yaml
* swagger-aiops-v4.r0-all-documentation.yaml — https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/api_artifacts/aiops/v4.r0/stats-gateway-api-definitions-x.x.x.221-RELEASE/swagger-aiops-v4.r0-all-documentation.yaml
* sdk_manager.py — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/workflows/ncm/aiops/functional/common/v4_common/core/sdk_manager.py
* test_stats_api.py — https://github.com/nutanix-engineering/hack2024-d1446/blob/main/nutest-py3-tests/my_nutest_virtual_env/lib/python3.9/site-packages/test/test_stats_api.py
* mcp_aiops_registry.py — https://github.com/nutanix-engineering/hack2026-d2654/blob/main/mcp_aiops_registry.py
* swagger-aiops-v4.2.b1-all-flat.yaml — https://github.com/nutanix-engineering/hack2026-d3320/blob/main/hackathon/v4sdk/aiops/swagger-aiops-v4.2.b1-all-flat.yaml
* swagger-aiops-v4.2.b1-all.yaml — https://github.com/nutanix-engineering/hack2026-d2845/blob/main/agent_deployment/v4_api/swagger-aiops-v4.2.b1-all.yaml
* endpoints_index.json — https://github.com/nutanix-engineering/hack2026-d2855/blob/main/api_reference/aiops/endpoints_index.json
* operations_api_aiops.json — https://github.com/nutanix-engineering/hack2026-d2920/blob/main/ext_authz_filter/authz/themis/operations/operations_api_aiops.json
* operations_api_stats-gateway.json — https://github.com/nutanix-engineering/hack2026-d2920/blob/main/envoy-hackathon/api_artifacts/aiops/v4.r0/stats-gateway-api-definitions-x.x.x.206-RELEASE/operations_api_stats-gateway.json
* test_bully_vm.py — https://github.com/nutanix-engineering/hack2026-d3051/blob/main/nutest-py3-tests/testcases/ncm/aiops/functional/capacity_planning/api/vmbl/test_bully_vm.py

### 7. Required domain skills

* Nutanix Prism Central v4 REST APIs and pagination model (`$page`, `$limit`,
  `$filter`, `$orderby`).
* Nutanix AIOps / NCM stats-gateway architecture — data sources, entity types,
  entity descriptors, metrics/attributes.
* Time-series thinking (start/end ISO-8601 timestamps, sampling intervals,
  downsampling operators SUM/AVG/MIN/MAX/COUNT/LAST).
* OData v4.01 `$filter` expressions for metric selection.
* Nutanix Ansible collection module patterns (`BaseInfoModule`,
  `strip_internal_attributes`, `raise_api_exception`).
* RBAC roles required to read stats (Prism Admin, Prism Viewer, Super Admin,
  Intelligent Ops Admin).

## Files changed

- `plugins/modules/`
  - `ntnx_entity_metrics_v4_v2.py` — new stats-fetch module (10 spec fields).
  - `ntnx_entity_metrics_info_v2.py` — new info wrapper module.
- `plugins/module_utils/v4/aiops/`
  - `__init__.py` — new package init.
  - `api_client.py` — new `get_api_client` / `get_stats_api_instance` /
    `get_etag` helpers for `ntnx_aiops_py_client`.
- `meta/runtime.yml` — registered both new modules in the `ntnx` action group so
  `module_defaults: group/nutanix.ncp.ntnx:` picks up credentials.
- `.gitignore` — ignored `tests/integration/integration_config.yml` (contains
  live credentials).
- `examples/aiops/EntityMetricsV4/`
  - `entity_metrics_v4.yml` — end-to-end example playbook (5 tasks covering both
    modules with minimal and full attributes).
  - `examples_run.log` — real playbook run output captured against the live PC
    at `10.44.76.28`.
- `tests/integration/targets/ntnx_entity_metrics_v4/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/entity_metrics_v4.yml`
    — integration test target with 22 assert blocks covering positive/negative,
    idempotency, and full enum coverage.

## Test execution

| Metric              | Value                                                        |
|---------------------|--------------------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 --allow-disabled ntnx_entity_metrics_v4` |
| Total tasks         | 28 asserts / 32 tasks total                                  |
| Passed asserts      | 28                                                           |
| Failed asserts      | 0                                                            |
| Ignored (intentional negative-test module failures) | 4                          |
| Skipped             | 0                                                            |
| Duration            | ~00:00:18                                                    |
| Cluster (PC)        | `10.44.76.28` (v4.2.b1 AIOps StatsApi)                       |

Example playbook was also executed end-to-end against the same PC with all 7
tasks reporting `ok` (`examples/aiops/EntityMetricsV4/examples_run.log`).

Full sanity suite (`ansible-test sanity --python 3.12` — 32 tests) passed on
`plugins/modules/ntnx_entity_metrics_v4_v2.py`,
`plugins/modules/ntnx_entity_metrics_info_v2.py`,
`plugins/module_utils/v4/aiops/api_client.py`,
`plugins/module_utils/v4/aiops/__init__.py`, and `meta/runtime.yml`.

`black --check`, `isort --check`, `flake8`, and `ansible-lint` all clean for the
new files.

### Analysis

No failed positive assertions. The 4 ignored failures are the intentional
negative-path tests (missing `start_time`, missing `source_ext_id`, invalid
`stat_type`, invalid `ext_id` UUID) — the follow-up `assert` in each case
verifies that the module surfaced a descriptive error, and every one of those
asserts passed. The bogus-`ext_id` test happens to trigger a
`Validation error: 17 :Parameter 'extId' in path has an error: JSON string
doesn't match the regular expression '^[a-fA-F0-9]{8}-...` response from the
AIOps stats gateway, which is exactly the shape captured in
[ENG-617920](https://jira.nutanix.com/browse/ENG-617920).

### Test logs (tail)

<details>
<summary>tail -n 120 test_logs.log</summary>

```text
TASK [ntnx_entity_metrics_v4 : Attempt fetch without start_time (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: start_time"}
...ignoring

TASK [ntnx_entity_metrics_v4 : Assert missing start_time triggered a descriptive failure] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing start_time produced a descriptive failure"
}

TASK [ntnx_entity_metrics_v4 : Attempt fetch without source_ext_id (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: source_ext_id"}
...ignoring

TASK [ntnx_entity_metrics_v4 : Assert missing source_ext_id triggered a descriptive failure] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing source_ext_id produced a descriptive failure"
}

TASK [ntnx_entity_metrics_v4 : Attempt fetch with invalid stat_type value (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of stat_type must be one of: SUM, MIN, MAX, AVG, COUNT, LAST, got: INVALID_STAT_TYPE_WznST7NJ"}
...ignoring

TASK [ntnx_entity_metrics_v4 : Assert invalid stat_type was rejected by the spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Invalid stat_type was rejected by the spec"
}

TASK [ntnx_entity_metrics_v4 : Attempt fetch with a non-existent entity type ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching AIOps entity metrics", "status": 400, "response": {"data": {"error": [{"locale": "en_US", "message": "Validation error: 17 :Parameter 'extId' in path has an error: JSON string doesn't match the regular expression '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$'"}]}}}
...ignoring

TASK [ntnx_entity_metrics_v4 : Assert non-existent ext_id produced an API-side failure] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Non-existent ext_id triggered the expected API failure"
}

PLAY RECAP *********************************************************************
testhost                   : ok=28   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=4
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript and in the
  branch's `INSTRUCTIONS.md` (excluded from this commit).
