### PR TITLE
code-gen(lifecycle/FoundationCentralConfig): ansible collection modules

### DIFF
--- a/examples/lifecycle/FoundationCentralConfig/example_run_logs.txt
+++ b/examples/lifecycle/FoundationCentralConfig/example_run_logs.txt
@@ -1,0 +1,19 @@
+# Example run logs for Foundation Central Config modules
+# Target: FCVM 10.97.44.170:9440
+# Date: 2026-09-07
+
+## Get Foundation Central config (ntnx_foundation_central_config_info_v2)
+changed: false
+response:
+  version: "2.2"
+  commit_id: "8701b044"
+  tls_certificate_fingerprint: "0789169a1c913336750712ad51ce22a27abcb6ba3a1bbce8a3155decf53c8757"
+  aos_download_timeout_minutes: 60
+  ahv_installation_timeout_minutes: 50
+
+## Update Foundation Central config (ntnx_foundation_central_config_v2)
+# Idempotent run with aos_download_timeout_minutes=60, ahv_installation_timeout_minutes=50
+changed: false
+skipped: true
+msg: "Nothing to change for Foundation Central config. Skipping update."
+response: (same as get above)

--- a/examples/lifecycle/FoundationCentralConfig/foundation_central_config_v2.yml
+++ b/examples/lifecycle/FoundationCentralConfig/foundation_central_config_v2.yml
@@ -1,0 +1,47 @@
+---
+# Summary:
+# This playbook exercises Foundation Central Config v4 modules against FCVM:
+# 1. Get Foundation Central configuration
+# 2. Update aos_download_timeout_minutes and ahv_installation_timeout_minutes
+# 3. Get Foundation Central configuration after update
+#
+# Target host: Foundation Central / FCVM (NOT Prism Central).
+# Use FOUNDATION_ENDPOINT / FOUNDATION_PORT (example: 10.97.44.170:9440).
+
+- name: Foundation Central Config playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "<foundation_central_ip>"
+      nutanix_port: 9440
+      nutanix_username: "<user>"
+      nutanix_password: "<pass>"
+      validate_certs: false
+  tasks:
+    - name: Get Foundation Central config
+      nutanix.ncp.ntnx_foundation_central_config_info_v2:
+      register: fcc_config_info
+      ignore_errors: true
+
+    - name: Update Foundation Central config timeouts
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        aos_download_timeout_minutes: 60
+        ahv_installation_timeout_minutes: 50
+      register: fcc_config_update
+      ignore_errors: true
+
+    - name: Update Foundation Central config with all optional fields shown
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        aos_download_timeout_minutes: 60
+        ahv_installation_timeout_minutes: 50
+        version: "2.2"
+        commit_id: "8701b044"
+        tls_certificate_fingerprint: "0789169a1c913336750712ad51ce22a27abcb6ba3a1bbce8a3155decf53c8757"
+      register: fcc_config_update_full
+      ignore_errors: true
+
+    - name: Get Foundation Central config after update
+      nutanix.ncp.ntnx_foundation_central_config_info_v2:
+      register: fcc_config_info_after
+      ignore_errors: true

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -59,6 +59,8 @@ action_groups:
     - ntnx_foundation_central_imaged_clusters_info
     - ntnx_foundation_central_api_keys
     - ntnx_foundation_central_api_keys_info
+    - ntnx_foundation_central_config_v2
+    - ntnx_foundation_central_config_info_v2
     - ntnx_karbon_clusters
     - ntnx_karbon_clusters_info
     - ntnx_karbon_clusters_node_pools

