### PR TITLE
WormCompliance Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml

--- a/examples/files/WormCompliance/enable_worm_compliance_v2.yml
+++ b/examples/files/WormCompliance/enable_worm_compliance_v2.yml
@@ -1,0 +1,33 @@
+---
+# Summary:
+# This playbook will do:
+# 1. Enable WORM compliance on a WORM-enabled mount target (share) of a file server
+#
+# Prerequisites:
+# - A file server must already exist on the cluster.
+# - The mount target (share) must already be WORM-enabled (worm_spec.worm_type set)
+#   before WORM compliance can be enabled on it.
+# - Enabling WORM compliance is an irreversible action.
+
+- name: WORM compliance playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: 10.44.76.28
+      nutanix_username: admin
+      nutanix_password: Nutanix.123
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        file_server_ext_id: "b2fb8f36-6b3a-4e1a-9b0e-3c2f7d1a9c4e"
+        mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+
+    - name: Enable WORM compliance on a mount target
+      nutanix.ncp.ntnx_files_worm_compliance_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ mount_target_ext_id }}"
+      register: result
+      ignore_errors: true

--- a/examples/files/WormCompliance/examples_run.log
+++ b/examples/files/WormCompliance/examples_run.log
@@ -1,0 +1,17 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [WORM compliance playbook] ************************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"file_server_ext_id": "b2fb8f36-6b3a-4e1a-9b0e-3c2f7d1a9c4e", "mount_target_ext_id": "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"}, "changed": false}
+
+TASK [Enable WORM compliance on a mount target] ********************************
+fatal: [localhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching mount target info using ext_id", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
+...ignoring
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=2    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,4 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_files_worm_compliance_v2

--- a/plugins/module_utils/v4/files/api_client.py
+++ b/plugins/module_utils/v4/files/api_client.py
@@ -1,0 +1,111 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_files_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details.
+    Args:
+        module (object): Ansible module object
+    return:
+        client (object): api client object
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_files_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_files_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_files_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_files_py_client.ApiClient(configuration=config)
+
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    # Setup API logging if debug is enabled
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    return:
+        etag (str): etag value
+    """
+    return ntnx_files_py_client.ApiClient.get_etag(data)
+
+
+def get_mount_target_api_instance(module):
+    """
+    This method will return MountTargetsApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): Mount Targets Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.MountTargetsApi(api_client=api_client)
+
+
+def get_file_server_api_instance(module):
+    """
+    This method will return FileServersApi instance.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): File Servers Api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_files_py_client.FileServersApi(api_client=api_client)

--- a/plugins/module_utils/v4/files/helpers.py
+++ b/plugins/module_utils/v4/files/helpers.py
@@ -1,0 +1,31 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_mount_target(module, api_instance, file_server_ext_id, ext_id):
+    """
+    This method will return mount target info using its file server and mount target ext_id.
+    Args:
+        module: Ansible module
+        api_instance: MountTargetsApi instance from ntnx_files_py_client sdk
+        file_server_ext_id (str): external ID of the file server the mount target belongs to
+        ext_id (str): mount target external ID
+    return:
+        info (object): mount target info
+    """
+    try:
+        return api_instance.get_mount_target_by_id(
+            fileServerExtId=file_server_ext_id, extId=ext_id
+        ).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching mount target info using ext_id",
+        )

--- a/plugins/modules/ntnx_files_worm_compliance_v2.py
+++ b/plugins/modules/ntnx_files_worm_compliance_v2.py
@@ -1,0 +1,242 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_files_worm_compliance_v2
+short_description: Enable WORM compliance on a Nutanix Files mount target (share)
+version_added: 2.7.0
+description:
+    - Enable Write Once Read Many (WORM) compliance on a WORM-enabled mount target (share) of a file server.
+    - Enabling WORM compliance is an irreversible action; once enabled it cannot be disabled on the share.
+    - The mount target must already be WORM-enabled before compliance can be enabled on it.
+    - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Enable WORM compliance) -
+      Required Roles: Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=files)"
+options:
+    state:
+        description:
+            - State of the module.
+            - If C(state) is present, the module will enable WORM compliance on the mount target.
+            - If C(state) is not present, the module will fail.
+        type: str
+        choices:
+            - present
+        default: present
+    file_server_ext_id:
+        description:
+            - The external identifier of the file server that the mount target belongs to.
+        type: str
+        required: true
+    ext_id:
+        description:
+            - The external identifier of the mount target (share) on which WORM compliance will be enabled.
+        type: str
+        required: true
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+    - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Enable WORM compliance on a mount target
+  nutanix.ncp.ntnx_files_worm_compliance_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    file_server_ext_id: "b2fb8f36-6b3a-4e1a-9b0e-3c2f7d1a9c4e"
+    ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+    description:
+        - Response for enabling WORM compliance on the mount target.
+        - Task details if C(wait) is true.
+        - Task details if C(wait) is false.
+    returned: always
+    type: dict
+    sample:
+        {
+            "cluster_ext_ids": [
+                "00061fa4-ef93-7dd8-185b-ac1f6b6f97e2"
+            ],
+            "completed_time": "2026-07-21T06:26:51.524581+00:00",
+            "completion_details": null,
+            "created_time": "2026-07-21T06:26:47.167906+00:00",
+            "entities_affected": [
+                {
+                    "ext_id": "9c1e537d-6777-4c22-5d41-ddd0c3337aa9",
+                    "name": "worm_share_ansible",
+                    "rel": "files:config:mount-target"
+                }
+            ],
+            "error_messages": null,
+            "ext_id": "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1",
+            "is_cancelable": false,
+            "last_updated_time": "2026-07-21T06:26:51.524581+00:00",
+            "legacy_error_message": null,
+            "operation": "EnableWormCompliance",
+            "operation_description": "Enable WORM compliance",
+            "owned_by": {
+                "ext_id": "00000000-0000-0000-0000-000000000000",
+                "name": "admin"
+            },
+            "parent_task": null,
+            "progress_percentage": 100,
+            "started_time": "2026-07-21T06:26:47.185754+00:00",
+            "status": "SUCCEEDED",
+            "sub_steps": null,
+            "sub_tasks": null,
+            "warnings": null
+        }
+
+changed:
+    description: This indicates whether the task resulted in any changes
+    returned: always
+    type: bool
+    sample: true
+
+msg:
+    description: This indicates the message if any message occurred
+    returned: When there is an error or in check mode
+    type: str
+    sample: "Api Exception raised while enabling WORM compliance for mount target"
+
+error:
+    description: This field typically holds information about if the task have errors that occurred during the task execution
+    returned: when an error occurs
+    type: str
+    sample: "Api Exception raised while fetching mount target info using ext_id"
+
+failed:
+    description: This field typically holds information about if the task have failed
+    returned: always
+    type: bool
+    sample: false
+
+task_ext_id:
+    description: The external ID of the task
+    returned: always
+    type: str
+    sample: "ZXJnb24=:0e040d14-5dcf-5302-8b48-d3c6cf115cd1"
+
+ext_id:
+    description: The external ID of the mount target on which WORM compliance was enabled
+    returned: always
+    type: str
+    sample: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.files.api_client import (  # noqa: E402
+    get_etag,
+    get_mount_target_api_instance,
+)
+from ..module_utils.v4.files.helpers import get_mount_target  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        file_server_ext_id=dict(type="str", required=True),
+        ext_id=dict(type="str", required=True),
+    )
+
+    return module_args
+
+
+def enable_worm_compliance(module, result, mount_targets):
+    file_server_ext_id = module.params.get("file_server_ext_id")
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = (
+            "WORM compliance will be enabled on the mount target with ext_id:{0} "
+            "of the file server with ext_id:{1}.".format(ext_id, file_server_ext_id)
+        )
+        return
+
+    mount_target = get_mount_target(module, mount_targets, file_server_ext_id, ext_id)
+    etag = get_etag(mount_target)
+    kwargs = {"if_match": etag} if etag else {}
+
+    resp = None
+    try:
+        resp = mount_targets.enable_worm_compliance(
+            fileServerExtId=file_server_ext_id, extId=ext_id, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while enabling WORM compliance for mount target",
+        )
+
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "error": None,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+    }
+    mount_targets = get_mount_target_api_instance(module)
+    enable_worm_compliance(module, result, mount_targets)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-files-py-client==latest

--- a/tests/integration/targets/ntnx_files_worm_compliance_v2/aliases
+++ b/tests/integration/targets/ntnx_files_worm_compliance_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_files_worm_compliance_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_files_worm_compliance_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_files_worm_compliance_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_files_worm_compliance_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import worm_compliance.yml
+      ansible.builtin.import_tasks: "worm_compliance.yml"

--- a/tests/integration/targets/ntnx_files_worm_compliance_v2/tasks/worm_compliance.yml
+++ b/tests/integration/targets/ntnx_files_worm_compliance_v2/tasks/worm_compliance.yml
@@ -1,0 +1,332 @@
+---
+# Test plan for ntnx_files_worm_compliance_v2 (Enable WORM compliance action module)
+#
+# The module wraps the Files v4 action:
+#   POST /api/files/v4.0/config/file-servers/{fileServerExtId}/mount-targets/{extId}/$actions/enable-worm-compliance
+# It only takes two path params (file_server_ext_id, ext_id) and no request body.
+#
+# Scenarios covered:
+#   1. check_mode enable with ALL attributes -> no API call, descriptive msg, changed=false.
+#   2. Negative: missing file_server_ext_id -> arg-spec validation error.
+#   3. Negative: missing ext_id -> arg-spec validation error.
+#   4. Negative: missing both required params -> arg-spec validation error.
+#   5. Negative: invalid state value (absent) -> choices validation error.
+#   6. Real API negative: enable on a non-existent reference -> module fails gracefully.
+#   7. Live end-to-end (only when a Files server + WORM-enabled share are discoverable):
+#        a. create a WORM-enabled mount target (prerequisite) via the Files v4 API,
+#        b. enable WORM compliance through the module and assert task success,
+#        c. verify worm_spec.is_compliance_enabled is true,
+#        d. negative: enable on a wrong mount target ext_id,
+#        e. clean up the created mount target.
+#
+# NOTE: WORM compliance is irreversible; the live block is gated behind the
+# availability of the Files service so it is skipped cleanly on clusters where
+# Files is not deployed.
+
+- name: Start ntnx_files_worm_compliance_v2 tests
+  ansible.builtin.debug:
+    msg: Start ntnx_files_worm_compliance_v2 tests
+
+- name: Generate random names
+  ansible.builtin.set_fact:
+    random_name: "{{ 99999999 | random | string }}"
+    suffix_name: "ansible"
+
+- name: Set share name and dummy external IDs
+  ansible.builtin.set_fact:
+    share_name: "worm_{{ suffix_name }}_{{ random_name }}"
+    dummy_file_server_ext_id: "b2fb8f36-6b3a-4e1a-9b0e-3c2f7d1a9c4e"
+    dummy_mount_target_ext_id: "9c1e537d-6777-4c22-5d41-ddd0c3337aa9"
+
+########################################################################################
+# check_mode
+########################################################################################
+
+- name: Enable WORM compliance in check mode with all attributes
+  nutanix.ncp.ntnx_files_worm_compliance_v2:
+    state: present
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+    ext_id: "{{ dummy_mount_target_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Enable WORM compliance in check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == dummy_mount_target_ext_id
+      - "'will be enabled' in result.msg"
+      - dummy_mount_target_ext_id in result.msg
+      - dummy_file_server_ext_id in result.msg
+    success_msg: "Enable WORM compliance check mode generated the expected result"
+    fail_msg: "Enable WORM compliance check mode did not behave as expected"
+
+########################################################################################
+# Negative / argument-spec validation tests (no API calls)
+########################################################################################
+
+- name: Enable WORM compliance with missing file_server_ext_id
+  nutanix.ncp.ntnx_files_worm_compliance_v2:
+    state: present
+    ext_id: "{{ dummy_mount_target_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Enable WORM compliance with missing file_server_ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'file_server_ext_id' in result.msg"
+    success_msg: "Missing file_server_ext_id failed as expected"
+    fail_msg: "Missing file_server_ext_id did not fail as expected"
+
+- name: Enable WORM compliance with missing ext_id
+  nutanix.ncp.ntnx_files_worm_compliance_v2:
+    state: present
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Enable WORM compliance with missing ext_id status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'ext_id' in result.msg"
+    success_msg: "Missing ext_id failed as expected"
+    fail_msg: "Missing ext_id did not fail as expected"
+
+- name: Enable WORM compliance with missing required params
+  nutanix.ncp.ntnx_files_worm_compliance_v2:
+    state: present
+  register: result
+  ignore_errors: true
+
+- name: Enable WORM compliance with missing required params status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'missing required arguments' in result.msg"
+    success_msg: "Missing required params failed as expected"
+    fail_msg: "Missing required params did not fail as expected"
+
+- name: Enable WORM compliance with invalid state value
+  nutanix.ncp.ntnx_files_worm_compliance_v2:
+    state: absent
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+    ext_id: "{{ dummy_mount_target_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Enable WORM compliance with invalid state value status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state' in result.msg"
+    success_msg: "Invalid state value failed as expected"
+    fail_msg: "Invalid state value did not fail as expected"
+
+########################################################################################
+# Real API negative test - enable on a non-existent reference
+########################################################################################
+
+- name: Enable WORM compliance on a non-existent reference
+  nutanix.ncp.ntnx_files_worm_compliance_v2:
+    state: present
+    file_server_ext_id: "{{ dummy_file_server_ext_id }}"
+    ext_id: "{{ dummy_mount_target_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Enable WORM compliance on a non-existent reference status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg is defined
+    success_msg: "Enable WORM compliance on a non-existent reference failed as expected"
+    fail_msg: "Enable WORM compliance on a non-existent reference did not fail as expected"
+
+########################################################################################
+# Discover Files service / file servers to decide if the live workflow can run
+########################################################################################
+
+- name: List file servers on the cluster
+  ansible.builtin.uri:
+    url: "https://{{ ip }}:{{ port | default('9440') }}/api/files/v4.0/config/file-servers?$limit=1"
+    method: GET
+    user: "{{ username }}"
+    password: "{{ password }}"
+    force_basic_auth: true
+    validate_certs: false
+    status_code: [200, 400, 401, 403, 404, 500, 503]
+    return_content: true
+  register: file_servers_resp
+  ignore_errors: true
+
+- name: Set file server availability facts
+  ansible.builtin.set_fact:
+    files_available: >-
+      {{ (file_servers_resp.status | default(0)) == 200
+         and (file_servers_resp.json.data | default([]) | length) > 0 }}
+
+- name: Print live workflow status
+  ansible.builtin.debug:
+    msg: >-
+      Files service reachable with file servers: {{ files_available }}.
+      Live enable-worm-compliance workflow will {{ 'run' if files_available else 'be skipped' }}.
+
+########################################################################################
+# Live end-to-end workflow (only when a file server exists)
+########################################################################################
+
+- name: Live WORM compliance workflow
+  when: files_available | bool
+  block:
+    - name: Set file server ext_id from discovery
+      ansible.builtin.set_fact:
+        file_server_ext_id: "{{ file_servers_resp.json.data[0].extId }}"
+
+    - name: Create a WORM-enabled mount target (prerequisite)
+      ansible.builtin.uri:
+        url: "https://{{ ip }}:{{ port | default('9440') }}/api/files/v4.0/config/file-servers/{{ file_server_ext_id }}/mount-targets"
+        method: POST
+        user: "{{ username }}"
+        password: "{{ password }}"
+        force_basic_auth: true
+        validate_certs: false
+        body_format: json
+        body:
+          name: "{{ share_name }}"
+          type: STANDARD
+          protocol: NFS
+          wormSpec:
+            wormType: SHARE_LEVEL
+            cooloffIntervalSeconds: 60
+            retentionPeriodSeconds: 120
+        status_code: [200, 202]
+        return_content: true
+      register: create_share_resp
+      ignore_errors: true
+
+    - name: Wait for the create mount target task to complete
+      ansible.builtin.uri:
+        url: "https://{{ ip }}:{{ port | default('9440') }}/api/prism/v4.0/config/tasks/{{ create_share_resp.json.data.extId }}"
+        method: GET
+        user: "{{ username }}"
+        password: "{{ password }}"
+        force_basic_auth: true
+        validate_certs: false
+        status_code: [200]
+        return_content: true
+      register: create_task_resp
+      until: create_task_resp.json.data.status in ['SUCCEEDED', 'FAILED']
+      retries: 30
+      delay: 10
+      ignore_errors: true
+
+    - name: Fetch the created WORM-enabled mount target ext_id
+      ansible.builtin.uri:
+        url: >-
+          https://{{ ip }}:{{ port | default('9440') }}/api/files/v4.0/config/file-servers/{{ file_server_ext_id }}/mount-targets?$filter=name eq '{{ share_name }}'
+        method: GET
+        user: "{{ username }}"
+        password: "{{ password }}"
+        force_basic_auth: true
+        validate_certs: false
+        status_code: [200]
+        return_content: true
+      register: share_lookup_resp
+      ignore_errors: true
+
+    - name: Set mount target ext_id
+      ansible.builtin.set_fact:
+        mount_target_ext_id: "{{ share_lookup_resp.json.data[0].extId }}"
+
+    - name: Enable WORM compliance on the mount target
+      nutanix.ncp.ntnx_files_worm_compliance_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ mount_target_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Enable WORM compliance on the mount target status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.ext_id == mount_target_ext_id
+          - result.task_ext_id is defined
+          - result.response is defined
+          - result.response.status == "SUCCEEDED"
+          - result.response.operation == "EnableWormCompliance"
+        success_msg: "WORM compliance enabled successfully on the mount target"
+        fail_msg: "WORM compliance enable failed on the mount target"
+
+    - name: Verify WORM compliance is enabled on the mount target
+      ansible.builtin.uri:
+        url: "https://{{ ip }}:{{ port | default('9440') }}/api/files/v4.0/config/file-servers/{{ file_server_ext_id }}/mount-targets/{{ mount_target_ext_id }}"
+        method: GET
+        user: "{{ username }}"
+        password: "{{ password }}"
+        force_basic_auth: true
+        validate_certs: false
+        status_code: [200]
+        return_content: true
+      register: verify_resp
+      ignore_errors: true
+
+    - name: Verify WORM compliance is enabled status
+      ansible.builtin.assert:
+        that:
+          - verify_resp.json.data.wormSpec.isComplianceEnabled == true
+        success_msg: "Mount target is now WORM-compliance enabled"
+        fail_msg: "Mount target WORM compliance flag was not set"
+
+    - name: Enable WORM compliance on a wrong mount target ext_id
+      nutanix.ncp.ntnx_files_worm_compliance_v2:
+        state: present
+        file_server_ext_id: "{{ file_server_ext_id }}"
+        ext_id: "{{ dummy_mount_target_ext_id }}"
+      register: result
+      ignore_errors: true
+
+    - name: Enable WORM compliance on a wrong mount target ext_id status
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == true
+        success_msg: "Enable WORM compliance on a wrong mount target ext_id failed as expected"
+        fail_msg: "Enable WORM compliance on a wrong mount target ext_id did not fail as expected"
+
+  always:
+    - name: Clean up the created mount target (best effort)
+      ansible.builtin.uri:
+        url: "https://{{ ip }}:{{ port | default('9440') }}/api/files/v4.0/config/file-servers/{{ file_server_ext_id }}/mount-targets/{{ mount_target_ext_id }}"
+        method: DELETE
+        user: "{{ username }}"
+        password: "{{ password }}"
+        force_basic_auth: true
+        validate_certs: false
+        status_code: [200, 202, 400, 404, 409]
+      register: cleanup_resp
+      when: mount_target_ext_id is defined
+      ignore_errors: true
+
+- name: Finish ntnx_files_worm_compliance_v2 tests
+  ansible.builtin.debug:
+    msg: Finish ntnx_files_worm_compliance_v2 tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection module for the **files** namespace, entity
**WormCompliance**, based on the inline `sdk_info.json`. One PR per code-gen run.

`WormCompliance` maps to the Files v4 action `EnableWormCompliance`
(`POST /api/files/v4.0/config/file-servers/{fileServerExtId}/mount-targets/{extId}/$actions/enable-worm-compliance`).
It takes only two path parameters and no request body, so it was implemented as an
**action-type** module (patterned after `ntnx_vm_revert_v2` /
`ntnx_promote_protected_resources_v2`). Per the instructions, the info module
(Step 2) is skipped for action-type entities — there is no `Get/List WormCompliance`
API; the only WORM-compliance operation exposed by the SDK is the enable action.

- Module generated: `ntnx_files_worm_compliance_v2` (action module)
- Info module: not applicable (action-type entity — no list/get API)
- API methods covered: `1` (`EnableWormCompliance`) of the 9 `MountTargetsApi` methods in the inline SDK info
- Fields in module spec: `3` (`state`, `file_server_ext_id`, `ext_id`)

## Domain knowledge (from Glean)

Domain context was gathered via the Glean MCP tools (the `glean__chat` endpoint
timed out, so `glean__company_search` was used). Per the repo hard rules, no
internal links, ticket IDs, Jira or Confluence URLs are reproduced here — only the
behavioural understanding used to build the module, tests and examples:

- **What it is** — Nutanix Files supports WORM (Write Once Read Many) on a mount
  target (share). A share is first made *WORM-enabled* by setting its `wormSpec`
  (`wormType: SHARE_LEVEL`, plus a `cooloffIntervalSeconds` and
  `retentionPeriodSeconds`). Enabling *WORM compliance* on such a share flips the
  read-only `wormSpec.isComplianceEnabled` flag to `true`.
- **Workflow** — files written to a WORM-compliance share transition through
  states (unlocked during the cool-off window, then locked/immutable for the
  retention period). Compliance is the strict variant of WORM.
- **Prerequisites** — the share must already be WORM-enabled; the file server and
  mount target must exist. Enabling compliance on a non-WORM share is rejected by
  the gateway validator.
- **Behavioural details / irreversibility** — enabling WORM compliance cannot be
  undone on the share, and a WORM-compliance share cannot be force-deleted. This is
  why the module is a one-way action (`state: present` only) and why the live
  integration workflow is gated behind cluster availability rather than run
  unconditionally.
- **Required skills** — Nutanix Files shares / mount targets, the WORM data model
  (`wormType`, cool-off vs retention, compliance vs legal hold), and the Files v4
  action API semantics (path-param actions returning an async task).

## Files changed

**plugins/modules/**
- `ntnx_files_worm_compliance_v2.py` — new action module (enable WORM compliance).

**plugins/module_utils/v4/files/**
- `api_client.py` — new Files SDK client helpers (`get_api_client`, `get_etag`,
  `get_mount_target_api_instance`, `get_file_server_api_instance`).
- `helpers.py` — new `get_mount_target` helper (fetch mount target + etag).

**meta/**
- `runtime.yml` — added `ntnx_files_worm_compliance_v2` to the `ntnx` action group.

**examples/files/WormCompliance/**
- `enable_worm_compliance_v2.yml` — example playbook (uses play-level `module_defaults`).
- `examples_run.log` — real output from running the example against the cluster.

**tests/integration/targets/ntnx_files_worm_compliance_v2/**
- `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/worm_compliance.yml` — integration tests.

**.gitignore**
- added `tests/integration/integration_config.yml` so the credentials file is never committed.

## Test execution

| Metric              | Value                                                                                          |
|---------------------|------------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_files_worm_compliance_v2 --allow-disabled --allow-unsupported --local --python 3.11` |
| Tasks OK            | `20`                                                                                           |
| Failed              | `0`                                                                                            |
| Ignored (expected)  | `5` (negative tests that intentionally fail-and-assert)                                        |
| Skipped             | `12` (live enable workflow — see analysis)                                                     |
| Duration            | `~0:01:40`                                                                                     |
| Cluster (PC)        | `10.44.76.28`                                                                                  |
| Example run         | `ansible-playbook examples/files/WormCompliance/enable_worm_compliance_v2.yml` — play completed (`failed=0`) |

### Analysis

All assertions passed (`failed=0`). Coverage that executed on the live PC:

- **check_mode** enable with all attributes — asserts `changed=false`, `failed=false`,
  the returned `ext_id`, and the descriptive `msg`.
- **Argument-spec negatives** — missing `file_server_ext_id`, missing `ext_id`,
  missing both, and an invalid `state` value each fail with the expected message.
- **Real API negative** — enabling on a non-existent reference hits the live API and
  the module fails gracefully with `Api Exception raised while fetching mount target
  info using ext_id` (the cluster returned `503 SERVICE UNAVAILABLE`).

**Why the live enable workflow was skipped (12 skipped tasks):** the Files service is
not deployed on PC `10.44.76.28`. The v4 endpoint
`GET /api/files/v4.0/config/file-servers` returns
`Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2`
(a backend `503`), while other PC v4 namespaces (e.g. `clustermgmt`) respond
normally. With no file server available, a WORM-enabled share cannot be created, so
the end-to-end enable + verify block is gated behind a discovery check and skipped
cleanly (the test prints an explicit skip message). For the same reason the example's
enable task returns `503` and is captured (with `ignore_errors`) in
`examples_run.log`; response `sample:` values in the module `RETURN` therefore use a
realistic constructed task response rather than live-captured output.

### Test logs (tail)

<details>
<summary>tail of test_logs.log</summary>

```text
TASK [ntnx_files_worm_compliance_v2 : Enable WORM compliance with invalid state value] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "value of state must be one of: present, got: absent"}
...ignoring

TASK [ntnx_files_worm_compliance_v2 : Enable WORM compliance on a non-existent reference] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "SERVICE UNAVAILABLE", "msg": "Api Exception raised while fetching mount target info using ext_id", "response": {"message": "Http request to endpoint 0:127.0.0.1:7509 failed with error. Response status: 2"}, "status": 503}
...ignoring

TASK [ntnx_files_worm_compliance_v2 : Print live workflow status] **************
ok: [testhost] => {
    "msg": "Files service reachable with file servers: False. Live enable-worm-compliance workflow will be skipped."
}

... (live enable/verify/cleanup block skipped) ...

PLAY RECAP *********************************************************************
testhost                   : ok=20   changed=0    unreachable=0    failed=0    skipped=12   rescued=0    ignored=5
```

</details>

Lint / sanity gate: `black`, `isort`, `flake8` all clean on the new files;
`ansible-test sanity` passes all 32 tests for the new module and module_utils.

### Known deviations

- **SDK import block (instruction 1.5):** the instructions ask for the
  `import ntnx_files_py_client as files_sdk` + `sdk_mock` fallback block in the
  module. This action has **no request body**, so the alias would be an unused
  import that fails the mandatory `ansible-test sanity` pylint gate. Following the
  merged action module `ntnx_promote_protected_resources_v2`, the SDK-missing guard
  is handled in `module_utils/v4/files/api_client.py` (`missing_required_lib`) and
  the module does not import the SDK directly.

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
