### PR TITLE
fix(v4/utils): preserve SDK models and handle null ip_config in remove_empty_ip_config

### DIFF
--- a/changelogs/fragments/1323-fix-remove-empty-ip-config.yml
+++ b/changelogs/fragments/1323-fix-remove-empty-ip-config.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ntnx_subnets_v2 - preserve SDK model object instances and safely handle null ip_config in remove_empty_ip_config (fixes #1320, #1019).

--- a/plugins/module_utils/v4/utils.py
+++ b/plugins/module_utils/v4/utils.py
@@ -112,33 +112,28 @@ def remove_empty_ip_config(obj):
     Returns:
         object: object with stripped empty ip_config
     """
-    internal_attributes = [
+    internal_attributes = (
         "_object_type",
         "_reserved",
         "_unknown_fields",
         "$dataItemDiscriminator",
-    ]
+    )
 
-    ip_config = obj.to_dict().get("ip_config", [])
-    empty_ipv4 = False
-    empty_ipv6 = False
-    for item in ip_config.copy():
-        if not item.get("ipv4") or all(
-            value is None
-            for key, value in item["ipv4"].items()
-            if key not in internal_attributes
-        ):
-            empty_ipv4 = True
-        if not item.get("ipv6") or all(
-            value is None
-            for key, value in item["ipv6"].items()
-            if key not in internal_attributes
-        ):
-            empty_ipv6 = True
+    def _empty(block):
+        return not block or all(
+            v is None for k, v in block.items() if k not in internal_attributes
+        )
 
-        if empty_ipv6 and empty_ipv4:
-            ip_config.remove(item)
-    setattr(obj, "ip_config", ip_config)
+    ip_config = getattr(obj, "ip_config", None)
+    if not ip_config:
+        return
+    kept = []
+    for item in ip_config:
+        data = item.to_dict() if hasattr(item, "to_dict") else item
+        if _empty(data.get("ipv4")) and _empty(data.get("ipv6")):
+            continue
+        kept.append(item)
+    setattr(obj, "ip_config", kept)
 
 
 def remove_fields_from_spec(obj, fields_to_remove, deep=False):


### PR DESCRIPTION
## Problem
1. `remove_empty_ip_config()` currently replaces SDK `IPConfig` model objects with standard python dictionaries. When updating a subnet via the v4 SDK (`ntnx_subnets_v2`), the SDK serializes snake_case keys and explicit nulls (`ipv6: null`, missing `ipSubnet`), resulting in HTTP 400 `SchemaValidationError` rejections from Prism Central.
2. For VLAN subnets without IPAM where `ip_config` is `None`, calling `to_dict()` on `None` raises an `AttributeError` (#1019).

## Solution
- Kept the original SDK model object instances in place, only using `to_dict()` as an evaluation predicate to determine emptiness.
- Handled `ip_config is None` safely with early return.
- Filtered internal attributes (`_object_type`, `_reserved`, etc.) cleanly.

Fixes #1320
Fixes #1019

## Testing
- Verified with unit tests covering `None` handling, empty item pruning, and preservation of live SDK model object references.
- Passes clean validation.