--- a/plugins/module_utils/v4/lcm/api_client.py
+++ b/plugins/module_utils/v4/lcm/api_client.py
@@ -159,3 +159,19 @@ def get_entity_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_lifecycle_py_client.EntitiesApi(api_client=api_client)
+
+
+def get_foundation_central_config_api_instance(module):
+    """
+    This method will return Foundation Central config API instance.
+
+    This API targets Foundation Central / FCVM (not Prism Central). Callers
+    must set nutanix_host/nutanix_port to the FCVM endpoint.
+
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): v4 Foundation Central config api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_lifecycle_py_client.FoundationCentralConfigApi(api_client=api_client)

--- a/plugins/module_utils/v4/lcm/helpers.py
+++ b/plugins/module_utils/v4/lcm/helpers.py
@@ -66,3 +66,26 @@ def get_lcm_entity(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching entity info using external identifier of the entity",
         )
+
+
+def get_foundation_central_config(module, api_instance):
+    """
+    Fetch Foundation Central configuration from FCVM/Foundation.
+
+    Args:
+        module (object): Ansible module object
+        api_instance (object): Foundation Central config api instance
+    Returns:
+        foundation_central_config (object): Foundation Central config data
+    """
+    try:
+        resp = api_instance.get_foundation_central_config()
+        if resp is None or resp.data is None:
+            module.fail_json(msg="Foundation Central config API returned empty data")
+        return resp.data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching Foundation Central config",
+        )

--- a/plugins/modules/ntnx_foundation_central_config_info_v2.py
+++ b/plugins/modules/ntnx_foundation_central_config_info_v2.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_foundation_central_config_info_v2
+short_description: Fetch Foundation Central configuration from FCVM/Foundation
+description:
+    - This module fetches Foundation Central configuration.
+    - Foundation Central config is a singleton Get API with no list, filter,
+      or get-by-ID parameters.
+    - This module talks to B(Foundation Central / FCVM), not Prism Central.
+      Set C(nutanix_host) / C(nutanix_port) to the FCVM endpoint
+      (for example C(FOUNDATION_ENDPOINT) / C(FOUNDATION_PORT)).
+version_added: 2.6.0
+notes:
+    - >-
+      This module requires Viewer or Admin role on Foundation Central / FCVM
+      for the user performing the operation.
+    - >-
+      Target host is Foundation Central / FCVM (lifecycle Foundation Central
+      Config API), not Prism Central.
+    - Filter, limit, page, orderby, and select are not supported by this API.
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=lifecycle)"
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+    - George Ghawali (@george-ghawali)
+options: {}
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_info_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+"""
+
+EXAMPLES = r"""
+- name: Get Foundation Central config from FCVM
+  nutanix.ncp.ntnx_foundation_central_config_info_v2:
+    nutanix_host: "<foundation_central_ip>"
+    nutanix_port: 9440
+    nutanix_username: "<user>"
+    nutanix_password: "<pass>"
+    validate_certs: false
+  register: fcc_config_info
+"""
+
+RETURN = r"""
+response:
+    description:
+        - The response from the Nutanix foundation central config info v4 API
+          (host is FCVM/Foundation, not Prism Central).
+        - Always a single foundation central config object (singleton GET).
+        - List/filter/limit are not supported by this API.
+    type: dict
+    returned: always
+    sample:
+        {
+            "ahv_installation_timeout_minutes": 50,
+            "aos_download_timeout_minutes": 60,
+            "commit_id": "8701b044",
+            "tls_certificate_fingerprint": "0789169a1c913336750712ad51ce22a27abcb6ba3a1bbce8a3155decf53c8757",
+            "version": "2.2"
+        }
+changed:
+    description: Whether the module made any changes
+    type: bool
+    returned: always
+    sample: false
+error:
+    description: Error details
+    type: str
+    returned: always
+    sample: null
+failed:
+    description: Whether the module failed
+    type: bool
+    returned: when something fails
+    sample: false
+msg:
+    description: Status or error message
+    type: str
+    returned: when applicable
+    sample: "Api Exception raised while fetching Foundation Central config"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.lcm.api_client import (  # noqa: E402
+    get_foundation_central_config_api_instance,
+)
+from ..module_utils.v4.lcm.helpers import get_foundation_central_config  # noqa: E402
+from ..module_utils.v4.utils import strip_internal_attributes  # noqa: E402
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_lifecycle_py_client as lifecycle_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as lifecycle_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+    return dict()
+
+
+def get_foundation_central_config_info(module, api_instance, result):
+    """
+    Fetch the singleton Foundation Central configuration.
+    """
+    resp = get_foundation_central_config(module, api_instance)
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+    )
+
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg="Missing required library ntnx_lifecycle_py_client",
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "error": None,
+    }
+
+    # Ensure SDK import is retained for sdk_mock fallback / import sanity.
+    if lifecycle_sdk is None:
+        module.fail_json(msg="Lifecycle SDK is unavailable")
+
+    api_instance = get_foundation_central_config_api_instance(module)
+    get_foundation_central_config_info(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_foundation_central_config_v2.py
+++ b/plugins/modules/ntnx_foundation_central_config_v2.py
@@ -1,0 +1,377 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_foundation_central_config_v2
+short_description: Update Foundation Central configuration on FCVM/Foundation
+description:
+    - This module updates Foundation Central configuration.
+    - Foundation Central config is a singleton; there is no create or delete API.
+    - C(state=present) without C(ext_id) applies the desired configuration (update).
+    - C(state=present) with C(ext_id) also updates the configuration.
+    - C(state=absent) is not supported and will fail.
+    - This module talks to B(Foundation Central / FCVM), not Prism Central.
+      Set C(nutanix_host) / C(nutanix_port) to the FCVM endpoint
+      (for example C(FOUNDATION_ENDPOINT) / C(FOUNDATION_PORT)).
+version_added: 2.6.0
+author:
+    - Abhinav Bansal (@abhinavbansal29)
+    - George Ghawali (@george-ghawali)
+notes:
+    - >-
+      This module requires Admin role on Foundation Central / FCVM for the user
+      performing the operation.
+    - >-
+      Target host is Foundation Central / FCVM (lifecycle Foundation Central
+      Config API), not Prism Central.
+    - "Ref: U(https://developers.nutanix.com/api-reference?namespace=lifecycle)"
+options:
+    state:
+        description:
+            - If C(state) is C(present) and C(ext_id) is not provided, apply
+              (update) the Foundation Central configuration.
+            - If C(state) is C(present) and C(ext_id) is provided, update the
+              Foundation Central configuration.
+            - If C(state) is C(absent), the module fails because delete is not
+              supported for this singleton resource.
+        type: str
+        choices:
+            - present
+            - absent
+        default: present
+    ext_id:
+        description:
+            - Optional external ID accepted for update dispatch compatibility.
+            - Foundation Central config is a singleton and does not use ext_id
+              in the API; the value is ignored for the update call.
+        type: str
+        required: false
+    version:
+        description:
+            - Foundation Central Version.
+            - Typically returned by the GET API and is read-only.
+        type: str
+        required: false
+    commit_id:
+        description:
+            - Foundation Central Commit ID.
+            - Typically returned by the GET API and is read-only.
+        type: str
+        required: false
+    tls_certificate_fingerprint:
+        description:
+            - SHA-256 fingerprint of the TLS certificate used by Foundation
+              Central service.
+            - Typically returned by the GET API and is read-only.
+        type: str
+        required: false
+    aos_download_timeout_minutes:
+        description:
+            - Timeout in minutes for AOS download.
+        type: int
+        required: false
+    ahv_installation_timeout_minutes:
+        description:
+            - Timeout in minutes for AHV installation.
+        type: int
+        required: false
+extends_documentation_fragment:
+    - nutanix.ncp.ntnx_credentials
+    - nutanix.ncp.ntnx_operations_v2
+    - nutanix.ncp.ntnx_logger
+    - nutanix.ncp.ntnx_proxy_v2
+"""
+
+EXAMPLES = r"""
+- name: Update Foundation Central config timeouts on FCVM
+  nutanix.ncp.ntnx_foundation_central_config_v2:
+    nutanix_host: "<foundation_central_ip>"
+    nutanix_port: 9440
+    nutanix_username: "<user>"
+    nutanix_password: "<pass>"
+    validate_certs: false
+    aos_download_timeout_minutes: 60
+    ahv_installation_timeout_minutes: 50
+  register: fcc_config_update
+"""
+
+RETURN = r"""
+response:
+    description:
+        - The Foundation Central configuration after the update operation.
+    type: dict
+    returned: always
+    sample:
+        {
+            "ahv_installation_timeout_minutes": 50,
+            "aos_download_timeout_minutes": 60,
+            "commit_id": "8701b044",
+            "tls_certificate_fingerprint": "0789169a1c913336750712ad51ce22a27abcb6ba3a1bbce8a3155decf53c8757",
+            "version": "2.2"
+        }
+changed:
+    description: Whether the module made any changes
+    type: bool
+    returned: always
+    sample: true
+ext_id:
+    description:
+        - External ID of the resource.
+        - Always null for this singleton Foundation Central config.
+    type: str
+    returned: always
+    sample: null
+task_ext_id:
+    description: The task external ID returned by the update API
+    type: str
+    returned: always
+    sample: "ZXJnb24=:04b8f6c2-80b0-5149-9e63-1077d02ae92e"
+skipped:
+    description: Indicates if the operation was skipped due to idempotency
+    type: bool
+    returned: when applicable
+    sample: true
+msg:
+    description: Status or error message
+    type: str
+    returned: when applicable
+    sample: "Nothing to change for Foundation Central config. Skipping update."
+error:
+    description: Error details
+    type: str
+    returned: always
+    sample: null
+failed:
+    description: Whether the module failed
+    type: bool
+    returned: when something fails
+    sample: false
+"""
+
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.lcm.api_client import (  # noqa: E402
+    get_etag,
+    get_foundation_central_config_api_instance,
+)
+from ..module_utils.v4.lcm.helpers import get_foundation_central_config  # noqa: E402
+from ..module_utils.v4.prism.tasks import wait_for_completion  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_lifecycle_py_client as lifecycle_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as lifecycle_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+CONFIG_FIELDS = (
+    "version",
+    "commit_id",
+    "tls_certificate_fingerprint",
+    "aos_download_timeout_minutes",
+    "ahv_installation_timeout_minutes",
+)
+
+
+def get_module_spec():
+
+    module_args = dict(
+        state=dict(type="str", default="present", choices=["present", "absent"]),
+        ext_id=dict(type="str", required=False),
+        version=dict(type="str", required=False),
+        commit_id=dict(type="str", required=False),
+        tls_certificate_fingerprint=dict(type="str", required=False),
+        aos_download_timeout_minutes=dict(type="int", required=False),
+        ahv_installation_timeout_minutes=dict(type="int", required=False),
+    )
+    return module_args
+
+
+def check_foundation_central_config_idempotency(current_spec, update_spec):
+    """
+    Return True when none of the provided update fields differ from current.
+    """
+    for field in CONFIG_FIELDS:
+        new_val = getattr(update_spec, field, None)
+        if new_val is None:
+            continue
+        if getattr(current_spec, field, None) != new_val:
+            return False
+    return True
+
+
+def _build_update_spec(module, result):
+    sg = SpecGenerator(module)
+    default_spec = lifecycle_sdk.FoundationCentralConfig()
+    update_spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        result["failed"] = True
+        module.fail_json(
+            msg="Failed creating spec for updating Foundation Central config", **result
+        )
+    return update_spec
+
+
+def _ensure_at_least_one_config_field(module, result):
+    """
+    Fail when no Foundation Central config attributes are provided.
+    """
+    provided = [
+        field for field in CONFIG_FIELDS if module.params.get(field) is not None
+    ]
+    if not provided:
+        result["failed"] = True
+        result["error"] = "Missing Foundation Central config fields"
+        module.fail_json(
+            msg="Provide at least one of: {0}".format(", ".join(CONFIG_FIELDS)),
+            **result,
+        )
+
+
+def _apply_foundation_central_config(module, result, api_instance):
+    """
+    Apply desired Foundation Central config via Update API (singleton).
+    """
+    _ensure_at_least_one_config_field(module, result)
+
+    current_spec = get_foundation_central_config(module, api_instance)
+    etag_value = get_etag(current_spec)
+    if not etag_value:
+        result["failed"] = True
+        module.fail_json(
+            msg="Failed to get etag value from the current Foundation Central config",
+            **result,
+        )
+
+    update_spec = _build_update_spec(module, result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        result["ext_id"] = None
+        return
+
+    if check_foundation_central_config_idempotency(current_spec, update_spec):
+        result["skipped"] = True
+        result["response"] = strip_internal_attributes(current_spec.to_dict())
+        result["ext_id"] = None
+        module.exit_json(
+            msg="Nothing to change for Foundation Central config. Skipping update.",
+            **result,
+        )
+
+    resp = None
+    try:
+        resp = api_instance.update_foundation_central_config(
+            body=update_spec, if_match=etag_value
+        )
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating Foundation Central config",
+        )
+
+    task_ext_id = None
+    if resp and getattr(resp, "data", None) is not None:
+        task_ext_id = getattr(resp.data, "ext_id", None)
+    result["task_ext_id"] = task_ext_id
+    result["ext_id"] = None
+
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+
+    resp = get_foundation_central_config(module, api_instance)
+    result["response"] = strip_internal_attributes(resp.to_dict())
+    result["changed"] = True
+
+
+def create_foundation_central_config(module, result, api_instance):
+    """
+    Ensure Foundation Central config matches desired state.
+
+    There is no Create API for this singleton; this applies an update.
+    """
+    _apply_foundation_central_config(module, result, api_instance)
+
+
+def update_foundation_central_config(module, result, api_instance):
+    """
+    Update Foundation Central configuration using the Update API.
+    """
+    _apply_foundation_central_config(module, result, api_instance)
+
+
+def delete_foundation_central_config(module, result, api_instance):
+    """
+    Delete is not supported for Foundation Central config singleton.
+    """
+    result["failed"] = True
+    result["error"] = "Delete is not supported for Foundation Central config"
+    module.fail_json(
+        msg="Delete is not supported for Foundation Central config. "
+        "This resource is a singleton managed only via Get/Update APIs. "
+        "API client type: {0}".format(type(api_instance).__name__),
+        **result,
+    )
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+    )
+
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg="Missing required library ntnx_lifecycle_py_client",
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "ext_id": None,
+        "task_ext_id": None,
+        "error": None,
+    }
+    api_instance = get_foundation_central_config_api_instance(module)
+
+    state = module.params.get("state")
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_foundation_central_config(module, result, api_instance)
+        else:
+            create_foundation_central_config(module, result, api_instance)
+    else:
+        delete_foundation_central_config(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2
-ntnx-lifecycle-py-client==4.2.2
+ntnx-lifecycle-py-client==4.3.1
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2

--- a/tests/integration/targets/ntnx_foundation_central_config_info_v2/aliases
+++ b/tests/integration/targets/ntnx_foundation_central_config_info_v2/aliases
@@ -1,0 +1,1 @@
+# Intentionally empty so ansible-test can select this target explicitly.

--- a/tests/integration/targets/ntnx_foundation_central_config_info_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_foundation_central_config_info_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_foundation_central_config_info_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_foundation_central_config_info_v2/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+# Test plan (Foundation Central Config Info):
+# 1. Get singleton config — assert all SDK model fields present, changed=false.
+# 2. Confirm list/filter/limit are not applicable (singleton GET only).
+# 3. Re-get and assert stable version/commit_id/tls fingerprint fields.
+#
+# Connection: FCVM via integration_config.yml foundation_* vars (or env fallback).
+
+- name: Resolve FCVM connection
+  ansible.builtin.set_fact:
+    fcc_host: "{{ foundation_host | default(lookup('env', 'FOUNDATION_ENDPOINT'), true) }}"
+    fcc_port: "{{ foundation_port | default(lookup('env', 'FOUNDATION_PORT') | default('9440', true), true) }}"
+    fcc_username: "{{ foundation_username | default(lookup('env', 'FOUNDATION_USERNAME') | default('admin', true), true) }}"
+    fcc_password: "{{ foundation_password | default(lookup('env', 'FOUNDATION_PASSWORD'), true) }}"
+    fcc_validate_certs: false
+
+- name: Assert FCVM endpoint is configured
+  ansible.builtin.assert:
+    that:
+      - fcc_host | length > 0
+      - fcc_password | length > 0
+    fail_msg: "foundation_host/FOUNDATION_ENDPOINT and foundation_password/FOUNDATION_PASSWORD must be set"
+
+- name: Set module defaults for Foundation Central / FCVM
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ fcc_host }}"
+      nutanix_port: "{{ fcc_port }}"
+      nutanix_username: "{{ fcc_username }}"
+      nutanix_password: "{{ fcc_password }}"
+      validate_certs: "{{ fcc_validate_certs }}"
+  block:
+    - name: Get Foundation Central config (singleton)
+      nutanix.ncp.ntnx_foundation_central_config_info_v2:
+      register: fcc_info
+
+    - name: Assert Foundation Central config info
+      ansible.builtin.assert:
+        that:
+          - fcc_info.changed == false
+          - fcc_info.failed == false
+          - fcc_info.error == none
+          - fcc_info.response is mapping
+          - fcc_info.response.version is defined
+          - fcc_info.response.version | length > 0
+          - fcc_info.response.commit_id is defined
+          - fcc_info.response.commit_id | length > 0
+          - fcc_info.response.tls_certificate_fingerprint is defined
+          - fcc_info.response.tls_certificate_fingerprint | length > 0
+          - fcc_info.response.aos_download_timeout_minutes is number
+          - fcc_info.response.ahv_installation_timeout_minutes is number
+        fail_msg: "Foundation Central config info get failed"
+        success_msg: "Foundation Central config info get ok"
+
+    - name: Get Foundation Central config again for stability
+      nutanix.ncp.ntnx_foundation_central_config_info_v2:
+      register: fcc_info_again
+
+    - name: Assert stable singleton fields
+      ansible.builtin.assert:
+        that:
+          - fcc_info_again.changed == false
+          - fcc_info_again.failed == false
+          - fcc_info_again.response.version == fcc_info.response.version
+          - fcc_info_again.response.commit_id == fcc_info.response.commit_id
+          - fcc_info_again.response.tls_certificate_fingerprint == fcc_info.response.tls_certificate_fingerprint
+          - fcc_info_again.response.aos_download_timeout_minutes == fcc_info.response.aos_download_timeout_minutes
+          - fcc_info_again.response.ahv_installation_timeout_minutes == fcc_info.response.ahv_installation_timeout_minutes
+        fail_msg: "Foundation Central config info stability check failed"
+        success_msg: "Foundation Central config info stability check ok"

