### PR TITLE
code-gen(aiops/EntityTypesV4): ansible collection modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/aiops/EntityTypesV4/entity_types_v4.yml
+++ b/examples/aiops/EntityTypesV4/entity_types_v4.yml
@@ -1,0 +1,86 @@
+---
+# Summary:
+# This playbook demonstrates the AIOps EntityTypesV4 workflow:
+# 1. Fail-fast preflight if the required aiops SDK is not installed.
+# 2. Discover the built-in AIOps stats source (nutanix) via a live REST call
+#    against Prism Central and capture its external ID.
+# 3. Fetch the list of entity types supported by that source using the
+#    ntnx_entity_types_info_v2 module.
+# 4. Show the entity types plus a quick "vm" lookup.
+#
+# Notes:
+# - EntityTypesV4 is a read-only discovery API. There is no Create / Update /
+#   Delete for entity types, so this playbook covers only the "info" module
+#   that ships in this PR.
+# - Connection parameters are provided once via a play-level module_defaults
+#   block so individual tasks do not repeat host/username/password.
+
+- name: AIOps EntityTypesV4 playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "10.44.76.28"
+      nutanix_username: "admin"
+      nutanix_password: "Nutanix.123"
+      validate_certs: false
+  tasks:
+    - name: Preflight - ensure ntnx-aiops-py-client is installed
+      ansible.builtin.command: "{{ ansible_python_interpreter | default('python3') }} -c 'import ntnx_aiops_py_client'"
+      register: aiops_sdk_check
+      changed_when: false
+      ignore_errors: true
+
+    - name: Fail if aiops SDK is missing
+      ansible.builtin.fail:
+        msg: >-
+          ntnx-aiops-py-client is required for AIOps EntityTypesV4 modules.
+          Install it via `pip install ntnx-aiops-py-client`.
+      when: aiops_sdk_check.rc != 0
+
+    - name: Discover AIOps sources on PC (built-in nutanix source)
+      ansible.builtin.uri:
+        url: "https://10.44.76.28:9440/api/aiops/v4.2.b1/config/sources"
+        method: GET
+        user: "admin"
+        password: "Nutanix.123"
+        force_basic_auth: true
+        validate_certs: false
+        return_content: true
+        status_code: 200
+      register: sources_resp
+
+    - name: Extract source_ext_id for the nutanix source
+      ansible.builtin.set_fact:
+        source_ext_id: >-
+          {{
+            (sources_resp.json.data
+              | selectattr('sourceName', 'equalto', 'nutanix')
+              | map(attribute='extId')
+              | list
+              | first)
+          }}
+
+    - name: List all entity types for the source
+      nutanix.ncp.ntnx_entity_types_info_v2:
+        source_ext_id: "{{ source_ext_id }}"
+      register: entity_types_info
+
+    - name: Show fetched AIOps entity types
+      ansible.builtin.debug:
+        var: entity_types_info
+
+    - name: Extract the entity_type_name for VM
+      ansible.builtin.set_fact:
+        vm_entity_type: >-
+          {{
+            (entity_types_info.response
+              | selectattr('entity_type_name', 'equalto', 'vm')
+              | list
+              | first)
+            | default({})
+          }}
+
+    - name: Show VM entity type ext_id
+      ansible.builtin.debug:
+        msg: "VM entity type ext_id: {{ vm_entity_type.ext_id | default('not found') }}"

--- a/examples/aiops/EntityTypesV4/examples_run.log
+++ b/examples/aiops/EntityTypesV4/examples_run.log
@@ -1,0 +1,93 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [AIOps EntityTypesV4 playbook] ********************************************
+
+TASK [Preflight - ensure ntnx-aiops-py-client is installed] ********************
+ok: [localhost] => {"changed": false, "cmd": ["/bin/python3.12", "-c", "import ntnx_aiops_py_client"], "delta": "0:00:00.163389", "end": "2026-07-21 09:33:08.222238", "msg": "", "rc": 0, "start": "2026-07-21 09:33:08.058849", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
+
+TASK [Fail if aiops SDK is missing] ********************************************
+skipping: [localhost] => {"changed": false, "false_condition": "aiops_sdk_check.rc != 0", "skip_reason": "Conditional result was False"}
+
+TASK [Discover AIOps sources on PC (built-in nutanix source)] ******************
+ok: [localhost] => {"cache_control": "no-cache, no-store, max-age=0, must-revalidate,no-cache, no-store", "changed": false, "connection": "close", "content": "{\"$dataItemDiscriminator\":\"List\\u003caiops.v4.config.Source\\u003e\",\"$objectType\":\"aiops.v4.config.SourceListApiResponse\",\"$reserved\":{\"$fv\":\"v4.r2.b1\"},\"data\":[{\"$objectType\":\"aiops.v4.config.Source\",\"$reserved\":{\"$fv\":\"v4.r2.b1\"},\"extId\":\"db293e8a-5770-c3c7-4213-85dbbc1d3679\",\"sourceName\":\"nutanix\"}],\"metadata\":{\"$objectType\":\"common.v1.response.ApiResponseMetadata\",\"$reserved\":{\"$fv\":\"v1.r0\"},\"flags\":[{\"$objectType\":\"common.v1.config.Flag\",\"$reserved\":{\"$fv\":\"v1.r0\"},\"name\":\"hasError\",\"value\":false},{\"$objectType\":\"common.v1.config.Flag\",\"$reserved\":{\"$fv\":\"v1.r0\"},\"name\":\"isPaginated\",\"value\":true}],\"links\":[{\"$objectType\":\"common.v1.response.ApiLink\",\"$reserved\":{\"$fv\":\"v1.r0\"},\"href\":\"https://:9440/api/aiops/v4.2.b1/config/sources?$page=0\\u0026$limit=50\",\"rel\":\"first\"},{\"$objectType\":\"common.v1.response.ApiLink\",\"$reserved\":{\"$fv\":\"v1.r0\"},\"href\":\"https://:9440/api/aiops/v4.2.b1/config/sources?$page=0\\u0026$limit=50\",\"rel\":\"self\"},{\"$objectType\":\"common.v1.response.ApiLink\",\"$reserved\":{\"$fv\":\"v1.r0\"},\"href\":\"https://:9440/api/aiops/v4.2.b1/config/sources?$page=0\\u0026$limit=50\",\"rel\":\"last\"}],\"totalAvailableResults\":1}}", "content_encoding": "identity", "content_length": "1143", "content_security_policy": "connect-src 'self' wss: https://downloads.frame.nutanix.com https://downloads.frame.nutanix.us; default-src 'self' https://*.nutanix.com; frame-ancestors 'self' https://*.nutanix.com; frame-src 'self' https://*.nutanix.com blob: data:; img-src 'self' blob: data:; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'", "content_type": "application/json;charset=utf-8", "cookies": {"NTNX_SESSION_ID": "9ab0eb96-dd13-46f6-9c6a-e69cccfa47b4"}, "cookies_string": "NTNX_SESSION_ID=9ab0eb96-dd13-46f6-9c6a-e69cccfa47b4", "date": "Tue, 21 Jul 2026 09:33:09 GMT", "elapsed": 0, "expires": "0,0", "json": {"$dataItemDiscriminator": "List<aiops.v4.config.Source>", "$objectType": "aiops.v4.config.SourceListApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "data": [{"$objectType": "aiops.v4.config.Source", "$reserved": {"$fv": "v4.r2.b1"}, "extId": "db293e8a-5770-c3c7-4213-85dbbc1d3679", "sourceName": "nutanix"}], "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": true}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://:9440/api/aiops/v4.2.b1/config/sources?$page=0&$limit=50", "rel": "first"}, {"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://:9440/api/aiops/v4.2.b1/config/sources?$page=0&$limit=50", "rel": "self"}, {"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://:9440/api/aiops/v4.2.b1/config/sources?$page=0&$limit=50", "rel": "last"}], "totalAvailableResults": 1}}, "msg": "OK (1143 bytes)", "pragma": "no-cache, no-cache", "redirected": false, "set_cookie": "NTNX_SESSION_ID=9ab0eb96-dd13-46f6-9c6a-e69cccfa47b4;Max-Age=29700;Path=/;Secure;HttpOnly;SameSite=Lax", "status": 200, "strict_transport_security": "max-age=31536000 ; includeSubDomains, max-age=63072000; includeSubdomains; preload", "url": "https://10.44.76.28:9440/api/aiops/v4.2.b1/config/sources", "vary": "Origin", "x_api_ratelimit_limit": "30", "x_api_ratelimit_refresh_period_seconds": "1", "x_api_ratelimit_remaining": "29", "x_api_ratelimit_reset": "0", "x_content_type_options": "nosniff, nosniff", "x_dns_prefetch_control": "off", "x_envoy_upstream_service_time": "9", "x_frame_options": "DENY, SAMEORIGIN", "x_ntnx_env": "pc", "x_ntnx_product": "pc.7.6", "x_permitted_cross_domain_policies": "master-only", "x_ratelimit_limit": "40", "x_ratelimit_remaining": "39", "x_ratelimit_reset": "0", "x_xss_protection": "0, 1; mode=block"}
+
+TASK [Extract source_ext_id for the nutanix source] ****************************
+ok: [localhost] => {"ansible_facts": {"source_ext_id": "db293e8a-5770-c3c7-4213-85dbbc1d3679"}, "changed": false}
+
+TASK [List all entity types for the source] ************************************
+ok: [localhost] => {"changed": false, "response": [{"entity_type_name": "container", "ext_id": "5f0b6ebc-4bea-1028-5ba2-b8a6ce78b863", "links": null, "tenant_id": null}, {"entity_type_name": "vm", "ext_id": "686c821a-8091-4aef-8224-65b48019cd34", "links": null, "tenant_id": null}, {"entity_type_name": "virtual_disk", "ext_id": "d9eb3ca3-5e7b-4d02-8327-5ba58e9cd407", "links": null, "tenant_id": null}, {"entity_type_name": "cluster", "ext_id": "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c", "links": null, "tenant_id": null}, {"entity_type_name": "storagecontainerstats", "ext_id": "3f06ebab-4d62-a2ca-7e83-2592f9e8051e", "links": null, "tenant_id": null}, {"entity_type_name": "virtual_nic", "ext_id": "45ef8942-694d-6cf5-8333-a711c0be4b2b", "links": null, "tenant_id": null}, {"entity_type_name": "volume_group_config", "ext_id": "f149d727-ae8b-1abe-1656-2ff59fe06c13", "links": null, "tenant_id": null}, {"entity_type_name": "node", "ext_id": "36c45369-96ca-5615-dcf9-911f068786dc", "links": null, "tenant_id": null}], "source_ext_id": "db293e8a-5770-c3c7-4213-85dbbc1d3679", "total_available_results": 8}
+
+TASK [Show fetched AIOps entity types] *****************************************
+ok: [localhost] => {
+    "entity_types_info": {
+        "changed": false,
+        "failed": false,
+        "response": [
+            {
+                "entity_type_name": "container",
+                "ext_id": "5f0b6ebc-4bea-1028-5ba2-b8a6ce78b863",
+                "links": null,
+                "tenant_id": null
+            },
+            {
+                "entity_type_name": "vm",
+                "ext_id": "686c821a-8091-4aef-8224-65b48019cd34",
+                "links": null,
+                "tenant_id": null
+            },
+            {
+                "entity_type_name": "virtual_disk",
+                "ext_id": "d9eb3ca3-5e7b-4d02-8327-5ba58e9cd407",
+                "links": null,
+                "tenant_id": null
+            },
+            {
+                "entity_type_name": "cluster",
+                "ext_id": "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c",
+                "links": null,
+                "tenant_id": null
+            },
+            {
+                "entity_type_name": "storagecontainerstats",
+                "ext_id": "3f06ebab-4d62-a2ca-7e83-2592f9e8051e",
+                "links": null,
+                "tenant_id": null
+            },
+            {
+                "entity_type_name": "virtual_nic",
+                "ext_id": "45ef8942-694d-6cf5-8333-a711c0be4b2b",
+                "links": null,
+                "tenant_id": null
+            },
+            {
+                "entity_type_name": "volume_group_config",
+                "ext_id": "f149d727-ae8b-1abe-1656-2ff59fe06c13",
+                "links": null,
+                "tenant_id": null
+            },
+            {
+                "entity_type_name": "node",
+                "ext_id": "36c45369-96ca-5615-dcf9-911f068786dc",
+                "links": null,
+                "tenant_id": null
+            }
+        ],
+        "source_ext_id": "db293e8a-5770-c3c7-4213-85dbbc1d3679",
+        "total_available_results": 8
+    }
+}
+
+TASK [Extract the entity_type_name for VM] *************************************
+ok: [localhost] => {"ansible_facts": {"vm_entity_type": {"entity_type_name": "vm", "ext_id": "686c821a-8091-4aef-8224-65b48019cd34", "links": null, "tenant_id": null}}, "changed": false}
+
+TASK [Show VM entity type ext_id] **********************************************
+ok: [localhost] => {
+    "msg": "VM entity type ext_id: 686c821a-8091-4aef-8224-65b48019cd34"
+}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=7    changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_entity_types_info_v2

