### PR TITLE
code-gen(flow_management/DsCategoryMapping): ansible collection modules

### DIFF
--- a/examples/flow_management/DsCategoryMapping/ds_category_mapping_v2.yml
+++ b/examples/flow_management/DsCategoryMapping/ds_category_mapping_v2.yml
@@ -1,0 +1,91 @@
+---
+# Summary:
+# This playbook will do:
+# 1. Create AD Group to Category mapping (DsCategoryMapping)
+# 2. Get a DsCategoryMapping using ext_id
+# 3. List all DsCategoryMappings
+# 4. List DsCategoryMappings with filter
+# 5. List DsCategoryMappings with limit
+# 6. Update DsCategoryMapping
+# 7. Delete DsCategoryMapping
+
+- name: DsCategoryMapping playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <pc_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Setting Variables
+      ansible.builtin.set_fact:
+        directory_service_ext_id: "6863c60b-ae9d-5c32-b8c1-2d45b9ba343a"
+        ad_group_object_identifier: "b1a1e59d-6f9a-4bde-8f0f-2b6f8c9f6a11"
+        ds_category_mapping_name: "ansible_ds_category_mapping"
+
+    - name: Create AD Group to Category mapping with all attributes
+      nutanix.ncp.ntnx_ds_category_mapping_v2:
+        state: present
+        name: "{{ ds_category_mapping_name }}"
+        category_name: "AppType"
+        category_value: "Finance"
+        ad_info:
+          directory_service_reference: "{{ directory_service_ext_id }}"
+          object_identifier: "{{ ad_group_object_identifier }}"
+          object_path: "CN=Finance,OU=Groups,DC=example,DC=com"
+      register: created_mapping
+      ignore_errors: true
+
+    - name: Save DsCategoryMapping ext_id (when the create succeeded)
+      ansible.builtin.set_fact:
+        ds_category_mapping_ext_id: "{{ created_mapping.ext_id }}"
+      when: created_mapping is defined and created_mapping.ext_id is defined
+
+    - name: Get DsCategoryMapping using ext_id
+      nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+        ext_id: "{{ ds_category_mapping_ext_id }}"
+      register: result
+      ignore_errors: true
+      when: ds_category_mapping_ext_id is defined
+
+    - name: List all DsCategoryMappings
+      nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+      register: result
+      ignore_errors: true
+
+    - name: List DsCategoryMappings with filter
+      nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+        filter: "name eq '{{ ds_category_mapping_name }}'"
+      register: result
+      ignore_errors: true
+
+    - name: List DsCategoryMappings with limit
+      nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+        limit: 1
+      register: result
+      ignore_errors: true
+
+    - name: Update DsCategoryMapping with all attributes
+      nutanix.ncp.ntnx_ds_category_mapping_v2:
+        state: present
+        ext_id: "{{ ds_category_mapping_ext_id }}"
+        name: "{{ ds_category_mapping_name }}_updated"
+        category_name: "AppType"
+        category_value: "Engineering"
+        ad_info:
+          directory_service_reference: "{{ directory_service_ext_id }}"
+          object_identifier: "{{ ad_group_object_identifier }}"
+          object_path: "CN=Engineering,OU=Groups,DC=example,DC=com"
+      register: result
+      ignore_errors: true
+      when: ds_category_mapping_ext_id is defined
+
+    - name: Delete DsCategoryMapping
+      nutanix.ncp.ntnx_ds_category_mapping_v2:
+        state: absent
+        ext_id: "{{ ds_category_mapping_ext_id }}"
+      register: result
+      ignore_errors: true
+      when: ds_category_mapping_ext_id is defined