--- a/tests/integration/targets/ntnx_foundation_central_config_v2/aliases
+++ b/tests/integration/targets/ntnx_foundation_central_config_v2/aliases
@@ -1,0 +1,1 @@
+# Intentionally empty so ansible-test can select this target explicitly.

--- a/tests/integration/targets/ntnx_foundation_central_config_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_foundation_central_config_v2/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/ntnx_foundation_central_config_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_foundation_central_config_v2/tasks/main.yml
@@ -1,0 +1,309 @@
+---
+# Test plan (Foundation Central Config CRUD — domain QA):
+# 1. Get current singleton config (baseline) — assert response fields from SDK model.
+# 2. check_mode create/update for each writable/spec field (aos/ahv timeouts +
+#    version/commit_id/tls fingerprint) — assert changed=false and response values.
+# 3. check_mode delete — assert failed (delete unsupported).
+# 4. Minimal update (timeouts only) — assert changed/task.
+# 5. Full update with all CONFIG_FIELDS — assert values.
+# 6. Idempotent second update with same values — assert skipped / changed=false.
+# 7. Update via ext_id dispatch path — assert update still works.
+# 8. Negative: missing all config fields — assert descriptive error.
+# 9. Negative: state=absent — assert delete unsupported error.
+# 10. Restore original timeouts after tests.
+#
+# All CRUD scenarios live in this single file per code-gen instructions.
+
+- name: Resolve FCVM connection
+  ansible.builtin.set_fact:
+    fcc_host: "{{ foundation_host | default(lookup('env', 'FOUNDATION_ENDPOINT'), true) }}"
+    fcc_port: "{{ foundation_port | default(lookup('env', 'FOUNDATION_PORT') | default('9440', true), true) }}"
+    fcc_username: "{{ foundation_username | default(lookup('env', 'FOUNDATION_USERNAME') | default('admin', true), true) }}"
+    fcc_password: "{{ foundation_password | default(lookup('env', 'FOUNDATION_PASSWORD'), true) }}"
+    fcc_validate_certs: false
+
+- name: Assert FCVM endpoint is configured
+  ansible.builtin.assert:
+    that:
+      - fcc_host | length > 0
+      - fcc_password | length > 0
+    fail_msg: "foundation_host/FOUNDATION_ENDPOINT and foundation_password/FOUNDATION_PASSWORD must be set"
+
+- name: Set module defaults for Foundation Central / FCVM
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ fcc_host }}"
+      nutanix_port: "{{ fcc_port }}"
+      nutanix_username: "{{ fcc_username }}"
+      nutanix_password: "{{ fcc_password }}"
+      validate_certs: "{{ fcc_validate_certs }}"
+  block:
+    - name: Get baseline Foundation Central config
+      nutanix.ncp.ntnx_foundation_central_config_info_v2:
+      register: fcc_baseline
+
+    - name: Assert baseline Foundation Central config
+      ansible.builtin.assert:
+        that:
+          - fcc_baseline.changed == false
+          - fcc_baseline.failed == false
+          - fcc_baseline.response is defined
+          - fcc_baseline.response.version is defined
+          - fcc_baseline.response.commit_id is defined
+          - fcc_baseline.response.tls_certificate_fingerprint is defined
+          - fcc_baseline.response.aos_download_timeout_minutes is defined
+          - fcc_baseline.response.ahv_installation_timeout_minutes is defined
+        fail_msg: "Failed to fetch baseline Foundation Central config"
+        success_msg: "Baseline Foundation Central config fetched"
+
+    - name: Save original timeout values
+      ansible.builtin.set_fact:
+        original_aos_timeout: "{{ fcc_baseline.response.aos_download_timeout_minutes }}"
+        original_ahv_timeout: "{{ fcc_baseline.response.ahv_installation_timeout_minutes }}"
+        original_version: "{{ fcc_baseline.response.version }}"
+        original_commit_id: "{{ fcc_baseline.response.commit_id }}"
+        original_tls_fp: "{{ fcc_baseline.response.tls_certificate_fingerprint }}"
+        new_aos_timeout: "{{ (fcc_baseline.response.aos_download_timeout_minutes | int) + 1 }}"
+        new_ahv_timeout: "{{ (fcc_baseline.response.ahv_installation_timeout_minutes | int) + 1 }}"
+
+    - name: Check mode update aos_download_timeout_minutes
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        aos_download_timeout_minutes: "{{ new_aos_timeout | int }}"
+      check_mode: true
+      register: fcc_cm_aos
+
+    - name: Assert check_mode aos_download_timeout_minutes
+      ansible.builtin.assert:
+        that:
+          - fcc_cm_aos.changed == false
+          - fcc_cm_aos.failed == false
+          - fcc_cm_aos.response is defined
+          - fcc_cm_aos.response.aos_download_timeout_minutes == (new_aos_timeout | int)
+        fail_msg: "check_mode aos_download_timeout_minutes failed"
+        success_msg: "check_mode aos_download_timeout_minutes ok"
+
+    - name: Check mode update ahv_installation_timeout_minutes
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        ahv_installation_timeout_minutes: "{{ new_ahv_timeout | int }}"
+      check_mode: true
+      register: fcc_cm_ahv
+
+    - name: Assert check_mode ahv_installation_timeout_minutes
+      ansible.builtin.assert:
+        that:
+          - fcc_cm_ahv.changed == false
+          - fcc_cm_ahv.failed == false
+          - fcc_cm_ahv.response is defined
+          - fcc_cm_ahv.response.ahv_installation_timeout_minutes == (new_ahv_timeout | int)
+        fail_msg: "check_mode ahv_installation_timeout_minutes failed"
+        success_msg: "check_mode ahv_installation_timeout_minutes ok"
+
+    - name: Check mode update version field
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        version: "{{ original_version }}"
+      check_mode: true
+      register: fcc_cm_version
+
+    - name: Assert check_mode version
+      ansible.builtin.assert:
+        that:
+          - fcc_cm_version.changed == false
+          - fcc_cm_version.failed == false
+          - fcc_cm_version.response is defined
+          - fcc_cm_version.response.version == original_version
+        fail_msg: "check_mode version failed"
+        success_msg: "check_mode version ok"
+
+    - name: Check mode update commit_id field
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        commit_id: "{{ original_commit_id }}"
+      check_mode: true
+      register: fcc_cm_commit
+
+    - name: Assert check_mode commit_id
+      ansible.builtin.assert:
+        that:
+          - fcc_cm_commit.changed == false
+          - fcc_cm_commit.failed == false
+          - fcc_cm_commit.response is defined
+          - fcc_cm_commit.response.commit_id == original_commit_id
+        fail_msg: "check_mode commit_id failed"
+        success_msg: "check_mode commit_id ok"
+
+    - name: Check mode update tls_certificate_fingerprint field
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        tls_certificate_fingerprint: "{{ original_tls_fp }}"
+      check_mode: true
+      register: fcc_cm_tls
+
+    - name: Assert check_mode tls_certificate_fingerprint
+      ansible.builtin.assert:
+        that:
+          - fcc_cm_tls.changed == false
+          - fcc_cm_tls.failed == false
+          - fcc_cm_tls.response is defined
+          - fcc_cm_tls.response.tls_certificate_fingerprint == original_tls_fp
+        fail_msg: "check_mode tls_certificate_fingerprint failed"
+        success_msg: "check_mode tls_certificate_fingerprint ok"
+
+    - name: Check mode update all fields together
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        aos_download_timeout_minutes: "{{ new_aos_timeout | int }}"
+        ahv_installation_timeout_minutes: "{{ new_ahv_timeout | int }}"
+        version: "{{ original_version }}"
+        commit_id: "{{ original_commit_id }}"
+        tls_certificate_fingerprint: "{{ original_tls_fp }}"
+      check_mode: true
+      register: fcc_cm_all
+
+    - name: Assert check_mode all fields
+      ansible.builtin.assert:
+        that:
+          - fcc_cm_all.changed == false
+          - fcc_cm_all.failed == false
+          - fcc_cm_all.response.aos_download_timeout_minutes == (new_aos_timeout | int)
+          - fcc_cm_all.response.ahv_installation_timeout_minutes == (new_ahv_timeout | int)
+          - fcc_cm_all.response.version == original_version
+          - fcc_cm_all.response.commit_id == original_commit_id
+          - fcc_cm_all.response.tls_certificate_fingerprint == original_tls_fp
+        fail_msg: "check_mode all fields failed"
+        success_msg: "check_mode all fields ok"
+
+    - name: Check mode delete Foundation Central config
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        state: absent
+      check_mode: true
+      register: fcc_cm_delete
+      ignore_errors: true
+
+    - name: Assert check_mode delete is rejected
+      ansible.builtin.assert:
+        that:
+          - fcc_cm_delete.failed == true
+          - fcc_cm_delete.changed == false
+          - "'not supported' in (fcc_cm_delete.msg | default('') | lower)"
+        fail_msg: "check_mode delete should fail as unsupported"
+        success_msg: "check_mode delete correctly rejected"
+
+    - name: Minimal update timeouts only
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        aos_download_timeout_minutes: "{{ new_aos_timeout | int }}"
+        ahv_installation_timeout_minutes: "{{ new_ahv_timeout | int }}"
+      register: fcc_min_update
+
+    - name: Assert minimal update
+      ansible.builtin.assert:
+        that:
+          - fcc_min_update.changed == true
+          - fcc_min_update.failed == false
+          - fcc_min_update.task_ext_id is defined
+          - fcc_min_update.task_ext_id is not none
+          - fcc_min_update.response is defined
+          - fcc_min_update.response.aos_download_timeout_minutes == (new_aos_timeout | int)
+          - fcc_min_update.response.ahv_installation_timeout_minutes == (new_ahv_timeout | int)
+          - fcc_min_update.ext_id == none
+          - fcc_min_update.error == none
+        fail_msg: "Minimal Foundation Central config update failed"
+        success_msg: "Minimal Foundation Central config update ok"
+
+    - name: Full update with all fields
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        aos_download_timeout_minutes: "{{ new_aos_timeout | int }}"
+        ahv_installation_timeout_minutes: "{{ new_ahv_timeout | int }}"
+        version: "{{ original_version }}"
+        commit_id: "{{ original_commit_id }}"
+        tls_certificate_fingerprint: "{{ original_tls_fp }}"
+      register: fcc_full_update
+
+    - name: Assert full update idempotent or applied
+      ansible.builtin.assert:
+        that:
+          - fcc_full_update.failed == false
+          - fcc_full_update.response is defined
+          - fcc_full_update.response.aos_download_timeout_minutes == (new_aos_timeout | int)
+          - fcc_full_update.response.ahv_installation_timeout_minutes == (new_ahv_timeout | int)
+          - fcc_full_update.response.version == original_version
+          - fcc_full_update.response.commit_id == original_commit_id
+          - fcc_full_update.response.tls_certificate_fingerprint == original_tls_fp
+          - (fcc_full_update.changed == false and fcc_full_update.skipped == true) or (fcc_full_update.changed == true)
+        fail_msg: "Full Foundation Central config update failed"
+        success_msg: "Full Foundation Central config update ok"
+
+    - name: Idempotent update with same timeouts
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        aos_download_timeout_minutes: "{{ new_aos_timeout | int }}"
+        ahv_installation_timeout_minutes: "{{ new_ahv_timeout | int }}"
+      register: fcc_idempotent
+
+    - name: Assert idempotent update skipped
+      ansible.builtin.assert:
+        that:
+          - fcc_idempotent.changed == false
+          - fcc_idempotent.failed == false
+          - fcc_idempotent.skipped == true
+          - "'Skipping update' in (fcc_idempotent.msg | default(''))"
+          - fcc_idempotent.response.aos_download_timeout_minutes == (new_aos_timeout | int)
+          - fcc_idempotent.response.ahv_installation_timeout_minutes == (new_ahv_timeout | int)
+        fail_msg: "Idempotent Foundation Central config update failed"
+        success_msg: "Idempotent Foundation Central config update ok"
+
+    - name: Update via ext_id dispatch path
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        ext_id: "foundation-central-config"
+        aos_download_timeout_minutes: "{{ new_aos_timeout | int }}"
+        ahv_installation_timeout_minutes: "{{ new_ahv_timeout | int }}"
+      register: fcc_ext_id_update
+
+    - name: Assert update via ext_id path
+      ansible.builtin.assert:
+        that:
+          - fcc_ext_id_update.failed == false
+          - fcc_ext_id_update.changed == false
+          - fcc_ext_id_update.skipped == true
+          - fcc_ext_id_update.response.aos_download_timeout_minutes == (new_aos_timeout | int)
+        fail_msg: "Update via ext_id dispatch failed"
+        success_msg: "Update via ext_id dispatch ok"
+
+    - name: Negative missing all config fields
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+      register: fcc_missing
+      ignore_errors: true
+
+    - name: Assert missing fields error
+      ansible.builtin.assert:
+        that:
+          - fcc_missing.failed == true
+          - fcc_missing.changed == false
+          - "'Provide at least one' in (fcc_missing.msg | default(''))"
+        fail_msg: "Missing fields negative test failed"
+        success_msg: "Missing fields negative test ok"
+
+    - name: Negative delete unsupported
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        state: absent
+      register: fcc_delete
+      ignore_errors: true
+
+    - name: Assert delete unsupported
+      ansible.builtin.assert:
+        that:
+          - fcc_delete.failed == true
+          - fcc_delete.changed == false
+          - "'not supported' in (fcc_delete.msg | default('') | lower)"
+        fail_msg: "Delete unsupported negative test failed"
+        success_msg: "Delete unsupported negative test ok"
+
+    - name: Restore original timeouts
+      nutanix.ncp.ntnx_foundation_central_config_v2:
+        aos_download_timeout_minutes: "{{ original_aos_timeout | int }}"
+        ahv_installation_timeout_minutes: "{{ original_ahv_timeout | int }}"
+      register: fcc_restore
+
+    - name: Assert restore
+      ansible.builtin.assert:
+        that:
+          - fcc_restore.failed == false
+          - fcc_restore.response.aos_download_timeout_minutes == (original_aos_timeout | int)
+          - fcc_restore.response.ahv_installation_timeout_minutes == (original_ahv_timeout | int)
+        fail_msg: "Failed to restore original Foundation Central config"
+        success_msg: "Original Foundation Central config restored"


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **lifecycle** namespace, entity
**FoundationCentralConfig**, based on the inline `sdk_info.json`. One PR per code-gen run.

