### PR TITLE
feat(aiops/Simulation): add ntnx_simulation_v2 CRUD and info modules

### DIFF
--- a/examples/aiops/Simulation/simulations_v2.yml
+++ b/examples/aiops/Simulation/simulations_v2.yml
@@ -1,0 +1,76 @@
+---
+# Summary:
+# This playbook demonstrates the AIOps capacity planning Simulation modules:
+# 1. Create a simulation (VM workload resource spec used by capacity planning scenarios)
+# 2. Fetch the simulation using ext_id
+# 3. List all simulations
+# 4. List simulations with a filter
+# 5. List simulations with a limit
+# 6. Update a simulation
+# 7. Delete a simulation
+
+- name: AIOps Simulation playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting variables
+      ansible.builtin.set_fact:
+        simulation_name: "simulation_ansible"
+
+    - name: Create simulation with all attributes
+      nutanix.ncp.ntnx_simulation_v2:
+        state: present
+        name: "{{ simulation_name }}"
+        simulation_spec:
+          vcpu_count: 4
+          ram_gb: 16.0
+          hdd_gb: 200.0
+          ssd_gb: 100.0
+      register: create_result
+
+    - name: Capture the simulation ext_id
+      ansible.builtin.set_fact:
+        simulation_ext_id: "{{ create_result.ext_id }}"
+
+    - name: Fetch simulation using ext_id
+      nutanix.ncp.ntnx_simulations_info_v2:
+        ext_id: "{{ simulation_ext_id }}"
+      register: get_result
+
+    - name: List all simulations
+      nutanix.ncp.ntnx_simulations_info_v2:
+      register: list_all_result
+
+    - name: List simulations with filter
+      nutanix.ncp.ntnx_simulations_info_v2:
+        filter: "name eq '{{ simulation_name }}'"
+      register: list_filter_result
+
+    - name: List simulations with limit
+      nutanix.ncp.ntnx_simulations_info_v2:
+        limit: 1
+      register: list_limit_result
+
+    - name: Update simulation with all attributes
+      nutanix.ncp.ntnx_simulation_v2:
+        state: present
+        ext_id: "{{ simulation_ext_id }}"
+        name: "{{ simulation_name }}_updated"
+        simulation_spec:
+          vcpu_count: 8
+          ram_gb: 32.0
+          hdd_gb: 400.0
+          ssd_gb: 200.0
+      register: update_result
+
+    - name: Delete simulation
+      nutanix.ncp.ntnx_simulation_v2:
+        state: absent
+        ext_id: "{{ simulation_ext_id }}"
+      register: delete_result

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_simulation_v2
+    - ntnx_simulations_info_v2

--- a/plugins/module_utils/v4/aiops/api_client.py
+++ b/plugins/module_utils/v4/aiops/api_client.py
@@ -1,0 +1,104 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return the aiops API client using the given connection
+    details from the Ansible module parameters.
+
+    Args:
+        module (object): Ansible module object
+
+    Returns:
+        client (object): aiops API client instance
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_aiops_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not api_key:
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_aiops_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_aiops_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method fetches the etag from a v4 API response.
+
+    Args:
+        data (dict): v4 API response
+
+    Returns:
+        etag (str): etag value
+    """
+    return ntnx_aiops_py_client.ApiClient.get_etag(data)
+
+
+def get_scenarios_api_instance(module):
+    """
+    This method returns the aiops ScenariosApi instance. The ScenariosApi
+    covers both capacity planning scenarios and simulations.
+
+    Args:
+        module (object): Ansible module object
+
+    Returns:
+        api_instance (object): ScenariosApi instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_aiops_py_client.ScenariosApi(api_client=api_client)