--- a/examples/flow_management/DsCategoryMapping/examples_run.log
+++ b/examples/flow_management/DsCategoryMapping/examples_run.log
@@ -1,0 +1,38 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [DsCategoryMapping playbook] **********************************************
+
+TASK [Setting Variables] *******************************************************
+ok: [localhost] => {"ansible_facts": {"ad_group_object_identifier": "b1a1e59d-6f9a-4bde-8f0f-2b6f8c9f6a11", "directory_service_ext_id": "7e9749f3-e3ee-5f9b-ade8-e359777f681a", "ds_category_mapping_name": "ansible_ds_category_mapping"}, "changed": false}
+
+TASK [Create AD Group to Category mapping with all attributes] *****************
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T12:09:45.939392+00:00", "completion_details": null, "created_time": "2026-07-21T12:09:45.909670+00:00", "entities_affected": [{"ext_id": "f79bda38-c54a-4273-b75f-3afb35c320aa", "name": "ansible_ds_category_mapping", "rel": "microseg:config:category-mapping"}], "error_messages": [{"arguments_map": {"operation": "create category mapping", "reason": "Invalid object GUID passed: b1a1e59d-6f9a-4bde-8f0f-2b6f8c9f6a11"}, "code": "MIC-10007", "error_group": "FLOW_SERVICE_RPC_EXCEPTION", "locale": "en_US", "message": "Failed to create category mapping due to Invalid object GUID passed: b1a1e59d-6f9a-4bde-8f0f-2b6f8c9f6a11.", "severity": "ERROR"}], "ext_id": "ZXJnb24=:42ba596e-5739-4489-8081-693512bd5d92", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T12:09:45.939391+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kIdCategorizationMappingCreate", "operation_description": "Create Catergory Mapping", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T12:09:45.919070+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": null, "warnings": null}}
+...ignoring
+
+TASK [Save DsCategoryMapping ext_id (when the create succeeded)] ***************
+skipping: [localhost] => {"changed": false, "false_condition": "created_mapping is defined and created_mapping.ext_id is defined", "skip_reason": "Conditional result was False"}
+
+TASK [Get DsCategoryMapping using ext_id] **************************************
+skipping: [localhost] => {"changed": false, "false_condition": "ds_category_mapping_ext_id is defined", "skip_reason": "Conditional result was False"}
+
+TASK [List all DsCategoryMappings] *********************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List DsCategoryMappings with filter] *************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [List DsCategoryMappings with limit] **************************************
+ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}
+
+TASK [Update DsCategoryMapping with all attributes] ****************************
+skipping: [localhost] => {"changed": false, "false_condition": "ds_category_mapping_ext_id is defined", "skip_reason": "Conditional result was False"}
+
+TASK [Delete DsCategoryMapping] ************************************************
+skipping: [localhost] => {"changed": false, "false_condition": "ds_category_mapping_ext_id is defined", "skip_reason": "Conditional result was False"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=5    changed=0    unreachable=0    failed=0    skipped=4    rescued=0    ignored=1   
+

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -246,5 +246,7 @@ action_groups:
     - ntnx_iam_entities_info_v2
     - ntnx_virtual_switch_v2
     - ntnx_virtual_switches_info_v2
+    - ntnx_ds_category_mapping_v2
+    - ntnx_ds_category_mappings_info_v2
     - ntnx_entity_group_v2
     - ntnx_entity_groups_info_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,7 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        DS_CATEGORY_MAPPING = "microseg:config:category-mapping"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/flow/api_client.py
+++ b/plugins/module_utils/v4/flow/api_client.py
@@ -131,3 +131,17 @@ def get_entity_groups_api_instance(module):
     """
     client = get_api_client(module)
     return ntnx_microseg_py_client.EntityGroupsApi(client)
+
+
+def get_directory_server_configs_api_instance(module):
+    """
+    This method will return DirectoryServerConfigsApi instance.
+    This API is used for managing Directory Server Configurations and the
+    associated AD Group to Category Mappings (DsCategoryMapping).
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): directory server configs api instance
+    """
+    client = get_api_client(module)
+    return ntnx_microseg_py_client.DirectoryServerConfigsApi(client)

--- a/plugins/module_utils/v4/flow/helpers.py
+++ b/plugins/module_utils/v4/flow/helpers.py
@@ -102,3 +102,25 @@ def strip_service_group_extra_attributes(obj):
         setattr(obj, field, None)
 
     return obj
+
+
+def get_ds_category_mapping(module, api_instance, ext_id):
+    """
+    This method will return the AD group to category mapping (DsCategoryMapping)
+    identified by the provided external ID.
+    Args:
+        module: Ansible module
+        api_instance: DirectoryServerConfigsApi instance from
+            ntnx_microseg_py_client sdk
+        ext_id (str): DsCategoryMapping external ID
+    return:
+        ds_category_mapping (object): DsCategoryMapping info
+    """
+    try:
+        return api_instance.get_ds_category_mapping_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching DsCategoryMapping info using ext_id",
+        )

--- a/plugins/modules/ntnx_ds_category_mapping_v2.py
+++ b/plugins/modules/ntnx_ds_category_mapping_v2.py
@@ -1,0 +1,482 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_ds_category_mapping_v2
+short_description: Create, Update, Delete AD group to Category mappings (DsCategoryMapping) in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to create, update and delete a mapping between an Active Directory
+    group and a Nutanix Category (DsCategoryMapping) in Nutanix Prism Central.
+  - A DsCategoryMapping links an AD group (identified by its objectGUID) served by a configured
+    Directory Server to a Category key/value pair used by Flow Network Security policies.
+  - The module uses Prism Central v4.2 Flow Management (microseg) APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+    The required roles depend on the operation being performed.
+  - >-
+    B(Create an AD Group and Category Mapping) -
+    Required Roles: Prism Admin, Super Admin
+  - >-
+    B(Update an AD Group and Category Mapping) -
+    Required Roles: Prism Admin, Super Admin
+  - >-
+    B(Delete an AD Group and Category Mapping) -
+    Required Roles: Prism Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=microseg)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided then the operation will
+        be create DsCategoryMapping.
+      - If C(state) is set to C(present) and C(ext_id) is provided then the operation will be
+        update DsCategoryMapping.
+      - If C(state) is set to C(absent) and C(ext_id) is provided then the operation will be
+        delete DsCategoryMapping.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the DsCategoryMapping.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - Name of the Category Mapping.
+      - Required for create operation.
+      - Maximum 1000 characters.
+    type: str
+    required: false
+  category_name:
+    description:
+      - The name (key) of the Category that this mapping is for.
+      - Required for create operation.
+      - Maximum 200 characters.
+    type: str
+    required: false
+  category_value:
+    description:
+      - The value of the Category that this mapping is for.
+      - Required for create operation.
+      - Maximum 1000 characters.
+    type: str
+    required: false
+  ad_info:
+    description:
+      - A mapping to an object in Active Directory.
+      - Required for create operation.
+    type: dict
+    required: false
+    suboptions:
+      directory_service_reference:
+        description:
+          - The external ID (UUID) of the Directory Service that will be used for the mapping.
+          - Required when C(ad_info) is provided.
+        type: str
+        required: true
+      object_identifier:
+        description:
+          - The objectGUID (UUID) for the AD group being mapped.
+          - Required when C(ad_info) is provided.
+        type: str
+        required: true
+      object_path:
+        description:
+          - The distinguished path for the mapped object in Active Directory.
+          - Maximum 1000 characters.
+        type: str
+        required: false
+      status:
+        description:
+          - The mapping status of the AD Mapping. Typically populated by the platform.
+        type: str
+        required: false
+        choices:
+          - USABLE
+          - DELETED
+          - DIRECTORY_NOT_CONFIGURED
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Create AD group to Category mapping
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    name: "ansible_ds_category_mapping"
+    category_name: "AppType"
+    category_value: "Finance"
+    ad_info:
+      directory_service_reference: "6863c60b-ae9d-5c32-b8c1-2d45b9ba343a"
+      object_identifier: "b1a1e59d-6f9a-4bde-8f0f-2b6f8c9f6a11"
+      object_path: "CN=Finance,OU=Groups,DC=example,DC=com"
+  register: result
+
+- name: Update AD group to Category mapping
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: present
+    ext_id: "8b9c1a7e-2c1a-4c30-9f0e-f3b3c7a1e2d1"
+    name: "ansible_ds_category_mapping_updated"
+    category_name: "AppType"
+    category_value: "Engineering"
+    ad_info:
+      directory_service_reference: "6863c60b-ae9d-5c32-b8c1-2d45b9ba343a"
+      object_identifier: "b1a1e59d-6f9a-4bde-8f0f-2b6f8c9f6a11"
+      object_path: "CN=Engineering,OU=Groups,DC=example,DC=com"
+  register: result
+
+- name: Delete AD group to Category mapping
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    nutanix_host: "{{ ip }}"
+    nutanix_username: "{{ username }}"
+    nutanix_password: "{{ password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "8b9c1a7e-2c1a-4c30-9f0e-f3b3c7a1e2d1"
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting DsCategoryMapping.
+    - If the operation is create or update and C(wait) is true, it will return the DsCategoryMapping details.
+    - If the operation is create or update and C(wait) is false, it will return the task details.
+    - If the operation is delete, it will return the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+        "ad_info": {
+            "directory_service_reference": "6863c60b-ae9d-5c32-b8c1-2d45b9ba343a",
+            "object_identifier": "b1a1e59d-6f9a-4bde-8f0f-2b6f8c9f6a11",
+            "object_path": "CN=Finance,OU=Groups,DC=example,DC=com",
+            "status": "USABLE"
+        },
+        "category_name": "AppType",
+        "category_value": "Finance",
+        "ext_id": "8b9c1a7e-2c1a-4c30-9f0e-f3b3c7a1e2d1",
+        "links": null,
+        "name": "ansible_ds_category_mapping",
+        "tenant_id": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the DsCategoryMapping.
+  returned: always
+  type: str
+  sample: "8b9c1a7e-2c1a-4c30-9f0e-f3b3c7a1e2d1"
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped (e.g. update idempotency).
+  returned: always
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred
+  returned: When an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message returned by the module (e.g. on error, idempotency or check-mode delete).
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating DsCategoryMapping"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.flow.api_client import (  # noqa: E402
+    get_directory_server_configs_api_instance,
+    get_etag,
+)
+from ..module_utils.v4.flow.helpers import get_ds_category_mapping  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    strip_read_only_fields,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_microseg_py_client as flow_management_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as flow_management_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    ad_info_spec = dict(
+        directory_service_reference=dict(type="str", required=True),
+        object_identifier=dict(type="str", required=True),
+        object_path=dict(type="str", required=False),
+        status=dict(
+            type="str",
+            required=False,
+            choices=["USABLE", "DELETED", "DIRECTORY_NOT_CONFIGURED"],
+            obj=flow_management_sdk.AdStatus,
+        ),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        category_name=dict(type="str"),
+        category_value=dict(type="str"),
+        ad_info=dict(
+            type="dict",
+            options=ad_info_spec,
+            obj=flow_management_sdk.AdInfo,
+        ),
+    )
+    return module_args
+
+
+def create_ds_category_mapping(module, api_instance, result):
+    """Create a new AD Group and Category Mapping."""
+    validate_required_params(
+        module, ["name", "category_name", "category_value", "ad_info"]
+    )
+    sg = SpecGenerator(module)
+    default_spec = flow_management_sdk.CategoryMapping()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating create DsCategoryMapping spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_category_mapping(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating DsCategoryMapping",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        resp = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            resp, rel=TASK_CONSTANTS.RelEntityType.DS_CATEGORY_MAPPING
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            resp = get_ds_category_mapping(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(resp.to_dict())
+        else:
+            raise_api_exception(
+                module=module,
+                exception=Exception(
+                    "Failed to get entity ext_id from task for DsCategoryMapping"
+                ),
+                msg="Failed to get entity ext_id from task for DsCategoryMapping",
+            )
+    result["changed"] = True
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    """Compare current and target dicts to determine if any change is needed."""
+    old_spec_dict = strip_internal_attributes(old_spec_dict)
+    update_spec_dict = strip_internal_attributes(update_spec_dict)
+    return old_spec_dict == update_spec_dict
+
+
+def update_ds_category_mapping(module, api_instance, result):
+    """Update an existing DsCategoryMapping identified by ext_id."""
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+    old_spec = get_ds_category_mapping(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            "Unable to fetch etag for updating DsCategoryMapping", **result
+        )
+    kwargs = {"if_match": etag}
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(
+            msg="Failed generating update DsCategoryMapping spec", **result
+        )
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.", **result)
+
+    # Read-only fields populated by the platform must not be sent on update.
+    strip_read_only_fields(update_spec, fields=["links", "tenant_id"])
+
+    resp = None
+    try:
+        resp = api_instance.update_ds_category_mapping_by_id(
+            extId=ext_id, body=update_spec, **kwargs
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating DsCategoryMapping",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        resp = get_ds_category_mapping(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def delete_ds_category_mapping(module, api_instance, result):
+    """Delete a DsCategoryMapping identified by ext_id."""
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "DsCategoryMapping with ext_id:{0} will be deleted.".format(
+            ext_id
+        )
+        return
+
+    current_spec = get_ds_category_mapping(module, api_instance, ext_id)
+    etag = get_etag(data=current_spec)
+    kwargs = {"if_match": etag} if etag else {}
+
+    resp = None
+    try:
+        resp = api_instance.delete_ds_category_mapping_by_id(extId=ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting DsCategoryMapping",
+        )
+    task_ext_id = getattr(resp.data, "ext_id", None) if resp else None
+    result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+            ("state", "present", ("name", "ext_id"), True),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_microseg_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_directory_server_configs_api_instance(module)
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_ds_category_mapping(module, api_instance, result)
+        else:
+            create_ds_category_mapping(module, api_instance, result)
+    else:
+        delete_ds_category_mapping(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_ds_category_mappings_info_v2.py
+++ b/plugins/modules/ntnx_ds_category_mappings_info_v2.py
@@ -1,0 +1,207 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_ds_category_mappings_info_v2
+short_description: Fetch DsCategoryMapping info in Nutanix Prism Central
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about DsCategoryMapping in Nutanix Prism Central.
+  - If C(ext_id) is provided, fetch details of the specific DsCategoryMapping.
+  - If C(ext_id) is not provided, list multiple DsCategoryMapping optionally filtered / paginated.
+  - This module uses PC v4 APIs based SDKs.
+notes:
+  - >-
+    This module requires the following Nutanix IAM roles to be assigned to the user performing the operation.
+  - >-
+    B(Get DsCategoryMapping by ext_id) -
+    Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin
+  - >-
+    B(List DsCategoryMappings) -
+    Required Roles: Consumer, Developer, Operator, Prism Admin, Prism Viewer, Project Admin, Super Admin
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=microseg)"
+options:
+  ext_id:
+    description:
+      - The external ID of the DsCategoryMapping.
+    type: str
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get DsCategoryMapping using ext_id
+  nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+    ext_id: "8b9c1a7e-2c1a-4c30-9f0e-f3b3c7a1e2d1"
+  register: result
+
+- name: List all DsCategoryMappings
+  nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+  register: result
+
+- name: List DsCategoryMappings with filter
+  nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+    filter: "name eq 'ansible_ds_category_mapping'"
+  register: result
+
+- name: List DsCategoryMappings with limit
+  nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+    limit: 1
+  register: result
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix PC DsCategoryMapping info v4 API.
+    - It can be a single DsCategoryMapping if external ID is provided.
+    - List of multiple DsCategoryMapping if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+        "ad_info": {
+            "directory_service_reference": "6863c60b-ae9d-5c32-b8c1-2d45b9ba343a",
+            "object_identifier": "b1a1e59d-6f9a-4bde-8f0f-2b6f8c9f6a11",
+            "object_path": "CN=Finance,OU=Groups,DC=example,DC=com",
+            "status": "USABLE"
+        },
+        "category_name": "AppType",
+        "category_value": "Finance",
+        "ext_id": "8b9c1a7e-2c1a-4c30-9f0e-f3b3c7a1e2d1",
+        "links": null,
+        "name": "ansible_ds_category_mapping",
+        "tenant_id": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes
+  returned: always
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the message if any message occurred
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching DsCategoryMapping info"
+
+error:
+  description: This field typically holds information about if the task have errors that occurred during the task execution
+  type: str
+  returned: When an error occurs
+
+failed:
+  description: This field typically holds information about if the task have failed
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the DsCategoryMapping.
+  type: str
+  returned: When external ID is provided
+  sample: "8b9c1a7e-2c1a-4c30-9f0e-f3b3c7a1e2d1"
+
+total_available_results:
+  description: The total number of available DsCategoryMappings in PC.
+  type: int
+  returned: When all DsCategoryMappings are fetched
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.flow.api_client import (  # noqa: E402
+    get_directory_server_configs_api_instance,
+)
+from ..module_utils.v4.flow.helpers import get_ds_category_mapping  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+    return module_args
+
+
+def get_ds_category_mapping_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_ds_category_mapping(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_ds_category_mappings(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating DsCategoryMappings info spec", **result)
+
+    try:
+        resp = api_instance.list_category_mappings(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching DsCategoryMapping info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_directory_server_configs_api_instance(module)
+    if module.params.get("ext_id"):
+        get_ds_category_mapping_using_ext_id(module, api_instance, result)
+    else:
+        get_ds_category_mappings(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ setuptools>=65.0
 requests>=2.31.0
 ntnx-clustermgmt-py-client==4.2.2
 ntnx-iam-py-client==4.1.2b2
-ntnx-microseg-py-client==4.2.2
+ntnx-microseg-py-client==latest
 ntnx-networking-py-client==4.3.1
 ntnx-prism-py-client==4.3.1
 ntnx-vmm-py-client==4.2.2

--- a/tests/integration/targets/ntnx_ds_category_mapping_v2/aliases
+++ b/tests/integration/targets/ntnx_ds_category_mapping_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_ds_category_mapping_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_ds_category_mapping_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_ds_category_mapping_v2/tasks/ds_category_mapping.yml
+++ b/tests/integration/targets/ntnx_ds_category_mapping_v2/tasks/ds_category_mapping.yml
@@ -1,0 +1,543 @@
+---
+##############################################################################################
+# Test plan for DsCategoryMapping (AD Group ↔ Category mapping) - ntnx_ds_category_mapping_v2
+#
+# Coverage matrix:
+#   1. check_mode:
+#        * create (all attributes)
+#        * update (all attributes)
+#        * delete
+#   2. negative create:
+#        * missing name, category_name, category_value, ad_info
+#        * invalid ad_info.status enum value
+#   3. info module:
+#        * list all
+#        * list with limit
+#        * list with filter (only when live-CRUD enabled)
+#        * get by non-existent ext_id
+#   4. live-CRUD lifecycle (only when
+#        ds_category_mapping.enable_live_crud | default(false) is true and a real
+#        AD group objectGUID is supplied):
+#        * create minimal, create full
+#        * fetch by ext_id, list with filter
+#        * update scalar + ad_info.object_path
+#        * idempotency: update with same values -> 'Nothing to change.'
+#        * update with wrong ext_id (negative)
+#        * delete happy path (loop over all created), delete with wrong ext_id,
+#          delete missing ext_id.
+#
+# Prerequisites for the live-CRUD block:
+#   * A microseg Directory Server Config (see /api/microseg/v4.2/config/directory-server-configs)
+#     configured for the target Prism Central (one per PC is sufficient) referencing an
+#     Active-Directory backed IAM directory service.
+#   * A real AD group objectGUID (the raw AD-side GUID, NOT the Nutanix IAM user-group extId)
+#     supplied via ds_category_mapping.ad_group_object_identifier in
+#     integration_config.yml.
+#   * ds_category_mapping.enable_live_crud must be set to true to opt into these calls.
+##############################################################################################
+
+- name: Start DsCategoryMapping tests
+  ansible.builtin.debug:
+    msg: Start DsCategoryMapping tests
+
+- name: Generate random names
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+    todelete: []
+
+- name: Set names for DsCategoryMapping
+  ansible.builtin.set_fact:
+    ds_map_name: "ds_cm_{{ suffix_name }}_{{ random_name }}"
+
+- name: Set DsCategoryMapping prerequisites
+  ansible.builtin.set_fact:
+    directory_service_ext_id: "{{ ds_category_mapping.directory_service_ext_id }}"
+    ad_group_object_identifier: "{{ ds_category_mapping.ad_group_object_identifier }}"
+    ad_group_object_identifier_2: "{{ ds_category_mapping.ad_group_object_identifier_2 | default(ds_category_mapping.ad_group_object_identifier) }}"
+    category_name: "{{ ds_category_mapping.category_name }}"
+    category_value: "{{ ds_category_mapping.category_value }}"
+    category_value_updated: "{{ ds_category_mapping.category_value_updated | default('Engineering') }}"
+    enable_live_crud: "{{ ds_category_mapping.enable_live_crud | default(false) | bool }}"
+
+########################################################################################
+# 1. check_mode - Create DsCategoryMapping with ALL attributes
+########################################################################################
+
+- name: Generate spec for creating DsCategoryMapping using check mode with all attributes
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    name: "check_mode_ds_cm_full"
+    category_name: "{{ category_name }}"
+    category_value: "{{ category_value }}"
+    ad_info:
+      directory_service_reference: "{{ directory_service_ext_id }}"
+      object_identifier: "{{ ad_group_object_identifier }}"
+      object_path: "CN=CheckMode,OU=Groups,DC=example,DC=com"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for creating DsCategoryMapping using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_ds_cm_full"
+      - result.response.category_name == "{{ category_name }}"
+      - result.response.category_value == "{{ category_value }}"
+      - result.response.ad_info is defined
+      - result.response.ad_info.directory_service_reference == "{{ directory_service_ext_id }}"
+      - result.response.ad_info.object_identifier == "{{ ad_group_object_identifier }}"
+      - result.response.ad_info.object_path == "CN=CheckMode,OU=Groups,DC=example,DC=com"
+    success_msg: "Spec for creating DsCategoryMapping using check mode with all attributes is generated successfully"
+    fail_msg: "Spec for creating DsCategoryMapping using check mode with all attributes is not generated successfully"
+
+########################################################################################
+# 2. Negative create tests (do not need a real AD group)
+########################################################################################
+
+- name: Create DsCategoryMapping with missing name
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    category_name: "{{ category_name }}"
+    category_value: "{{ category_value }}"
+    ad_info:
+      directory_service_reference: "{{ directory_service_ext_id }}"
+      object_identifier: "{{ ad_group_object_identifier }}"
+  register: result
+  ignore_errors: true
+
+- name: Create DsCategoryMapping with missing name status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "state is present but any of the following are missing: name, ext_id"
+    success_msg: "Create DsCategoryMapping with missing name failed as expected"
+    fail_msg: "Create DsCategoryMapping with missing name did not fail as expected"
+
+- name: Create DsCategoryMapping with missing category_name
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    name: "missing_category_name"
+    category_value: "{{ category_value }}"
+    ad_info:
+      directory_service_reference: "{{ directory_service_ext_id }}"
+      object_identifier: "{{ ad_group_object_identifier }}"
+  register: result
+  ignore_errors: true
+
+- name: Create DsCategoryMapping with missing category_name status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): category_name"
+    success_msg: "Create DsCategoryMapping with missing category_name failed as expected"
+    fail_msg: "Create DsCategoryMapping with missing category_name did not fail as expected"
+
+- name: Create DsCategoryMapping with missing category_value
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    name: "missing_category_value"
+    category_name: "{{ category_name }}"
+    ad_info:
+      directory_service_reference: "{{ directory_service_ext_id }}"
+      object_identifier: "{{ ad_group_object_identifier }}"
+  register: result
+  ignore_errors: true
+
+- name: Create DsCategoryMapping with missing category_value status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): category_value"
+    success_msg: "Create DsCategoryMapping with missing category_value failed as expected"
+    fail_msg: "Create DsCategoryMapping with missing category_value did not fail as expected"
+
+- name: Create DsCategoryMapping with missing ad_info
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    name: "missing_ad_info"
+    category_name: "{{ category_name }}"
+    category_value: "{{ category_value }}"
+  register: result
+  ignore_errors: true
+
+- name: Create DsCategoryMapping with missing ad_info status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): ad_info"
+    success_msg: "Create DsCategoryMapping with missing ad_info failed as expected"
+    fail_msg: "Create DsCategoryMapping with missing ad_info did not fail as expected"
+
+- name: Create DsCategoryMapping with invalid ad_info.status enum value
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    name: "invalid_status"
+    category_name: "{{ category_name }}"
+    category_value: "{{ category_value }}"
+    ad_info:
+      directory_service_reference: "{{ directory_service_ext_id }}"
+      object_identifier: "{{ ad_group_object_identifier }}"
+      status: "INVALID_STATUS_VALUE"
+  register: result
+  ignore_errors: true
+
+- name: Create DsCategoryMapping with invalid ad_info.status enum value status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'value of status must be one of' in result.msg"
+    success_msg: "Create DsCategoryMapping with invalid ad_info.status failed as expected"
+    fail_msg: "Create DsCategoryMapping with invalid ad_info.status did not fail as expected"
+
+########################################################################################
+# 3. Info Module Tests
+########################################################################################
+
+- name: List all DsCategoryMappings
+  nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List all DsCategoryMappings status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 0
+      - result.total_available_results is defined
+    success_msg: "List all DsCategoryMappings passed"
+    fail_msg: "List all DsCategoryMappings failed"
+
+- name: List DsCategoryMappings with limit
+  nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List DsCategoryMappings with limit status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length <= 1
+    success_msg: "List DsCategoryMappings with limit passed"
+    fail_msg: "List DsCategoryMappings with limit failed"
+
+- name: Fetch DsCategoryMapping using wrong external ID
+  nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+  register: result
+  ignore_errors: true
+
+- name: Fetch DsCategoryMapping using wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Fetch DsCategoryMapping using wrong external ID failed as expected"
+    fail_msg: "Fetch DsCategoryMapping using wrong external ID did not fail as expected"
+
+########################################################################################
+# 4. Delete negatives (do not need a real AD group)
+########################################################################################
+
+- name: Delete DsCategoryMapping with wrong external ID
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Delete DsCategoryMapping with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Delete DsCategoryMapping with wrong external ID failed as expected"
+    fail_msg: "Delete DsCategoryMapping with wrong external ID did not fail as expected"
+
+- name: Delete DsCategoryMapping with missing external ID
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Delete DsCategoryMapping with missing external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete DsCategoryMapping with missing external ID failed as expected"
+    fail_msg: "Delete DsCategoryMapping with missing external ID did not fail as expected"
+
+- name: Delete DsCategoryMapping with check mode using a fake ext_id
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+    state: absent
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Delete DsCategoryMapping with check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+    success_msg: "Delete DsCategoryMapping with check mode passed"
+    fail_msg: "Delete DsCategoryMapping with check mode failed"
+
+########################################################################################
+# 5. Live CRUD lifecycle (skipped unless enable_live_crud is set)
+#
+# This block requires a REAL AD group objectGUID and a configured directory
+# server config on the target PC. When those are unavailable, we still exercise
+# the create+task path via a "well formed but rejected" call and confirm the
+# module reports the API failure gracefully.
+########################################################################################
+
+- name: Create DsCategoryMapping with a well-formed (but unresolvable) AD group GUID to exercise the task error path
+  nutanix.ncp.ntnx_ds_category_mapping_v2:
+    name: "{{ ds_map_name }}_task_err"
+    category_name: "{{ category_name }}"
+    category_value: "{{ category_value }}"
+    ad_info:
+      directory_service_reference: "{{ directory_service_ext_id }}"
+      object_identifier: "{{ ad_group_object_identifier }}"
+  register: task_err
+  ignore_errors: true
+  when: not enable_live_crud
+
+- name: Assert task error path is surfaced correctly (create -> task -> FAILED)
+  ansible.builtin.assert:
+    that:
+      - task_err is defined
+      - task_err.skipped is defined or task_err.failed is defined
+      - (task_err.skipped | default(false)) or (task_err.failed == true)
+    success_msg: "Create with unresolvable AD group GUID surfaced the task failure cleanly"
+    fail_msg: "Create with unresolvable AD group GUID did not surface the task failure correctly"
+  when: not enable_live_crud
+
+- name: Live CRUD block
+  when: enable_live_crud
+  block:
+    - name: Create DsCategoryMapping with minimum attributes (live)
+      nutanix.ncp.ntnx_ds_category_mapping_v2:
+        name: "{{ ds_map_name }}_min"
+        category_name: "{{ category_name }}"
+        category_value: "{{ category_value }}"
+        ad_info:
+          directory_service_reference: "{{ directory_service_ext_id }}"
+          object_identifier: "{{ ad_group_object_identifier }}"
+      register: result
+
+    - name: Create DsCategoryMapping with minimum attributes status (live)
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.ext_id is defined
+          - result.task_ext_id is defined
+          - result.response is defined
+          - result.response.name == "{{ ds_map_name }}_min"
+          - result.response.category_name == "{{ category_name }}"
+          - result.response.category_value == "{{ category_value }}"
+          - result.response.ad_info.directory_service_reference == "{{ directory_service_ext_id }}"
+          - result.response.ad_info.object_identifier == "{{ ad_group_object_identifier }}"
+        success_msg: "Live: DsCategoryMapping (min) created successfully"
+        fail_msg: "Live: DsCategoryMapping (min) creation failed"
+
+    - name: Add DsCategoryMapping to todelete list
+      ansible.builtin.set_fact:
+        todelete: "{{ todelete + [result.ext_id] }}"
+
+    - name: Create DsCategoryMapping with all attributes (live)
+      nutanix.ncp.ntnx_ds_category_mapping_v2:
+        name: "{{ ds_map_name }}_full"
+        category_name: "{{ category_name }}"
+        category_value: "{{ category_value }}"
+        ad_info:
+          directory_service_reference: "{{ directory_service_ext_id }}"
+          object_identifier: "{{ ad_group_object_identifier_2 }}"
+          object_path: "CN=Full,OU=Groups,DC=example,DC=com"
+      register: result
+
+    - name: Create DsCategoryMapping with all attributes status (live)
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.ext_id is defined
+          - result.task_ext_id is defined
+          - result.response is defined
+          - result.response.name == "{{ ds_map_name }}_full"
+          - result.response.category_name == "{{ category_name }}"
+          - result.response.category_value == "{{ category_value }}"
+          - result.response.ad_info.object_identifier == "{{ ad_group_object_identifier_2 }}"
+          - result.response.ad_info.object_path == "CN=Full,OU=Groups,DC=example,DC=com"
+        success_msg: "Live: DsCategoryMapping (full) created successfully"
+        fail_msg: "Live: DsCategoryMapping (full) creation failed"
+
+    - name: Add DsCategoryMapping to todelete list
+      ansible.builtin.set_fact:
+        todelete: "{{ todelete + [result.ext_id] }}"
+
+    - name: Fetch DsCategoryMapping using external ID (live)
+      nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+        ext_id: "{{ todelete[0] }}"
+      register: result
+
+    - name: Fetch DsCategoryMapping using external ID status (live)
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.failed == false
+          - result.ext_id == todelete[0]
+          - result.response.name == "{{ ds_map_name }}_min"
+          - result.response.category_name == "{{ category_name }}"
+        success_msg: "Live: Fetch DsCategoryMapping by ext_id passed"
+        fail_msg: "Live: Fetch DsCategoryMapping by ext_id failed"
+
+    - name: List DsCategoryMappings with filter (live)
+      nutanix.ncp.ntnx_ds_category_mappings_info_v2:
+        filter: "name eq '{{ ds_map_name }}_min'"
+      register: result
+
+    - name: List DsCategoryMappings with filter status (live)
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.failed == false
+          - result.response | length == 1
+          - result.response[0].name == "{{ ds_map_name }}_min"
+        success_msg: "Live: List DsCategoryMappings with filter passed"
+        fail_msg: "Live: List DsCategoryMappings with filter failed"
+
+    - name: Generate spec for updating DsCategoryMapping using check mode with all attributes (live)
+      nutanix.ncp.ntnx_ds_category_mapping_v2:
+        ext_id: "{{ todelete[0] }}"
+        name: "{{ ds_map_name }}_updated"
+        category_name: "{{ category_name }}"
+        category_value: "{{ category_value_updated }}"
+        ad_info:
+          directory_service_reference: "{{ directory_service_ext_id }}"
+          object_identifier: "{{ ad_group_object_identifier }}"
+          object_path: "CN=Updated,OU=Groups,DC=example,DC=com"
+      check_mode: true
+      register: result
+
+    - name: Generate spec for updating DsCategoryMapping using check mode status (live)
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.failed == false
+          - result.response is defined
+          - result.response.name == "{{ ds_map_name }}_updated"
+          - result.response.category_value == "{{ category_value_updated }}"
+          - result.response.ad_info.object_path == "CN=Updated,OU=Groups,DC=example,DC=com"
+        success_msg: "Live: Update DsCategoryMapping check mode spec generated"
+        fail_msg: "Live: Update DsCategoryMapping check mode spec generation failed"
+
+    - name: Update DsCategoryMapping with all attributes (live)
+      nutanix.ncp.ntnx_ds_category_mapping_v2:
+        ext_id: "{{ todelete[0] }}"
+        name: "{{ ds_map_name }}_updated"
+        category_name: "{{ category_name }}"
+        category_value: "{{ category_value_updated }}"
+        ad_info:
+          directory_service_reference: "{{ directory_service_ext_id }}"
+          object_identifier: "{{ ad_group_object_identifier }}"
+          object_path: "CN=Updated,OU=Groups,DC=example,DC=com"
+      register: result
+
+    - name: Update DsCategoryMapping with all attributes status (live)
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.failed == false
+          - result.response.name == "{{ ds_map_name }}_updated"
+          - result.response.category_value == "{{ category_value_updated }}"
+          - result.response.ad_info.object_path == "CN=Updated,OU=Groups,DC=example,DC=com"
+        success_msg: "Live: Update DsCategoryMapping with all attributes passed"
+        fail_msg: "Live: Update DsCategoryMapping with all attributes failed"
+
+    - name: Update DsCategoryMapping with same values (idempotency) (live)
+      nutanix.ncp.ntnx_ds_category_mapping_v2:
+        ext_id: "{{ todelete[0] }}"
+        name: "{{ ds_map_name }}_updated"
+        category_name: "{{ category_name }}"
+        category_value: "{{ category_value_updated }}"
+        ad_info:
+          directory_service_reference: "{{ directory_service_ext_id }}"
+          object_identifier: "{{ ad_group_object_identifier }}"
+          object_path: "CN=Updated,OU=Groups,DC=example,DC=com"
+      register: result
+
+    - name: Update DsCategoryMapping with same values status (live)
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == false
+          - result.msg == "Nothing to change."
+        success_msg: "Live: Update DsCategoryMapping idempotency passed"
+        fail_msg: "Live: Update DsCategoryMapping idempotency failed"
+
+    - name: Update DsCategoryMapping with wrong external ID (live)
+      nutanix.ncp.ntnx_ds_category_mapping_v2:
+        ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+        name: "test_wrong_ext_id"
+        category_name: "{{ category_name }}"
+        category_value: "{{ category_value }}"
+        ad_info:
+          directory_service_reference: "{{ directory_service_ext_id }}"
+          object_identifier: "{{ ad_group_object_identifier }}"
+      register: result
+      ignore_errors: true
+
+    - name: Update DsCategoryMapping with wrong external ID status (live)
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == false
+          - result.failed == true
+        success_msg: "Live: Update DsCategoryMapping with wrong external ID failed as expected"
+        fail_msg: "Live: Update DsCategoryMapping with wrong external ID did not fail as expected"
+
+    - name: Delete all created DsCategoryMappings (live)
+      nutanix.ncp.ntnx_ds_category_mapping_v2:
+        ext_id: "{{ item }}"
+        state: absent
+      register: result
+      loop: "{{ todelete }}"
+
+    - name: Deletion status (live)
+      ansible.builtin.assert:
+        that:
+          - result is defined
+          - result.changed == true
+          - result.results | length == todelete | length
+          - result.msg == "All items completed"
+        fail_msg: "Live: Unable to delete all DsCategoryMappings"
+        success_msg: "Live: All DsCategoryMappings are deleted successfully"

--- a/tests/integration/targets/ntnx_ds_category_mapping_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_ds_category_mapping_v2/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ ip }}"
+      nutanix_username: "{{ username | default(omit) }}"
+      nutanix_password: "{{ password | default(omit) }}"
+      nutanix_api_key: "{{ nutanix_api_key | default(omit) }}"
+      validate_certs: "{{ validate_certs }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import ds_category_mapping.yml
+      ansible.builtin.import_tasks: ds_category_mapping.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **flow_management** namespace, entity **DsCategoryMapping**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_ds_category_mapping_v2`, `ntnx_ds_category_mappings_info_v2`
- API methods covered: 5 (`create_category_mapping`, `get_ds_category_mapping_by_id`, `list_category_mappings`, `update_ds_category_mapping_by_id`, `delete_ds_category_mapping_by_id`)
- Fields in CRUD module spec: 5 top-level (`state`, `ext_id`, `name`, `category_name`, `category_value`) + `ad_info` dict with 4 sub-fields (`directory_service_reference`, `object_identifier`, `object_path`, `status`)
- Fields in info module spec: 1 (`ext_id`) plus the standard info-module `filter/page/limit/orderby/select`

## Files changed

- `plugins/modules/`
  - `ntnx_ds_category_mapping_v2.py` (new — CRUD)
  - `ntnx_ds_category_mappings_info_v2.py` (new — info / list)
- `plugins/module_utils/v4/`
  - `flow/api_client.py` (added `get_directory_server_configs_api_instance`)
  - `flow/helpers.py` (added `get_ds_category_mapping`)
  - `constants.py` (added `Tasks.RelEntityType.DS_CATEGORY_MAPPING = "microseg:config:category-mapping"`)
- `meta/runtime.yml` (added both new modules to the `nutanix.ncp.ntnx` action group)
- `tests/integration/targets/ntnx_ds_category_mapping_v2/`
  - `aliases`, `meta/main.yml`, `tasks/main.yml`, `tasks/ds_category_mapping.yml`
- `examples/flow_management/DsCategoryMapping/`
  - `ds_category_mapping_v2.yml` (example playbook)
  - `examples_run.log` (real playbook output from a live PC run)

## Test execution

| Metric              | Value                                                              |
|---------------------|--------------------------------------------------------------------|
| Command             | `ansible-playbook /tmp/run_tests.yml -v` (uses `tests/integration/targets/ntnx_ds_category_mapping_v2/tasks/main.yml`) |
| Total tasks         | 51                                                                 |
| Passed (ok)         | 21 (all assertions passed)                                         |
| Ignored (task_err_expected) | 9 (`fatal:` followed by `...ignoring`; expected negative-path failures) |
| Skipped             | 20 (live-CRUD block skipped — no real AD group objectGUID present) |
| Failed              | 0                                                                  |
| Duration            | ~10s                                                               |
| Cluster (PC)        | 10.44.76.28 (v4.2 flow / microseg)                                 |

Sanity: `ansible-test sanity --python 3.12` on all new/changed files passed (all 31 sanity checks). `black --check`, `isort --check`, `flake8`, and `ansible-lint` all pass.

### Analysis

All non-live tests pass on the live cluster:
- **check_mode** create with all attributes → correct spec generated.
- **negative create** — missing `name`, `category_name`, `category_value`, `ad_info` — each fails with the expected `Missing required parameter(s)` / `state is present but any of the following are missing` message.
- **invalid enum** — `ad_info.status: INVALID_STATUS_VALUE` is rejected by argspec with the expected `value of status must be one of ...` message.
- **info: list all** → returns empty list + `total_available_results: 0` (no mappings exist on cluster).
- **info: list with limit** → returns `length <= 1`.
- **info: get by non-existent ext_id** → API returns 404 `MIC-30400` and the module raises with `Api Exception raised while fetching DsCategoryMapping info using ext_id`.
- **delete negatives** — wrong ext_id, missing ext_id, check_mode all behave as expected.
- **task error path** — `create` with a well-formed but AD-unresolvable objectGUID goes through the full spec → create → task-poll → `Task Failed (MIC-10007: Invalid object GUID)` path, proving the wait-for-completion / task-failure path is wired.

The live-CRUD block (create/update/delete with real API-observable side effects) is gated on `ds_category_mapping.enable_live_crud` and requires a real AD group `objectGUID` (see the block header in `tests/integration/targets/ntnx_ds_category_mapping_v2/tasks/ds_category_mapping.yml`). It is skipped on this cluster because we do not have a live AD group whose raw `objectGUID` is known here — the IAM `user-group` extIds Prism exposes are Nutanix-assigned IDs, not the AD-side GUIDs the DsCategoryMapping API expects.

### Known issues / limitations

- **`examples_run.log` — Create task fails with `MIC-10007: Invalid object GUID`.** The example playbook is authored with the correct request shape; running it end-to-end succeeds *up to* the Prism task, which then fails because the placeholder `object_identifier` is not a real AD group. Every subsequent example task is guarded by `when: ds_category_mapping_ext_id is defined` so the play still completes with `failed=0`. To make the create succeed on a real deployment, replace `object_identifier` with the real AD group `objectGUID`.
- The **live-CRUD** integration block is deliberately gated behind `ds_category_mapping.enable_live_crud` for the same reason.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
[WARNING]: Found variable using reserved name: port
No config file found; using defaults

PLAY [Run DsCategoryMapping integration tests] *********************************

TASK [Run tasks] ***************************************************************
included: /tmp/codegen/813a04676d414e41b475ad94a7dd8c74/repo/tests/integration/targets/ntnx_ds_category_mapping_v2/tasks/main.yml for localhost

TASK [Start DsCategoryMapping tests] *******************************************
ok: [localhost] => {
    "msg": "Start DsCategoryMapping tests"
}

TASK [Generate random names] ***************************************************
[WARNING]: Collection community.general does not support Ansible version 2.16.0
ok: [localhost] => {"ansible_facts": {"random_name": "nUpjWYVwagio", "suffix_name": "ansible", "todelete": []}, "changed": false}

TASK [Set names for DsCategoryMapping] *****************************************
ok: [localhost] => {"ansible_facts": {"ds_map_name": "ds_cm_ansible_nUpjWYVwagio"}, "changed": false}

TASK [Set DsCategoryMapping prerequisites] *************************************
ok: [localhost] => {"ansible_facts": {"ad_group_object_identifier": "b1a1e59d-6f9a-4bde-8f0f-2b6f8c9f6a11", "ad_group_object_identifier_2": "c2b2f6ae-7f8b-4dcf-9a1e-a4c5d8e0f2b3", "category_name": "AppType", "category_value": "Finance", "category_value_updated": "Engineering", "directory_service_ext_id": "7e9749f3-e3ee-5f9b-ade8-e359777f681a", "enable_live_crud": false}, "changed": false}

TASK [Generate spec for creating DsCategoryMapping using check mode with all attributes] ***
ok: [localhost] => {"changed": false, "ext_id": null, "response": {"ad_info": {"directory_service_reference": "7e9749f3-e3ee-5f9b-ade8-e359777f681a", "object_identifier": "b1a1e59d-6f9a-4bde-8f0f-2b6f8c9f6a11", "object_path": "CN=CheckMode,OU=Groups,DC=example,DC=com", "status": null}, "category_name": "AppType", "category_value": "Finance", "ext_id": null, "links": null, "name": "check_mode_ds_cm_full", "tenant_id": null}}

TASK [Generate spec for creating DsCategoryMapping using check mode with all attributes status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Spec for creating DsCategoryMapping using check mode with all attributes is generated successfully"
}

TASK [Create DsCategoryMapping with missing name] ******************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "state is present but any of the following are missing: name, ext_id"}
...ignoring

TASK [Create DsCategoryMapping with missing name status] ***********************
ok: [localhost] => {
    "changed": false,
    "msg": "Create DsCategoryMapping with missing name failed as expected"
}

TASK [Create DsCategoryMapping with missing category_name] *********************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): category_name"}
...ignoring

TASK [Create DsCategoryMapping with missing category_name status] **************
ok: [localhost] => {
    "changed": false,
    "msg": "Create DsCategoryMapping with missing category_name failed as expected"
}

TASK [Create DsCategoryMapping with missing category_value] ********************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): category_value"}
...ignoring

TASK [Create DsCategoryMapping with missing category_value status] *************
ok: [localhost] => {
    "changed": false,
    "msg": "Create DsCategoryMapping with missing category_value failed as expected"
}

TASK [Create DsCategoryMapping with missing ad_info] ***************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Missing required parameter(s): ad_info"}
...ignoring

TASK [Create DsCategoryMapping with missing ad_info status] ********************
ok: [localhost] => {
    "changed": false,
    "msg": "Create DsCategoryMapping with missing ad_info failed as expected"
}

TASK [Create DsCategoryMapping with invalid ad_info.status enum value] *********
fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of status must be one of: USABLE, DELETED, DIRECTORY_NOT_CONFIGURED, got: INVALID_STATUS_VALUE found in ad_info"}
...ignoring

TASK [Create DsCategoryMapping with invalid ad_info.status enum value status] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Create DsCategoryMapping with invalid ad_info.status failed as expected"
}

TASK [List all DsCategoryMappings] *********************************************
ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [List all DsCategoryMappings status] **************************************
ok: [localhost] => {
    "changed": false,
    "msg": "List all DsCategoryMappings passed"
}

TASK [List DsCategoryMappings with limit] **************************************
ok: [localhost] => {"changed": false, "response": [], "total_available_results": 0}

TASK [List DsCategoryMappings with limit status] *******************************
ok: [localhost] => {
    "changed": false,
    "msg": "List DsCategoryMappings with limit passed"
}

TASK [Fetch DsCategoryMapping using wrong external ID] *************************
fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching DsCategoryMapping info using ext_id", "response": {"$objectType": "microseg.v4.config.GetDsCategoryMappingApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "microseg.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "microseg.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "code": "MIC-30400", "locale": "en_US", "message": "Failed to get category mapping because category mapping with extId {{{extId}}} does not exist.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://127.0.0.1/api/microseg/v4/config/category-mappings/04595a7b-010c-4a89-58dd-060c94e9a1f0", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [Fetch DsCategoryMapping using wrong external ID status] ******************
ok: [localhost] => {
    "changed": false,
    "msg": "Fetch DsCategoryMapping using wrong external ID failed as expected"
}

TASK [Delete DsCategoryMapping with wrong external ID] *************************
fatal: [localhost]: FAILED! => {"changed": false, "error": "NOT FOUND", "msg": "Api Exception raised while fetching DsCategoryMapping info using ext_id", "response": {"$objectType": "microseg.v4.config.GetDsCategoryMappingApiResponse", "$reserved": {"$fv": "v4.r3"}, "data": {"$objectType": "microseg.v4.error.ErrorResponse", "$reserved": {"$fv": "v4.r3"}, "error": [{"$objectType": "microseg.v4.error.AppMessage", "$reserved": {"$fv": "v4.r3"}, "code": "MIC-30400", "locale": "en_US", "message": "Failed to get category mapping because category mapping with extId {{{extId}}} does not exist.", "severity": "ERROR"}]}, "metadata": {"$objectType": "common.v1.response.ApiResponseMetadata", "$reserved": {"$fv": "v1.r0"}, "flags": [{"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "hasError", "value": true}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isPaginated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isTruncated", "value": false}, {"$objectType": "common.v1.config.Flag", "$reserved": {"$fv": "v1.r0"}, "name": "isExpandRestricted", "value": false}], "links": [{"$objectType": "common.v1.response.ApiLink", "$reserved": {"$fv": "v1.r0"}, "href": "https://127.0.0.1/api/microseg/v4/config/category-mappings/04595a7b-010c-4a89-58dd-060c94e9a1f0", "rel": "self"}], "totalAvailableResults": 0}}, "status": 404}
...ignoring

TASK [Delete DsCategoryMapping with wrong external ID status] ******************
ok: [localhost] => {
    "changed": false,
    "msg": "Delete DsCategoryMapping with wrong external ID failed as expected"
}

TASK [Delete DsCategoryMapping with missing external ID] ***********************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id"}
...ignoring

TASK [Delete DsCategoryMapping with missing external ID status] ****************
ok: [localhost] => {
    "changed": false,
    "msg": "Delete DsCategoryMapping with missing external ID failed as expected"
}

TASK [Delete DsCategoryMapping with check mode using a fake ext_id] ************
ok: [localhost] => {"changed": false, "ext_id": "04595a7b-010c-4a89-58dd-060c94e9a1f0", "msg": "DsCategoryMapping with ext_id:04595a7b-010c-4a89-58dd-060c94e9a1f0 will be deleted.", "response": null}

TASK [Delete DsCategoryMapping with check mode status] *************************
ok: [localhost] => {
    "changed": false,
    "msg": "Delete DsCategoryMapping with check mode passed"
}

TASK [Create DsCategoryMapping with a well-formed (but unresolvable) AD group GUID to exercise the task error path] ***
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-07-21T12:09:03.016631+00:00", "completion_details": null, "created_time": "2026-07-21T12:09:02.142231+00:00", "entities_affected": [{"ext_id": "7b4488bb-c53a-4381-9bb7-9928fb55fc45", "name": "ds_cm_ansible_nUpjWYVwagio_task_err", "rel": "microseg:config:category-mapping"}], "error_messages": [{"arguments_map": {"operation": "create category mapping", "reason": "Invalid object GUID passed: b1a1e59d-6f9a-4bde-8f0f-2b6f8c9f6a11"}, "code": "MIC-10007", "error_group": "FLOW_SERVICE_RPC_EXCEPTION", "locale": "en_US", "message": "Failed to create category mapping due to Invalid object GUID passed: b1a1e59d-6f9a-4bde-8f0f-2b6f8c9f6a11.", "severity": "ERROR"}], "ext_id": "ZXJnb24=:c4fb7885-d58e-4dc3-b247-9dd7ee15f195", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-07-21T12:09:03.016629+00:00", "legacy_error_message": null, "number_of_entities_affected": 1, "number_of_subtasks": 0, "operation": "kIdCategorizationMappingCreate", "operation_description": "Create Catergory Mapping", "owned_by": {"ext_id": "00000000-0000-0000-0000-000000000000", "name": "admin"}, "parent_task": null, "progress_percentage": 100, "projectExtId": "00000000-0000-0000-0000-000000000000", "resource_links": null, "root_task": null, "started_time": "2026-07-21T12:09:02.152461+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": null, "warnings": null}}
...ignoring

TASK [Assert task error path is surfaced correctly (create -> task -> FAILED)] ***
ok: [localhost] => {
    "changed": false,
    "msg": "Create with unresolvable AD group GUID surfaced the task failure cleanly"
}

TASK [Create DsCategoryMapping with minimum attributes (live)] *****************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Create DsCategoryMapping with minimum attributes status (live)] **********
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Add DsCategoryMapping to todelete list] **********************************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Create DsCategoryMapping with all attributes (live)] *********************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Create DsCategoryMapping with all attributes status (live)] **************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Add DsCategoryMapping to todelete list] **********************************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Fetch DsCategoryMapping using external ID (live)] ************************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Fetch DsCategoryMapping using external ID status (live)] *****************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [List DsCategoryMappings with filter (live)] ******************************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [List DsCategoryMappings with filter status (live)] ***********************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Generate spec for updating DsCategoryMapping using check mode with all attributes (live)] ***
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Generate spec for updating DsCategoryMapping using check mode status (live)] ***
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Update DsCategoryMapping with all attributes (live)] *********************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Update DsCategoryMapping with all attributes status (live)] **************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Update DsCategoryMapping with same values (idempotency) (live)] **********
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Update DsCategoryMapping with same values status (live)] *****************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Update DsCategoryMapping with wrong external ID (live)] ******************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Update DsCategoryMapping with wrong external ID status (live)] ***********
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

TASK [Delete all created DsCategoryMappings (live)] ****************************
skipping: [localhost] => {"changed": false, "skipped_reason": "No items in the list"}

TASK [Deletion status (live)] **************************************************
skipping: [localhost] => {"changed": false, "false_condition": "enable_live_crud", "skip_reason": "Conditional result was False"}

PLAY RECAP *********************************************************************
localhost                  : ok=31   changed=0    unreachable=0    failed=0    skipped=20   rescued=0    ignored=9   

```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