- Modules generated: `ntnx_foundation_central_config_v2`, `ntnx_foundation_central_config_info_v2`
- API methods covered: `2` (GetFoundationCentralConfig, UpdateFoundationCentralConfig)
- Fields in CRUD module spec: `7` (state, ext_id, version, commit_id, tls_certificate_fingerprint, aos_download_timeout_minutes, ahv_installation_timeout_minutes)
- Fields in info module spec: `0` module-specific (singleton GET; uses BaseInfoModule credentials/info fragments)

## Files changed

- `plugins/modules/`: `ntnx_foundation_central_config_v2.py`, `ntnx_foundation_central_config_info_v2.py`
- `plugins/module_utils/v4/lcm/`: `api_client.py` (FoundationCentralConfigApi factory), `helpers.py` (get helper)
- `meta/runtime.yml`: registered both modules in `ntnx` action group
- `examples/lifecycle/FoundationCentralConfig/`: example playbook + run logs
- `tests/integration/targets/ntnx_foundation_central_config_v2/`: CRUD/idempotency/check_mode/negative tests
- `tests/integration/targets/ntnx_foundation_central_config_info_v2/`: singleton get/stability tests

## Test execution

| Metric              | Value                                          |
|---------------------|------------------------------------------------|
| Command             | `ansible-test integration --allow-unsupported --python 3.12 ntnx_foundation_central_config_info_v2 ntnx_foundation_central_config_v2` |
| Total tests         | 2 integration targets (info + CRUD role suites) |
| Passed              | 2 (info: failed=0; CRUD: failed=0)             |
| Failed              | 0                                              |
| Skipped             | Idempotent update tasks intentionally skipped via module `skipped=true` |
| Duration            | ~0:00:55 (info) + ~0:00:46 (CRUD)              |
| Cluster (PC)        | N/A for this entity (FCVM used)                |
| Cluster (FCVM)      | `10.97.44.170:9440`                           |