--- a/plugins/module_utils/v4/aiops/helpers.py
+++ b/plugins/module_utils/v4/aiops/helpers.py
@@ -1,0 +1,30 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_simulation(module, api_instance, ext_id):
+    """
+    Fetch a single simulation by its external ID.
+
+    Args:
+        module (object): Ansible module object
+        api_instance (object): aiops ScenariosApi instance
+        ext_id (str): External ID of the simulation
+
+    Returns:
+        info (object): simulation info object
+    """
+    try:
+        return api_instance.get_simulation_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching simulation info using ext_id",
+        )

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,8 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        SIMULATION = "aiops:config:simulation"
+        SCENARIO = "aiops:config:scenario"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/modules/ntnx_simulation_v2.py
+++ b/plugins/modules/ntnx_simulation_v2.py
@@ -1,0 +1,404 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_simulation_v2
+short_description: Create, Update, Delete AIOps capacity planning simulations in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to create, update, and delete AIOps capacity
+    planning simulations in Nutanix Prism Central.
+  - A simulation captures a "what-if" resource specification for a VM
+    workload (vCPU, RAM, HDD, SSD) that is later referenced from capacity
+    planning scenarios to project runway and generate hardware
+    recommendations.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the Nutanix IAM roles that grant read/write access
+      to the AIOps capacity planning APIs (typically Prism Admin or Super
+      Admin) for the user performing the operation.
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will create a simulation.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will update the simulation.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will delete the simulation.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the simulation.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - Name of the simulation.
+      - Required for create operation.
+    type: str
+    required: false
+  simulation_spec:
+    description:
+      - Simulated resource specification for a VM workload.
+      - Required for create operation.
+    type: dict
+    required: false
+    suboptions:
+      vcpu_count:
+        description:
+          - Number of vCPUs for each simulated VM.
+        type: int
+        required: false
+      ram_gb:
+        description:
+          - RAM in GB for each simulated VM.
+        type: float
+        required: false
+      hdd_gb:
+        description:
+          - HDD storage in GB for each simulated VM.
+        type: float
+        required: false
+      ssd_gb:
+        description:
+          - SSD storage in GB for each simulated VM.
+        type: float
+        required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create simulation with all attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "simulation_ansible"
+    simulation_spec:
+      vcpu_count: 4
+      ram_gb: 16.0
+      hdd_gb: 200.0
+      ssd_gb: 100.0
+  register: result
+  ignore_errors: true
+
+- name: Update simulation
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+    name: "simulation_ansible_updated"
+    simulation_spec:
+      vcpu_count: 8
+      ram_gb: 32.0
+      hdd_gb: 400.0
+      ssd_gb: 200.0
+  register: result
+  ignore_errors: true
+
+- name: Delete simulation
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting a simulation.
+    - For create and update, the response is the full simulation entity (re-fetched from Get after mutation).
+    - For delete, the module returns a success message dict since the aiops Delete API returns no body.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d",
+      "links": null,
+      "name": "simulation_ansible",
+      "simulation_spec": {
+        "hdd_gb": 200.0,
+        "ram_gb": 16.0,
+        "ssd_gb": 100.0,
+        "vcpu_count": 4
+      },
+      "tenant_id": null
+    }
+
+ext_id:
+  description:
+    - The external ID of the simulation.
+  returned: always
+  type: str
+  sample: "7c6bc5f3-c18c-4702-4c2d-b769fd5f94b0"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating simulation"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import (  # noqa: E402
+    get_etag,
+    get_scenarios_api_instance,
+)
+from ..module_utils.v4.aiops.helpers import get_simulation  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client as aiops_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as aiops_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    simulation_spec = dict(
+        vcpu_count=dict(type="int", required=False),
+        ram_gb=dict(type="float", required=False),
+        hdd_gb=dict(type="float", required=False),
+        ssd_gb=dict(type="float", required=False),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        simulation_spec=dict(
+            type="dict",
+            options=simulation_spec,
+            obj=aiops_sdk.SimulatedVmResourceSpec,
+        ),
+    )
+    return module_args
+
+
+def create_simulation(module, api_instance, result):
+    """Create a Simulation. The aiops Create API is synchronous and returns
+    the created entity directly (there is no task workflow), so we simply
+    read the ``ext_id`` from ``resp.data`` and re-fetch the entity to
+    normalize the response shape.
+    """
+    validate_required_params(module, ["name", "simulation_spec"])
+
+    sg = SpecGenerator(module)
+    default_spec = aiops_sdk.Simulation()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create simulation spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    try:
+        resp = api_instance.create_simulation(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating simulation",
+        )
+
+    created = getattr(resp, "data", None) if resp else None
+    if not created or not getattr(created, "ext_id", None):
+        module.fail_json(
+            msg="Simulation create returned no entity ext_id",
+            response=strip_internal_attributes(resp.to_dict()) if resp else None,
+            **result,
+        )
+
+    ext_id = created.ext_id
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(created.to_dict())
+    result["changed"] = True
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    """Return True when the update payload matches the existing simulation."""
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    return old_spec_dict == update_spec_dict
+
+
+def update_simulation(module, api_instance, result):
+    """Update a Simulation. The aiops Update API is synchronous and requires
+    an ``If-Match`` etag, and the response body is a list of AppMessage
+    entries (not the updated entity), so we re-fetch the simulation after
+    the update to return its current state.
+    """
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    old_spec = get_simulation(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            msg="Unable to fetch etag for updating simulation with ext_id: {0}".format(
+                ext_id
+            ),
+            **result,
+        )
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update simulation spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    try:
+        api_instance.update_simulation_by_id(
+            extId=ext_id, body=update_spec, if_match=etag
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating simulation",
+        )
+
+    simulation = get_simulation(module, api_instance, ext_id)
+    result["response"] = strip_internal_attributes(simulation.to_dict())
+    result["changed"] = True
+
+
+def delete_simulation(module, api_instance, result):
+    """Delete a Simulation. The aiops Delete API is synchronous and returns
+    an empty body on success, so we surface a status message instead.
+    """
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "Simulation with ext_id:{0} will be deleted.".format(ext_id)
+        return
+
+    try:
+        api_instance.delete_simulation_by_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting simulation",
+        )
+
+    result["response"] = {
+        "status": "SUCCEEDED",
+        "message": "Simulation with ext_id:{0} deleted successfully.".format(ext_id),
+    }
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+            ("state", "present", ("name", "ext_id"), True),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "skipped": False,
+    }
+    api_instance = get_scenarios_api_instance(module)
+    state = module.params.get("state")
+
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_simulation(module, api_instance, result)
+        else:
+            create_simulation(module, api_instance, result)
+    else:
+        delete_simulation(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_simulations_info_v2.py
+++ b/plugins/modules/ntnx_simulations_info_v2.py
@@ -1,0 +1,205 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_simulations_info_v2
+short_description: Fetch AIOps capacity planning Simulation info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about Simulation in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific Simulation.
+  - If C(ext_id) is not provided, list multiple Simulation optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+    - >-
+      This module requires the Nutanix IAM roles that grant read access to
+      the AIOps capacity planning APIs (typically Prism Viewer or higher).
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+  ext_id:
+    description:
+      - The external ID of the simulation.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+EXAMPLES = r"""
+- name: Fetch simulation using ext_id
+  nutanix.ncp.ntnx_simulations_info_v2:
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+  ignore_errors: true
+
+- name: List all simulations
+  nutanix.ncp.ntnx_simulations_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List simulations with filter
+  nutanix.ncp.ntnx_simulations_info_v2:
+    filter: "name eq 'simulation_ansible'"
+  register: result
+  ignore_errors: true
+
+- name: List simulations with limit
+  nutanix.ncp.ntnx_simulations_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC Simulation info v4 API.
+    - It can be a single Simulation if external ID is provided.
+    - List of multiple Simulation if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "2e40ff57-20aa-4d2b-b179-298db969c20d",
+      "links": null,
+      "name": "simulation_ansible",
+      "simulation_spec": {
+        "hdd_gb": 200.0,
+        "ram_gb": 16.0,
+        "ssd_gb": 100.0,
+        "vcpu_count": 4
+      },
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching simulations info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: when an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the simulation.
+  type: str
+  returned: when external ID is provided
+  sample: "7bea69e9-684c-4736-7805-d658ee17c1b6"
+
+total_available_results:
+  description: The total number of available simulations in PC.
+  type: int
+  returned: when all simulations are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import get_scenarios_api_instance  # noqa: E402
+from ..module_utils.v4.aiops.helpers import get_simulation  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_simulation_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_simulation(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_simulations(module, api_instance, result):
+
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating simulations info spec", **result)
+
+    try:
+        resp = api_instance.list_simulations(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching simulations info",
+        )
+
+    metadata = getattr(resp, "metadata", None)
+    total_available_results = getattr(metadata, "total_available_results", 0) or 0
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_scenarios_api_instance(module)
+    if module.params.get("ext_id"):
+        get_simulation_using_ext_id(module, api_instance, result)
+    else:
+        get_simulations(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
-ntnx-aiops-py-client==latest
+ntnx-aiops-py-client==4.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-aiops-py-client==latest

--- a/tests/integration/targets/ntnx_simulation_v2/aliases
+++ b/tests/integration/targets/ntnx_simulation_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_simulation_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_simulation_v2/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_simulation_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_simulation_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import simulations.yml
+      ansible.builtin.import_tasks: simulations.yml

--- a/tests/integration/targets/ntnx_simulation_v2/tasks/simulations.yml
+++ b/tests/integration/targets/ntnx_simulation_v2/tasks/simulations.yml
@@ -1,0 +1,454 @@
+---
+# Test plan (AIOps Simulation CRUD + info)
+# ----------------------------------------
+# check_mode:
+#   - Create Simulation with ALL attributes (spec projection only, no API call)
+#   - Update Simulation with ALL attributes (spec projection only, no API call)
+#   - Delete Simulation (dry-run — module returns a "will be deleted" msg)
+# create:
+#   - Create simulation with minimum attributes (name + one vcpu_count)
+#   - Create simulation with all attributes (name + full simulation_spec)
+# info:
+#   - Fetch simulation using ext_id
+#   - Fetch simulation using an invalid ext_id (expect failure)
+#   - List all simulations
+#   - List simulations with filter
+#   - List simulations with limit
+# update:
+#   - Update simulation with all attributes (change name + all resource fields)
+#   - Idempotency: run the same update again — should skip
+#   - Update simulation with wrong external ID (expect failure)
+# negative:
+#   - Create simulation without name (expect required_if failure)
+#   - Create simulation without simulation_spec (expect validate_required_params failure)
+#   - Delete simulation without ext_id (expect required_if failure)
+# delete:
+#   - Delete simulation with check mode
+#   - Delete all created simulations
+#   - Delete simulation with an invalid ext_id (expect failure)
+
+- name: Start AIOps Simulation tests
+  ansible.builtin.debug:
+    msg: Start AIOps Simulation tests
+
+- name: Generate random suffix and reset todelete
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+    todelete: []
+
+- name: Compose simulation name
+  ansible.builtin.set_fact:
+    sim_name: "sim_{{ suffix_name }}_{{ random_name }}"
+
+########################################################################################
+# Create Simulation Tests
+########################################################################################
+
+- name: Generate spec for creating simulation using check mode with all attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "check_mode_sim_full"
+    simulation_spec:
+      vcpu_count: 8
+      ram_gb: 32.0
+      hdd_gb: 400.0
+      ssd_gb: 200.0
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for creating simulation using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_sim_full"
+      - result.response.simulation_spec is defined
+      - result.response.simulation_spec.vcpu_count == 8
+      - result.response.simulation_spec.ram_gb == 32.0
+      - result.response.simulation_spec.hdd_gb == 400.0
+      - result.response.simulation_spec.ssd_gb == 200.0
+    success_msg: "Spec for creating simulation with all attributes generated successfully"
+    fail_msg: "Spec for creating simulation with all attributes generation failed"
+
+- name: Create simulation with minimum attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "{{ sim_name }}_min"
+    simulation_spec:
+      vcpu_count: 1
+      ram_gb: 1.0
+      hdd_gb: 1.0
+      ssd_gb: 1.0
+  register: result
+  ignore_errors: true
+
+- name: Create simulation with minimum attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.response is defined
+      - result.response.name == "{{ sim_name }}_min"
+      - result.response.simulation_spec.vcpu_count == 1
+      - result.response.simulation_spec.ram_gb == 1.0
+      - result.response.simulation_spec.hdd_gb == 1.0
+      - result.response.simulation_spec.ssd_gb == 1.0
+    success_msg: "Simulation with minimum attributes created successfully"
+    fail_msg: "Simulation with minimum attributes creation failed"
+
+- name: Add simulation to todelete list
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+- name: Create simulation with all attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "{{ sim_name }}_all"
+    simulation_spec:
+      vcpu_count: 4
+      ram_gb: 16.0
+      hdd_gb: 200.0
+      ssd_gb: 100.0
+  register: result
+  ignore_errors: true
+
+- name: Create simulation with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.response is defined
+      - result.response.name == "{{ sim_name }}_all"
+      - result.response.simulation_spec is defined
+      - result.response.simulation_spec.vcpu_count == 4
+      - result.response.simulation_spec.ram_gb == 16.0
+      - result.response.simulation_spec.hdd_gb == 200.0
+      - result.response.simulation_spec.ssd_gb == 100.0
+    success_msg: "Simulation with all attributes created successfully"
+    fail_msg: "Simulation with all attributes creation failed"
+
+- name: Add simulation to todelete list
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+########################################################################################
+# Create Simulation - Negative Tests
+########################################################################################
+
+- name: Create simulation with missing name
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    simulation_spec:
+      vcpu_count: 2
+      ram_gb: 8.0
+  register: result
+  ignore_errors: true
+
+- name: Create simulation with missing name status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is present but any of the following are missing' in result.msg"
+    success_msg: "Create simulation with missing name failed as expected"
+    fail_msg: "Create simulation with missing name did not fail as expected"
+
+- name: Create simulation with missing simulation_spec
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "sim_missing_spec"
+  register: result
+  ignore_errors: true
+
+- name: Create simulation with missing simulation_spec status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): simulation_spec"
+    success_msg: "Create simulation with missing simulation_spec failed as expected"
+    fail_msg: "Create simulation with missing simulation_spec did not fail as expected"
+
+########################################################################################
+# Info Module Tests - Get Single Simulation
+########################################################################################
+
+- name: Fetch simulation using external ID
+  nutanix.ncp.ntnx_simulations_info_v2:
+    ext_id: "{{ todelete[1] }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch simulation using external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.ext_id == "{{ todelete[1] }}"
+      - result.response.name == "{{ sim_name }}_all"
+      - result.response.simulation_spec.vcpu_count == 4
+      - result.response.simulation_spec.ram_gb == 16.0
+      - result.response.simulation_spec.hdd_gb == 200.0
+      - result.response.simulation_spec.ssd_gb == 100.0
+    success_msg: "Fetch simulation using external ID passed"
+    fail_msg: "Fetch simulation using external ID failed"
+
+- name: Fetch simulation using wrong external ID
+  nutanix.ncp.ntnx_simulations_info_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+  register: result
+  ignore_errors: true
+
+- name: Fetch simulation using wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Fetch simulation using wrong external ID failed as expected"
+    fail_msg: "Fetch simulation using wrong external ID did not fail as expected"
+
+########################################################################################
+# Info Module Tests - List Simulations
+########################################################################################
+
+- name: List all simulations
+  nutanix.ncp.ntnx_simulations_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List all simulations status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 2
+    success_msg: "List all simulations passed"
+    fail_msg: "List all simulations failed"
+
+- name: List simulations with filter
+  nutanix.ncp.ntnx_simulations_info_v2:
+    filter: "name eq '{{ sim_name }}_all'"
+  register: result
+  ignore_errors: true
+
+- name: List simulations with filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+      - result.response[0].name == "{{ sim_name }}_all"
+      - result.response[0].simulation_spec.vcpu_count == 4
+    success_msg: "List simulations with filter passed"
+    fail_msg: "List simulations with filter failed"
+
+- name: List simulations with limit
+  nutanix.ncp.ntnx_simulations_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List simulations with limit status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    success_msg: "List simulations with limit passed"
+    fail_msg: "List simulations with limit failed"
+
+########################################################################################
+# Update Simulation Tests
+########################################################################################
+
+- name: Generate spec for updating simulation using check mode with all attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "{{ todelete[1] }}"
+    name: "{{ sim_name }}_updated"
+    simulation_spec:
+      vcpu_count: 16
+      ram_gb: 64.0
+      hdd_gb: 800.0
+      ssd_gb: 400.0
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for updating simulation using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "{{ sim_name }}_updated"
+      - result.response.simulation_spec.vcpu_count == 16
+      - result.response.simulation_spec.ram_gb == 64.0
+      - result.response.simulation_spec.hdd_gb == 800.0
+      - result.response.simulation_spec.ssd_gb == 400.0
+    success_msg: "Spec for updating simulation with all attributes generated successfully"
+    fail_msg: "Spec for updating simulation with all attributes generation failed"
+
+- name: Update simulation with all attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "{{ todelete[1] }}"
+    name: "{{ sim_name }}_updated"
+    simulation_spec:
+      vcpu_count: 16
+      ram_gb: 64.0
+      hdd_gb: 800.0
+      ssd_gb: 400.0
+  register: result
+  ignore_errors: true
+
+- name: Update simulation with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.response is defined
+      - result.response.ext_id == "{{ todelete[1] }}"
+      - result.response.name == "{{ sim_name }}_updated"
+      - result.response.simulation_spec.vcpu_count == 16
+      - result.response.simulation_spec.ram_gb == 64.0
+      - result.response.simulation_spec.hdd_gb == 800.0
+      - result.response.simulation_spec.ssd_gb == 400.0
+    success_msg: "Update simulation with all attributes passed"
+    fail_msg: "Update simulation with all attributes failed"
+
+- name: Update simulation with same values (idempotency test)
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "{{ todelete[1] }}"
+    name: "{{ sim_name }}_updated"
+    simulation_spec:
+      vcpu_count: 16
+      ram_gb: 64.0
+      hdd_gb: 800.0
+      ssd_gb: 400.0
+  register: result
+  ignore_errors: true
+
+- name: Update simulation with same values to test idempotency status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.msg == "Nothing to change."
+      - result.skipped == true
+    success_msg: "Update simulation idempotency passed"
+    fail_msg: "Update simulation idempotency failed"
+
+- name: Update simulation with wrong external ID
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+    name: "sim_wrong_ext_id"
+    simulation_spec:
+      vcpu_count: 2
+      ram_gb: 8.0
+  register: result
+  ignore_errors: true
+
+- name: Update simulation with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Update simulation with wrong external ID failed as expected"
+    fail_msg: "Update simulation with wrong external ID did not fail as expected"
+
+########################################################################################
+# Delete Simulation Tests
+########################################################################################
+
+- name: Delete simulation with check mode
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "{{ todelete[0] }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Delete simulation with check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+    success_msg: "Delete simulation with check mode passed"
+    fail_msg: "Delete simulation with check mode failed"
+
+- name: Delete all created simulations
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  register: result
+  ignore_errors: true
+  loop: "{{ todelete }}"
+
+- name: Deletion Status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.results | length == todelete | length
+      - result.msg == "All items completed"
+    success_msg: "All simulations deleted successfully"
+    fail_msg: "Unable to delete all simulations"
+
+- name: Delete simulation with wrong external ID
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+  register: result
+  ignore_errors: true
+
+- name: Delete simulation with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Delete simulation with wrong external ID failed as expected"
+    fail_msg: "Delete simulation with wrong external ID did not fail as expected"
+
+- name: Delete simulation with missing external ID
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Delete simulation with missing external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete simulation with missing external ID failed as expected"
+    fail_msg: "Delete simulation with missing external ID did not fail as expected"


### PR DESCRIPTION
## Summary

Adds AIOps capacity planning **Simulation** modules to the `nutanix.ncp` collection using Nutanix PC v4 APIs (SDK: `ntnx-aiops-py-client`).

- `plugins/modules/ntnx_simulation_v2.py` — Create/Update/Delete
- `plugins/modules/ntnx_simulations_info_v2.py` — Get / List (with filter/limit)
- `plugins/module_utils/v4/aiops/{api_client.py, helpers.py, __init__.py}` — shared aiops SDK plumbing
- `examples/aiops/Simulation/simulations_v2.yml` — example playbook
- `tests/integration/targets/ntnx_simulation_v2/` — full integration test target (CRUD lifecycle, info, negative cases, idempotency, check_mode)
- `meta/runtime.yml` — action group entries
- `plugins/module_utils/v4/constants.py` — new `RelEntityType.SIMULATION` / `SCENARIO`
- `requirements.txt` — pinned `ntnx-aiops-py-client==4.0.2`

### API notes

The aiops Simulation endpoints are synchronous and diverge from the v4 async task pattern used elsewhere:

- **Create**: synchronous; response body is the created `Simulation` (the module returns it directly via `ext_id`/`response`)
- **Update**: synchronous, requires `If-Match`; response body is `[AppMessage]`, not the entity — module re-`Get`s to normalize `response`
- **Delete**: synchronous with empty body on success — module returns a synthetic `{status: SUCCEEDED, ...}` message

Idempotent update is implemented by diffing the existing entity against the projected update spec.

## Test plan

- [x] `black`, `isort`, `flake8` — clean (see artifacts)
- [x] `ansible-lint` — 0 failures on modules, examples, integration target
- [x] `ansible-test sanity` — all 33 tests pass on 3.12 for new files
- [x] Live PC (10.44.76.28) run of example playbook: create/get/list/update/idempotency/delete — all pass
- [x] Live PC run of integration target: 40 ok, 4 changed, 1 skipped (idempotent update), 6 ignored (expected negative failures), 0 real failures

Artifacts: `/tmp/aiops_simulation_artifacts/{integration_run.log, example_run.log, sanity.log, ansible-lint.log, black.log, isort.log, flake8.log, example_test.yml}`
