### PR TITLE
Simulation Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+__pycache__/
+*.pyc

--- a/examples/aiops/Simulation/examples_run.log
+++ b/examples/aiops/Simulation/examples_run.log
@@ -1,0 +1,37 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [AIOps VM Simulation playbook] ********************************************
+
+TASK [Set common variables] ****************************************************
+ok: [localhost] => {"ansible_facts": {"simulation_name": "vdi_medium_workload"}, "changed": false}
+
+TASK [Create a VM simulation] **************************************************
+changed: [localhost] => {"changed": true, "ext_id": "2be9c6fd-638d-4401-b88e-c6c962e7c477", "response": {"ext_id": "2be9c6fd-638d-4401-b88e-c6c962e7c477", "links": null, "name": "vdi_medium_workload", "simulation_spec": {"hdd_gb": 100.0, "ram_gb": 8.0, "ssd_gb": 200.0, "vcpu_count": 4}, "tenant_id": null}, "task_ext_id": null}
+
+TASK [Capture created simulation ext_id] ***************************************
+ok: [localhost] => {"ansible_facts": {"simulation_ext_id": "2be9c6fd-638d-4401-b88e-c6c962e7c477"}, "changed": false}
+
+TASK [Get VM simulation using ext_id] ******************************************
+ok: [localhost] => {"changed": false, "ext_id": "2be9c6fd-638d-4401-b88e-c6c962e7c477", "response": {"ext_id": "2be9c6fd-638d-4401-b88e-c6c962e7c477", "links": null, "name": "vdi_medium_workload", "simulation_spec": {"hdd_gb": 100.0, "ram_gb": 8.0, "ssd_gb": 200.0, "vcpu_count": 4}, "tenant_id": null}}
+
+TASK [List all VM simulations] *************************************************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "2be9c6fd-638d-4401-b88e-c6c962e7c477", "links": null, "name": "vdi_medium_workload", "simulation_spec": {"hdd_gb": 100.0, "ram_gb": 8.0, "ssd_gb": 200.0, "vcpu_count": 4}, "tenant_id": null}], "total_available_results": 1}
+
+TASK [List VM simulations with filter] *****************************************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "2be9c6fd-638d-4401-b88e-c6c962e7c477", "links": null, "name": "vdi_medium_workload", "simulation_spec": {"hdd_gb": 100.0, "ram_gb": 8.0, "ssd_gb": 200.0, "vcpu_count": 4}, "tenant_id": null}], "total_available_results": 1}
+
+TASK [List VM simulations with limit] ******************************************
+ok: [localhost] => {"changed": false, "response": [{"ext_id": "2be9c6fd-638d-4401-b88e-c6c962e7c477", "links": null, "name": "vdi_medium_workload", "simulation_spec": {"hdd_gb": 100.0, "ram_gb": 8.0, "ssd_gb": 200.0, "vcpu_count": 4}, "tenant_id": null}], "total_available_results": 1}
+
+TASK [Update the VM simulation] ************************************************
+changed: [localhost] => {"changed": true, "ext_id": "2be9c6fd-638d-4401-b88e-c6c962e7c477", "response": {"ext_id": "2be9c6fd-638d-4401-b88e-c6c962e7c477", "links": null, "name": "vdi_medium_workload_updated", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 400.0, "vcpu_count": 8}, "tenant_id": null}, "task_ext_id": null}
+
+TASK [Delete the VM simulation] ************************************************
+changed: [localhost] => {"changed": true, "ext_id": "2be9c6fd-638d-4401-b88e-c6c962e7c477", "response": {"message": "Simulation with ext_id:2be9c6fd-638d-4401-b88e-c6c962e7c477 deleted successfully.", "status": "SUCCEEDED"}, "task_ext_id": null}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=9    changed=3    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+

--- a/examples/aiops/Simulation/simulation_v2.yml
+++ b/examples/aiops/Simulation/simulation_v2.yml
@@ -1,0 +1,75 @@
+---
+# Summary:
+# This playbook demonstrates the AIOps VM Simulation lifecycle:
+# 1. Create a VM simulation with all fields.
+# 2. Fetch the simulation by ext_id.
+# 3. List all VM simulations.
+# 4. List VM simulations with filter and limit.
+# 5. Update the VM simulation with all fields.
+# 6. Delete the VM simulation.
+
+- name: AIOps VM Simulation playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Set common variables
+      ansible.builtin.set_fact:
+        simulation_name: "vdi_medium_workload"
+
+    - name: Create a VM simulation
+      nutanix.ncp.ntnx_simulation_v2:
+        state: present
+        name: "{{ simulation_name }}"
+        simulation_spec:
+          vcpu_count: 4
+          ram_gb: 8.0
+          hdd_gb: 100.0
+          ssd_gb: 200.0
+      register: create_result
+
+    - name: Capture created simulation ext_id
+      ansible.builtin.set_fact:
+        simulation_ext_id: "{{ create_result.ext_id }}"
+
+    - name: Get VM simulation using ext_id
+      nutanix.ncp.ntnx_simulations_info_v2:
+        ext_id: "{{ simulation_ext_id }}"
+      register: get_result
+
+    - name: List all VM simulations
+      nutanix.ncp.ntnx_simulations_info_v2:
+      register: list_all_result
+
+    - name: List VM simulations with filter
+      nutanix.ncp.ntnx_simulations_info_v2:
+        filter: "name eq '{{ simulation_name }}'"
+      register: list_filter_result
+
+    - name: List VM simulations with limit
+      nutanix.ncp.ntnx_simulations_info_v2:
+        limit: 1
+      register: list_limit_result
+
+    - name: Update the VM simulation
+      nutanix.ncp.ntnx_simulation_v2:
+        state: present
+        ext_id: "{{ simulation_ext_id }}"
+        name: "{{ simulation_name }}_updated"
+        simulation_spec:
+          vcpu_count: 8
+          ram_gb: 16.0
+          hdd_gb: 200.0
+          ssd_gb: 400.0
+      register: update_result
+
+    - name: Delete the VM simulation
+      nutanix.ncp.ntnx_simulation_v2:
+        state: absent
+        ext_id: "{{ simulation_ext_id }}"
+      register: delete_result

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -248,3 +248,5 @@ action_groups:
     - ntnx_virtual_switches_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2
+    - ntnx_simulation_v2
+    - ntnx_simulations_info_v2