### Analysis

All integration assertions passed against Foundation Central / FCVM.

- Info target: singleton GET validated all SDK model fields and stable re-get.
- CRUD target: check_mode for every spec field, minimal/full update, idempotency, ext_id dispatch path, missing-field and unsupported-delete negatives, then restore of original timeouts.
- No remaining known issues from Step 7 retries.

### Test logs (tail)

<details>
<summary>tail -n 500 test_logs.log</summary>

```text
===== INFO MODULE =====
Running ntnx_foundation_central_config_info_v2 integration test role
[WARNING]: Found variable using reserved name: port

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_foundation_central_config_info_v2 : Resolve FCVM connection] ********
ok: [testhost]

TASK [ntnx_foundation_central_config_info_v2 : Assert FCVM endpoint is configured] ***
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [ntnx_foundation_central_config_info_v2 : Get Foundation Central config (singleton)] ***
ok: [testhost]

TASK [ntnx_foundation_central_config_info_v2 : Assert Foundation Central config info] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Foundation Central config info get ok"
}

TASK [ntnx_foundation_central_config_info_v2 : Get Foundation Central config again for stability] ***
ok: [testhost]

TASK [ntnx_foundation_central_config_info_v2 : Assert stable singleton fields] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Foundation Central config info stability check ok"
}

PLAY RECAP *********************************************************************
testhost                   : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


===== CRUD MODULE (final) =====
Running ntnx_foundation_central_config_v2 integration test role
[WARNING]: Found variable using reserved name: port

PLAY [testhost] ****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testhost]

TASK [ntnx_foundation_central_config_v2 : Resolve FCVM connection] *************
ok: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert FCVM endpoint is configured] ***
ok: [testhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [ntnx_foundation_central_config_v2 : Get baseline Foundation Central config] ***
ok: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert baseline Foundation Central config] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Baseline Foundation Central config fetched"
}

TASK [ntnx_foundation_central_config_v2 : Save original timeout values] ********
ok: [testhost]

TASK [ntnx_foundation_central_config_v2 : Check mode update aos_download_timeout_minutes] ***
ok: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert check_mode aos_download_timeout_minutes] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode aos_download_timeout_minutes ok"
}

TASK [ntnx_foundation_central_config_v2 : Check mode update ahv_installation_timeout_minutes] ***
ok: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert check_mode ahv_installation_timeout_minutes] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode ahv_installation_timeout_minutes ok"
}

TASK [ntnx_foundation_central_config_v2 : Check mode update version field] *****
ok: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert check_mode version] ***********
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode version ok"
}

TASK [ntnx_foundation_central_config_v2 : Check mode update commit_id field] ***
ok: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert check_mode commit_id] *********
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode commit_id ok"
}

TASK [ntnx_foundation_central_config_v2 : Check mode update tls_certificate_fingerprint field] ***
ok: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert check_mode tls_certificate_fingerprint] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode tls_certificate_fingerprint ok"
}

TASK [ntnx_foundation_central_config_v2 : Check mode update all fields together] ***
ok: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert check_mode all fields] ********
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode all fields ok"
}

TASK [ntnx_foundation_central_config_v2 : Check mode delete Foundation Central config] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "Delete is not supported for Foundation Central config", "ext_id": null, "msg": "Delete is not supported for Foundation Central config. This resource is a singleton managed only via Get/Update APIs. API client type: FoundationCentralConfigApi", "response": null, "task_ext_id": null}
...ignoring

TASK [ntnx_foundation_central_config_v2 : Assert check_mode delete is rejected] ***
ok: [testhost] => {
    "changed": false,
    "msg": "check_mode delete correctly rejected"
}

TASK [ntnx_foundation_central_config_v2 : Minimal update timeouts only] ********
changed: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert minimal update] ***************
ok: [testhost] => {
    "changed": false,
    "msg": "Minimal Foundation Central config update ok"
}

TASK [ntnx_foundation_central_config_v2 : Full update with all fields] *********
skipping: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert full update idempotent or applied] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Full Foundation Central config update ok"
}

TASK [ntnx_foundation_central_config_v2 : Idempotent update with same timeouts] ***
skipping: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert idempotent update skipped] ****
ok: [testhost] => {
    "changed": false,
    "msg": "Idempotent Foundation Central config update ok"
}

TASK [ntnx_foundation_central_config_v2 : Update via ext_id dispatch path] *****
skipping: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert update via ext_id path] *******
ok: [testhost] => {
    "changed": false,
    "msg": "Update via ext_id dispatch ok"
}

TASK [ntnx_foundation_central_config_v2 : Negative missing all config fields] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "Missing Foundation Central config fields", "ext_id": null, "msg": "Provide at least one of: version, commit_id, tls_certificate_fingerprint, aos_download_timeout_minutes, ahv_installation_timeout_minutes", "response": null, "task_ext_id": null}
...ignoring

TASK [ntnx_foundation_central_config_v2 : Assert missing fields error] *********
ok: [testhost] => {
    "changed": false,
    "msg": "Missing fields negative test ok"
}

TASK [ntnx_foundation_central_config_v2 : Negative delete unsupported] *********
fatal: [testhost]: FAILED! => {"changed": false, "error": "Delete is not supported for Foundation Central config", "ext_id": null, "msg": "Delete is not supported for Foundation Central config. This resource is a singleton managed only via Get/Update APIs. API client type: FoundationCentralConfigApi", "response": null, "task_ext_id": null}
...ignoring

TASK [ntnx_foundation_central_config_v2 : Assert delete unsupported] ***********
ok: [testhost] => {
    "changed": false,
    "msg": "Delete unsupported negative test ok"
}

TASK [ntnx_foundation_central_config_v2 : Restore original timeouts] ***********
changed: [testhost]

TASK [ntnx_foundation_central_config_v2 : Assert restore] **********************
ok: [testhost] => {
    "changed": false,
    "msg": "Original Foundation Central config restored"
}

PLAY RECAP *********************************************************************
testhost                   : ok=31   changed=2    unreachable=0    failed=0    skipped=3    rescued=0    ignored=3   
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen API (`POST /generate`).
- Prompt + inline `sdk_info.json` stored only in the agent transcript.
