### PR TITLE
code-gen(aiops/Simulation): ansible collection modules

### DIFF
--- a/examples/aiops/Simulation/examples_run.log
+++ b/examples/aiops/Simulation/examples_run.log
@@ -1,0 +1,37 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Simulation playbook (aiops)] *********************************************
+
+TASK [Set common variables for the playbook] ***********************************
+ok: [localhost] => {"ansible_facts": {"simulation_name": "simulation_ansible_example"}, "changed": false}
+
+TASK [Create a Simulation with all fields] *************************************
+changed: [localhost] => {"changed": true, "ext_id": "3c2f3473-9e99-4d9b-8d1b-f0bf5b1de10c", "response": {"ext_id": "3c2f3473-9e99-4d9b-8d1b-f0bf5b1de10c", "links": null, "name": "simulation_ansible_example", "simulation_spec": {"hdd_gb": 100.0, "ram_gb": 8.0, "ssd_gb": 50.0, "vcpu_count": 4}, "tenant_id": null}, "task_ext_id": null}
+
+TASK [Capture created Simulation ext_id] ***************************************
+ok: [localhost] => {"ansible_facts": {"simulation_ext_id": "3c2f3473-9e99-4d9b-8d1b-f0bf5b1de10c"}, "changed": false}
+
+TASK [Update the Simulation with all fields] ***********************************
+changed: [localhost] => {"changed": true, "ext_id": "3c2f3473-9e99-4d9b-8d1b-f0bf5b1de10c", "response": {"ext_id": "3c2f3473-9e99-4d9b-8d1b-f0bf5b1de10c", "links": null, "name": "simulation_ansible_example_updated", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 100.0, "vcpu_count": 8}, "tenant_id": null}, "task_ext_id": null}
+
+TASK [Get Simulation using ext_id] *********************************************
+ok: [localhost] => {"changed": false, "ext_id": "3c2f3473-9e99-4d9b-8d1b-f0bf5b1de10c", "response": {"ext_id": "3c2f3473-9e99-4d9b-8d1b-f0bf5b1de10c", "links": null, "name": "simulation_ansible_example_updated", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 100.0, "vcpu_count": 8}, "tenant_id": null}}
+
+TASK [List all Simulations] ****************************************************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "3c2f3473-9e99-4d9b-8d1b-f0bf5b1de10c", "links": null, "name": "simulation_ansible_example_updated", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 100.0, "vcpu_count": 8}, "tenant_id": null}], "total_available_results": 1}
+
+TASK [List Simulations with filter (by name)] **********************************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "3c2f3473-9e99-4d9b-8d1b-f0bf5b1de10c", "links": null, "name": "simulation_ansible_example_updated", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 100.0, "vcpu_count": 8}, "tenant_id": null}], "total_available_results": 1}
+
+TASK [List Simulations with limit] *********************************************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "3c2f3473-9e99-4d9b-8d1b-f0bf5b1de10c", "links": null, "name": "simulation_ansible_example_updated", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 100.0, "vcpu_count": 8}, "tenant_id": null}], "total_available_results": 1}
+
+TASK [Delete the Simulation] ***************************************************
+changed: [localhost] => {"changed": true, "ext_id": "3c2f3473-9e99-4d9b-8d1b-f0bf5b1de10c", "msg": "Simulation with ext_id:3c2f3473-9e99-4d9b-8d1b-f0bf5b1de10c deleted successfully.", "response": {"status": "SUCCEEDED"}, "task_ext_id": null}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=9    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/aiops/Simulation/simulation_v2.yml
+++ b/examples/aiops/Simulation/simulation_v2.yml
@@ -1,0 +1,83 @@
+---
+# Summary:
+# This playbook demonstrates end-to-end usage of the aiops Simulation modules:
+#   1. Create a Simulation (VM workload capacity spec)
+#   2. Update the Simulation
+#   3. Get Simulation using ext_id
+#   4. List all Simulations (with filter and limit variants)
+#   5. Delete the Simulation
+
+- name: Simulation playbook (aiops)
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ lookup('env', 'NUTANIX_HOST') | default('10.44.76.28', true) }}"
+      nutanix_username: "{{ lookup('env', 'NUTANIX_USERNAME') | default('admin', true) }}"
+      nutanix_password: "{{ lookup('env', 'NUTANIX_PASSWORD') | default('Nutanix.123', true) }}"
+      nutanix_port: "{{ lookup('env', 'NUTANIX_PORT') | default(9440, true) }}"
+      validate_certs: false
+  tasks:
+    - name: Set common variables for the playbook
+      ansible.builtin.set_fact:
+        simulation_name: "simulation_ansible_example"
+
+    - name: Create a Simulation with all fields
+      nutanix.ncp.ntnx_simulation_v2:
+        state: present
+        name: "{{ simulation_name }}"
+        simulation_spec:
+          vcpu_count: 4
+          ram_gb: 8.0
+          hdd_gb: 100.0
+          ssd_gb: 50.0
+      register: create_result
+      ignore_errors: true
+
+    - name: Capture created Simulation ext_id
+      ansible.builtin.set_fact:
+        simulation_ext_id: "{{ create_result.ext_id }}"
+      when: create_result.ext_id is defined and create_result.ext_id | length > 0
+
+    - name: Update the Simulation with all fields
+      nutanix.ncp.ntnx_simulation_v2:
+        state: present
+        ext_id: "{{ simulation_ext_id }}"
+        name: "{{ simulation_name }}_updated"
+        simulation_spec:
+          vcpu_count: 8
+          ram_gb: 16.0
+          hdd_gb: 200.0
+          ssd_gb: 100.0
+      register: update_result
+      ignore_errors: true
+
+    - name: Get Simulation using ext_id
+      nutanix.ncp.ntnx_simulations_info_v2:
+        ext_id: "{{ simulation_ext_id }}"
+      register: get_result
+      ignore_errors: true
+
+    - name: List all Simulations
+      nutanix.ncp.ntnx_simulations_info_v2:
+      register: list_result
+      ignore_errors: true
+
+    - name: List Simulations with filter (by name)
+      nutanix.ncp.ntnx_simulations_info_v2:
+        filter: "name eq '{{ simulation_name }}_updated'"
+      register: list_filtered_result
+      ignore_errors: true
+
+    - name: List Simulations with limit
+      nutanix.ncp.ntnx_simulations_info_v2:
+        limit: 1
+      register: list_limited_result
+      ignore_errors: true
+
+    - name: Delete the Simulation
+      nutanix.ncp.ntnx_simulation_v2:
+        state: absent
+        ext_id: "{{ simulation_ext_id }}"
+      register: delete_result
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_simulation_v2
+    - ntnx_simulations_info_v2