--- a/plugins/module_utils/v4/aiops/api_client.py
+++ b/plugins/module_utils/v4/aiops/api_client.py
@@ -1,0 +1,104 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+from base64 import b64encode
+
+from ansible.module_utils.basic import missing_required_lib
+
+from ...constants import ALLOW_VERSION_NEGOTIATION
+from ..api_logger import setup_api_logging
+from ..utils import _apply_proxy_from_env
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client
+except ImportError:
+    SDK_IMP_ERROR = traceback.format_exc()
+
+
+def get_api_client(module):
+    """
+    This method will return client to be used in api connection using
+    given connection details.
+    Args:
+        module (object): Ansible module object
+    return:
+        client (object): api client object
+    """
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    config = ntnx_aiops_py_client.Configuration()
+    config.host = module.params.get("nutanix_host")
+    config.port = module.params.get("nutanix_port")
+    api_key = module.params.get("nutanix_api_key")
+    nutanix_username = module.params.get("nutanix_username")
+    nutanix_password = module.params.get("nutanix_password")
+    if (not nutanix_username or not nutanix_password) and not (api_key):
+        module.fail_json(
+            msg="Either nutanix_username and nutanix_password or nutanix_api_key is required"
+        )
+    if api_key:
+        config.set_api_key(api_key)
+    else:
+        config.username = nutanix_username
+        config.password = nutanix_password
+    config.verify_ssl = module.params.get("validate_certs")
+    try:
+        client = ntnx_aiops_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_aiops_py_client.ApiClient(configuration=config)
+    config.read_timeout = module.params.get("read_timeout")
+    _apply_proxy_from_env(config, module)
+    try:
+        client = ntnx_aiops_py_client.ApiClient(
+            configuration=config, allow_version_negotiation=ALLOW_VERSION_NEGOTIATION
+        )
+    except TypeError:
+        client = ntnx_aiops_py_client.ApiClient(configuration=config)
+    if not api_key:
+        cred = "{0}:{1}".format(config.username, config.password)
+        try:
+            encoded_cred = b64encode(bytes(cred, encoding="ascii")).decode("ascii")
+        except BaseException:
+            encoded_cred = b64encode(bytes(cred).encode("ascii")).decode("ascii")
+        auth_header = "Basic " + encoded_cred
+        client.add_default_header(header_name="Authorization", header_value=auth_header)
+
+    setup_api_logging(module, client)
+
+    return client
+
+
+def get_etag(data):
+    """
+    This method will fetch etag from a v4 api response.
+    Args:
+        data (dict): v4 api response
+    return:
+        etag (str): etag value
+    """
+    return ntnx_aiops_py_client.ApiClient.get_etag(data)
+
+
+def get_scenarios_api_instance(module):
+    """
+    This method will return ScenariosApi instance which serves both capacity
+    planning scenarios and VM simulations under the aiops namespace.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): scenarios api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_aiops_py_client.ScenariosApi(api_client=api_client)

--- a/plugins/module_utils/v4/aiops/helpers.py
+++ b/plugins/module_utils/v4/aiops/helpers.py
@@ -1,0 +1,28 @@
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ..utils import raise_api_exception  # noqa: E402
+
+
+def get_simulation(module, api_instance, ext_id):
+    """
+    Fetch a Simulation by its external ID using ScenariosApi.
+    Args:
+        module: Ansible module.
+        api_instance: ScenariosApi instance from ntnx_aiops_py_client SDK.
+        ext_id (str): Simulation external ID.
+    return:
+        info (object): Simulation info object.
+    """
+    try:
+        return api_instance.get_simulation_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching simulation info using ext_id",
+        )

--- a/plugins/modules/ntnx_simulation_v2.py
+++ b/plugins/modules/ntnx_simulation_v2.py
@@ -1,0 +1,423 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_simulation_v2
+short_description: Create, Update, Delete VM Simulations for AIOps Capacity Planning in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to create, update, and delete VM Simulations in Nutanix Prism Central.
+  - A Simulation defines a hypothetical VM sizing profile (vCPU/RAM/HDD/SSD) that can be reused
+    across What-If capacity planning scenarios.
+  - Simulations are used by AIOps capacity planning to model the impact of adding new workloads
+    on cluster runway and hardware recommendations.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    The required roles depend on the operation being performed.
+  - >-
+    B(Create a VM Simulation) -
+    Required Roles: Prism Admin, Super Admin
+  - >-
+    B(Update a VM Simulation) -
+    Required Roles: Prism Admin, Super Admin
+  - >-
+    B(Delete a VM Simulation) -
+    Required Roles: Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will be create simulation.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be update simulation.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be delete simulation.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the simulation.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - User-visible name of the VM simulation.
+      - Required for create operation.
+    type: str
+    required: false
+  simulation_spec:
+    description:
+      - The hypothetical VM resource specification used by capacity planning simulations.
+      - Required for create operation.
+    type: dict
+    required: false
+    suboptions:
+      vcpu_count:
+        description:
+          - Number of virtual CPUs for the simulated VM.
+        type: int
+        required: false
+      ram_gb:
+        description:
+          - Memory (RAM) in GiB for the simulated VM.
+        type: float
+        required: false
+      hdd_gb:
+        description:
+          - HDD storage size in GiB for the simulated VM.
+        type: float
+        required: false
+      ssd_gb:
+        description:
+          - SSD storage size in GiB for the simulated VM.
+        type: float
+        required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Create a VM simulation
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "vdi_medium_workload"
+    simulation_spec:
+      vcpu_count: 4
+      ram_gb: 8.0
+      hdd_gb: 100.0
+      ssd_gb: 200.0
+  register: result
+
+- name: Update a VM simulation
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+    name: "vdi_large_workload"
+    simulation_spec:
+      vcpu_count: 8
+      ram_gb: 16.0
+      hdd_gb: 200.0
+      ssd_gb: 400.0
+  register: result
+
+- name: Delete a VM simulation
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting a VM simulation.
+    - For create and update, this contains the current simulation details fetched after the API call.
+    - For delete, this contains a status message indicating the simulation was removed.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "8e2b45a3-15cf-4a2e-b40c-3d1c42908b12",
+      "name": "vdi_medium_workload",
+      "simulation_spec": {
+        "vcpu_count": 4,
+        "ram_gb": 8.0,
+        "hdd_gb": 100.0,
+        "ssd_gb": 200.0
+      },
+      "links": null,
+      "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+    - The AIOps simulation APIs are synchronous, so this field is not populated by the platform.
+  returned: always
+  type: str
+  sample: null
+
+ext_id:
+  description:
+    - The external ID of the simulation.
+  returned: always
+  type: str
+  sample: "8e2b45a3-15cf-4a2e-b40c-3d1c42908b12"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped.
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Simulation with name 'vdi_medium_workload' already exists. Skipping creation."
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import get_scenarios_api_instance  # noqa: E402
+from ..module_utils.v4.aiops.helpers import get_simulation  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_aiops_py_client as aiops_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as aiops_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    simulation_spec = dict(
+        vcpu_count=dict(type="int", required=False),
+        ram_gb=dict(type="float", required=False),
+        hdd_gb=dict(type="float", required=False),
+        ssd_gb=dict(type="float", required=False),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        simulation_spec=dict(
+            type="dict",
+            options=simulation_spec,
+            obj=aiops_sdk.SimulatedVmResourceSpec,
+        ),
+    )
+    return module_args
+
+
+def _find_simulation_by_name(module, api_instance, name):
+    """Return an existing Simulation object with the given name, or None."""
+    try:
+        resp = api_instance.list_simulations(_filter="name eq '{0}'".format(name))
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while looking up simulation by name",
+        )
+    entities = resp.data if resp and resp.data else []
+    for entity in entities:
+        if entity.name == name:
+            return entity
+    return None
+
+
+def create_simulation(module, result, api_instance):
+    validate_required_params(module, ["name", "simulation_spec"])
+
+    existing = _find_simulation_by_name(module, api_instance, module.params.get("name"))
+    if existing is not None:
+        result["ext_id"] = existing.ext_id
+        result["response"] = strip_internal_attributes(existing.to_dict())
+        result["skipped"] = True
+        result["changed"] = False
+        module.exit_json(
+            msg="Simulation with name '{0}' already exists. Skipping creation.".format(
+                module.params.get("name")
+            ),
+            **result,
+        )
+
+    sg = SpecGenerator(module)
+    default_spec = aiops_sdk.Simulation()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create simulation spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    try:
+        resp = api_instance.create_simulation(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating simulation",
+        )
+
+    entity = resp.data
+    result["response"] = strip_internal_attributes(entity.to_dict())
+    result["ext_id"] = getattr(entity, "ext_id", None)
+    result["changed"] = True
+
+
+def _simulation_spec_equal(current_spec, desired_spec):
+    """Compare the mutable fields on two Simulation objects."""
+    if current_spec.name != desired_spec.name:
+        return False
+    current_res = current_spec.simulation_spec
+    desired_res = desired_spec.simulation_spec
+    if current_res is None and desired_res is None:
+        return True
+    if current_res is None or desired_res is None:
+        return False
+    for field in ("vcpu_count", "ram_gb", "hdd_gb", "ssd_gb"):
+        if getattr(current_res, field, None) != getattr(desired_res, field, None):
+            return False
+    return True
+
+
+def update_simulation(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    current_spec = get_simulation(module, api_instance, ext_id)
+
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(current_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update simulation spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if _simulation_spec_equal(current_spec, update_spec):
+        result["skipped"] = True
+        result["response"] = strip_internal_attributes(current_spec.to_dict())
+        module.exit_json(msg="Nothing to change.", **result)
+
+    try:
+        api_instance.update_simulation_by_id(extId=ext_id, body=update_spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating simulation",
+        )
+
+    refreshed = get_simulation(module, api_instance, ext_id)
+    result["response"] = strip_internal_attributes(refreshed.to_dict())
+    result["changed"] = True
+
+
+def delete_simulation(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "Simulation with ext_id:{0} will be deleted.".format(ext_id)
+        return
+
+    try:
+        api_instance.delete_simulation_by_id(extId=ext_id)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting simulation",
+        )
+
+    result["response"] = {
+        "status": "SUCCEEDED",
+        "message": "Simulation with ext_id:{0} deleted successfully.".format(ext_id),
+    }
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_aiops_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+        "task_ext_id": None,
+        "skipped": False,
+    }
+    api_instance = get_scenarios_api_instance(module)
+    state = module.params.get("state")
+
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_simulation(module, result, api_instance)
+        else:
+            create_simulation(module, result, api_instance)
+    else:
+        delete_simulation(module, result, api_instance)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_simulations_info_v2.py
+++ b/plugins/modules/ntnx_simulations_info_v2.py
@@ -1,0 +1,213 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_simulations_info_v2
+short_description: Fetch VM simulations info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about Simulation in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific Simulation.
+  - If C(ext_id) is not provided, list multiple Simulation optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(Get a VM Simulation by ext_id) -
+    Required Roles: Prism Viewer, Prism Admin, Super Admin
+  - >-
+    B(List VM Simulations) -
+    Required Roles: Prism Viewer, Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=aiops)"
+options:
+  ext_id:
+    description:
+      - The external ID of the simulation.
+      - If provided, fetch a specific simulation.
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - George Ghawali (@george-ghawali)
+  - Abhinav Bansal (@abhinavbansal29)
+"""
+
+EXAMPLES = r"""
+- name: Get VM simulation using ext_id
+  nutanix.ncp.ntnx_simulations_info_v2:
+    ext_id: "2e40ff57-20aa-4d2b-b179-298db969c20d"
+  register: result
+
+- name: List all VM simulations
+  nutanix.ncp.ntnx_simulations_info_v2:
+  register: result
+
+- name: List VM simulations with filter
+  nutanix.ncp.ntnx_simulations_info_v2:
+    filter: "name eq 'vdi_medium_workload'"
+  register: result
+
+- name: List VM simulations with limit
+  nutanix.ncp.ntnx_simulations_info_v2:
+    limit: 1
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC Simulation info v4 API.
+    - It can be a single Simulation if external ID is provided.
+    - List of multiple Simulation if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "ext_id": "8e2b45a3-15cf-4a2e-b40c-3d1c42908b12",
+      "name": "vdi_medium_workload",
+      "simulation_spec": {
+        "vcpu_count": 4,
+        "ram_gb": 8.0,
+        "hdd_gb": 100.0,
+        "ssd_gb": 200.0
+      },
+      "links": null,
+      "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching simulations info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution.
+  type: str
+  returned: When an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the simulation.
+  type: str
+  returned: When external ID is provided
+  sample: "8e2b45a3-15cf-4a2e-b40c-3d1c42908b12"
+
+total_available_results:
+  description: The total number of available simulations in PC.
+  type: int
+  returned: When all simulations are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.aiops.api_client import get_scenarios_api_instance  # noqa: E402
+from ..module_utils.v4.aiops.helpers import get_simulation  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_simulation_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_simulation(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_simulations(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating simulations info spec", **result)
+
+    try:
+        resp = api_instance.list_simulations(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching simulations info",
+        )
+
+    total_available_results = 0
+    if resp is not None and resp.metadata is not None:
+        total_available_results = (
+            getattr(resp.metadata, "total_available_results", 0) or 0
+        )
+    result["total_available_results"] = total_available_results
+
+    data = None
+    if resp is not None and resp.data is not None:
+        data = strip_internal_attributes(resp.to_dict()).get("data")
+    if not data:
+        data = []
+    result["response"] = data
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_scenarios_api_instance(module)
+    if module.params.get("ext_id"):
+        get_simulation_using_ext_id(module, api_instance, result)
+    else:
+        get_simulations(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ntnx-lifecycle-py-client==4.2.2
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2
+ntnx-aiops-py-client==latest

--- a/tests/integration/targets/ntnx_simulation_v2/aliases
+++ b/tests/integration/targets/ntnx_simulation_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_simulation_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_simulation_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_simulation_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_simulation_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import simulation.yml
+      ansible.builtin.import_tasks: simulation.yml

--- a/tests/integration/targets/ntnx_simulation_v2/tasks/simulation.yml
+++ b/tests/integration/targets/ntnx_simulation_v2/tasks/simulation.yml
@@ -1,0 +1,566 @@
+---
+########################################################################################
+# Test plan for AIOps VM Simulation modules
+#
+# Simulation models a hypothetical VM workload (vCPU/RAM/HDD/SSD) reused across
+# What-If capacity planning scenarios. The v4 APIs are synchronous.
+#
+# Coverage:
+# 1. check_mode: create/update with all attributes, delete with ext_id.
+# 2. CRUD: minimal create, full create, get by ext_id, meaningful update, idempotent
+#    update, delete.
+# 3. Info: list all + total_available_results, list with filter, list with limit,
+#    fetch with wrong ext_id, mutually exclusive ext_id+filter.
+# 4. Negative: missing required fields (create), delete missing ext_id, delete a
+#    non-existent ext_id, create-idempotency (skipped when name already exists).
+########################################################################################
+
+- name: Start Simulation tests
+  ansible.builtin.debug:
+    msg: Start AIOps VM Simulation tests
+
+- name: Generate random suffix to avoid parallel test collisions
+  ansible.builtin.set_fact:
+    random_suffix: "{{ query('community.general.random_string', numbers=true, upper=false, special=false, length=10)[0] }}"
+    todelete: []
+
+- name: Set unique simulation names
+  ansible.builtin.set_fact:
+    sim_name_min: "ansible_sim_min_{{ random_suffix }}"
+    sim_name_full: "ansible_sim_full_{{ random_suffix }}"
+    sim_name_update: "ansible_sim_upd_{{ random_suffix }}"
+
+########################################################################################
+# Purge any leftover simulations from prior runs to guarantee a clean baseline.
+########################################################################################
+
+- name: List all existing simulations for baseline cleanup
+  nutanix.ncp.ntnx_simulations_info_v2: {}
+  register: baseline_list
+  ignore_errors: true
+
+- name: Delete any leftover simulations from earlier ansible runs
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "{{ item.ext_id }}"
+  register: baseline_purge
+  loop: "{{ baseline_list.response | default([]) | selectattr('name', 'defined') |
+            selectattr('name', 'match', '^ansible_sim_') | list }}"
+  when: baseline_list.response is defined
+  ignore_errors: true
+
+########################################################################################
+# 1a. check_mode — Create with ALL attributes
+########################################################################################
+
+- name: Create simulation using check mode with all attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "check_mode_sim_full"
+    simulation_spec:
+      vcpu_count: 6
+      ram_gb: 12.0
+      hdd_gb: 150.0
+      ssd_gb: 250.0
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check_mode create with all attributes generates spec
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_sim_full"
+      - result.response.simulation_spec.vcpu_count == 6
+      - result.response.simulation_spec.ram_gb == 12.0
+      - result.response.simulation_spec.hdd_gb == 150.0
+      - result.response.simulation_spec.ssd_gb == 250.0
+    success_msg: "Check mode create with all attributes passed"
+    fail_msg: "Check mode create with all attributes failed"
+
+########################################################################################
+# 2a. Create minimal simulation (only required fields)
+########################################################################################
+
+- name: Create simulation with minimum attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "{{ sim_name_min }}"
+    simulation_spec:
+      vcpu_count: 2
+      ram_gb: 4.0
+      hdd_gb: 50.0
+      ssd_gb: 100.0
+  register: result
+  ignore_errors: true
+
+- name: Assert minimal simulation creation
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.response is defined
+      - result.response.name == sim_name_min
+      - result.response.simulation_spec.vcpu_count == 2
+      - result.response.simulation_spec.ram_gb == 4.0
+      - result.response.simulation_spec.hdd_gb == 50.0
+      - result.response.simulation_spec.ssd_gb == 100.0
+    success_msg: "Minimal simulation created successfully"
+    fail_msg: "Minimal simulation creation failed"
+
+- name: Track minimal simulation ext_id for cleanup
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+
+########################################################################################
+# 2b. Create simulation with ALL fields populated
+########################################################################################
+
+- name: Create simulation with all attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "{{ sim_name_full }}"
+    simulation_spec:
+      vcpu_count: 8
+      ram_gb: 16.0
+      hdd_gb: 200.0
+      ssd_gb: 400.0
+  register: result
+  ignore_errors: true
+
+- name: Assert full simulation creation
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.response is defined
+      - result.response.name == sim_name_full
+      - result.response.simulation_spec.vcpu_count == 8
+      - result.response.simulation_spec.ram_gb == 16.0
+      - result.response.simulation_spec.hdd_gb == 200.0
+      - result.response.simulation_spec.ssd_gb == 400.0
+    success_msg: "Full simulation created successfully"
+    fail_msg: "Full simulation creation failed"
+
+- name: Track full simulation ext_id for cleanup
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+    full_sim_ext_id: "{{ result.ext_id }}"
+
+########################################################################################
+# 4a. Negative — create with missing name
+########################################################################################
+
+- name: Create simulation with missing name (should fail)
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    simulation_spec:
+      vcpu_count: 2
+      ram_gb: 4.0
+      hdd_gb: 50.0
+      ssd_gb: 100.0
+  register: result
+  ignore_errors: true
+
+- name: Assert create with missing name fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): name"
+    success_msg: "Create with missing name failed as expected"
+    fail_msg: "Create with missing name did not fail as expected"
+
+########################################################################################
+# 4b. Negative — create with missing simulation_spec
+########################################################################################
+
+- name: Create simulation with missing simulation_spec (should fail)
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "should_not_be_created_{{ random_suffix }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert create with missing simulation_spec fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): simulation_spec"
+    success_msg: "Create with missing simulation_spec failed as expected"
+    fail_msg: "Create with missing simulation_spec did not fail as expected"
+
+########################################################################################
+# 4e. Create idempotency — creating with same name is a no-op
+########################################################################################
+
+- name: Create simulation with an existing name (idempotency)
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    name: "{{ sim_name_full }}"
+    simulation_spec:
+      vcpu_count: 8
+      ram_gb: 16.0
+      hdd_gb: 200.0
+      ssd_gb: 400.0
+  register: result
+  ignore_errors: true
+
+- name: Assert duplicate-name create is skipped
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.ext_id == full_sim_ext_id
+      - result.msg == "Simulation with name '" + sim_name_full + "' already exists. Skipping creation."
+    success_msg: "Create idempotency by name skipped as expected"
+    fail_msg: "Create idempotency by name did not skip as expected"
+
+########################################################################################
+# 3a. Info module — get by ext_id
+########################################################################################
+
+- name: Fetch simulation using ext_id
+  nutanix.ncp.ntnx_simulations_info_v2:
+    ext_id: "{{ full_sim_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Assert fetch by ext_id
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.ext_id == full_sim_ext_id
+      - result.response is defined
+      - result.response.name == sim_name_full
+      - result.response.simulation_spec.vcpu_count == 8
+      - result.response.simulation_spec.ram_gb == 16.0
+      - result.response.simulation_spec.hdd_gb == 200.0
+      - result.response.simulation_spec.ssd_gb == 400.0
+    success_msg: "Fetch simulation by ext_id passed"
+    fail_msg: "Fetch simulation by ext_id failed"
+
+########################################################################################
+# 3b. Info module — list all
+########################################################################################
+
+- name: List all simulations
+  nutanix.ncp.ntnx_simulations_info_v2: {}
+  register: list_all_result
+  ignore_errors: true
+
+- name: Assert list-all returns at least the two created simulations
+  ansible.builtin.assert:
+    that:
+      - list_all_result is defined
+      - list_all_result.changed == false
+      - list_all_result.failed == false
+      - list_all_result.response is defined
+      - list_all_result.response | length >= 2
+      - list_all_result.total_available_results is defined
+      - list_all_result.total_available_results >= 2
+    success_msg: "List-all simulations passed"
+    fail_msg: "List-all simulations failed"
+
+- name: Assert both created simulation names are present in list-all
+  ansible.builtin.assert:
+    that:
+      - sim_name_min in (list_all_result.response | map(attribute='name') | list)
+      - sim_name_full in (list_all_result.response | map(attribute='name') | list)
+    success_msg: "Both simulations appear in the list"
+    fail_msg: "Created simulations not found in list-all"
+
+########################################################################################
+# 3c. Info module — list with filter
+########################################################################################
+
+- name: List simulations with name filter
+  nutanix.ncp.ntnx_simulations_info_v2:
+    filter: "name eq '{{ sim_name_full }}'"
+  register: filter_result
+  ignore_errors: true
+
+- name: Assert filter returns only the matching simulation
+  ansible.builtin.assert:
+    that:
+      - filter_result is defined
+      - filter_result.changed == false
+      - filter_result.failed == false
+      - filter_result.response is defined
+      - filter_result.response | length == 1
+      - filter_result.response[0].name == sim_name_full
+      - filter_result.response[0].simulation_spec.vcpu_count == 8
+    success_msg: "List with filter passed"
+    fail_msg: "List with filter failed"
+
+########################################################################################
+# 3d. Info module — list with limit
+########################################################################################
+
+- name: List simulations with limit=1
+  nutanix.ncp.ntnx_simulations_info_v2:
+    limit: 1
+  register: limit_result
+  ignore_errors: true
+
+- name: Assert limit=1 returns at most one simulation
+  ansible.builtin.assert:
+    that:
+      - limit_result is defined
+      - limit_result.changed == false
+      - limit_result.failed == false
+      - limit_result.response is defined
+      - limit_result.response | length == 1
+    success_msg: "List with limit passed"
+    fail_msg: "List with limit failed"
+
+########################################################################################
+# 3e. Info module — mutually exclusive ext_id + filter
+########################################################################################
+
+- name: Fetch with both ext_id and filter (should fail)
+  nutanix.ncp.ntnx_simulations_info_v2:
+    ext_id: "{{ full_sim_ext_id }}"
+    filter: "name eq '{{ sim_name_full }}'"
+  register: result
+  ignore_errors: true
+
+- name: Assert mutually exclusive ext_id + filter fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.msg == "parameters are mutually exclusive: ext_id|filter"
+    success_msg: "Mutually exclusive ext_id and filter rejected as expected"
+    fail_msg: "Mutually exclusive ext_id and filter was not rejected"
+
+########################################################################################
+# 3f. Info module — fetch with wrong ext_id (not-found)
+########################################################################################
+
+- name: Fetch simulation with a bogus ext_id (should fail)
+  nutanix.ncp.ntnx_simulations_info_v2:
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Assert not-found ext_id fetch fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == true
+      - result.msg == "Api Exception raised while fetching simulation info using ext_id"
+    success_msg: "Fetch with wrong ext_id failed as expected"
+    fail_msg: "Fetch with wrong ext_id did not fail as expected"
+
+########################################################################################
+# 1b. check_mode — Update with ALL attributes
+########################################################################################
+
+- name: Update simulation using check mode with all attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "{{ full_sim_ext_id }}"
+    name: "check_mode_updated_name"
+    simulation_spec:
+      vcpu_count: 12
+      ram_gb: 24.0
+      hdd_gb: 300.0
+      ssd_gb: 500.0
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check_mode update generates spec
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_updated_name"
+      - result.response.simulation_spec.vcpu_count == 12
+      - result.response.simulation_spec.ram_gb == 24.0
+      - result.response.simulation_spec.hdd_gb == 300.0
+      - result.response.simulation_spec.ssd_gb == 500.0
+    success_msg: "Check mode update with all attributes passed"
+    fail_msg: "Check mode update with all attributes failed"
+
+########################################################################################
+# 2d. Update — real state transition
+########################################################################################
+
+- name: Update simulation with all attributes
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "{{ full_sim_ext_id }}"
+    name: "{{ sim_name_update }}"
+    simulation_spec:
+      vcpu_count: 16
+      ram_gb: 32.0
+      hdd_gb: 500.0
+      ssd_gb: 1000.0
+  register: result
+  ignore_errors: true
+
+- name: Assert simulation update
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id == full_sim_ext_id
+      - result.response is defined
+      - result.response.name == sim_name_update
+      - result.response.simulation_spec.vcpu_count == 16
+      - result.response.simulation_spec.ram_gb == 32.0
+      - result.response.simulation_spec.hdd_gb == 500.0
+      - result.response.simulation_spec.ssd_gb == 1000.0
+    success_msg: "Simulation update passed"
+    fail_msg: "Simulation update failed"
+
+########################################################################################
+# 2e. Update idempotency — repeat the same update, expect skipped
+########################################################################################
+
+- name: Update simulation with identical values (idempotency)
+  nutanix.ncp.ntnx_simulation_v2:
+    state: present
+    ext_id: "{{ full_sim_ext_id }}"
+    name: "{{ sim_name_update }}"
+    simulation_spec:
+      vcpu_count: 16
+      ram_gb: 32.0
+      hdd_gb: 500.0
+      ssd_gb: 1000.0
+  register: result
+  ignore_errors: true
+
+- name: Assert update idempotency is a no-op
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.skipped == true
+      - result.msg == "Nothing to change."
+      - result.response is defined
+      - result.response.name == sim_name_update
+    success_msg: "Update idempotency passed"
+    fail_msg: "Update idempotency failed"
+
+########################################################################################
+# 1c. check_mode — Delete
+########################################################################################
+
+- name: Delete simulation with check mode
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "{{ todelete[0] }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Assert check_mode delete
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.msg == "Simulation with ext_id:" + todelete[0] + " will be deleted."
+    success_msg: "Delete with check mode passed"
+    fail_msg: "Delete with check mode failed"
+
+########################################################################################
+# 2f. Delete — real deletion of created simulations
+########################################################################################
+
+- name: Delete all created simulations
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  register: delete_result
+  loop: "{{ todelete }}"
+  ignore_errors: true
+
+- name: Assert deletions succeeded
+  ansible.builtin.assert:
+    that:
+      - delete_result is defined
+      - delete_result.results | length == todelete | length
+      - delete_result.results | selectattr('failed', 'equalto', true) | list | length == 0
+      - delete_result.results | selectattr('changed', 'equalto', true) | list | length == todelete | length
+    success_msg: "All created simulations were deleted"
+    fail_msg: "One or more simulations failed to delete"
+
+- name: Assert each delete response individually
+  ansible.builtin.assert:
+    that:
+      - item.changed == true
+      - item.failed == false
+      - item.response is defined
+      - item.response.status == "SUCCEEDED"
+      - item.ext_id == todelete[ansible_loop.index0]
+    success_msg: "Delete assertion passed for {{ item.ext_id }}"
+    fail_msg: "Delete assertion failed for {{ item.ext_id }}"
+  loop: "{{ delete_result.results }}"
+  loop_control:
+    extended: true
+
+########################################################################################
+# 4c. Negative — delete without ext_id
+########################################################################################
+
+- name: Delete simulation without ext_id (should fail)
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Assert delete without ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete without ext_id failed as expected"
+    fail_msg: "Delete without ext_id did not fail as expected"
+
+########################################################################################
+# 4d. Negative — delete non-existent ext_id
+########################################################################################
+
+- name: Delete simulation with a bogus ext_id (should fail)
+  nutanix.ncp.ntnx_simulation_v2:
+    state: absent
+    ext_id: "00000000-0000-0000-0000-000000000000"
+  register: result
+  ignore_errors: true
+
+- name: Assert delete with wrong ext_id fails
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Api Exception raised while deleting simulation"
+    success_msg: "Delete with wrong ext_id failed as expected"
+    fail_msg: "Delete with wrong ext_id did not fail as expected"
+
+- name: End Simulation tests
+  ansible.builtin.debug:
+    msg: End AIOps VM Simulation tests


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **aiops** namespace, entity
**Simulation**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_simulation_v2`, `ntnx_simulations_info_v2`
- API methods covered: 5 (`create_simulation`, `get_simulation_by_id`, `update_simulation_by_id`, `delete_simulation_by_id`, `list_simulations`)
- Fields in CRUD module spec: 3 top-level (`ext_id`, `name`, `simulation_spec`) + 4 nested (`vcpu_count`, `ram_gb`, `hdd_gb`, `ssd_gb`)
- Fields in info module spec: 1 (`ext_id`) plus the standard `filter`, `limit`, `page`, `orderby`, `select` from `BaseInfoModule`

The AIOps VM Simulation entity models a hypothetical VM workload (vCPU / RAM /
HDD / SSD) that is reused across What-If capacity planning scenarios to forecast
runway and hardware recommendations. The v4 APIs are **synchronous** (no task
polling required), so the modules return the entity payload directly instead of
waiting on a task.

## Files changed

**`plugins/modules/`**
- `ntnx_simulation_v2.py` — CRUD module (create / update / delete + name-based create idempotency + spec-based update idempotency).
- `ntnx_simulations_info_v2.py` — info module (get-by-ID and list with filter / limit / page / orderby / select).

**`plugins/module_utils/v4/aiops/`**
- `api_client.py` — AIOps SDK client bootstrap + `get_scenarios_api_instance()` factory.
- `helpers.py` — shared `get_simulation()` helper.

**`meta/runtime.yml`**
- Registered `ntnx_simulation_v2` and `ntnx_simulations_info_v2` in the `ntnx` action_group so `module_defaults: group/nutanix.ncp.ntnx` resolves credentials.

**`examples/aiops/Simulation/`**
- `simulation_v2.yml` — end-to-end example playbook (create → get → list-all → list-with-filter → list-with-limit → update → delete).
- `examples_run.log` — real captured output from running the example against the live PC.

**`tests/integration/targets/ntnx_simulation_v2/`**
- `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/simulation.yml` — full integration coverage (check_mode, CRUD, info, negative, idempotency).

**`.gitignore`**
- Excluded `tests/integration/integration_config.yml` (holds credentials) and Python `__pycache__/`.

## Test execution

| Metric              | Value                                                                                                    |
|---------------------|----------------------------------------------------------------------------------------------------------|
| Command             | `ansible-test integration ntnx_simulation_v2 --python 3.12 --allow-unsupported --allow-disabled -v`      |
| Total tasks         | 55 (46 ok + 3 skipped + 6 intentional ignore-failure negative tasks)                                     |
| Passed              | 46                                                                                                       |
| Failed              | 0                                                                                                        |
| Skipped             | 3                                                                                                        |
| Duration            | ~15 seconds                                                                                              |
| Cluster (PC)        | `10.44.76.28`                                                                                            |

**Example playbook execution:** `ansible-playbook examples/aiops/Simulation/simulation_v2.yml`
executed cleanly against the same PC — 9 tasks, 3 changed, 0 failed. Real
responses have been captured in `examples/aiops/Simulation/examples_run.log`.

### Analysis

All integration tasks passed on the first successful run after the following
in-flight fixes:

1. **`meta/runtime.yml` action_group registration.** Without registering the
   two new modules in the `ntnx` action_group, `group/nutanix.ncp.ntnx`
   `module_defaults` did not inject `nutanix_host` and every task failed with
   `missing required arguments: nutanix_host`. Registered both modules under
   the existing `ntnx` group and re-ran.
2. **`allow_version_negotiation` kwarg guard.** The installed
   `ntnx-aiops-py-client` version does not accept
   `allow_version_negotiation` in `ApiClient.__init__`. Wrapped the second
   `ApiClient(...)` construction in `get_api_client()` with the same
   `try/except TypeError` fallback that the first construction already used.

No known issues remain. The tests intentionally ignore 6 tasks that are the
"failure" half of negative test cases (missing required fields, mutually
exclusive params, non-existent ext_ids) — the paired assertion tasks then
verify the failure was correct.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
Configured locale: en_US.UTF-8
Falling back to tests in "tests/integration/targets/" because "roles/test/" was not found.
Detected architecture x86_64 for Python interpreter: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python
Creating container database.
Run command: /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python /home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/lib64/python3.12/site-packages/ansible_test/_util/target/tools/yamlcheck.py
Configuring target inventory.
Running ntnx_simulation_v2 integration test role
Initializing "/tmp/ansible-test-m8wm3i8a-injector" as the temporary injector directory.
Injecting "/tmp/python-qi3g6mdd-ansible/python" as a execv wrapper for the "/home/george.ghawali/code_gen/terraform-provider-nutanix/.venv/bin/python" interpreter.
Stream command: ansible-playbook ntnx_simulation_v2-0cqmmo1q.yml -i inventory -v
[WARNING]: Found variable using reserved name: port
Using /tmp/ansible-coll.gn8AFt/ansible_collections/nutanix/ncp/tests/output/.tmp/integration/ntnx_simulation_v2-1yoap9gv-ÅÑŚÌβŁÈ/tests/integration/integration.cfg as config file
running playbook inside collection nutanix.ncp

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_simulation_v2 : Start Simulation tests] *****************************
ok: [testhost] => {
    "msg": "Start AIOps VM Simulation tests"
}

TASK [ntnx_simulation_v2 : Generate random suffix to avoid parallel test collisions] ***
[WARNING]: Collection community.general does not support Ansible version 2.16.0
ok: [testhost] => {"ansible_facts": {"random_suffix": "sva279e2kp", "todelete": []}, "changed": false}

TASK [ntnx_simulation_v2 : Set unique simulation names] ************************
ok: [testhost] => {"ansible_facts": {"sim_name_full": "ansible_sim_full_sva279e2kp", "sim_name_min": "ansible_sim_min_sva279e2kp", "sim_name_update": "ansible_sim_upd_sva279e2kp"}, "changed": false}

TASK [ntnx_simulation_v2 : List all existing simulations for baseline cleanup] ***
ok: [testhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [ntnx_simulation_v2 : Delete any leftover simulations from earlier ansible runs] ***
skipping: [testhost] => {"changed": false, "skipped_reason": "No items in the list"}

TASK [ntnx_simulation_v2 : Create simulation using check mode with all attributes] ***
ok: [testhost] => {"changed": false, "ext_id": null, "response": {"ext_id": null, "links": null, "name": "check_mode_sim_full", "simulation_spec": {"hdd_gb": 150.0, "ram_gb": 12.0, "ssd_gb": 250.0, "vcpu_count": 6}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert check_mode create with all attributes generates spec] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Check mode create with all attributes passed"
}

TASK [ntnx_simulation_v2 : Create simulation with minimum attributes] **********
changed: [testhost] => {"changed": true, "ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f", "response": {"ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f", "links": null, "name": "ansible_sim_min_sva279e2kp", "simulation_spec": {"hdd_gb": 50.0, "ram_gb": 4.0, "ssd_gb": 100.0, "vcpu_count": 2}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert minimal simulation creation] *****************
ok: [testhost] => {
    "changed": false,
    "msg": "Minimal simulation created successfully"
}

TASK [ntnx_simulation_v2 : Track minimal simulation ext_id for cleanup] ********
ok: [testhost] => {"ansible_facts": {"todelete": ["0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f"]}, "changed": false}

TASK [ntnx_simulation_v2 : Create simulation with all attributes] **************
changed: [testhost] => {"changed": true, "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "response": {"ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "links": null, "name": "ansible_sim_full_sva279e2kp", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 400.0, "vcpu_count": 8}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert full simulation creation] ********************
ok: [testhost] => {
    "changed": false,
    "msg": "Full simulation created successfully"
}

TASK [ntnx_simulation_v2 : Track full simulation ext_id for cleanup] ***********
ok: [testhost] => {"ansible_facts": {"full_sim_ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "todelete": ["0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f", "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5"]}, "changed": false}

TASK [ntnx_simulation_v2 : Create simulation with missing name (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): name"}
...ignoring

TASK [ntnx_simulation_v2 : Assert create with missing name fails] **************
ok: [testhost] => {
    "changed": false,
    "msg": "Create with missing name failed as expected"
}

TASK [ntnx_simulation_v2 : Create simulation with missing simulation_spec (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): simulation_spec"}
...ignoring

TASK [ntnx_simulation_v2 : Assert create with missing simulation_spec fails] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Create with missing simulation_spec failed as expected"
}

TASK [ntnx_simulation_v2 : Create simulation with an existing name (idempotency)] ***
skipping: [testhost] => {"changed": false, "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "msg": "Simulation with name 'ansible_sim_full_sva279e2kp' already exists. Skipping creation.", "response": {"ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "links": null, "name": "ansible_sim_full_sva279e2kp", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 400.0, "vcpu_count": 8}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert duplicate-name create is skipped] ************
ok: [testhost] => {
    "changed": false,
    "msg": "Create idempotency by name skipped as expected"
}

TASK [ntnx_simulation_v2 : Fetch simulation using ext_id] **********************
ok: [testhost] => {"changed": false, "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "response": {"ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "links": null, "name": "ansible_sim_full_sva279e2kp", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 400.0, "vcpu_count": 8}, "tenant_id": null}}

TASK [ntnx_simulation_v2 : Assert fetch by ext_id] *****************************
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch simulation by ext_id passed"
}

TASK [ntnx_simulation_v2 : List all simulations] *******************************
ok: [testhost] => {"changed": false, "response": [{"ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f", "links": null, "name": "ansible_sim_min_sva279e2kp", "simulation_spec": {"hdd_gb": 50.0, "ram_gb": 4.0, "ssd_gb": 100.0, "vcpu_count": 2}, "tenant_id": null}, {"ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "links": null, "name": "ansible_sim_full_sva279e2kp", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 400.0, "vcpu_count": 8}, "tenant_id": null}], "total_available_results": 2}

TASK [ntnx_simulation_v2 : Assert list-all returns at least the two created simulations] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List-all simulations passed"
}

TASK [ntnx_simulation_v2 : Assert both created simulation names are present in list-all] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Both simulations appear in the list"
}

TASK [ntnx_simulation_v2 : List simulations with name filter] ******************
ok: [testhost] => {"changed": false, "response": [{"ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "links": null, "name": "ansible_sim_full_sva279e2kp", "simulation_spec": {"hdd_gb": 200.0, "ram_gb": 16.0, "ssd_gb": 400.0, "vcpu_count": 8}, "tenant_id": null}], "total_available_results": 1}

TASK [ntnx_simulation_v2 : Assert filter returns only the matching simulation] ***
ok: [testhost] => {
    "changed": false,
    "msg": "List with filter passed"
}

TASK [ntnx_simulation_v2 : List simulations with limit=1] **********************
ok: [testhost] => {"changed": false, "response": [{"ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f", "links": null, "name": "ansible_sim_min_sva279e2kp", "simulation_spec": {"hdd_gb": 50.0, "ram_gb": 4.0, "ssd_gb": 100.0, "vcpu_count": 2}, "tenant_id": null}], "total_available_results": 2}

TASK [ntnx_simulation_v2 : Assert limit=1 returns at most one simulation] ******
ok: [testhost] => {
    "changed": false,
    "msg": "List with limit passed"
}

TASK [ntnx_simulation_v2 : Fetch with both ext_id and filter (should fail)] ****
fatal: [testhost]: FAILED! => {"changed": false, "msg": "parameters are mutually exclusive: ext_id|filter"}
...ignoring

TASK [ntnx_simulation_v2 : Assert mutually exclusive ext_id + filter fails] ****
ok: [testhost] => {
    "changed": false,
    "msg": "Mutually exclusive ext_id and filter rejected as expected"
}

TASK [ntnx_simulation_v2 : Fetch simulation with a bogus ext_id (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching simulation info using ext_id", "response": {"$objectType": "aiops.v4.config.GetSimulationApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "data": {"$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "code": "AIO-60006", "locale": "en_US", "message": "Failed to perform the request because the resource identified by the provided external identifier 00000000-0000-0000-0000-000000000000 was not found.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 404}
...ignoring

TASK [ntnx_simulation_v2 : Assert not-found ext_id fetch fails] ****************
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch with wrong ext_id failed as expected"
}

TASK [ntnx_simulation_v2 : Update simulation using check mode with all attributes] ***
ok: [testhost] => {"changed": false, "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "response": {"ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "links": null, "name": "check_mode_updated_name", "simulation_spec": {"hdd_gb": 300.0, "ram_gb": 24.0, "ssd_gb": 500.0, "vcpu_count": 12}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert check_mode update generates spec] ************
ok: [testhost] => {
    "changed": false,
    "msg": "Check mode update with all attributes passed"
}

TASK [ntnx_simulation_v2 : Update simulation with all attributes] **************
changed: [testhost] => {"changed": true, "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "response": {"ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "links": null, "name": "ansible_sim_upd_sva279e2kp", "simulation_spec": {"hdd_gb": 500.0, "ram_gb": 32.0, "ssd_gb": 1000.0, "vcpu_count": 16}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert simulation update] ***************************
ok: [testhost] => {
    "changed": false,
    "msg": "Simulation update passed"
}

TASK [ntnx_simulation_v2 : Update simulation with identical values (idempotency)] ***
skipping: [testhost] => {"changed": false, "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "msg": "Nothing to change.", "response": {"ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "links": null, "name": "ansible_sim_upd_sva279e2kp", "simulation_spec": {"hdd_gb": 500.0, "ram_gb": 32.0, "ssd_gb": 1000.0, "vcpu_count": 16}, "tenant_id": null}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert update idempotency is a no-op] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "Update idempotency passed"
}

TASK [ntnx_simulation_v2 : Delete simulation with check mode] ******************
ok: [testhost] => {"changed": false, "ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f", "msg": "Simulation with ext_id:0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f will be deleted.", "response": null, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert check_mode delete] ***************************
ok: [testhost] => {
    "changed": false,
    "msg": "Delete with check mode passed"
}

TASK [ntnx_simulation_v2 : Delete all created simulations] *********************
changed: [testhost] => (item=0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f) => {"ansible_loop_var": "item", "changed": true, "ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f", "item": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f", "response": {"message": "Simulation with ext_id:0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f deleted successfully.", "status": "SUCCEEDED"}, "task_ext_id": null}
changed: [testhost] => (item=6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5) => {"ansible_loop_var": "item", "changed": true, "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "item": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5", "response": {"message": "Simulation with ext_id:6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5 deleted successfully.", "status": "SUCCEEDED"}, "task_ext_id": null}

TASK [ntnx_simulation_v2 : Assert deletions succeeded] *************************
ok: [testhost] => {
    "changed": false,
    "msg": "All created simulations were deleted"
}

TASK [ntnx_simulation_v2 : Assert each delete response individually] ***********
ok: [testhost] => (item={'changed': True, 'response': {'status': 'SUCCEEDED', 'message': 'Simulation with ext_id:0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f deleted successfully.'}, 'failed': False, 'ext_id': '0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f', 'task_ext_id': None, 'skipped': False, 'invocation': {'module_args': {'nutanix_host': '10.44.76.28', 'nutanix_username': 'admin', 'nutanix_password': 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER', 'validate_certs': False, 'state': 'absent', 'ext_id': '0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f', 'nutanix_port': '9440', 'wait': True, 'nutanix_debug': False, 'nutanix_log_file': '/tmp/nutanix_ansible_debug.log', 'read_timeout': 30000}}, 'item': '0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f', 'ansible_loop_var': 'item'}) => {
    "ansible_loop": {
        "allitems": [
            {
                "ansible_loop_var": "item",
                "changed": true,
                "ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f",
                "failed": false,
                "invocation": {
                    "module_args": {
                        "ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f",
                        "nutanix_debug": false,
                        "nutanix_host": "10.44.76.28",
                        "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                        "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                        "nutanix_port": "9440",
                        "nutanix_username": "admin",
                        "read_timeout": 30000,
                        "state": "absent",
                        "validate_certs": false,
                        "wait": true
                    }
                },
                "item": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f",
                "response": {
                    "message": "Simulation with ext_id:0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f deleted successfully.",
                    "status": "SUCCEEDED"
                },
                "skipped": false,
                "task_ext_id": null
            },
            {
                "ansible_loop_var": "item",
                "changed": true,
                "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5",
                "failed": false,
                "invocation": {
                    "module_args": {
                        "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5",
                        "nutanix_debug": false,
                        "nutanix_host": "10.44.76.28",
                        "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                        "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                        "nutanix_port": "9440",
                        "nutanix_username": "admin",
                        "read_timeout": 30000,
                        "state": "absent",
                        "validate_certs": false,
                        "wait": true
                    }
                },
                "item": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5",
                "response": {
                    "message": "Simulation with ext_id:6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5 deleted successfully.",
                    "status": "SUCCEEDED"
                },
                "skipped": false,
                "task_ext_id": null
            }
        ],
        "first": true,
        "index": 1,
        "index0": 0,
        "last": false,
        "length": 2,
        "nextitem": {
            "ansible_loop_var": "item",
            "changed": true,
            "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5",
            "failed": false,
            "invocation": {
                "module_args": {
                    "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5",
                    "nutanix_debug": false,
                    "nutanix_host": "10.44.76.28",
                    "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                    "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                    "nutanix_port": "9440",
                    "nutanix_username": "admin",
                    "read_timeout": 30000,
                    "state": "absent",
                    "validate_certs": false,
                    "wait": true
                }
            },
            "item": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5",
            "response": {
                "message": "Simulation with ext_id:6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5 deleted successfully.",
                "status": "SUCCEEDED"
            },
            "skipped": false,
            "task_ext_id": null
        },
        "revindex": 2,
        "revindex0": 1
    },
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "ansible_loop_var": "item",
        "changed": true,
        "ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f",
        "failed": false,
        "invocation": {
            "module_args": {
                "ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f",
                "nutanix_debug": false,
                "nutanix_host": "10.44.76.28",
                "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "nutanix_port": "9440",
                "nutanix_username": "admin",
                "read_timeout": 30000,
                "state": "absent",
                "validate_certs": false,
                "wait": true
            }
        },
        "item": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f",
        "response": {
            "message": "Simulation with ext_id:0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f deleted successfully.",
            "status": "SUCCEEDED"
        },
        "skipped": false,
        "task_ext_id": null
    },
    "msg": "Delete assertion passed for 0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f"
}
ok: [testhost] => (item={'changed': True, 'response': {'status': 'SUCCEEDED', 'message': 'Simulation with ext_id:6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5 deleted successfully.'}, 'failed': False, 'ext_id': '6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5', 'task_ext_id': None, 'skipped': False, 'invocation': {'module_args': {'nutanix_host': '10.44.76.28', 'nutanix_username': 'admin', 'nutanix_password': 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER', 'validate_certs': False, 'state': 'absent', 'ext_id': '6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5', 'nutanix_port': '9440', 'wait': True, 'nutanix_debug': False, 'nutanix_log_file': '/tmp/nutanix_ansible_debug.log', 'read_timeout': 30000}}, 'item': '6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5', 'ansible_loop_var': 'item'}) => {
    "ansible_loop": {
        "allitems": [
            {
                "ansible_loop_var": "item",
                "changed": true,
                "ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f",
                "failed": false,
                "invocation": {
                    "module_args": {
                        "ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f",
                        "nutanix_debug": false,
                        "nutanix_host": "10.44.76.28",
                        "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                        "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                        "nutanix_port": "9440",
                        "nutanix_username": "admin",
                        "read_timeout": 30000,
                        "state": "absent",
                        "validate_certs": false,
                        "wait": true
                    }
                },
                "item": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f",
                "response": {
                    "message": "Simulation with ext_id:0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f deleted successfully.",
                    "status": "SUCCEEDED"
                },
                "skipped": false,
                "task_ext_id": null
            },
            {
                "ansible_loop_var": "item",
                "changed": true,
                "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5",
                "failed": false,
                "invocation": {
                    "module_args": {
                        "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5",
                        "nutanix_debug": false,
                        "nutanix_host": "10.44.76.28",
                        "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                        "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                        "nutanix_port": "9440",
                        "nutanix_username": "admin",
                        "read_timeout": 30000,
                        "state": "absent",
                        "validate_certs": false,
                        "wait": true
                    }
                },
                "item": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5",
                "response": {
                    "message": "Simulation with ext_id:6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5 deleted successfully.",
                    "status": "SUCCEEDED"
                },
                "skipped": false,
                "task_ext_id": null
            }
        ],
        "first": false,
        "index": 2,
        "index0": 1,
        "last": true,
        "length": 2,
        "previtem": {
            "ansible_loop_var": "item",
            "changed": true,
            "ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f",
            "failed": false,
            "invocation": {
                "module_args": {
                    "ext_id": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f",
                    "nutanix_debug": false,
                    "nutanix_host": "10.44.76.28",
                    "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                    "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                    "nutanix_port": "9440",
                    "nutanix_username": "admin",
                    "read_timeout": 30000,
                    "state": "absent",
                    "validate_certs": false,
                    "wait": true
                }
            },
            "item": "0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f",
            "response": {
                "message": "Simulation with ext_id:0b05bf95-aa80-4557-a6f3-69f5cc5a4e1f deleted successfully.",
                "status": "SUCCEEDED"
            },
            "skipped": false,
            "task_ext_id": null
        },
        "revindex": 1,
        "revindex0": 0
    },
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "ansible_loop_var": "item",
        "changed": true,
        "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5",
        "failed": false,
        "invocation": {
            "module_args": {
                "ext_id": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5",
                "nutanix_debug": false,
                "nutanix_host": "10.44.76.28",
                "nutanix_log_file": "/tmp/nutanix_ansible_debug.log",
                "nutanix_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "nutanix_port": "9440",
                "nutanix_username": "admin",
                "read_timeout": 30000,
                "state": "absent",
                "validate_certs": false,
                "wait": true
            }
        },
        "item": "6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5",
        "response": {
            "message": "Simulation with ext_id:6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5 deleted successfully.",
            "status": "SUCCEEDED"
        },
        "skipped": false,
        "task_ext_id": null
    },
    "msg": "Delete assertion passed for 6882fdb7-4ac9-4bf2-b664-79cbe6f7c6c5"
}

TASK [ntnx_simulation_v2 : Delete simulation without ext_id (should fail)] *****
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_simulation_v2 : Assert delete without ext_id fails] *****************
ok: [testhost] => {
    "changed": false,
    "msg": "Delete without ext_id failed as expected"
}

TASK [ntnx_simulation_v2 : Delete simulation with a bogus ext_id (should fail)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "BAD REQUEST", "msg": "Api Exception raised while deleting simulation", "response": {"$objectType": "aiops.v4.config.DeleteSimulationApiResponse", "$reserved": {"$fv": "v4.r2.b1"}, "data": {"$objectType": "aiops.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r2.b1"}, "error": [{"$objectType": "aiops.v4.error.AppMessage", "$reserved": {"$fv": "v4.r2.b1"}, "code": "AIO-60008", "locale": "en_US", "message": "Failed to perform the request because the provided external identifier 00000000-0000-0000-0000-000000000000 is incorrect.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}]}}, "status": 400}
...ignoring

TASK [ntnx_simulation_v2 : Assert delete with wrong ext_id fails] **************
ok: [testhost] => {
    "changed": false,
    "msg": "Delete with wrong ext_id failed as expected"
}

TASK [ntnx_simulation_v2 : End Simulation tests] *******************************
ok: [testhost] => {
    "msg": "End AIOps VM Simulation tests"
}

PLAY RECAP *********************************************************************
testhost                   : ok=46   changed=4    unreachable=0    failed=0    skipped=3    rescued=0    ignored=6   

```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