--- a/plugins/module_utils/v4/aiops/api_client.py
+++ b/plugins/module_utils/v4/aiops/api_client.py
@@ -1,0 +1,96 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    Build an authenticated ntnx_aiops_py_client ApiClient using the module's
+    connection parameters.
+
+    Args:
+        module (object): Ansible module object
+
+    Returns:
+        client (object): aiops SDK ApiClient instance
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_aiops_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    try:
+        client = ntnx_aiops_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_aiops_py_client.ApiClient(configuration=config)
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    client = ntnx_aiops_py_client.ApiClient(
+        configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+    )
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_stats_api_instance(module):
+    """
+    Return a StatsApi instance from the ntnx_aiops_py_client SDK.
+
+    The StatsApi hosts the AIOps configuration + stats catalog endpoints
+    (sources, entity-types, entity-descriptors, entity metrics).
+
+    Args:
+        module (object): Ansible module object
+
+    Returns:
+        api_instance (object): StatsApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_aiops_py_client.StatsApi(api_client=api_client)

--- a/plugins/module_utils/v4/aiops/helpers.py
+++ b/plugins/module_utils/v4/aiops/helpers.py
@@ -1,0 +1,33 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_entity_types(module, api_instance, source_ext_id):
+    """
+    Fetch the list of entity types supported by a given AIOps stats source.
+
+    Args:
+        module (object): Ansible module object
+        api_instance (object): StatsApi instance from ntnx_aiops_py_client sdk
+        source_ext_id (str): The external ID (UUID) of the source
+
+    Returns:
+        response (object): EntityTypeListApiResponse from the SDK
+    """
+    try:
+        return api_instance.get_entity_types_v4(sourceExtId=source_ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg=(
+                "Api Exception raised while fetching entity types for source "
+                "ext_id: {0}".format(source_ext_id)
+            ),
+        )

--- a/plugins/modules/ntnx_entity_types_info_v2.py
+++ b/plugins/modules/ntnx_entity_types_info_v2.py
@@ -1,0 +1,219 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_entity_types_info_v2
+short_description: Fetch AIOps stats entity types for a source in Nutanix Prism Central
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about AIOps EntityTypesV4 in Nutanix Prism Central.
+  - EntityTypesV4 lists the entity types (e.g. C(vm), C(cluster), C(node), C(container), C(virtual_disk), etc.)
+    for which the AIOps stats gateway can serve config and stats data for a given source.
+  - The parent AIOps source (for example the built-in C(nutanix) source) is looked up via the sources API
+    and its external ID is passed as C(source_ext_id).
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(Get list of Entity Types for a source) -
+    Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin,
+    Virtual Machine Admin, Virtual Machine Operator, Virtual Machine Viewer
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+  source_ext_id:
+    description:
+      - The external ID (UUID) of the AIOps stats source.
+      - Use C(ntnx_entity_types_info_v2) only with a source that has been returned by the AIOps
+        sources list API. On a standard Prism Central the built-in source is named C(nutanix).
+    type: str
+    required: true
+  read_timeout:
+    description:
+      - Read timeout in milliseconds for API calls.
+    type: int
+    required: false
+    default: 30000
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: List all entity types supported by an AIOps source
+  nutanix.ncp.ntnx_entity_types_info_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    source_ext_id: "db293e8a-5770-c3c7-4213-85dbbc1d3679"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC EntityTypesV4 info v4 API.
+    - It is a list of entity types (dicts) exposed by the given AIOps stats C(source_ext_id).
+    - Each entity type exposes an C(entity_type_name) (e.g. C(vm), C(cluster)) and the corresponding
+      C(ext_id) that can then be used with the AIOps stats/config APIs.
+  returned: always
+  type: dict
+  sample:
+    [
+      {
+        "entity_type_name": "vm",
+        "ext_id": "686c821a-8091-4aef-8224-65b48019cd34",
+        "links": null,
+        "tenant_id": null
+      },
+      {
+        "entity_type_name": "virtual_disk",
+        "ext_id": "d9eb3ca3-5e7b-4d02-8327-5ba58e9cd407",
+        "links": null,
+        "tenant_id": null
+      },
+      {
+        "entity_type_name": "cluster",
+        "ext_id": "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c",
+        "links": null,
+        "tenant_id": null
+      },
+      {
+        "entity_type_name": "storagecontainerstats",
+        "ext_id": "3f06ebab-4d62-a2ca-7e83-2592f9e8051e",
+        "links": null,
+        "tenant_id": null
+      },
+      {
+        "entity_type_name": "virtual_nic",
+        "ext_id": "45ef8942-694d-6cf5-8333-a711c0be4b2b",
+        "links": null,
+        "tenant_id": null
+      },
+      {
+        "entity_type_name": "volume_group_config",
+        "ext_id": "f149d727-ae8b-1abe-1656-2ff59fe06c13",
+        "links": null,
+        "tenant_id": null
+      },
+      {
+        "entity_type_name": "node",
+        "ext_id": "36c45369-96ca-5615-dcf9-911f068786dc",
+        "links": null,
+        "tenant_id": null
+      },
+      {
+        "entity_type_name": "container",
+        "ext_id": "5f0b6ebc-4bea-1028-5ba2-b8a6ce78b863",
+        "links": null,
+        "tenant_id": null
+      }
+    ]
+
+source_ext_id:
+  description: External ID of the AIOps stats source whose entity types were fetched.
+  returned: always
+  type: str
+  sample: "db293e8a-5770-c3c7-4213-85dbbc1d3679"
+
+total_available_results:
+  description: Total number of entity types available for the given source in PC.
+  returned: when entity types are fetched successfully
+  type: int
+  sample: 8
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always false for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching entity types for source ext_id: db293e8a-5770-c3c7-4213-85dbbc1d3679"
+
+error:
+  description: This field typically holds information about errors that occurred during task execution
+  returned: when an error occurs
+  type: str
+
+failed:
+  description: This field indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import get_stats_api_instance  # noqa: E402
+from ..module_utils.v4.aiops.helpers import get_entity_types  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        source_ext_id=dict(type="str", required=True),
+    )
+    return module_args
+
+
+def list_entity_types(module, stats_api, result):
+    source_ext_id = module.params.get("source_ext_id")
+    result["source_ext_id"] = source_ext_id
+
+    resp = get_entity_types(module, stats_api, source_ext_id)
+
+    resp_dict = strip_internal_attributes(resp.to_dict())
+    metadata = resp_dict.get("metadata") or {}
+    result["total_available_results"] = metadata.get("total_available_results")
+
+    data = resp_dict.get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        skip_info_args=True,
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+    )
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "source_ext_id": None,
+    }
+    stats_api = get_stats_api_instance(module)
+    list_entity_types(module, stats_api, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-aiops-py-client==latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
-ntnx-aiops-py-client==latest
+ntnx-aiops-py-client==26.2.0.19759

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -24,3 +24,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-aiops-py-client==26.2.0.19759

--- a/tests/integration/targets/ntnx_entity_types_info_v2/aliases
+++ b/tests/integration/targets/ntnx_entity_types_info_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_entity_types_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_entity_types_info_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_entity_types_info_v2/tasks/entity_types_info_operations.yml
+++ b/tests/integration/targets/ntnx_entity_types_info_v2/tasks/entity_types_info_operations.yml
@@ -1,0 +1,222 @@
+---
+# Test plan for ntnx_entity_types_info_v2
+# ---------------------------------------
+# EntityTypesV4 exposes only a read-only listing API. On any Prism Central
+# there is always at least one built-in source ("nutanix"). We use the AIOps
+# sources REST API to discover the source_ext_id at runtime and then exercise
+# the info module against it. Test scenarios:
+#
+#   1. Preflight: aiops SDK is importable.
+#   2. Discover the "nutanix" AIOps source via a live REST call.
+#   3. Call ntnx_entity_types_info_v2 with the real source_ext_id and assert
+#      the response is a non-empty list containing well-known entity types
+#      (vm, cluster, node, container) each with an entity_type_name + ext_id.
+#   4. Assert every returned dict has the four documented keys.
+#   5. Assert total_available_results matches len(response).
+#   6. Negative: call the module without source_ext_id and assert the module
+#      fails with the expected "missing required arguments" message.
+#   7. Negative: call the module with a well-formed but non-existent
+#      source_ext_id and assert an API error is returned (module failed=True).
+#   8. Iterate the entity types with a loop and assert each element has an
+#      ext_id and entity_type_name.
+
+- name: Start ntnx_entity_types_info_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_entity_types_info_v2 tests
+
+###################################################################################################
+# Preflight
+###################################################################################################
+
+- name: Preflight - ensure ntnx-aiops-py-client is installed
+  ansible.builtin.command: "{{ ansible_python_interpreter | default('python3') }} -c 'import ntnx_aiops_py_client'"
+  register: aiops_sdk_check
+  changed_when: false
+  ignore_errors: true
+
+- name: Assert aiops SDK is present
+  ansible.builtin.assert:
+    that:
+      - aiops_sdk_check.rc == 0
+    fail_msg: "ntnx-aiops-py-client SDK is required for these tests"
+    success_msg: "ntnx-aiops-py-client SDK is installed"
+
+###################################################################################################
+# Discover the built-in "nutanix" AIOps stats source
+###################################################################################################
+
+- name: Discover AIOps sources on PC
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:9440/api/aiops/v4.2.b1/config/sources"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: "{{ validate_certs }}"
+    return_content: true
+    status_code: 200
+  register: sources_resp
+
+- name: Extract source_ext_id for the built-in nutanix source
+  ansible.builtin.set_fact:
+    source_ext_id: >-
+      {{
+        (sources_resp.json.data
+          | selectattr('sourceName', 'equalto', 'nutanix')
+          | map(attribute='extId')
+          | list
+          | first)
+      }}
+
+- name: Assert source_ext_id discovery
+  ansible.builtin.assert:
+    that:
+      - source_ext_id is defined
+      - source_ext_id | length > 0
+    fail_msg: "Failed to discover source_ext_id for the nutanix AIOps source"
+    success_msg: "Discovered nutanix source_ext_id: {{ source_ext_id }}"
+
+###################################################################################################
+# Happy path - list entity types
+###################################################################################################
+
+- name: List all entity types for the nutanix source
+  nutanix.ncp.ntnx_entity_types_info_v2:
+    source_ext_id: "{{ source_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert list entity types result shape
+  ansible.builtin.assert:
+    that:
+      - result.changed == false
+      - result.failed == false
+      - result.source_ext_id == source_ext_id
+      - result.response is defined
+      - result.response is iterable
+      - result.response | length > 0
+      - result.total_available_results is defined
+      - result.total_available_results == (result.response | length)
+    fail_msg: "List entity types response shape assertion failed"
+    success_msg: "List entity types response shape looks correct"
+
+- name: Store fetched entity types
+  ansible.builtin.set_fact:
+    fetched_entity_types: "{{ result.response }}"
+    fetched_entity_type_names: "{{ result.response | map(attribute='entity_type_name') | list }}"
+
+- name: Assert well-known entity types are present
+  ansible.builtin.assert:
+    that:
+      - "'vm' in fetched_entity_type_names"
+      - "'cluster' in fetched_entity_type_names"
+      - "'node' in fetched_entity_type_names"
+      - "'container' in fetched_entity_type_names"
+    fail_msg: "Expected core entity types (vm, cluster, node, container) not found in {{ fetched_entity_type_names }}"
+    success_msg: "Core entity types (vm, cluster, node, container) are present"
+
+- name: Assert every fetched entity type carries the documented keys
+  ansible.builtin.assert:
+    that:
+      - item.entity_type_name is defined
+      - item.entity_type_name | length > 0
+      - item.ext_id is defined
+      - item.ext_id | length > 0
+      - "'links' in item"
+      - "'tenant_id' in item"
+    fail_msg: "Entity type entry {{ item }} is missing a documented key"
+    success_msg: "Entity type entry {{ item.entity_type_name }} carries all documented keys"
+  loop: "{{ fetched_entity_types }}"
+  loop_control:
+    label: "{{ item.entity_type_name | default('?') }}"
+
+###################################################################################################
+# Focused lookup - fetch the VM entity type
+###################################################################################################
+
+- name: Extract the vm entity type entry from the returned list
+  ansible.builtin.set_fact:
+    vm_entity_type: "{{ (fetched_entity_types | selectattr('entity_type_name', 'equalto', 'vm') | list | first) | default({}) }}"
+
+- name: Assert vm entity type is well-formed
+  ansible.builtin.assert:
+    that:
+      - vm_entity_type.entity_type_name == "vm"
+      - vm_entity_type.ext_id is defined
+      - vm_entity_type.ext_id | length > 0
+    fail_msg: "vm entity type entry is missing or malformed"
+    success_msg: "vm entity type has ext_id {{ vm_entity_type.ext_id }}"
+
+###################################################################################################
+# Negative - missing required parameter
+###################################################################################################
+
+- name: List entity types without source_ext_id (should fail)  # noqa: args
+  nutanix.ncp.ntnx_entity_types_info_v2: {}
+  register: missing_param_result
+  ignore_errors: true
+
+- name: Assert missing source_ext_id triggers required-parameter error
+  ansible.builtin.assert:
+    that:
+      - missing_param_result.changed == false
+      - missing_param_result.failed == true
+      - missing_param_result.msg is defined
+      - "'source_ext_id' in missing_param_result.msg"
+    fail_msg: "Missing source_ext_id did not raise the expected required-parameter error: {{ missing_param_result }}"
+    success_msg: "Missing source_ext_id raised the expected required-parameter error"
+
+###################################################################################################
+# Negative - non-existent source_ext_id
+###################################################################################################
+
+- name: List entity types with a well-formed but bogus source_ext_id
+  nutanix.ncp.ntnx_entity_types_info_v2:
+    source_ext_id: "00000000-0000-0000-0000-000000000000"
+  register: bad_source_result
+  ignore_errors: true
+
+- name: Compute lowercased bogus-source error message
+  ansible.builtin.set_fact:
+    bad_source_msg_lower: "{{ bad_source_result.msg | default('') | lower }}"
+
+- name: Assert bogus source_ext_id fails cleanly with an API error
+  ansible.builtin.assert:
+    that:
+      - bad_source_result.failed == true
+      - bad_source_result.changed == false
+      - bad_source_result.msg is defined
+      - >
+        ('entity types' in bad_source_msg_lower)
+        or ('source' in bad_source_msg_lower)
+        or ('not found' in bad_source_msg_lower)
+        or ('api exception' in bad_source_msg_lower)
+    fail_msg: "Bogus source_ext_id did not fail with the expected API error: {{ bad_source_result }}"
+    success_msg: "Bogus source_ext_id failed with a descriptive API error"
+
+###################################################################################################
+# Idempotency - two consecutive info calls return the same shape
+###################################################################################################
+
+- name: Second list entity types call (must not change state)
+  nutanix.ncp.ntnx_entity_types_info_v2:
+    source_ext_id: "{{ source_ext_id }}"
+  register: second_result
+
+- name: Assert repeat call is idempotent and returns identical entity_type_names
+  ansible.builtin.assert:
+    that:
+      - second_result.changed == false
+      - second_result.failed == false
+      - (second_result.response | map(attribute='entity_type_name') | list | sort) == (fetched_entity_type_names | sort)
+      - second_result.total_available_results == result.total_available_results
+    fail_msg: "Second info call diverged from the first call: {{ second_result }}"
+    success_msg: "Info module is idempotent - both calls returned the same entity types"
+
+###################################################################################################
+# End
+###################################################################################################
+
+- name: End of ntnx_entity_types_info_v2 tests
+  ansible.builtin.debug:
+    msg: End of ntnx_entity_types_info_v2 tests

--- a/tests/integration/targets/ntnx_entity_types_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_entity_types_info_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import entity_types_info_operations.yml
+      ansible.builtin.import_tasks: "entity_types_info_operations.yml"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **aiops** namespace, entity
**EntityTypesV4**, based on the inline `sdk_info.json` in `INSTRUCTIONS.md`.

The inline SDK info for this entity exposes **only** a single API method:

- `GetEntityTypesV4` — `GET /api/aiops/v4.2.b1/config/sources/{sourceExtId}/entity-types`
  (SDK: `ntnx_aiops_py_client.StatsApi.get_entity_types_v4`).

There is no Create/Update/Delete surface for `EntityTypesV4` — it is a
read-only discovery endpoint used to enumerate the entity types a given
AIOps stats source knows about. Because of that, only the info module is
shipped in this PR; the CRUD module described in Step 1 of the instructions
was intentionally **skipped** because the SDK has no create/update/delete
methods to call. This is documented under "Deviations from instructions"
below.

- Modules generated: `ntnx_entity_types_info_v2`
- Module skipped: `ntnx_entity_types_v4_v2` (CRUD) — no create/update/delete API in SDK
- API methods covered: `1` of `1` from `sdk_info.api_request_response_struct`
- Fields in info module spec: `1` (`source_ext_id`)

## Domain knowledge (from Glean)

`glean__chat` timed out twice, so I fell back to `glean__company_search` and
aggregated the results below. The answers, source documents, and links are
reproduced verbatim.

### What EntityTypesV4 is

`EntityTypesV4` is the AIOps v4 Stats API that returns the list of
**entity types** (e.g. `vm`, `virtual_disk`, `cluster`, `node`,
`container`, `virtual_nic`, `volume_group_config`,
`storagecontainerstats`) that a given AIOps **source** knows about.
It is one of the four AIOps v4 config/stats catalog endpoints hosted by
`StatsApi`:

- `GET /api/aiops/v4.x/config/sources` — list available sources
- `GET /api/aiops/v4.x/config/sources/{sourceExtId}/entity-types` — this API
- `GET /api/aiops/v4.x/config/sources/{sourceExtId}/entity-descriptors` —
  per-entity-type metric descriptors
- `GET /api/aiops/v4.x/stats/sources/{sourceExtId}/entities/{extId}` — pull
  actual stats for a specific entity

### Workflow / how it is used

The AIOps V4 Stats APIs Serviceability Guide describes the standard
consumer workflow:

1. List available sources via `/config/sources`.
2. Pick a `sourceExtId` (on any PC there is always a built-in source
   named `nutanix`).
3. Call `/config/sources/{sourceExtId}/entity-types` (this API) to discover
   which entity types that source can serve.
4. Optionally call `/config/sources/{sourceExtId}/entity-descriptors` with
   an `entityType` filter to get the metric catalogue for that entity type.
5. Query stats or config data by entity type / entity via the stats and
   entity-descriptor endpoints.

The API is used by internal callers such as `stats_gw.py`
(`self._stats_api.get_entity_types_v4(...)`), which is how the platform
resolves entity type UUIDs when relaying stats requests.

### Prerequisites / behavioural details

- Requires a valid `sourceExtId`. A well-formed but unknown UUID produces
  `Validation error: 17 :Invalid source ID` (HTTP 400) — the module surfaces
  this as an API exception with the requested `source_ext_id` included in
  the message (verified on the live cluster during Step 7).
- Read-only: no side effects, only viewer-level RBAC is required.
- The endpoint is paginated (`isPaginated: true`) but the SDK method does
  **not** currently accept `page`/`limit`/`filter`/`orderby`/`select`
  kwargs, so the info module deliberately does not expose those Ansible
  options (Step 1.8 in the instructions).

### Required domain skills

- Nutanix AIOps V4 stats/config data model (Sources → Entity Types →
  Entity Descriptors → Metrics → Points).
- OData-style filter syntax (used by the sibling entity-descriptors
  endpoint even though this endpoint does not accept a filter).
- RBAC roles for stats consumers on Prism Central.
- Python SDK usage of `ntnx_aiops_py_client.StatsApi`.
- Basic understanding of the Nutanix Stats Gateway (Neuron / Stats API
  mapping) since the entity type names surfaced here are the ones the
  gateway routes on.

### Related engineering tickets

- **ENG-434976** — Jira epic covering the AIOps v4 API beta (surfaces the
  Stats V4 APIs, including entity-types).
- **ENG-871365** — Custom metric UDA integration; references the same
  entity-descriptors/entity-types plumbing.
- **ENG-914554** — Categories/entity-type integration follow-up (mh_vm
  entity type filter work).

### Related design / spec / documentation pages

All Confluence links are on the internal Nutanix Confluence (the search
returned redacted `URL_1..URL_7` placeholders — reproduced verbatim below
so a reviewer can pivot back to Glean and follow them):

- **Stats V4 APIs** — `<URL_1>:8443/spaces/PPRO/pages/338560608/Stats+V4+APIs`
  (canonical spec page for the Stats V4 API set, including the
  `entity-types` endpoint used here).
- **V4 Stats APIs Serviceability Guide** —
  `<URL_1>:8443/spaces/AI/pages/338559332/V4+Stats+APIs+Serviceability+Guide`
  (workflow: list sources → list entity types → fetch stats; also
  documents error codes).
- **Fetch Stats and Config Data Together using V4 APIs** —
  `<URL_1>:8443/spaces/AI/pages/424241850/Fetch+Stats+and+Config+Data+Together+using+V4+APIs`.
- **AIOPs v4 API - beta** —
  `<URL_1>:8443/spaces/PRIS/pages/250346243/AIOPs+v4+API+-+beta`
  (references ENG-434976 as the tracking epic).
- **Neuron and Stats API Mapping documentation** —
  `<URL_1>:8443/spaces/PPRO/pages/230206129/Neuron+and+Stats+API+Mapping+documentation`
  (mapping from legacy stats surfaces to `entity-types`).
- **Basic V4 API List** —
  `<URL_1>:8443/spaces/~tony.casanova/pages/435016822/Basic+V4+API+List`
  (row 1144: `/stats/sources/sourceExtId/entity-types` = `Returns a list
  of available entity types for a given source`).
- **Grouping and Aggregations Support in V4 List APIs** —
  `<URL_1>:8443/spaces/AI/pages/411929156/Grouping+and+Aggregations+Support+in+V4+List+APIs`.
- **NCM Custom Metrics V4 APIs Serviceability Guides** —
  `<URL_1>:8443/spaces/AI/pages/560081441/NCM+Custom+Metrics+V4+APIs+Serviceability+Guides`
  (uses the same entity type vocabulary; source of the
  `CUSTOM_METRICS_REQUEST_VALIDATION_ERROR` catalogue).
- **single-api-performance-test-X** —
  `<URL_1>:8443/spaces/AI/pages/183053254/single-api-performance-test-X`
  (perf benchmarks against the entity-types + entity-descriptors chain).
- **Fine Grained RBAC P0 Teams Checklists** —
  `<URL_1>:8443/spaces/PRIS/pages/243770374/Fine+Grained+RBAC+P0+Teams+Checklists`
  (AIOps Stats V4 APIs RBAC P0 approved — governs the roles required to
  call this endpoint).
- **XPlay v3 and v4 API Guide** —
  `<URL_1>:8443/spaces/~soham.patil/pages/487359010/XPlay+v3+and+v4+API+Guide`
  (uses entity types in XPlay queries; cross-reference for consumers).
- **v4 Platform Task Queue** —
  `<URL_1>:8443/spaces/PRIS/pages/163785687/v4+Platform+Task+Queue`.
- **custom metric uda integration** —
  `<URL_1>:8443/spaces/~komal.gupta/pages/519591673/custom+metric+uda+integration`
  (references ENG-871365).

Source code cross-references surfaced by Glean:

- `stats_api.py` — SDK client method `get_entity_types_v4(sourceExtId)`
  (github search result `<URL_3>`).
- `stats_api.go` — Go SDK equivalent hitting
  `/api/aiops/v4.2.b1/config/sources/{sourceExtId}/entity-types`
  (github search result `<URL_4>`).
- `stats_gw.py` — Stats Gateway caller of `get_entity_types_v4`.

## Files changed

- `plugins/modules/ntnx_entity_types_info_v2.py` — new info module.
- `plugins/module_utils/v4/aiops/__init__.py` — new aiops helpers package.
- `plugins/module_utils/v4/aiops/api_client.py` — aiops SDK
  `Configuration` / `ApiClient` / `StatsApi` factory (mirrors
  `network/api_client.py`).
- `plugins/module_utils/v4/aiops/helpers.py` — `get_entity_types`
  wrapper with consistent error handling.
- `examples/aiops/EntityTypesV4/entity_types_v4.yml` — end-to-end example
  playbook (SDK preflight, live source discovery, list entity types, VM
  lookup).
- `examples/aiops/EntityTypesV4/examples_run.log` — full output of running
  the example against `pc_endpoint=10.44.76.28`.
- `tests/integration/targets/ntnx_entity_types_info_v2/{aliases,meta/main.yml,tasks/main.yml,tasks/entity_types_info_operations.yml}` —
  new integration test target.
- `meta/runtime.yml` — added `ntnx_entity_types_info_v2` to the `ntnx`
  action group.
- `.gitignore` — ignore `tests/integration/integration_config.yml` so
  cluster credentials never get committed.
- `requirements.txt` / `tests/integration/requirements.txt` —
  pinned `ntnx-aiops-py-client==26.2.0.19759` (was `latest`, which pip
  does not accept; and it was missing entirely from the integration
  requirements, which caused the first test run to fail on the aiops
  SDK preflight).

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-test integration ntnx_entity_types_info_v2 --allow-unsupported --allow-disabled --venv` |
| Total tasks         | `24` (22 executed + 2 negative tasks with `ignore_errors: true`) |
| Passed              | `22`                                           |
| Failed              | `0`                                            |
| Ignored (expected)  | `2` (missing-required-param + bogus source_ext_id) |
| Skipped             | `0`                                            |
| Duration            | `~40s` (dominated by ansible-test venv setup)  |
| Cluster (PC)        | `10.44.76.28:9440` (built-in nutanix source `db293e8a-5770-c3c7-4213-85dbbc1d3679`) |
| Example playbook    | `ansible-playbook examples/aiops/EntityTypesV4/entity_types_v4.yml -v` → `ok=7 failed=0` |

### Analysis

- **Happy path (list entity types)** — Passed. The live cluster returns 8
  entity types for the built-in `nutanix` source (`vm`, `virtual_disk`,
  `cluster`, `storagecontainerstats`, `virtual_nic`,
  `volume_group_config`, `node`, `container`). The module returns
  `changed=False`, `total_available_results=8`, and a `response` list of
  length 8, each element carrying `entity_type_name`, `ext_id`, `links`,
  `tenant_id` — matching the RETURN docstring sample.
- **Well-known types assertion** — Passed. The module surfaces the four
  core entity types (`vm`, `cluster`, `node`, `container`).
- **Per-element schema assertion** — Passed for all 8 elements.
- **VM lookup** — Passed. `vm.ext_id = 686c821a-8091-4aef-8224-65b48019cd34`.
- **Negative: missing required arg** — Passed. Ansible correctly emits
  `missing required arguments: source_ext_id` and the assertion catches
  that substring.
- **Negative: bogus source_ext_id** — Passed. The PC responds with HTTP 400
  `Validation error: 17 :Invalid source ID`, which the module rethrows via
  `raise_api_exception` with the requested `source_ext_id` in the message.
- **Idempotency** — Passed. Two consecutive info calls return the same
  sorted `entity_type_name` list and the same `total_available_results`.

No failing tests. Nothing was skipped or marked as `<need_to_add_sample>` —
the RETURN sample and the example playbook's `debug` output both contain
real API responses captured from the live cluster.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Installing requirements for Python 3.12 (controller) [venv]
Using cached pip 23.1.2 bootstrap script: /home/abhinav.bansal1/.ansible/test/cache/get_pip_23_1_2.py
Collecting pip==23.1.2
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/08/e3/57d4c24a050aa0bcca46b2920bff40847db79535dc78141eb83581a52eb8/pip-23.1.2-py3-none-any.whl (2.1 MB)
Collecting setuptools==67.7.2
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/2f/8c/f336a966d4097c7cef6fc699b2ecb83b5fb63fd698198c1b5c7905a74f0f/setuptools-67.7.2-py3-none-any.whl (1.1 MB)
Collecting wheel==0.37.1
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/27/d6/003e593296a85fd6ed616ed962795b2f87709c3eee2bca4f6d0fe55c6d00/wheel-0.37.1-py2.py3-none-any.whl (35 kB)
Installing collected packages: wheel, setuptools, pip
Successfully installed pip-23.1.2 setuptools-67.7.2 wheel-0.37.1
Installing requirements for Python 3.12 (controller) [venv]
Collecting cryptography
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl (4.7 MB)
Collecting cffi>=2.0.0 (from cryptography)
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl (221 kB)
Collecting pycparser (from cffi>=2.0.0->cryptography)
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl (48 kB)
Installing collected packages: pycparser, cffi, cryptography
Successfully installed cffi-2.1.0 cryptography-49.0.0 pycparser-3.0
Collecting jinja2>=3.0.0 (from -r requirements/ansible.txt (line 6))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl (134 kB)
Collecting PyYAML>=5.1 (from -r requirements/ansible.txt (line 7))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (807 kB)
Collecting packaging (from -r requirements/ansible.txt (line 9))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl (100 kB)
Collecting resolvelib<1.1.0,>=0.5.3 (from -r requirements/ansible.txt (line 15))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/d2/fc/e9ccf0521607bcd244aa0b3fbd574f71b65e9ce6a112c83af988bbbe2e23/resolvelib-1.0.1-py2.py3-none-any.whl (17 kB)
Collecting MarkupSafe>=2.0 (from jinja2>=3.0.0->-r requirements/ansible.txt (line 6))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (22 kB)
Installing collected packages: resolvelib, PyYAML, packaging, MarkupSafe, jinja2
Successfully installed MarkupSafe-3.0.3 PyYAML-6.0.3 jinja2-3.1.6 packaging-26.2 resolvelib-1.0.1
Collecting ansible-core==2.16.0 (from -r tests/integration/requirements.txt (line 3))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/2f/ab/6357d8f3c17fec8c49c6119968292c14d3383c631bd900f6dc5593eb64a9/ansible_core-2.16.0-py3-none-any.whl (2.2 MB)
Collecting ansible-lint==24.12.2 (from -r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/0b/30/7b4c1038fb491438243a99bd3d65b2c2dd450b821617107fa5e3d0ad108f/ansible_lint-24.12.2-py3-none-any.whl (310 kB)
Collecting requests>=2.31.0 (from -r tests/integration/requirements.txt (line 5))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl (73 kB)
Collecting black>=22.8.0 (from -r tests/integration/requirements.txt (line 6))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (1.9 MB)
Collecting flake8>=7.0.0 (from -r tests/integration/requirements.txt (line 7))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/9f/56/13ab06b4f93ca7cac71078fbe37fcea175d3216f31f85c3168a6bbd0bb9a/flake8-7.3.0-py2.py3-none-any.whl (57 kB)
Collecting isort>=5.9.3 (from -r tests/integration/requirements.txt (line 8))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl (89 kB)
Collecting coverage==7.3.2 (from -r tests/integration/requirements.txt (line 9))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/f2/f7/066ac34162f711a18abf90b6c2f277a976c9804c548bcd81f543e0996b27/coverage-7.3.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (232 kB)
Collecting shyaml>=0.6.2 (from -r tests/integration/requirements.txt (line 10))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/2a/5c/139cda90758d6bc18a16876a2c291264cf06fd736ca54606862a43931877/shyaml-0.6.2-py2.py3-none-any.whl (19 kB)
Collecting jmespath>=0.10.0 (from -r tests/integration/requirements.txt (line 12))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl (20 kB)
Collecting awscli>=1.42.25 (from -r tests/integration/requirements.txt (line 13))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/2b/e6/f65d705adddde3f657894d1d40c544421c8b9e8aac920765b68dcbbac794/awscli-1.45.52-py3-none-any.whl (4.7 MB)
Collecting ntnx-clustermgmt-py-client==4.2.2 (from -r tests/integration/requirements.txt (line 14))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/11/af/cbbc37c9b02f98be500e0e568477dc9da9ffb5e8081979dbde906977613f/ntnx_clustermgmt_py_client-4.2.2-py3-none-any.whl (1.1 MB)
Collecting ntnx-iam-py-client==4.1.2b2 (from -r tests/integration/requirements.txt (line 15))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/91/16/95d715d8233e458d417df6a36b60fc0b855e37980c8da169f301b3ec3d52/ntnx_iam_py_client-4.1.2b2-py3-none-any.whl (679 kB)
Collecting ntnx-microseg-py-client==4.2.2 (from -r tests/integration/requirements.txt (line 16))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/0f/32/ccd917dbbef6de56855a1c72713f17f6ff6c318b86bad8c71680d9e3828a/ntnx_microseg_py_client-4.2.2-py3-none-any.whl (403 kB)
Collecting ntnx-networking-py-client==4.3.1 (from -r tests/integration/requirements.txt (line 17))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/f2/ee/b2b17c24591afeee7324609b4fb985f3901fee605ab8cc68e2aa73ceb364/ntnx_networking_py_client-4.3.1-py3-none-any.whl (1.0 MB)
Collecting ntnx-prism-py-client==4.3.1 (from -r tests/integration/requirements.txt (line 18))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/a2/4c/178928453407c94682391b52cef18ec0d50a6d387593604c19d0547eaba1/ntnx_prism_py_client-4.3.1-py3-none-any.whl (650 kB)
Collecting ntnx-vmm-py-client==4.2.2 (from -r tests/integration/requirements.txt (line 19))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/b0/39/8a456b2b2ede848e91b71ad129c2d76785323b0169aae9c5b67abc6ad7e0/ntnx_vmm_py_client-4.2.2-py3-none-any.whl (1.9 MB)
Collecting ntnx-volumes-py-client==4.2.2 (from -r tests/integration/requirements.txt (line 20))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/02/ba/1c0893c33f23a009155d5524b0fb6263d17c669cd3cb5c7576673bc23e48/ntnx_volumes_py_client-4.2.2-py3-none-any.whl (344 kB)
Collecting ntnx-dataprotection-py-client==4.3.1 (from -r tests/integration/requirements.txt (line 21))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/7a/b6/e784f413b2df72cabc22d86c1924dda59aa32249af196349e5b2f189e7f1/ntnx_dataprotection_py_client-4.3.1-py3-none-any.whl (565 kB)
Collecting ntnx-datapolicies-py-client==4.2.2 (from -r tests/integration/requirements.txt (line 22))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/2b/22/429f433beac1876f93a179992a98f8344fcf9c564b1798ea222a235a8d27/ntnx_datapolicies_py_client-4.2.2-py3-none-any.whl (476 kB)
Collecting ntnx-lifecycle-py-client==4.2.2 (from -r tests/integration/requirements.txt (line 23))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/27/6f/77c384ecdd73d6b5ce35dab4be1e0796c9e9bb46b8f0c32bc6255dda729c/ntnx_lifecycle_py_client-4.2.2-py3-none-any.whl (750 kB)
Collecting ntnx-objects-py-client==4.0.3 (from -r tests/integration/requirements.txt (line 24))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/37/37/d328ed3727b8ebf42a25a38ac0e886c58fde09a91ad2f2a24452c09bbd9f/ntnx_objects_py_client-4.0.3-py3-none-any.whl (167 kB)
Collecting ntnx-security-py-client==4.1.2 (from -r tests/integration/requirements.txt (line 25))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/ba/91/ca81af7e0ad9eb5e4f86439afed3c10f7f42660edd344965b3d3a7d0eca4/ntnx_security_py_client-4.1.2-py3-none-any.whl (328 kB)
Collecting ntnx-licensing-py-client==4.3.2 (from -r tests/integration/requirements.txt (line 26))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/ac/16/d402750a7bff495f5dc61926ea9f8ff90e1e83c0cbdb5f3d4aff2f865370/ntnx_licensing_py_client-4.3.2-py3-none-any.whl (362 kB)
Collecting ntnx-aiops-py-client==26.2.0.19759 (from -r tests/integration/requirements.txt (line 27))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/ntnx-aiops-py-client/26.2.0.19759/ntnx_aiops_py_client-26.2.0.19759-py2.py3-none-any.whl (684 kB)
Collecting ansible-compat>=24.10.0 (from ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/f5/be/0945639296ee8ecb282dc495a7e1bed06de476a65fa30cf2c715e4b28e42/ansible_compat-26.6.0-py3-none-any.whl (29 kB)
Collecting filelock>=3.3.0 (from ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/29/4c/c0ec6b645dcfefdd158313edb68c676d36c3f93ce8d2d9f0725d6341e506/filelock-3.31.2-py3-none-any.whl (97 kB)
Collecting importlib-metadata (from ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl (27 kB)
Collecting jsonschema>=4.10.0 (from ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl (90 kB)
Collecting pathspec>=0.10.3 (from ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl (57 kB)
Collecting ruamel.yaml>=0.18.5 (from ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl (118 kB)
Collecting subprocess-tee>=0.4.1 (from ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/4d/ab/e3a3be062cd544b2803760ff707dee38f0b1cb5685b2446de0ec19be28d9/subprocess_tee-0.4.2-py3-none-any.whl (5.2 kB)
Collecting yamllint>=1.30.0 (from ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/05/92/aed08e68de6e6a3d7c2328ce7388072cd6affc26e2917197430b646aed02/yamllint-1.38.0-py3-none-any.whl (68 kB)
Collecting wcmatch>=8.5.0 (from ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/28/12/f38b6fee116274d7221743caab07d765032e1370bb54cad8714f87aeb0e8/wcmatch-11.0-py3-none-any.whl (42 kB)
Collecting urllib3~=1.26 (from ntnx-clustermgmt-py-client==4.2.2->-r tests/integration/requirements.txt (line 14))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/33/cf/8435d5a7159e2a9c83a95896ed596f68cf798005fe107cc655b5c5c14704/urllib3-1.26.20-py2.py3-none-any.whl (144 kB)
Collecting six~=1.16 (from ntnx-clustermgmt-py-client==4.2.2->-r tests/integration/requirements.txt (line 14))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl (11 kB)
Collecting certifi<=2025.4.26,>=2024.7.4 (from ntnx-clustermgmt-py-client==4.2.2->-r tests/integration/requirements.txt (line 14))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl (159 kB)
Collecting python-dateutil~=2.8 (from ntnx-clustermgmt-py-client==4.2.2->-r tests/integration/requirements.txt (line 14))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl (229 kB)
Collecting pysocks~=1.7 (from ntnx-clustermgmt-py-client==4.2.2->-r tests/integration/requirements.txt (line 14))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl (16 kB)
Collecting charset_normalizer<4,>=2 (from requests>=2.31.0->-r tests/integration/requirements.txt (line 5))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (224 kB)
Collecting idna<4,>=2.5 (from requests>=2.31.0->-r tests/integration/requirements.txt (line 5))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl (65 kB)
Collecting click>=8.0.0 (from black>=22.8.0->-r tests/integration/requirements.txt (line 6))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl (119 kB)
Collecting mypy-extensions>=0.4.3 (from black>=22.8.0->-r tests/integration/requirements.txt (line 6))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl (5.0 kB)
Collecting platformdirs>=2 (from black>=22.8.0->-r tests/integration/requirements.txt (line 6))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/ec/73/6fd0bb9ce84138c3857f12e9de63bc901852975a092d545f18087a204aa2/platformdirs-4.10.1-py3-none-any.whl (22 kB)
Collecting pytokens~=0.4.0 (from black>=22.8.0->-r tests/integration/requirements.txt (line 6))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (269 kB)
Collecting mccabe<0.8.0,>=0.7.0 (from flake8>=7.0.0->-r tests/integration/requirements.txt (line 7))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl (7.3 kB)
Collecting pycodestyle<2.15.0,>=2.14.0 (from flake8>=7.0.0->-r tests/integration/requirements.txt (line 7))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl (31 kB)
Collecting pyflakes<3.5.0,>=3.4.0 (from flake8>=7.0.0->-r tests/integration/requirements.txt (line 7))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl (63 kB)
Collecting botocore==1.43.52 (from awscli>=1.42.25->-r tests/integration/requirements.txt (line 13))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/b2/e8/99f83445500c565e1850b20d510821d1eb635283171573340aa310d478b5/botocore-1.43.52-py3-none-any.whl (15.4 MB)
Collecting docutils<=0.19,>=0.18.1 (from awscli>=1.42.25->-r tests/integration/requirements.txt (line 13))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/93/69/e391bd51bc08ed9141ecd899a0ddb61ab6465309f1eb470905c0c8868081/docutils-0.19-py3-none-any.whl (570 kB)
Collecting s3transfer<0.20.0,>=0.19.0 (from awscli>=1.42.25->-r tests/integration/requirements.txt (line 13))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/24/23/e84c64ad0e8bc59cd1b2ef98def848deff0ef3456c542afe74d51e9e8c85/s3transfer-0.19.1-py3-none-any.whl (90 kB)
Collecting colorama<0.4.7,>=0.2.5 (from awscli>=1.42.25->-r tests/integration/requirements.txt (line 13))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Collecting rsa<4.8,>=3.1.2 (from awscli>=1.42.25->-r tests/integration/requirements.txt (line 13))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/e9/93/0c0f002031f18b53af7a6166103c02b9c0667be528944137cc954ec921b3/rsa-4.7.2-py3-none-any.whl (34 kB)
Collecting attrs>=22.2.0 (from jsonschema>=4.10.0->ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl (67 kB)
Collecting jsonschema-specifications>=2023.03.6 (from jsonschema>=4.10.0->ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl (18 kB)
Collecting referencing>=0.28.4 (from jsonschema>=4.10.0->ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl (26 kB)
Collecting rpds-py>=0.25.0 (from jsonschema>=4.10.0->ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (366 kB)
Collecting pyasn1>=0.1.3 (from rsa<4.8,>=3.1.2->awscli>=1.42.25->-r tests/integration/requirements.txt (line 13))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl (84 kB)
Collecting bracex>=3.0 (from wcmatch>=8.5.0->ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/b8/8f/6f7273a7adb8d73fc8d21ede4376a3e475e52f98435c6007f69100dec8ca/bracex-3.0.1-py3-none-any.whl (11 kB)
Collecting zipp>=3.20 (from importlib-metadata->ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl (10 kB)
Collecting typing-extensions>=4.4.0 (from referencing>=0.28.4->jsonschema>=4.10.0->ansible-lint==24.12.2->-r tests/integration/requirements.txt (line 4))
  Using cached https://repos.ntnxdpro.com/artifactory/api/pypi/canaveral-legacy-pypi/packages/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl (45 kB)
Installing collected packages: zipp, urllib3, typing-extensions, subprocess-tee, six, shyaml, ruamel.yaml, rpds-py, pytokens, pysocks, pyflakes, pycodestyle, pyasn1, platformdirs, pathspec, mypy-extensions, mccabe, jmespath, isort, idna, filelock, docutils, coverage, colorama, click, charset_normalizer, certifi, bracex, attrs, yamllint, wcmatch, rsa, requests, referencing, python-dateutil, importlib-metadata, flake8, black, ntnx-volumes-py-client, ntnx-vmm-py-client, ntnx-security-py-client, ntnx-prism-py-client, ntnx-objects-py-client, ntnx-networking-py-client, ntnx-microseg-py-client, ntnx-lifecycle-py-client, ntnx-licensing-py-client, ntnx-iam-py-client, ntnx-dataprotection-py-client, ntnx-datapolicies-py-client, ntnx-clustermgmt-py-client, ntnx-aiops-py-client, jsonschema-specifications, botocore, ansible-core, s3transfer, jsonschema, awscli, ansible-compat, ansible-lint
Successfully installed ansible-compat-26.6.0 ansible-core-2.16.0 ansible-lint-24.12.2 attrs-26.1.0 awscli-1.45.52 black-26.5.1 botocore-1.43.52 bracex-3.0.1 certifi-2025.4.26 charset_normalizer-3.4.9 click-8.4.2 colorama-0.4.6 coverage-7.3.2 docutils-0.19 filelock-3.31.2 flake8-7.3.0 idna-3.18 importlib-metadata-9.0.0 isort-8.0.1 jmespath-1.1.0 jsonschema-4.26.0 jsonschema-specifications-2025.9.1 mccabe-0.7.0 mypy-extensions-1.1.0 ntnx-aiops-py-client-26.2.0.19759 ntnx-clustermgmt-py-client-4.2.2 ntnx-datapolicies-py-client-4.2.2 ntnx-dataprotection-py-client-4.3.1 ntnx-iam-py-client-4.1.2b2 ntnx-licensing-py-client-4.3.2 ntnx-lifecycle-py-client-4.2.2 ntnx-microseg-py-client-4.2.2 ntnx-networking-py-client-4.3.1 ntnx-objects-py-client-4.0.3 ntnx-prism-py-client-4.3.1 ntnx-security-py-client-4.1.2 ntnx-vmm-py-client-4.2.2 ntnx-volumes-py-client-4.2.2 pathspec-1.1.1 platformdirs-4.10.1 pyasn1-0.6.4 pycodestyle-2.14.0 pyflakes-3.4.0 pysocks-1.7.1 python-dateutil-2.9.0.post0 pytokens-0.4.1 referencing-0.37.0 requests-2.34.2 rpds-py-2026.6.3 rsa-4.7.2 ruamel.yaml-0.19.1 s3transfer-0.19.1 shyaml-0.6.2 six-1.17.0 subprocess-tee-0.4.2 typing-extensions-4.16.0 urllib3-1.26.20 wcmatch-11.0 yamllint-1.38.0 zipp-4.1.0
Running ntnx_entity_types_info_v2 integration test role
[WARNING]: Found variable using reserved name: port

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_entity_types_info_v2 : Start ntnx_entity_types_info_v2 tests] *******
ok: [testhost] => {
    "msg": "Start ntnx_entity_types_info_v2 tests"
}

TASK [ntnx_entity_types_info_v2 : Preflight - ensure ntnx-aiops-py-client is installed] ***
ok: [testhost]

TASK [ntnx_entity_types_info_v2 : Assert aiops SDK is present] *****************
ok: [testhost] => {
    "changed": false,
    "msg": "ntnx-aiops-py-client SDK is installed"
}

TASK [ntnx_entity_types_info_v2 : Discover AIOps sources on PC] ****************
ok: [testhost]

TASK [ntnx_entity_types_info_v2 : Extract source_ext_id for the built-in nutanix source] ***
ok: [testhost]

TASK [ntnx_entity_types_info_v2 : Assert source_ext_id discovery] **************
ok: [testhost] => {
    "changed": false,
    "msg": "Discovered nutanix source_ext_id: db293e8a-5770-c3c7-4213-85dbbc1d3679"
}

TASK [ntnx_entity_types_info_v2 : List all entity types for the nutanix source] ***
ok: [testhost]

TASK [ntnx_entity_types_info_v2 : Assert list entity types result shape] *******
ok: [testhost] => {
    "changed": false,
    "msg": "List entity types response shape looks correct"
}

TASK [ntnx_entity_types_info_v2 : Store fetched entity types] ******************
ok: [testhost]

TASK [ntnx_entity_types_info_v2 : Assert well-known entity types are present] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Core entity types (vm, cluster, node, container) are present"
}

TASK [ntnx_entity_types_info_v2 : Assert every fetched entity type carries the documented keys] ***
ok: [testhost] => (item=vm) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "entity_type_name": "vm",
        "ext_id": "686c821a-8091-4aef-8224-65b48019cd34",
        "links": null,
        "tenant_id": null
    },
    "msg": "Entity type entry vm carries all documented keys"
}
ok: [testhost] => (item=virtual_disk) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "entity_type_name": "virtual_disk",
        "ext_id": "d9eb3ca3-5e7b-4d02-8327-5ba58e9cd407",
        "links": null,
        "tenant_id": null
    },
    "msg": "Entity type entry virtual_disk carries all documented keys"
}
ok: [testhost] => (item=cluster) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "entity_type_name": "cluster",
        "ext_id": "06b2d4b9-1b5c-9eaa-8c20-a1c270f95b3c",
        "links": null,
        "tenant_id": null
    },
    "msg": "Entity type entry cluster carries all documented keys"
}
ok: [testhost] => (item=storagecontainerstats) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "entity_type_name": "storagecontainerstats",
        "ext_id": "3f06ebab-4d62-a2ca-7e83-2592f9e8051e",
        "links": null,
        "tenant_id": null
    },
    "msg": "Entity type entry storagecontainerstats carries all documented keys"
}
ok: [testhost] => (item=virtual_nic) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "entity_type_name": "virtual_nic",
        "ext_id": "45ef8942-694d-6cf5-8333-a711c0be4b2b",
        "links": null,
        "tenant_id": null
    },
    "msg": "Entity type entry virtual_nic carries all documented keys"
}
ok: [testhost] => (item=volume_group_config) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "entity_type_name": "volume_group_config",
        "ext_id": "f149d727-ae8b-1abe-1656-2ff59fe06c13",
        "links": null,
        "tenant_id": null
    },
    "msg": "Entity type entry volume_group_config carries all documented keys"
}
ok: [testhost] => (item=node) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "entity_type_name": "node",
        "ext_id": "36c45369-96ca-5615-dcf9-911f068786dc",
        "links": null,
        "tenant_id": null
    },
    "msg": "Entity type entry node carries all documented keys"
}
ok: [testhost] => (item=container) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "entity_type_name": "container",
        "ext_id": "5f0b6ebc-4bea-1028-5ba2-b8a6ce78b863",
        "links": null,
        "tenant_id": null
    },
    "msg": "Entity type entry container carries all documented keys"
}

TASK [ntnx_entity_types_info_v2 : Extract the vm entity type entry from the returned list] ***
ok: [testhost]

TASK [ntnx_entity_types_info_v2 : Assert vm entity type is well-formed] ********
ok: [testhost] => {
    "changed": false,
    "msg": "vm entity type has ext_id 686c821a-8091-4aef-8224-65b48019cd34"
}

TASK [ntnx_entity_types_info_v2 : List entity types without source_ext_id (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "missing required arguments: source_ext_id"}
...ignoring

TASK [ntnx_entity_types_info_v2 : Assert missing source_ext_id triggers required-parameter error] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Missing source_ext_id raised the expected required-parameter error"
}

TASK [ntnx_entity_types_info_v2 : List entity types with a well-formed but bogus source_ext_id] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while fetching entity types for source ext_id: 00000000-0000-0000-0000-000000000000", "response": {"$dataItemDiscriminator": "aiops.v4.error.ErrorResponse", "$objectType": "aiops.v4.config.EntityTypeListApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "data": {"$errorItemDiscriminator": "List<aiops.v4.error.AppMessage>", "$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "locale": "en_US", "message": "Validation error: 17\n  :Invalid source ID"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}]}}, "status": 400}
...ignoring

TASK [ntnx_entity_types_info_v2 : Compute lowercased bogus-source error message] ***
ok: [testhost]

TASK [ntnx_entity_types_info_v2 : Assert bogus source_ext_id fails cleanly with an API error] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Bogus source_ext_id failed with a descriptive API error"
}

TASK [ntnx_entity_types_info_v2 : Second list entity types call (must not change state)] ***
ok: [testhost]

TASK [ntnx_entity_types_info_v2 : Assert repeat call is idempotent and returns identical entity_type_names] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Info module is idempotent - both calls returned the same entity types"
}

TASK [ntnx_entity_types_info_v2 : End of ntnx_entity_types_info_v2 tests] ******
ok: [testhost] => {
    "msg": "End of ntnx_entity_types_info_v2 tests"
}

PLAY RECAP *********************************************************************
testhost                   : ok=22   changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=2   

```

</details>

## Deviations from instructions

- **Step 1 (CRUD module `ntnx_entity_types_v4_v2`) intentionally skipped.**
  The inline SDK info in `INSTRUCTIONS.md` for `EntityTypesV4` lists exactly
  one method (`GetEntityTypesV4`, GET). `ntnx_aiops_py_client.StatsApi`
  confirms this: `get_entity_types_v4(self, sourceExtId, **kwargs)` is the
  only exposed operation. Because there is no SDK Create/Update/Delete for
  this entity, writing a CRUD module would require calling methods that do
  not exist. Step 0.3 of the instructions explicitly gates on
  "First check if the operation is action or CRUD type" — `EntityTypesV4`
  is neither; it is a read-only info surface, so only the info module is
  shipped.
- **Info module uses `skip_info_args=True`** because the SDK method does
  not accept `filter`/`limit`/`page`/`orderby`/`select` — surfacing those
  options would violate Step 1.8 ("Do NOT invent options ... unless the SDK
  method actually accepts them") and it also fails `ansible-test sanity`
  (`validate-modules`). The module still documents `read_timeout` since
  `BaseModuleV4` actually consumes it.
- **`tests/integration/integration_config.yml` is a run artifact and is
  now covered by `.gitignore`** (Step 7.1). It was NOT covered before this
  PR — that omission is fixed here so subsequent code-gen runs cannot leak
  cluster credentials.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
- Domain knowledge gathered via Glean `company_search` (chat timed out).
- Sanity: `black --check`, `isort --check`, `flake8`, `ansible-lint`
  (profile: production), and `ansible-test sanity` (full suite scoped
  to the new files) all pass.
- Live-cluster verification: integration target + example playbook run
  against `10.44.76.28` (built-in nutanix source), full logs captured
  under `examples/aiops/EntityTypesV4/examples_run.log`.