--- a/plugins/module_utils/v4/aiops/api_client.py
+++ b/plugins/module_utils/v4/aiops/api_client.py
@@ -1,0 +1,91 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    Build an authenticated aiops SDK ApiClient using the module's connection
+    parameters.
+
+    Args:
+        module (object): Ansible module object
+    Returns:
+        client (object): api client object
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_aiops_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_aiops_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_aiops_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    Fetch the ETag header from a v4 aiops SDK response.
+    """
+    return ntnx_aiops_py_client.ApiClient.get_etag(data)
+
+
+def get_scenarios_api_instance(module):
+    """
+    Build a ScenariosApi instance for the aiops namespace. The SDK groups both
+    Scenario and Simulation endpoints under this single receiver.
+    """
+    api_client = get_api_client(module)
+    return ntnx_aiops_py_client.ScenariosApi(api_client=api_client)

--- a/plugins/module_utils/v4/aiops/helpers.py
+++ b/plugins/module_utils/v4/aiops/helpers.py
@@ -1,0 +1,30 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_simulation(module, api_instance, ext_id):
+    """
+    Fetch a single Simulation using its external ID.
+
+    Args:
+        module: Ansible module
+        api_instance: ScenariosApi instance from the ntnx_aiops_py_client SDK.
+        ext_id (str): External ID of the Simulation.
+
+    Returns:
+        info (object): Simulation info object
+    """
+    try:
+        return api_instance.get_simulation_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching simulation info using ext_id",
+        )

--- a/plugins/modules/ntnx_simulation_v2.py
+++ b/plugins/modules/ntnx_simulation_v2.py
@@ -1,0 +1,451 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_simulation_v2
+short_description: Create, Update, Delete a Simulation in Nutanix Prism Central (aiops)
+version_added: 2.5.0
+description:
+  - This module allows you to create, update, and delete a Simulation in Nutanix Prism Central.
+  - A Simulation captures a projected VM workload (vCPU, RAM, storage) that can be
+    referenced from a capacity planning Scenario.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+      The required roles depend on the operation being performed.
+    - >-
+      B(Create a Simulation) -
+      Required Roles: Prism Admin, Super Admin
+    - >-
+      B(Update a Simulation) -
+      Required Roles: Prism Admin, Super Admin
+    - >-
+      B(Delete a Simulation) -
+      Required Roles: Prism Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will be create Simulation.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be update Simulation.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be delete Simulation.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the Simulation.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - Name of the resource used in a scenario.
+      - Required for create operation.
+      - Minimum 1 character, maximum 256 characters.
+    type: str
+    required: false
+  simulation_spec:
+    description:
+      - Simulated resource specification for the VM workload used in the Simulation.
+    type: dict
+    required: false
+    suboptions:
+      vcpu_count:
+        description:
+          - Number of vCPUs for the simulated VM workload.
+        type: int
+        required: false
+      ram_gb:
+        description:
+          - Amount of RAM in GB for the simulated VM workload.
+        type: float
+        required: false
+      hdd_gb:
+        description:
+          - Amount of HDD storage in GB for the simulated VM workload.
+        type: float
+        required: false
+      ssd_gb:
+        description:
+          - Amount of SSD storage in GB for the simulated VM workload.
+        type: float
+        required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create simulation
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "simulation_ansible"
+    simulation_spec:
+      vcpu_count: 4
+      ram_gb: 8.0
+      hdd_gb: 100.0
+      ssd_gb: 50.0
+  register: result
+  ignore_errors: true
+
+- name: Update simulation
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+    name: "simulation_ansible_updated"
+    simulation_spec:
+      vcpu_count: 8
+      ram_gb: 16.0
+      hdd_gb: 200.0
+      ssd_gb: 100.0
+  register: result
+  ignore_errors: true
+
+- name: Delete simulation
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting a Simulation.
+    - For create and update operations it returns the Simulation details.
+    - For delete operations it returns a status dict indicating SUCCEEDED.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "3236a842-f0c6-42a6-a6da-4cff299d219b",
+      "links": null,
+      "name": "simulation_ansible_example_updated",
+      "simulation_spec": {
+          "hdd_gb": 200.0,
+          "ram_gb": 16.0,
+          "ssd_gb": 100.0,
+          "vcpu_count": 8
+      },
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+    - The aiops Simulation APIs are synchronous, so this is C(None) for a successful call.
+  returned: always
+  type: str
+  sample: null
+
+ext_id:
+  description:
+    - The external ID of the Simulation.
+  returned: always
+  type: str
+  sample: "3236a842-f0c6-42a6-a6da-4cff299d219b"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped (e.g. idempotency)
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description:
+    - Status/error message.
+    - "Sample: Simulation with name 'simulation_ansible' already exists. Skipping creation."
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating simulation"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import (  # noqa: E402
+    get_etag,
+    get_scenarios_api_instance,
+)
+from ..module_utils.v4.aiops.helpers import get_simulation  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client as aiops_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as aiops_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    simulation_spec = dict(
+        vcpu_count=dict(type="int", required=False),
+        ram_gb=dict(type="float", required=False),
+        hdd_gb=dict(type="float", required=False),
+        ssd_gb=dict(type="float", required=False),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        simulation_spec=dict(
+            type="dict",
+            options=simulation_spec,
+            obj=aiops_sdk.SimulatedVmResourceSpec,
+        ),
+    )
+    return module_args
+
+
+def _find_simulation_by_name(module, api_instance, name):
+    """
+    Return the first Simulation whose name matches ``name`` (used for idempotency
+    on create). Returns None when nothing matches or the API rejects the filter.
+    """
+    try:
+        resp = api_instance.list_simulations(
+            _filter="name eq '{0}'".format(name), _limit=1
+        )
+    except Exception:
+        return None
+    data = getattr(resp, "data", None)
+    if not data:
+        return None
+    if isinstance(data, list):
+        return data[0]
+    return None
+
+
+def create_simulation(module, api_instance, result):
+    validate_required_params(module, ["name", "simulation_spec"])
+    name = module.params.get("name")
+
+    existing = _find_simulation_by_name(module, api_instance, name)
+    if existing is not None:
+        result["ext_id"] = getattr(existing, "ext_id", None)
+        result["response"] = strip_internal_attributes(existing.to_dict())
+        result["skipped"] = True
+        result["changed"] = False
+        result["msg"] = (
+            "Simulation with name '{0}' already exists. Skipping creation.".format(name)
+        )
+        return
+
+    sg = SpecGenerator(module)
+    default_spec = aiops_sdk.Simulation()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create simulation spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    try:
+        resp = api_instance.create_simulation(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating simulation",
+        )
+
+    data = getattr(resp, "data", None)
+    if data is not None and hasattr(data, "ext_id"):
+        result["ext_id"] = data.ext_id
+        result["response"] = strip_internal_attributes(data.to_dict())
+    else:
+        result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    return old_spec_dict == update_spec_dict
+
+
+def _reset_read_only_attributes(spec):
+    """
+    Reset server-populated read-only attributes on the Simulation spec before
+    sending it back as an update body. The SDK model does not permit deletion of
+    these attributes (no `deleter` on the properties), so we clear them to None.
+    """
+    for field in ("links", "tenant_id"):
+        try:
+            setattr(spec, field, None)
+        except AttributeError:
+            pass
+
+
+def update_simulation(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    old_spec = get_simulation(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    kwargs = {}
+    if etag:
+        kwargs["if_match"] = etag
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update simulation spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        result["changed"] = False
+        result["response"] = strip_internal_attributes(old_spec.to_dict())
+        module.exit_json(msg="Nothing to change.", **result)
+
+    _reset_read_only_attributes(update_spec)
+
+    try:
+        resp = api_instance.update_simulation_by_id(
+            extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating simulation",
+        )
+
+    data = getattr(resp, "data", None)
+    if data is not None and hasattr(data, "ext_id"):
+        result["ext_id"] = data.ext_id
+        result["response"] = strip_internal_attributes(data.to_dict())
+    else:
+        try:
+            refreshed = get_simulation(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(refreshed.to_dict())
+        except Exception:
+            result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def delete_simulation(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "Simulation with ext_id:{0} will be deleted.".format(ext_id)
+        return
+
+    try:
+        resp = api_instance.delete_simulation_by_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting simulation",
+        )
+
+    if resp is not None and hasattr(resp, "to_dict"):
+        result["response"] = strip_internal_attributes(resp.to_dict())
+    else:
+        result["response"] = {"status": "SUCCEEDED"}
+    result["msg"] = "Simulation with ext_id:{0} deleted successfully.".format(ext_id)
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+            ("state", "present", ("name", "ext_id"), True),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+    }
+    api_instance = get_scenarios_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_simulation(module, api_instance, result)
+        else:
+            create_simulation(module, api_instance, result)
+    else:
+        delete_simulation(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_simulations_info_v2.py
+++ b/plugins/modules/ntnx_simulations_info_v2.py
@@ -1,0 +1,208 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_simulations_info_v2
+short_description: Fetch information about Simulation(s) in Nutanix Prism Central (aiops)
+version_added: 2.5.0
+description:
+  - This module allows you to fetch information about Simulation in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific Simulation.
+  - If C(ext_id) is not provided, list multiple Simulation optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    - >-
+      B(Get Simulation by ext_id) -
+      Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin
+    - >-
+      B(Get list of Simulations) -
+      Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+  ext_id:
+    description:
+      - The external ID of the Simulation to fetch. When provided, returns a single Simulation.
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get simulation using ext_id
+  nutanix.ncp.ntnx_simulations_info_v2:
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+  ignore_errors: true
+
+- name: List all simulations
+  nutanix.ncp.ntnx_simulations_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List simulations with filter
+  nutanix.ncp.ntnx_simulations_info_v2:
+    filter: "name eq 'simulation_ansible'"
+  register: result
+  ignore_errors: true
+
+- name: List simulations with limit
+  nutanix.ncp.ntnx_simulations_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC Simulation info v4 API.
+    - It can be a single Simulation if external ID is provided.
+    - List of multiple Simulation if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "3236a842-f0c6-42a6-a6da-4cff299d219b",
+      "links": null,
+      "name": "simulation_ansible_example_updated",
+      "simulation_spec": {
+          "hdd_gb": 200.0,
+          "ram_gb": 16.0,
+          "ssd_gb": 100.0,
+          "vcpu_count": 8
+      },
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching simulations info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the Simulation
+  type: str
+  returned: when external ID is provided
+  sample: "7bea69e9-684c-4736-7805-d658ee17c1b6"
+
+total_available_results:
+  description: The total number of available Simulations in Prism Central.
+  type: int
+  returned: when all Simulations are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import get_scenarios_api_instance  # noqa: E402
+from ..module_utils.v4.aiops.helpers import get_simulation  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_simulation_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_simulation(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_simulations(module, api_instance, result):
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating simulations info spec", **result)
+
+    try:
+        resp = api_instance.list_simulations(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching simulations info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_scenarios_api_instance(module)
+    if module.params.get("ext_id"):
+        get_simulation_using_ext_id(module, api_instance, result)
+    else:
+        get_simulations(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-aiops-py-client==latest

--- a/tests/integration/targets/ntnx_simulation_v2/aliases
+++ b/tests/integration/targets/ntnx_simulation_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_simulation_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_simulation_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_simulation_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_simulation_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import simulations.yml
+      ansible.builtin.import_tasks: simulations.yml

--- a/tests/integration/targets/ntnx_simulation_v2/tasks/simulations.yml
+++ b/tests/integration/targets/ntnx_simulation_v2/tasks/simulations.yml
@@ -1,0 +1,543 @@
+---
+# Test plan:
+#   1) check_mode: create with ALL attributes -> assert spec preview only
+#   2) check_mode: update with ALL attributes -> assert changed spec preview
+#   3) check_mode: delete -> assert "will be deleted" message
+#   4) Create with MINIMUM attributes (name only) -> assert entity created
+#   5) Create with ALL attributes (name + full simulation_spec) -> assert entity
+#   6) Create idempotency: create with same name -> skipped=true, changed=false
+#   7) Update with ALL attributes (name + simulation_spec transitions) -> changed=true
+#   8) Update idempotency: same values twice -> skipped=true, changed=false
+#   9) Update with wrong ext_id -> failed=true
+#  10) Info: fetch by ext_id -> matches created values
+#  11) Info: fetch by wrong ext_id -> failed=true
+#  12) Info: list all -> length >= 2, includes both created
+#  13) Info: list with filter=name -> exactly one item, correct name
+#  14) Info: list with limit=1 -> exactly one item
+#  15) Create missing name -> required_if failure
+#  16) Delete with missing ext_id -> required_if failure
+#  17) Delete with wrong ext_id -> failed=true
+#  18) Delete all created -> loop completes, each changed=true
+
+- name: Start Simulation (aiops) tests
+  ansible.builtin.debug:
+    msg: Start Simulation (aiops) tests
+
+- name: Generate random suffix for resource names
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+    todelete: []
+
+- name: Set simulation names for this run
+  ansible.builtin.set_fact:
+    sim_name_min: "sim_{{ suffix_name }}_{{ random_name }}_min"
+    sim_name_all: "sim_{{ suffix_name }}_{{ random_name }}_all"
+    sim_name_updated: "sim_{{ suffix_name }}_{{ random_name }}_updated"
+    invalid_ext_id: "00000000-0000-0000-0000-000000000000"
+
+########################################################################################
+# 1) check_mode: create with ALL attributes
+########################################################################################
+
+- name: Generate spec for creating simulation using check_mode with all attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "check_mode_sim_full"
+    simulation_spec:
+      vcpu_count: 4
+      ram_gb: 8.0
+      hdd_gb: 100.0
+      ssd_gb: 50.0
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check_mode create with all attributes
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_sim_full"
+      - result.response.simulation_spec.vcpu_count == 4
+      - result.response.simulation_spec.ram_gb == 8.0
+      - result.response.simulation_spec.hdd_gb == 100.0
+      - result.response.simulation_spec.ssd_gb == 50.0
+    success_msg: "check_mode create with all attributes generated spec successfully"
+    fail_msg: "check_mode create with all attributes did NOT generate expected spec"
+
+########################################################################################
+# 4) Create with MINIMUM required attributes (name + simulation_spec)
+########################################################################################
+
+- name: Create simulation with minimum attributes (name + simulation_spec)
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "{{ sim_name_min }}"
+    simulation_spec:
+      vcpu_count: 2
+      ram_gb: 4.0
+      hdd_gb: 50.0
+      ssd_gb: 25.0
+  register: result
+  ignore_errors: true
+
+- name: Assert create with minimum attributes
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.ext_id | length > 0
+      - result.response is defined
+      - result.response.name == "{{ sim_name_min }}"
+      - result.response.simulation_spec.vcpu_count == 2
+      - result.response.simulation_spec.ram_gb == 4.0
+      - result.response.simulation_spec.hdd_gb == 50.0
+      - result.response.simulation_spec.ssd_gb == 25.0
+    success_msg: "Simulation with minimum attributes created successfully"
+    fail_msg: "Simulation with minimum attributes creation failed"
+
+- name: Track minimum simulation for teardown
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+    sim_min_ext_id: "{{ result.ext_id }}"
+
+########################################################################################
+# 4b) Create missing simulation_spec -> validate_required_params
+########################################################################################
+
+- name: Create simulation with missing simulation_spec
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "sim_missing_spec_{{ random_name }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert missing simulation_spec fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): simulation_spec"
+    success_msg: "Create simulation with missing simulation_spec failed as expected"
+    fail_msg: "Create simulation with missing simulation_spec did NOT fail as expected"
+
+########################################################################################
+# 5) Create with ALL attributes
+########################################################################################
+
+- name: Create simulation with ALL attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "{{ sim_name_all }}"
+    simulation_spec:
+      vcpu_count: 4
+      ram_gb: 8.0
+      hdd_gb: 100.0
+      ssd_gb: 50.0
+  register: result
+  ignore_errors: true
+
+- name: Assert create with all attributes
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.ext_id | length > 0
+      - result.response is defined
+      - result.response.name == "{{ sim_name_all }}"
+      - result.response.simulation_spec.vcpu_count == 4
+      - result.response.simulation_spec.ram_gb == 8.0
+      - result.response.simulation_spec.hdd_gb == 100.0
+      - result.response.simulation_spec.ssd_gb == 50.0
+    success_msg: "Simulation with all attributes created successfully"
+    fail_msg: "Simulation with all attributes creation failed"
+
+- name: Track full simulation for teardown
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+    sim_all_ext_id: "{{ result.ext_id }}"
+
+########################################################################################
+# 6) Create idempotency (same name already exists)
+########################################################################################
+
+- name: Create simulation with duplicate name (idempotency)
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "{{ sim_name_all }}"
+    simulation_spec:
+      vcpu_count: 4
+      ram_gb: 8.0
+      hdd_gb: 100.0
+      ssd_gb: 50.0
+  register: result
+  ignore_errors: true
+
+- name: Assert create idempotency
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.msg is defined
+      - "'already exists' in result.msg"
+      - result.ext_id == sim_all_ext_id
+    success_msg: "Simulation create idempotency behaves correctly"
+    fail_msg: "Simulation create idempotency did NOT behave as expected"
+
+########################################################################################
+# 2) check_mode: update with ALL attributes
+########################################################################################
+
+- name: Generate spec for updating simulation using check_mode with all attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "{{ sim_all_ext_id }}"
+    name: "{{ sim_name_updated }}"
+    simulation_spec:
+      vcpu_count: 8
+      ram_gb: 16.0
+      hdd_gb: 200.0
+      ssd_gb: 100.0
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check_mode update with all attributes
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "{{ sim_name_updated }}"
+      - result.response.simulation_spec.vcpu_count == 8
+      - result.response.simulation_spec.ram_gb == 16.0
+      - result.response.simulation_spec.hdd_gb == 200.0
+      - result.response.simulation_spec.ssd_gb == 100.0
+    success_msg: "check_mode update with all attributes generated spec successfully"
+    fail_msg: "check_mode update with all attributes did NOT generate expected spec"
+
+########################################################################################
+# 7) Update with ALL attributes (state transition)
+########################################################################################
+
+- name: Update simulation with ALL attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "{{ sim_all_ext_id }}"
+    name: "{{ sim_name_updated }}"
+    simulation_spec:
+      vcpu_count: 8
+      ram_gb: 16.0
+      hdd_gb: 200.0
+      ssd_gb: 100.0
+  register: result
+  ignore_errors: true
+
+- name: Assert update with all attributes
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == sim_all_ext_id
+      - result.response is defined
+      - result.response.name == "{{ sim_name_updated }}"
+      - result.response.simulation_spec.vcpu_count == 8
+      - result.response.simulation_spec.ram_gb == 16.0
+      - result.response.simulation_spec.hdd_gb == 200.0
+      - result.response.simulation_spec.ssd_gb == 100.0
+    success_msg: "Update simulation with all attributes passed"
+    fail_msg: "Update simulation with all attributes failed"
+
+########################################################################################
+# 8) Update idempotency
+########################################################################################
+
+- name: Update simulation with same values (idempotency)
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "{{ sim_all_ext_id }}"
+    name: "{{ sim_name_updated }}"
+    simulation_spec:
+      vcpu_count: 8
+      ram_gb: 16.0
+      hdd_gb: 200.0
+      ssd_gb: 100.0
+  register: result
+  ignore_errors: true
+
+- name: Assert update idempotency
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.msg == "Nothing to change."
+    success_msg: "Update simulation idempotency passed"
+    fail_msg: "Update simulation idempotency failed"
+
+########################################################################################
+# 9) Update with wrong ext_id
+########################################################################################
+
+- name: Update simulation with wrong ext_id
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "{{ invalid_ext_id }}"
+    name: "sim_wrong_ext_id"
+    simulation_spec:
+      vcpu_count: 2
+      ram_gb: 4.0
+      hdd_gb: 50.0
+      ssd_gb: 25.0
+  register: result
+  ignore_errors: true
+
+- name: Assert update with wrong ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Update simulation with wrong ext_id failed as expected"
+    fail_msg: "Update simulation with wrong ext_id did NOT fail as expected"
+
+########################################################################################
+# 10) Info: fetch by ext_id
+########################################################################################
+
+- name: Fetch simulation using external ID
+  nutanix.ncp.ntnx_simulations_info_v2:
+    ext_id: "{{ sim_all_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert fetch by ext_id
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == sim_all_ext_id
+      - result.response is defined
+      - result.response.name == "{{ sim_name_updated }}"
+      - result.response.simulation_spec.vcpu_count == 8
+      - result.response.simulation_spec.ram_gb == 16.0
+      - result.response.simulation_spec.hdd_gb == 200.0
+      - result.response.simulation_spec.ssd_gb == 100.0
+    success_msg: "Fetch simulation by ext_id passed"
+    fail_msg: "Fetch simulation by ext_id failed"
+
+########################################################################################
+# 11) Info: fetch by wrong ext_id
+########################################################################################
+
+- name: Fetch simulation using wrong external ID
+  nutanix.ncp.ntnx_simulations_info_v2:
+    ext_id: "{{ invalid_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert fetch by wrong ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Fetch simulation by wrong ext_id failed as expected"
+    fail_msg: "Fetch simulation by wrong ext_id did NOT fail as expected"
+
+########################################################################################
+# 12) Info: list all
+########################################################################################
+
+- name: List all simulations
+  nutanix.ncp.ntnx_simulations_info_v2:
+  register: list_all_result
+  ignore_errors: true
+
+- name: Assert list all simulations
+  ansible.builtin.assert:
+    that:
+      - list_all_result is defined
+      - list_all_result.changed == false
+      - list_all_result.failed == false
+      - list_all_result.response is defined
+      - list_all_result.response | length >= 2
+      - list_all_result.total_available_results is defined
+      - list_all_result.total_available_results >= 2
+    success_msg: "List all simulations passed"
+    fail_msg: "List all simulations failed"
+
+########################################################################################
+# 13) Info: list with filter by name
+########################################################################################
+
+- name: List simulations with filter by name
+  nutanix.ncp.ntnx_simulations_info_v2:
+    filter: "name eq '{{ sim_name_updated }}'"
+  register: result
+  ignore_errors: true
+
+- name: Assert list with filter
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+      - result.response[0].name == "{{ sim_name_updated }}"
+      - result.response[0].ext_id == sim_all_ext_id
+    success_msg: "List simulations with filter passed"
+    fail_msg: "List simulations with filter failed"
+
+########################################################################################
+# 14) Info: list with limit
+########################################################################################
+
+- name: List simulations with limit=1
+  nutanix.ncp.ntnx_simulations_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: Assert list with limit
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    success_msg: "List simulations with limit passed"
+    fail_msg: "List simulations with limit failed"
+
+########################################################################################
+# 15) Create with missing name (required_if)
+########################################################################################
+
+- name: Create simulation with missing name
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    simulation_spec:
+      vcpu_count: 2
+      ram_gb: 4.0
+      hdd_gb: 50.0
+      ssd_gb: 25.0
+  register: result
+  ignore_errors: true
+
+- name: Assert missing name fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "state is present but any of the following are missing: name, ext_id"
+    success_msg: "Create simulation with missing name failed as expected"
+    fail_msg: "Create simulation with missing name did NOT fail as expected"
+
+########################################################################################
+# 3) check_mode: delete
+########################################################################################
+
+- name: Delete simulation with check_mode
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "{{ sim_min_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check_mode delete
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+    success_msg: "check_mode delete generated correct message"
+    fail_msg: "check_mode delete did NOT generate expected message"
+
+########################################################################################
+# 16) Delete with missing ext_id
+########################################################################################
+
+- name: Delete simulation with missing ext_id
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Assert delete missing ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete simulation with missing ext_id failed as expected"
+    fail_msg: "Delete simulation with missing ext_id did NOT fail as expected"
+
+########################################################################################
+# 17) Delete with wrong ext_id
+########################################################################################
+
+- name: Delete simulation with wrong ext_id
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "{{ invalid_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert delete with wrong ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Delete simulation with wrong ext_id failed as expected"
+    fail_msg: "Delete simulation with wrong ext_id did NOT fail as expected"
+
+########################################################################################
+# 18) Delete all created
+########################################################################################
+
+- name: Delete all created simulations
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  register: delete_all_result
+  ignore_errors: true
+  loop: "{{ todelete }}"
+
+- name: Assert delete all created
+  ansible.builtin.assert:
+    that:
+      - delete_all_result is defined
+      - delete_all_result.results | length == todelete | length
+      - delete_all_result.msg == "All items completed"
+    success_msg: "All simulations deleted successfully"
+    fail_msg: "Unable to delete all simulations"
+
+- name: Assert per-item delete success
+  ansible.builtin.assert:
+    that:
+      - item.failed == false
+      - item.changed == true
+    success_msg: "Simulation {{ item.ext_id }} deleted"
+    fail_msg: "Simulation {{ item.ext_id }} was not deleted successfully"
+  loop: "{{ delete_all_result.results }}"
+  loop_control:
+    label: "{{ item.ext_id | default(omit) }}"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **aiops** namespace, entity
**Simulation**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_simulation_v2`, `ntnx_simulations_info_v2`
- API methods covered: `create_simulation`, `update_simulation_by_id`, `delete_simulation_by_id`, `get_simulation_by_id`, `list_simulations` (5 of the 5 Simulation methods in `ntnx_aiops_py_client`).
- Fields in CRUD module spec: `9` (`state`, `ext_id`, `name`, `simulation_spec` + 4 sub-fields `vcpu_count`, `ram_gb`, `hdd_gb`, `ssd_gb`, plus the operations/credentials fragments).
- Fields in info module spec: `1` (`ext_id`; list variants inherit `filter`, `limit`, `page`, `orderby`, `select` from `ntnx_info_v2`).

Very Important: No Glean, Jira, or Confluence links have been included. The Glean
MCP tool timed out during this run, so no external knowledge was retained.

## Files changed

### `plugins/modules/`
- `ntnx_simulation_v2.py` — CRUD module (create / update / delete) for a Simulation.
- `ntnx_simulations_info_v2.py` — info module (get-by-ext_id and list) for Simulations.

### `plugins/module_utils/v4/aiops/`
- `api_client.py` — new aiops-namespace SDK client helper (`get_scenarios_api_instance`, `get_api_client`, `get_etag`).
- `helpers.py` — new `get_simulation` helper used by both modules.

### `examples/`
- `examples/aiops/Simulation/simulation_v2.yml` — end-to-end example playbook (create → update → get → list → filter → limit → delete).
- `examples/aiops/Simulation/examples_run.log` — real captured output from running the playbook against the live cluster (`PLAY RECAP: ok=9 changed=3 failed=0`).

### `tests/`
- `tests/integration/targets/ntnx_simulation_v2/` — new integration target with `aliases`, `meta/main.yml`, `tasks/main.yml`, and `tasks/simulations.yml` covering CRUD lifecycle, check_mode, idempotency (create + update), negative paths, and info-module variants.

### `meta/runtime.yml`
- Added the two new modules to the `ntnx` action group so `module_defaults: group/nutanix.ncp.ntnx` applies to them.

## Test execution

| Metric              | Value                                                                                     |
|---------------------|-------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration --python 3.12 --allow-disabled ntnx_simulation_v2 -v`           |
| Total tasks         | `45`                                                                                      |
| Passed (`ok`)       | `43`                                                                                      |
| Failed              | `0`                                                                                       |
| Skipped             | `2` (idempotency `skipping:` in create + update, which is the expected behaviour)         |
| Changed             | `4`                                                                                       |
| Ignored             | `6` (`ignore_errors: true` on negative-path tasks that are asserted to fail)              |
| Duration            | ~`0:00:22`                                                                                |
| Cluster (PC)        | `10.44.76.28:9440` (Nutanix Prism Central, aiops v4.0)                                    |

### Analysis

All integration test tasks passed on the first successful run after fixing three
issues identified while iterating on the live cluster:

1. `ntnx_aiops_py_client.ApiClient.__init__()` does not accept
   `allow_version_negotiation` (unlike the networking SDK). Wrapped the call
   in `try / except TypeError` and dropped the second unconditional retry.
2. The API rejects creates without `simulationSpec` (`AIO SchemaValidationError`).
   `simulation_spec` is now enforced via `validate_required_params` on create.
3. `Simulation.links` / `Simulation.tenant_id` are read-only properties without
   `deleter`. Replaced `strip_read_only_fields` with a local
   `_reset_read_only_attributes` helper that clears them to `None` via
   `setattr`.

There are no known-issue failures remaining.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python
Creating container database.
Run command: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/lib64/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_simulation_v2 integration test role
Initializing "/tmp/ansible-test-b4h1m4r8-injector" as the temporary injector directory.
Injecting "/tmp/python-efcqh2fp-ansible/python" as a execv wrapper for the "/home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python" interpreter.
Stream command: ansible-playbook ntnx_simulation_v2-_1auy3op.yml -i inventory -v
[WARNING]: Found variable using reserved name: port
Using /home/george.ghawali/.ansible/collections/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_simulation_v2-gt1mm_ny-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_simulation_v2 : Start Simulation (aiops) tests] *********************
ok: [testhost] => {
    "msg": "Start Simulation (aiops) tests"
}

TASK [ntnx_simulation_v2 : Generate random suffix for resource names] **********
[WARNING]: Collection community.general does not support Ansible version 2.16.0
ok: [testhost] => {"ansible_facts": {"random_name": "jRYEccBurdQs", "suffix_name": "ansible", "todelete": []}, "changed": false}

TASK [ntnx_simulation_v2 : Set simulation names for this run] ******************
ok: [testhost] => {"ansible_facts": {"invalid_ext_id": "00000000-0000-0000-0000-000000000000", "sim_name_all": "sim_ansible_jRYEccBurdQs_all", "sim_name_min": "sim_ansible_jRYEccBurdQs_min", "sim_name_updated": "sim_ansible_jRYEccBurdQs_updated"}, "changed": false}

TASK [ntnx_simulation_v2 : Generate spec for creating simulation using check_mode with all attributes] ***
ok: [testhost] => {"changed": false, "ext_id": null, "response": {"ext_id": null, "links": null, "name": "check_mode_sim_full", "simulation_spec": {"hdd_gb": 100.0, "ram_gb": 8.0, "ssd_gb": 50.0, "vcpu_count": 4}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert check_mode create with all attributes] *******
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode create with all attributes generated spec successfully"
}

TASK [ntnx_simulation_v2 : Create simulation with minimum attributes (name + simulation_spec)] ***
changed: [testhost] => {"changed": true, "ext_id": "83d0ee6c-96ca-48d5-bff1-64b9f75038b7", "response": {"ext_id": "83d0ee6c-96ca-48d5-bff1-64b9f75038b7", "links": null, "name": "sim_ansible_jRYEccBurdQs_min", "simulation_spec": {"hdd_gb": 50.0, "ram_gb": 4.0, "ssd_gb": 25.0, "vcpu_count": 2}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert create with minimum attributes] **************
ok: [testhost] => {
    "changed": false,
    "msg": "Simulation with minimum attributes created successfully"
}

TASK [ntnx_simulation_v2 : Track minimum simulation for teardown] **************
ok: [testhost] => {"ansible_facts": {"sim_min_ext_id": "83d0ee6c-96ca-48d5-bff1-64b9f75038b7", "todelete": ["83d0ee6c-96ca-48d5-bff1-64b9f75038b7"]}, "changed": false}

TASK [ntnx_simulation_v2 : Create simulation with missing simulation_spec] *****
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): simulation_spec"}
...ignoring

TASK [ntnx_simulation_v2 : Assert missing simulation_spec fails] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "Create simulation with missing simulation_spec failed as expected"
}

TASK [ntnx_simulation_v2 : Create simulation with ALL attributes] **************
changed: [testhost] => {"changed": true, "ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "response": {"ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "links": null, "name": "sim_ansible_jRYEccBurdQs_all", "simulation_spec": {"hdd_gb": 100.0, "ram_gb": 8.0, "ssd_gb": 50.0, "vcpu_count": 4}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert create with all attributes] ******************
ok: [testhost] => {
    "changed": false,
    "msg": "Simulation with all attributes created successfully"
}

TASK [ntnx_simulation_v2 : Track full simulation for teardown] *****************
ok: [testhost] => {"ansible_facts": {"sim_all_ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "todelete": ["83d0ee6c-96ca-48d5-bff1-64b9f75038b7", "8464ce23-1d4f-4189-91e1-a8402c785a79"]}, "changed": false}

TASK [ntnx_simulation_v2 : Create simulation with duplicate name (idempotency)] ***
skipping: [testhost] => {"changed": false, "ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "msg": "Simulation with name 'sim_ansible_jRYEccBurdQs_all' already exists. Skipping creation.", "response": {"ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "links": null, "name": "sim_ansible_jRYEccBurdQs_all", "simulation_spec": {"hdd_gb": 100.0, "ram_gb": 8.0, "ssd_gb": 50.0, "vcpu_count": 4}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert create idempotency] **************************
ok: [testhost] => {
    "changed": false,
    "msg": "Simulation create idempotency behaves correctly"
}

TASK [ntnx_simulation_v2 : Generate spec for updating simulation using check_mode with all attributes] ***
ok: [testhost] => {"changed": false, "ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "response": {"ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "links": null, "name": "sim_ansible_jRYEccBurdQs_updated", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 100.0, "vcpu_count": 8}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert check_mode update with all attributes] *******
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode update with all attributes generated spec successfully"
}

TASK [ntnx_simulation_v2 : Update simulation with ALL attributes] **************
changed: [testhost] => {"changed": true, "ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "response": {"ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "links": null, "name": "sim_ansible_jRYEccBurdQs_updated", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 100.0, "vcpu_count": 8}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert update with all attributes] ******************
ok: [testhost] => {
    "changed": false,
    "msg": "Update simulation with all attributes passed"
}

TASK [ntnx_simulation_v2 : Update simulation with same values (idempotency)] ***
skipping: [testhost] => {"changed": false, "ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "msg": "Nothing to change.", "response": {"ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "links": null, "name": "sim_ansible_jRYEccBurdQs_updated", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 100.0, "vcpu_count": 8}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert update idempotency] **************************
ok: [testhost] => {
    "changed": false,
    "msg": "Update simulation idempotency passed"
}

TASK [ntnx_simulation_v2 : Update simulation with wrong ext_id] ****************
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching simulation info using ext_id", "response": {"$objectType": "aiops.v4.config.GetSimulationApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "data": {"$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "code": "AIO-60006", "locale": "en_US", "message": "Failed to perform the request because the resource identified by the provided external identifier 00000000-0000-0000-0000-000000000000 was not found.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
...ignoring

TASK [ntnx_simulation_v2 : Assert update with wrong ext_id fails] **************
ok: [testhost] => {
    "changed": false,
    "msg": "Update simulation with wrong ext_id failed as expected"
}

TASK [ntnx_simulation_v2 : Fetch simulation using external ID] *****************
ok: [testhost] => {"changed": false, "ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "response": {"ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "links": null, "name": "sim_ansible_jRYEccBurdQs_updated", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 100.0, "vcpu_count": 8}, "tenant_id": null}}

TASK [ntnx_simulation_v2 : Assert fetch by ext_id] *****************************
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch simulation by ext_id passed"
}

TASK [ntnx_simulation_v2 : Fetch simulation using wrong external ID] ***********
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching simulation info using ext_id", "response": {"$objectType": "aiops.v4.config.GetSimulationApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "data": {"$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "code": "AIO-60006", "locale": "en_US", "message": "Failed to perform the request because the resource identified by the provided external identifier 00000000-0000-0000-0000-000000000000 was not found.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
...ignoring

TASK [ntnx_simulation_v2 : Assert fetch by wrong ext_id fails] *****************
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch simulation by wrong ext_id failed as expected"
}

TASK [ntnx_simulation_v2 : List all simulations] *******************************
ok: [testhost] => {"changed": false, "response": [{"ext_id": "83d0ee6c-96ca-48d5-bff1-64b9f75038b7", "links": null, "name": "sim_ansible_jRYEccBurdQs_min", "simulation_spec": {"hdd_gb": 50.0, "ram_gb": 4.0, "ssd_gb": 25.0, "vcpu_count": 2}, "tenant_id": null}, {"ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "links": null, "name": "sim_ansible_jRYEccBurdQs_updated", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 100.0, "vcpu_count": 8}, "tenant_id": null}], "total_available_results": 2}

TASK [ntnx_simulation_v2 : Assert list all simulations] ************************
ok: [testhost] => {
    "changed": false,
    "msg": "List all simulations passed"
}

TASK [ntnx_simulation_v2 : List simulations with filter by name] ***************
ok: [testhost] => {"changed": false, "response": [{"ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "links": null, "name": "sim_ansible_jRYEccBurdQs_updated", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 100.0, "vcpu_count": 8}, "tenant_id": null}], "total_available_results": 1}

TASK [ntnx_simulation_v2 : Assert list with filter] ****************************
ok: [testhost] => {
    "changed": false,
    "msg": "List simulations with filter passed"
}

TASK [ntnx_simulation_v2 : List simulations with limit=1] **********************
ok: [testhost] => {"changed": false, "response": [{"ext_id": "83d0ee6c-96ca-48d5-bff1-64b9f75038b7", "links": null, "name": "sim_ansible_jRYEccBurdQs_min", "simulation_spec": {"hdd_gb": 50.0, "ram_gb": 4.0, "ssd_gb": 25.0, "vcpu_count": 2}, "tenant_id": null}], "total_available_results": 2}

TASK [ntnx_simulation_v2 : Assert list with limit] *****************************
ok: [testhost] => {
    "changed": false,
    "msg": "List simulations with limit passed"
}

TASK [ntnx_simulation_v2 : Create simulation with missing name] ****************
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is present but any of the following are missing: name, ext_id"}
...ignoring

TASK [ntnx_simulation_v2 : Assert missing name fails] **************************
ok: [testhost] => {
    "changed": false,
    "msg": "Create simulation with missing name failed as expected"
}

TASK [ntnx_simulation_v2 : Delete simulation with check_mode] ******************
ok: [testhost] => {"changed": false, "ext_id": "83d0ee6c-96ca-48d5-bff1-64b9f75038b7", "msg": "Simulation with ext_id:83d0ee6c-96ca-48d5-bff1-64b9f75038b7 will be deleted.", "response": null, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert check_mode delete] ***************************
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode delete generated correct message"
}

TASK [ntnx_simulation_v2 : Delete simulation with missing ext_id] **************
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_simulation_v2 : Assert delete missing ext_id fails] *****************
ok: [testhost] => {
    "changed": false,
    "msg": "Delete simulation with missing ext_id failed as expected"
}

TASK [ntnx_simulation_v2 : Delete simulation with wrong ext_id] ****************
fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while deleting simulation", "response": {"$objectType": "aiops.v4.config.DeleteSimulationApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "data": {"$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "code": "AIO-60008", "locale": "en_US", "message": "Failed to perform the request because the provided external identifier 00000000-0000-0000-0000-000000000000 is incorrect.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 400}
...ignoring

TASK [ntnx_simulation_v2 : Assert delete with wrong ext_id fails] **************
ok: [testhost] => {
    "changed": false,
    "msg": "Delete simulation with wrong ext_id failed as expected"
}

TASK [ntnx_simulation_v2 : Delete all created simulations] *********************
changed: [testhost] => (item=83d0ee6c-96ca-48d5-bff1-64b9f75038b7) => {"ansible_loop_var": "item", "changed": true, "ext_id": "83d0ee6c-96ca-48d5-bff1-64b9f75038b7", "item": "83d0ee6c-96ca-48d5-bff1-64b9f75038b7", "msg": "Simulation with ext_id:83d0ee6c-96ca-48d5-bff1-64b9f75038b7 deleted successfully.", "response": {"status": "SUCCEEDED"}, "task_ext_id": null}
changed: [testhost] => (item=8464ce23-1d4f-4189-91e1-a8402c785a79) => {"ansible_loop_var": "item", "changed": true, "ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79", "item": "8464ce23-1d4f-4189-91e1-a8402c785a79", "msg": "Simulation with ext_id:8464ce23-1d4f-4189-91e1-a8402c785a79 deleted successfully.", "response": {"status": "SUCCEEDED"}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert delete all created] **************************
ok: [testhost] => {
    "changed": false,
    "msg": "All simulations deleted successfully"
}

TASK [ntnx_simulation_v2 : Assert per-item delete success] *********************
ok: [testhost] => (item=83d0ee6c-96ca-48d5-bff1-64b9f75038b7) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "ansible_loop_var": "item",
        "changed": true,
        "ext_id": "83d0ee6c-96ca-48d5-bff1-64b9f75038b7",
        "failed": false,
        "invocation": {
            "module_args": {
                "ext_id": "83d0ee6c-96ca-48d5-bff1-64b9f75038b7",
                "nutanix_debug": false,
                "nutanix_host": "10.44.76.28",
                "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "nutanix_port": "9440",
                "nutanix_username": "admin",
                "read_timeout": 30000,
                "state": "absent",
                "validate_certs": false,
                "wait": true
            }
        },
        "item": "83d0ee6c-96ca-48d5-bff1-64b9f75038b7",
        "msg": "Simulation with ext_id:83d0ee6c-96ca-48d5-bff1-64b9f75038b7 deleted successfully.",
        "response": {
            "status": "SUCCEEDED"
        },
        "skipped": false,
        "task_ext_id": null
    },
    "msg": "Simulation 83d0ee6c-96ca-48d5-bff1-64b9f75038b7 deleted"
}
ok: [testhost] => (item=8464ce23-1d4f-4189-91e1-a8402c785a79) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "ansible_loop_var": "item",
        "changed": true,
        "ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79",
        "failed": false,
        "invocation": {
            "module_args": {
                "ext_id": "8464ce23-1d4f-4189-91e1-a8402c785a79",
                "nutanix_debug": false,
                "nutanix_host": "10.44.76.28",
                "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "nutanix_port": "9440",
                "nutanix_username": "admin",
                "read_timeout": 30000,
                "state": "absent",
                "validate_certs": false,
                "wait": true
            }
        },
        "item": "8464ce23-1d4f-4189-91e1-a8402c785a79",
        "msg": "Simulation with ext_id:8464ce23-1d4f-4189-91e1-a8402c785a79 deleted successfully.",
        "response": {
            "status": "SUCCEEDED"
        },
        "skipped": false,
        "task_ext_id": null
    },
    "msg": "Simulation 8464ce23-1d4f-4189-91e1-a8402c785a79 deleted"
}

PLAY RECAP *********************************************************************
testhost                   : ok=43   changed=4    unreachable=0    failed=0    skipped=2    rescued=0    ignored=6   

```

</details>

## Example execution

The example playbook `examples/aiops/Simulation/simulation_v2.yml` was executed
against the same Prism Central used for integration tests. Real playbook output
is committed to `examples/aiops/Simulation/examples_run.log`.

```text
PLAY RECAP *********************************************************************
localhost                  : ok=9    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

Sample real-response captured from a `create` task:

```json
{
    "ext_id": "3236a842-f0c6-42a6-a6da-4cff299d219b",
    "links": null,
    "name": "simulation_ansible_example",
    "simulation_spec": {
        "hdd_gb": 100.0,
        "ram_gb": 8.0,
        "ssd_gb": 50.0,
        "vcpu_count": 4
    },
    "tenant_id": null
}
```

## Domain knowledge (from Glean)

Glean MCP was unavailable during this run — every `glean__chat` call returned an
MCP timeout (`Request timed out`). No engineering tickets, design docs, or
Confluence pages could be retained. Domain understanding was reconstructed from
the inline `sdk_info.json` payload and the aiops SDK (`ntnx_aiops_py_client`):

- A **Simulation** models a projected VM workload (`vcpu_count`, `ram_gb`,
  `hdd_gb`, `ssd_gb`) that a capacity planning **Scenario** can reference to
  compute runway/recommendations against a cluster.
- The Simulation CRUD endpoints are synchronous — the create / update / delete
  responses do not include a task reference, so `task_ext_id` is always `None`.
- Required attributes for create: `name` (1–256 chars) and `simulationSpec` (the
  API rejects requests missing it, confirmed on 10.44.76.28).

## Lint & sanity

- `black --check .` ✅
- `isort --check .` ✅
- `flake8` ✅
- `ansible-lint plugins/modules/ntnx_simulation_v2.py plugins/modules/ntnx_simulations_info_v2.py examples/aiops/Simulation/simulation_v2.yml` — **0 failures, 0 warnings** (informational `Unable to load module ... for options validation` messages come from ansible-lint running before the collection is re-installed and are harmless).
- `ansible-test sanity --python 3.12` — passes for all four new files (`ntnx_simulation_v2.py`, `ntnx_simulations_info_v2.py`, `aiops/api_client.py`, `aiops/helpers.py`).

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
