### PR TITLE
installer images Dev, Tests and Examples with Documentation V4 module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 nutanix-ncp-*
 .ansible/
 py3.12_virt
+tests/integration/integration_config.yml
+__pycache__/
+*.pyc

--- a/examples/lifecycle/InstallerImages/examples_run.log
+++ b/examples/lifecycle/InstallerImages/examples_run.log
@@ -1,0 +1,29 @@
+[WARNING]: No inventory was parsed, only implicit localhost is available
+[WARNING]: provided hosts list is empty, only localhost is available. Note that
+the implicit localhost does not match 'all'
+No config file found; using defaults
+
+PLAY [Installer Images playbook] ***********************************************
+
+TASK [Create installer image] **************************************************
+changed: [localhost] => {"changed": true, "ext_id": "da23f7f6-1dee-41f5-a076-f953c3d7818d", "response": {"certificate_chain": null, "checksum": null, "created_time": "2026-09-09T05:59:02.370436+00:00", "ext_id": "da23f7f6-1dee-41f5-a076-f953c3d7818d", "file_status": "NOT_AVAILABLE", "links": null, "metadata_download_url": null, "metadata_status": "NOT_AVAILABLE", "name": "aos_image_ansible", "source": "REMOTE_URL", "tenant_id": "703c7c79-5e87-4813-a137-76c09b808db9", "type": "AOS", "url": null, "version": null}, "task_ext_id": "ZXJnb24=:9e4fb87e-ffe4-5a39-98b4-e45e93bb470c"}
+
+TASK [Set installer image external ID] *****************************************
+ok: [localhost] => {"ansible_facts": {"installer_image_ext_id": "da23f7f6-1dee-41f5-a076-f953c3d7818d"}, "changed": false}
+
+TASK [Update installer image with all attributes] ******************************
+fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task Failed", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-09-09T05:59:05.042869+00:00", "completion_details": null, "created_time": "2026-09-09T05:59:04.994812+00:00", "entities_affected": null, "error_messages": [{"arguments_map": null, "code": "TSKS-20801", "error_group": "LEGACY_ERROR", "locale": "en_US", "message": "Operation failed due to legacy error and 'legacyErrorMessage' should be referred to for details", "severity": "ERROR"}], "ext_id": "ZXJnb24=:a43e6aab-ddc1-5040-afa6-b060fbf1c882", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-09-09T05:59:05.042868+00:00", "legacy_error_message": "Metadata is not available for image: da23f7f6-1dee-41f5-a076-f953c3d7818d: 400", "number_of_entities_affected": 0, "number_of_subtasks": 0, "operation": "InstallerImageTask", "operation_description": "Installer image task", "owned_by": null, "parent_task": null, "progress_percentage": 100, "resource_links": null, "root_task": null, "started_time": "2026-09-09T05:59:05.008300+00:00", "status": "FAILED", "sub_steps": null, "sub_tasks": null, "warnings": null}}
+...ignoring
+
+TASK [Fetch installer image using external ID] *********************************
+ok: [localhost] => {"changed": false, "ext_id": "da23f7f6-1dee-41f5-a076-f953c3d7818d", "response": {"certificate_chain": null, "checksum": null, "created_time": "2026-09-09T05:59:02.370436+00:00", "ext_id": "da23f7f6-1dee-41f5-a076-f953c3d7818d", "file_status": "NOT_AVAILABLE", "links": null, "metadata_download_url": null, "metadata_status": "NOT_AVAILABLE", "name": "aos_image_ansible", "source": "REMOTE_URL", "tenant_id": "703c7c79-5e87-4813-a137-76c09b808db9", "type": "AOS", "url": null, "version": null}}
+
+TASK [List all installer images] ***********************************************
+ok: [localhost] => {"changed": false, "response": [{"certificate_chain": null, "checksum": null, "created_time": "2026-09-09T05:59:02.370436+00:00", "ext_id": "da23f7f6-1dee-41f5-a076-f953c3d7818d", "file_status": "NOT_AVAILABLE", "links": null, "metadata_download_url": null, "metadata_status": "NOT_AVAILABLE", "name": "aos_image_ansible", "source": "REMOTE_URL", "tenant_id": "703c7c79-5e87-4813-a137-76c09b808db9", "type": "AOS", "url": null, "version": null}], "total_available_results": 1}
+
+TASK [Delete installer image] **************************************************
+changed: [localhost] => {"changed": true, "ext_id": "da23f7f6-1dee-41f5-a076-f953c3d7818d", "response": {"app_name": null, "batch_summary": null, "cluster_ext_ids": null, "completed_time": "2026-09-09T05:59:06.770000+00:00", "completion_details": null, "created_time": "2026-09-09T05:59:06.671650+00:00", "entities_affected": null, "error_messages": null, "ext_id": "ZXJnb24=:885ed609-3f8e-5092-b6a0-07af182f5efd", "is_background_task": false, "is_cancelable": false, "last_updated_time": "2026-09-09T05:59:06.769999+00:00", "legacy_error_message": null, "number_of_entities_affected": 0, "number_of_subtasks": 0, "operation": "ImageEntityDeletionTask", "operation_description": "Image entity deletion task", "owned_by": null, "parent_task": null, "progress_percentage": 100, "resource_links": null, "root_task": null, "started_time": "2026-09-09T05:59:06.684920+00:00", "status": "SUCCEEDED", "sub_steps": null, "sub_tasks": null, "warnings": null}, "task_ext_id": "ZXJnb24=:885ed609-3f8e-5092-b6a0-07af182f5efd"}
+
+PLAY RECAP *********************************************************************
+localhost                  : ok=6    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=1   
+

--- a/examples/lifecycle/InstallerImages/installer_images_v2.yml
+++ b/examples/lifecycle/InstallerImages/installer_images_v2.yml
@@ -1,0 +1,135 @@
+---
+# Summary:
+# This playbook demonstrates the lifecycle of LCM installer images using the
+# ntnx_installer_images_v2 and ntnx_installer_images_info_v2 modules.
+#
+# IMPORTANT — endpoint awareness:
+# The LCM installer images APIs are served by Foundation Central (FCVM),
+# NOT by Prism Central. The connection details in the module_defaults block
+# below MUST point to the FCVM/Foundation endpoint (default port 9440).
+#
+# Domain behavior:
+# 1. On create only name, type and source are accepted by Foundation Central.
+# 2. The image URL (and checksum/metadata for AHV images with source REMOTE_URL)
+#    is applied through the update operation.
+# 3. The image name cannot be modified after creation.
+#
+# This playbook will:
+# 1. Create an installer image (name, type, source only)
+# 2. Update the installer image to set its URL, checksum and metadata URL
+# 3. Fetch the installer image using its external ID
+# 4. List all installer images
+# 5. Delete the installer image
+
+- name: Installer Images playbook
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: <fcvm_ip>
+      nutanix_username: <user>
+      nutanix_password: <pass>
+      validate_certs: false
+  tasks:
+    - name: Create installer image
+      nutanix.ncp.ntnx_installer_images_v2:
+        state: present
+        name: "aos_image_ansible"
+        type: "AOS"
+        source: "REMOTE_URL"
+      register: create_result
+      ignore_errors: true
+      # sample (real output captured from a live Foundation Central run):
+      #   changed: true
+      #   ext_id: "da23f7f6-1dee-41f5-a076-f953c3d7818d"
+      #   task_ext_id: "ZXJnb24=:9e4fb87e-ffe4-5a39-98b4-e45e93bb470c"
+      #   response:
+      #     name: "aos_image_ansible"
+      #     type: "AOS"
+      #     source: "REMOTE_URL"
+      #     checksum: null
+      #     certificate_chain: null
+      #     url: null
+      #     metadata_download_url: null
+      #     file_status: "NOT_AVAILABLE"
+      #     metadata_status: "NOT_AVAILABLE"
+      #     version: null
+      #     created_time: "2026-09-09T05:59:02.370436+00:00"
+      #     ext_id: "da23f7f6-1dee-41f5-a076-f953c3d7818d"
+      #     tenant_id: "703c7c79-5e87-4813-a137-76c09b808db9"
+
+    - name: Set installer image external ID
+      ansible.builtin.set_fact:
+        installer_image_ext_id: "{{ create_result.ext_id }}"
+
+    - name: Update installer image with all attributes
+      nutanix.ncp.ntnx_installer_images_v2:
+        state: present
+        ext_id: "{{ installer_image_ext_id }}"
+        name: "aos_image_ansible"
+        type: "AOS"
+        source: "REMOTE_URL"
+        url: "https://download.example.com/aos/nutanix_installer_package.tar.gz"
+        metadata_download_url: "https://download.example.com/aos/metadata.json"
+      register: update_result
+      ignore_errors: true
+      # sample: <Need to add sample>
+      # The update submits an image download task on Foundation Central. When the
+      # URL points to a real, reachable installer bundle the task succeeds and
+      # returns the updated image; with the placeholder URL used here the async
+      # download task fails, so no real success sample could be captured.
+
+    - name: Fetch installer image using external ID
+      nutanix.ncp.ntnx_installer_images_info_v2:
+        ext_id: "{{ installer_image_ext_id }}"
+      register: info_result
+      ignore_errors: true
+      # sample (real output captured from a live Foundation Central run):
+      #   changed: false
+      #   ext_id: "da23f7f6-1dee-41f5-a076-f953c3d7818d"
+      #   response:
+      #     name: "aos_image_ansible"
+      #     type: "AOS"
+      #     source: "REMOTE_URL"
+      #     checksum: null
+      #     certificate_chain: null
+      #     url: null
+      #     metadata_download_url: null
+      #     file_status: "NOT_AVAILABLE"
+      #     metadata_status: "NOT_AVAILABLE"
+      #     created_time: "2026-09-09T05:59:02.370436+00:00"
+      #     ext_id: "da23f7f6-1dee-41f5-a076-f953c3d7818d"
+      #     tenant_id: "703c7c79-5e87-4813-a137-76c09b808db9"
+
+    - name: List all installer images
+      nutanix.ncp.ntnx_installer_images_info_v2:
+      register: list_result
+      ignore_errors: true
+      # sample (real output captured from a live Foundation Central run):
+      #   changed: false
+      #   total_available_results: 1
+      #   response:
+      #     - name: "aos_image_ansible"
+      #       type: "AOS"
+      #       source: "REMOTE_URL"
+      #       file_status: "NOT_AVAILABLE"
+      #       metadata_status: "NOT_AVAILABLE"
+      #       created_time: "2026-09-09T05:59:02.370436+00:00"
+      #       ext_id: "da23f7f6-1dee-41f5-a076-f953c3d7818d"
+      #       tenant_id: "703c7c79-5e87-4813-a137-76c09b808db9"
+
+    - name: Delete installer image
+      nutanix.ncp.ntnx_installer_images_v2:
+        state: absent
+        ext_id: "{{ installer_image_ext_id }}"
+      register: delete_result
+      ignore_errors: true
+      # sample (real output captured from a live Foundation Central run):
+      #   changed: true
+      #   ext_id: "da23f7f6-1dee-41f5-a076-f953c3d7818d"
+      #   task_ext_id: "ZXJnb24=:885ed609-3f8e-5092-b6a0-07af182f5efd"
+      #   response:
+      #     operation: "ImageEntityDeletionTask"
+      #     operation_description: "Image entity deletion task"
+      #     progress_percentage: 100
+      #     status: "SUCCEEDED"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -211,6 +211,8 @@ action_groups:
     - ntnx_lcm_upgrades_v2
     - ntnx_lcm_entities_info_v2
     - ntnx_lcm_status_info_v2
+    - ntnx_installer_images_v2
+    - ntnx_installer_images_info_v2
     - ntnx_users_api_key_v2
     - ntnx_users_api_key_info_v2
     - ntnx_users_revoke_api_key_v2

--- a/plugins/module_utils/v4/constants.py
+++ b/plugins/module_utils/v4/constants.py
@@ -48,6 +48,7 @@ class Tasks:
         NETWORK_FUNCTION = "Networking:config:network-function"
         VIRTUAL_SWITCH = "networking:config:virtual-switch"
         ENTITY_GROUP = "microseg:config:entity-group"
+        INSTALLER_IMAGE = "lifecycle:config:installer_image"
 
     class CompletetionDetailsName:
         """Completion details name for the task entities affected"""

--- a/plugins/module_utils/v4/lcm/api_client.py
+++ b/plugins/module_utils/v4/lcm/api_client.py
@@ -159,3 +159,21 @@ def get_entity_api_instance(module):
     """
     api_client = get_api_client(module)
     return ntnx_lifecycle_py_client.EntitiesApi(api_client=api_client)
+
+
+def get_installer_images_api_instance(module):
+    """
+    This method will return LCM installer images API instance.
+
+    Note:
+        The installer images APIs are served by Foundation Central (FCVM),
+        NOT by Prism Central. The connection details (nutanix_host,
+        nutanix_username, nutanix_password, nutanix_port) supplied to the
+        module must therefore point to the FCVM/Foundation endpoint.
+    Args:
+        module (object): Ansible module object
+    return:
+        api_instance (object): v4 LCM installer images api instance
+    """
+    api_client = get_api_client(module)
+    return ntnx_lifecycle_py_client.InstallerImagesApi(api_client=api_client)

--- a/plugins/module_utils/v4/lcm/helpers.py
+++ b/plugins/module_utils/v4/lcm/helpers.py
@@ -66,3 +66,23 @@ def get_lcm_entity(module, api_instance, ext_id):
             exception=e,
             msg="Api Exception raised while fetching entity info using external identifier of the entity",
         )
+
+
+def get_installer_image(module, api_instance, ext_id):
+    """
+    This method will return an LCM installer image using its external ID.
+    Args:
+        module (object): Ansible module object
+        api_instance (object): Installer images api instance
+        ext_id (str): External id of the installer image
+    Returns:
+        installer_image (object): Installer image info
+    """
+    try:
+        return api_instance.get_image_by_id(extId=ext_id).data
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching installer image using external ID",
+        )

--- a/plugins/modules/ntnx_installer_images_info_v2.py
+++ b/plugins/modules/ntnx_installer_images_info_v2.py
@@ -1,0 +1,235 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_installer_images_info_v2
+short_description: Fetch LCM installer images info from Nutanix Foundation Central (FCVM)
+version_added: 2.7.0
+description:
+  - This module allows you to fetch information about LCM installer images.
+  - If C(ext_id) is provided, fetch a particular installer image using its external ID.
+  - If C(ext_id) is not provided, fetch multiple installer images with/without using filters, limit, etc.
+  - This module uses v4 API based SDKs.
+notes:
+  - This module talks to B(Foundation Central (FCVM)), B(not) Prism Central.
+    The C(nutanix_host), C(nutanix_username), C(nutanix_password) and
+    C(nutanix_port) parameters MUST point to the FCVM/Foundation endpoint.
+  - The installer images APIs are served under C(/api/lifecycle/v4.3/config/images)
+    and are not available on Prism Central.
+  - >-
+    B(Get installer image(s)) -
+    Requires an administrator role on Foundation Central.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=lifecycle)"
+options:
+  ext_id:
+    description:
+      - The external ID of the installer image.
+      - If provided, the module fetches a single installer image.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_info_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+- name: Get installer image using ext_id
+  nutanix.ncp.ntnx_installer_images_info_v2:
+    nutanix_host: "{{ foundation_host }}"
+    nutanix_username: "{{ foundation_username }}"
+    nutanix_password: "{{ foundation_password }}"
+    validate_certs: false
+    ext_id: "d1f27805-4ce3-9212-2ca4-e4b4d258fe9c"
+  register: result
+  ignore_errors: true
+
+- name: List all installer images
+  nutanix.ncp.ntnx_installer_images_info_v2:
+    nutanix_host: "{{ foundation_host }}"
+    nutanix_username: "{{ foundation_username }}"
+    nutanix_password: "{{ foundation_password }}"
+    validate_certs: false
+  register: result
+  ignore_errors: true
+
+- name: List installer images with filter
+  nutanix.ncp.ntnx_installer_images_info_v2:
+    nutanix_host: "{{ foundation_host }}"
+    nutanix_username: "{{ foundation_username }}"
+    nutanix_password: "{{ foundation_password }}"
+    validate_certs: false
+    filter: "name eq 'ahv_image_ansible'"
+  register: result
+  ignore_errors: true
+
+- name: List installer images with limit
+  nutanix.ncp.ntnx_installer_images_info_v2:
+    nutanix_host: "{{ foundation_host }}"
+    nutanix_username: "{{ foundation_username }}"
+    nutanix_password: "{{ foundation_password }}"
+    validate_certs: false
+    limit: 1
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - The response from the Nutanix installer images info v4 API. The host is
+      B(FCVM/Foundation) (not Prism Central).
+    - It can be a single installer image if external ID is provided.
+    - List of multiple installer images if external ID is not provided with optional filter or limit.
+  returned: always
+  type: dict
+  sample:
+    {
+      "certificate_chain": null,
+      "checksum": {
+          "hex_digest": "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+      },
+      "created_time": "2026-09-09T05:50:00.000000+00:00",
+      "ext_id": "d1f27805-4ce3-9212-2ca4-e4b4d258fe9c",
+      "file_status": "URL_AVAILABLE",
+      "links": null,
+      "metadata_download_url": "https://download.example.com/ahv/metadata.json",
+      "metadata_status": "NOT_AVAILABLE",
+      "name": "ahv_image_ansible",
+      "source": "REMOTE_URL",
+      "tenant_id": null,
+      "type": "AHV",
+      "url": "https://download.example.com/ahv/host-bundle-el8.nutanix.20230302.el8.x86_64.tar.gz",
+      "version": null
+    }
+
+changed:
+  description: This indicates whether the task resulted in any changes. Always False for info modules.
+  returned: always
+  type: bool
+  sample: false
+
+ext_id:
+  description: External ID of the installer image.
+  returned: when external ID is provided
+  type: str
+  sample: "d1f27805-4ce3-9212-2ca4-e4b4d258fe9c"
+
+msg:
+  description: This indicates the status/error message if any message occurred.
+  returned: When there is an error
+  type: str
+  sample: "Api Exception raised while fetching installer images info"
+
+error:
+  description: This field typically holds information about any error that occurred during the task execution.
+  returned: when an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: when something fails
+  type: bool
+  sample: false
+
+total_available_results:
+  description: The total number of available installer images.
+  returned: when all installer images are fetched
+  type: int
+  sample: 5
+"""
+
+import warnings  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_info_module import BaseInfoModule  # noqa: E402
+from ..module_utils.v4.lcm.api_client import (  # noqa: E402
+    get_installer_images_api_instance,
+)
+from ..module_utils.v4.lcm.helpers import get_installer_image  # noqa: E402
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+)
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+    )
+
+    return module_args
+
+
+def get_installer_image_using_ext_id(module, api_instance, result):
+    ext_id = module.params.get("ext_id")
+    resp = get_installer_image(module, api_instance, ext_id)
+    result["ext_id"] = ext_id
+    result["response"] = strip_internal_attributes(resp.to_dict())
+
+
+def get_installer_images(module, api_instance, result):
+    sg = SpecGenerator(module)
+    kwargs, err = sg.get_info_spec(attr=module.params)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating installer images info spec", **result)
+
+    try:
+        resp = api_instance.list_images(**kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while fetching installer images info",
+        )
+
+    total_available_results = resp.metadata.total_available_results
+    result["total_available_results"] = total_available_results
+    resp = strip_internal_attributes(resp.to_dict()).get("data")
+    if not resp:
+        resp = []
+    result["response"] = resp
+
+
+def run_module():
+    module = BaseInfoModule(
+        argument_spec=get_module_spec(),
+        supports_check_mode=False,
+        mutually_exclusive=[
+            ("ext_id", "filter"),
+        ],
+    )
+    remove_param_with_none_value(module.params)
+    result = {"changed": False, "response": None, "failed": False}
+    api_instance = get_installer_images_api_instance(module)
+    if module.params.get("ext_id"):
+        get_installer_image_using_ext_id(module, api_instance, result)
+    else:
+        get_installer_images(module, api_instance, result)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ntnx_installer_images_v2.py
+++ b/plugins/modules/ntnx_installer_images_v2.py
@@ -1,0 +1,519 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Nutanix
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: ntnx_installer_images_v2
+short_description: Create, Update and Delete LCM installer images on Nutanix Foundation Central (FCVM)
+version_added: 2.7.0
+description:
+  - This module allows you to create, update, and delete Life Cycle Management (LCM) installer images.
+  - An installer image is an LCM image (AHV, AOS or ESX) used to image or upgrade nodes.
+  - If C(state) is C(present) and C(ext_id) is not provided, the image is created.
+  - If C(state) is C(present) and C(ext_id) is provided, the image is updated.
+  - If C(state) is C(absent) and C(ext_id) is provided, the image is deleted.
+  - This module uses v4 API based SDKs.
+notes:
+  - This module talks to B(Foundation Central (FCVM)), B(not) Prism Central.
+    The C(nutanix_host), C(nutanix_username), C(nutanix_password) and
+    C(nutanix_port) parameters MUST point to the FCVM/Foundation endpoint.
+  - The installer images APIs are served under C(/api/lifecycle/v4.3/config/images)
+    and are not available on Prism Central.
+  - >-
+    B(Create/Update/Delete an installer image) -
+    Requires an administrator role on Foundation Central.
+  - For AHV images a checksum (MD5 or SHA-256) is applicable.
+  - "Ref: U(https://developers.nutanix.com/api-reference?namespace=lifecycle)"
+options:
+  state:
+    description:
+      - If C(state) is set to C(present) and C(ext_id) is not provided, the operation is create installer image.
+      - If C(state) is set to C(present) and C(ext_id) is provided, the operation is update installer image.
+      - If C(state) is set to C(absent) and C(ext_id) is provided, the operation is delete installer image.
+    type: str
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  ext_id:
+    description:
+      - The external ID of the installer image.
+      - Required for update and delete operations.
+    type: str
+    required: false
+  name:
+    description:
+      - Name of the installer image.
+      - Required for create operation.
+    type: str
+    required: false
+  type:
+    description:
+      - Type of the installer image.
+      - Required for create operation.
+    type: str
+    required: false
+    choices:
+      - AHV
+      - AOS
+      - ESX
+  source:
+    description:
+      - Source of the installer image.
+      - C(LOCAL) means the file is uploaded locally, C(REMOTE_URL) means it is fetched from a URL.
+      - Required for create operation.
+    type: str
+    required: false
+    choices:
+      - LOCAL
+      - REMOTE_URL
+  url:
+    description:
+      - URL from which the installer image file will be downloaded.
+      - Applicable when C(source) is C(REMOTE_URL).
+    type: str
+    required: false
+  metadata_download_url:
+    description:
+      - URL from which the installer image metadata file will be downloaded.
+    type: str
+    required: false
+  certificate_chain:
+    description:
+      - Certificate chain used to validate the image download over HTTPS.
+    type: str
+    required: false
+  checksum:
+    description:
+      - Checksum of the installer image.
+      - Required and applicable only for AHV images.
+      - Provide exactly one of C(md5) or C(sha256).
+    type: dict
+    required: false
+    suboptions:
+      md5:
+        description:
+          - MD5 checksum of the image.
+        type: dict
+        required: false
+        suboptions:
+          hex_digest:
+            description:
+              - MD5 checksum value in hexadecimal format (32 characters).
+            type: str
+            required: true
+      sha256:
+        description:
+          - SHA-256 checksum of the image.
+        type: dict
+        required: false
+        suboptions:
+          hex_digest:
+            description:
+              - SHA-256 checksum value in hexadecimal format (64 characters).
+            type: str
+            required: true
+extends_documentation_fragment:
+  - nutanix.ncp.ntnx_credentials
+  - nutanix.ncp.ntnx_operations_v2
+  - nutanix.ncp.ntnx_logger
+  - nutanix.ncp.ntnx_proxy_v2
+author:
+  - Abhinav Bansal (@abhinavbansal29)
+  - George Ghawali (@george-ghawali)
+"""
+
+EXAMPLES = r"""
+# Note: On create only name, type and source are accepted by Foundation Central.
+# The image URL (and checksum/metadata for AHV) is applied through the update
+# operation for images whose source is REMOTE_URL.
+- name: Create installer image
+  nutanix.ncp.ntnx_installer_images_v2:
+    nutanix_host: "{{ foundation_host }}"
+    nutanix_username: "{{ foundation_username }}"
+    nutanix_password: "{{ foundation_password }}"
+    validate_certs: false
+    state: present
+    name: "ahv_image_ansible"
+    type: "AHV"
+    source: "REMOTE_URL"
+  register: result
+  ignore_errors: true
+
+- name: Update installer image with all attributes
+  nutanix.ncp.ntnx_installer_images_v2:
+    nutanix_host: "{{ foundation_host }}"
+    nutanix_username: "{{ foundation_username }}"
+    nutanix_password: "{{ foundation_password }}"
+    validate_certs: false
+    state: present
+    ext_id: "d1f27805-4ce3-9212-2ca4-e4b4d258fe9c"
+    name: "ahv_image_ansible"
+    type: "AHV"
+    source: "REMOTE_URL"
+    url: "https://download.example.com/ahv/host-bundle-el8.nutanix.20230302.el8.x86_64.tar.gz"
+    metadata_download_url: "https://download.example.com/ahv/metadata.json"
+    certificate_chain: "-----BEGIN CERTIFICATE-----\nMIIB...==\n-----END CERTIFICATE-----"
+    checksum:
+      sha256:
+        hex_digest: "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+  register: result
+  ignore_errors: true
+
+- name: Delete installer image
+  nutanix.ncp.ntnx_installer_images_v2:
+    nutanix_host: "{{ foundation_host }}"
+    nutanix_username: "{{ foundation_username }}"
+    nutanix_password: "{{ foundation_password }}"
+    validate_certs: false
+    state: absent
+    ext_id: "d1f27805-4ce3-9212-2ca4-e4b4d258fe9c"
+  register: result
+  ignore_errors: true
+"""
+
+RETURN = r"""
+response:
+  description:
+    - Response for creating, updating, or deleting an installer image.
+    - If the operation is create or update and C(wait) is true, it returns the installer image details.
+    - If the operation is create or update and C(wait) is false, it returns the task details.
+    - If the operation is delete, it returns the task details.
+  returned: always
+  type: dict
+  sample:
+    {
+      "certificate_chain": null,
+      "checksum": {
+          "hex_digest": "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+      },
+      "created_time": "2026-09-09T05:50:00.000000+00:00",
+      "ext_id": "d1f27805-4ce3-9212-2ca4-e4b4d258fe9c",
+      "file_status": "URL_AVAILABLE",
+      "links": null,
+      "metadata_download_url": "https://download.example.com/ahv/metadata.json",
+      "metadata_status": "NOT_AVAILABLE",
+      "name": "ahv_image_ansible",
+      "source": "REMOTE_URL",
+      "tenant_id": null,
+      "type": "AHV",
+      "url": "https://download.example.com/ahv/host-bundle-el8.nutanix.20230302.el8.x86_64.tar.gz",
+      "version": null
+    }
+
+task_ext_id:
+  description:
+    - The external ID of the task.
+  returned: always
+  type: str
+  sample: "ZXJnb24=:90458bc7-a12b-4616-ac66-562fdb00c209"
+
+ext_id:
+  description:
+    - The external ID of the installer image.
+  returned: always
+  type: str
+  sample: "d1f27805-4ce3-9212-2ca4-e4b4d258fe9c"
+
+changed:
+  description: This indicates whether the task resulted in any changes.
+  returned: always
+  type: bool
+  sample: true
+
+skipped:
+  description: This indicates whether the task was skipped due to idempotency.
+  returned: when applicable
+  type: bool
+  sample: false
+
+error:
+  description: This indicates the error message if any error occurred.
+  returned: when an error occurs
+  type: str
+
+failed:
+  description: This indicates whether the task failed.
+  returned: when something fails
+  type: bool
+  sample: false
+
+msg:
+  description: This indicates the status/error message if any message occurred.
+  returned: When there is an error, module is idempotent or check mode (in delete operation)
+  type: str
+  sample: "Api Exception raised while creating installer image"
+"""
+
+import traceback  # noqa: E402
+import warnings  # noqa: E402
+from copy import deepcopy  # noqa: E402
+
+from ansible.module_utils.basic import missing_required_lib  # noqa: E402
+
+from ..module_utils.utils import remove_param_with_none_value  # noqa: E402
+from ..module_utils.v4.base_module_v4 import BaseModuleV4  # noqa: E402
+from ..module_utils.v4.constants import Tasks as TASK_CONSTANTS  # noqa: E402
+from ..module_utils.v4.lcm.api_client import (  # noqa: E402
+    get_etag,
+    get_installer_images_api_instance,
+)
+from ..module_utils.v4.lcm.helpers import get_installer_image  # noqa: E402
+from ..module_utils.v4.prism.tasks import (  # noqa: E402
+    get_entity_ext_id_from_task,
+    wait_for_completion,
+)
+from ..module_utils.v4.spec_generator import SpecGenerator  # noqa: E402
+from ..module_utils.v4.utils import (  # noqa: E402
+    raise_api_exception,
+    strip_internal_attributes,
+    validate_required_params,
+)
+
+SDK_IMP_ERROR = None
+try:
+    import ntnx_lifecycle_py_client as lifecycle_sdk  # noqa: E402
+except ImportError:
+
+    from ..module_utils.v4.sdk_mock import mock_sdk as lifecycle_sdk  # noqa: E402
+
+    SDK_IMP_ERROR = traceback.format_exc()
+
+# Suppress the InsecureRequestWarning
+warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made")
+
+
+def get_module_spec():
+
+    md5_checksum_spec = dict(
+        hex_digest=dict(type="str", required=True),
+    )
+
+    sha256_checksum_spec = dict(
+        hex_digest=dict(type="str", required=True),
+    )
+
+    checksum_spec = dict(
+        md5=dict(
+            type="dict",
+            options=md5_checksum_spec,
+            obj=lifecycle_sdk.ImageMd5Checksum,
+        ),
+        sha256=dict(
+            type="dict",
+            options=sha256_checksum_spec,
+            obj=lifecycle_sdk.ImageSha256Checksum,
+        ),
+    )
+
+    module_args = dict(
+        ext_id=dict(type="str"),
+        name=dict(type="str"),
+        type=dict(
+            type="str",
+            choices=["AHV", "AOS", "ESX"],
+            obj=lifecycle_sdk.ImageType,
+        ),
+        source=dict(
+            type="str",
+            choices=["LOCAL", "REMOTE_URL"],
+            obj=lifecycle_sdk.ImageSource,
+        ),
+        url=dict(type="str"),
+        metadata_download_url=dict(type="str"),
+        certificate_chain=dict(type="str"),
+        checksum=dict(
+            type="dict",
+            options=checksum_spec,
+            mutually_exclusive=[("md5", "sha256")],
+            obj={
+                "md5": lifecycle_sdk.ImageMd5Checksum,
+                "sha256": lifecycle_sdk.ImageSha256Checksum,
+            },
+        ),
+    )
+    return module_args
+
+
+def create_installer_image(module, result, api_instance):
+    validate_required_params(module, ["name", "type", "source"])
+    sg = SpecGenerator(module)
+    default_spec = lifecycle_sdk.ConfigImage()
+    spec, err = sg.generate_spec(obj=default_spec)
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating create installer image spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(spec.to_dict())
+        return
+
+    resp = None
+    try:
+        resp = api_instance.create_image(body=spec)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while creating installer image",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        task_resp = wait_for_completion(module, task_ext_id)
+        result["response"] = strip_internal_attributes(task_resp.to_dict())
+        ext_id = get_entity_ext_id_from_task(
+            task_resp, rel=TASK_CONSTANTS.RelEntityType.INSTALLER_IMAGE
+        )
+        if ext_id:
+            result["ext_id"] = ext_id
+            image = get_installer_image(module, api_instance, ext_id)
+            result["response"] = strip_internal_attributes(image.to_dict())
+    result["changed"] = True
+
+
+def _remove_read_only_attributes(spec):
+    """Reset server-populated read-only attributes before an update call."""
+    spec.file_status = None
+    spec.metadata_status = None
+    spec.version = None
+    spec.created_time = None
+
+
+def check_for_idempotency(old_spec_dict, update_spec_dict):
+    old_spec_dict = strip_internal_attributes(deepcopy(old_spec_dict))
+    update_spec_dict = strip_internal_attributes(deepcopy(update_spec_dict))
+    read_only = ["file_status", "metadata_status", "version", "created_time", "links"]
+    for key in read_only:
+        old_spec_dict.pop(key, None)
+        update_spec_dict.pop(key, None)
+    return old_spec_dict == update_spec_dict
+
+
+def update_installer_image(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    old_spec = get_installer_image(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    if not etag:
+        return module.fail_json(
+            "Unable to fetch etag for updating installer image", **result
+        )
+    kwargs = {"if_match": etag}
+    sg = SpecGenerator(module)
+    update_spec, err = sg.generate_spec(obj=deepcopy(old_spec))
+    if err:
+        result["error"] = err
+        module.fail_json(msg="Failed generating update installer image spec", **result)
+
+    if module.check_mode:
+        result["response"] = strip_internal_attributes(update_spec.to_dict())
+        return
+
+    if check_for_idempotency(old_spec.to_dict(), update_spec.to_dict()):
+        result["skipped"] = True
+        module.exit_json(msg="Nothing to change.")
+
+    _remove_read_only_attributes(update_spec)
+
+    resp = None
+    try:
+        resp = api_instance.update_image_by_id(extId=ext_id, body=update_spec, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while updating installer image",
+        )
+    task_ext_id = resp.data.ext_id
+    result["task_ext_id"] = task_ext_id
+    result["response"] = strip_internal_attributes(resp.data.to_dict())
+    if task_ext_id and module.params.get("wait"):
+        wait_for_completion(module, task_ext_id)
+        image = get_installer_image(module, api_instance, ext_id)
+        result["response"] = strip_internal_attributes(image.to_dict())
+    result["changed"] = True
+
+
+def delete_installer_image(module, result, api_instance):
+    ext_id = module.params.get("ext_id")
+    result["ext_id"] = ext_id
+
+    if module.check_mode:
+        result["msg"] = "Installer image with ext_id:{0} will be deleted.".format(
+            ext_id
+        )
+        return
+
+    old_spec = get_installer_image(module, api_instance, ext_id)
+    etag = get_etag(data=old_spec)
+    kwargs = {"if_match": etag} if etag else {}
+
+    resp = None
+    try:
+        resp = api_instance.delete_image_by_id(extId=ext_id, **kwargs)
+    except Exception as e:
+        raise_api_exception(
+            module=module,
+            exception=e,
+            msg="Api Exception raised while deleting installer image",
+        )
+    task_ext_id = getattr(resp.data, "ext_id", None) if resp else None
+    result["task_ext_id"] = task_ext_id
+    if task_ext_id and module.params.get("wait"):
+        task_status = wait_for_completion(module, task_ext_id, True)
+        result["response"] = strip_internal_attributes(task_status.to_dict())
+    result["changed"] = True
+
+
+def run_module():
+    module = BaseModuleV4(
+        argument_spec=get_module_spec(),
+        supports_check_mode=True,
+        required_if=[
+            ("state", "absent", ("ext_id",)),
+            ("state", "present", ("name", "ext_id"), True),
+        ],
+    )
+    if SDK_IMP_ERROR:
+        module.fail_json(
+            msg=missing_required_lib("ntnx_lifecycle_py_client"),
+            exception=SDK_IMP_ERROR,
+        )
+
+    remove_param_with_none_value(module.params)
+    result = {
+        "changed": False,
+        "response": None,
+        "failed": False,
+        "ext_id": None,
+    }
+    api_instance = get_installer_images_api_instance(module)
+    state = module.params.get("state")
+
+    if state == "present":
+        if module.params.get("ext_id"):
+            update_installer_image(module, result, api_instance)
+        else:
+            create_installer_image(module, result, api_instance)
+    else:
+        delete_installer_image(module, result, api_instance)
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2
-ntnx-lifecycle-py-client==4.2.2
+ntnx-lifecycle-py-client==4.3.1
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -20,7 +20,7 @@ ntnx-vmm-py-client==4.2.2
 ntnx-volumes-py-client==4.2.2
 ntnx-dataprotection-py-client==4.3.1
 ntnx-datapolicies-py-client==4.2.2
-ntnx-lifecycle-py-client==4.2.2
+ntnx-lifecycle-py-client==4.3.1
 ntnx-objects-py-client==4.0.3
 ntnx-security-py-client==4.1.2
 ntnx-licensing-py-client==4.3.2

--- a/tests/integration/targets/ntnx_installer_images_v2/aliases
+++ b/tests/integration/targets/ntnx_installer_images_v2/aliases
@@ -1,0 +1,1 @@
+disabled

--- a/tests/integration/targets/ntnx_installer_images_v2/meta/main.yml
+++ b/tests/integration/targets/ntnx_installer_images_v2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_env

--- a/tests/integration/targets/ntnx_installer_images_v2/tasks/installer_images.yml
+++ b/tests/integration/targets/ntnx_installer_images_v2/tasks/installer_images.yml
@@ -1,0 +1,542 @@
+---
+# Test plan for ntnx_installer_images_v2 / ntnx_installer_images_info_v2
+#
+# These modules talk to Foundation Central (FCVM), not Prism Central.
+#
+# Scenarios covered:
+#   1. check_mode create with ALL attributes (asserts generated spec, no API call)
+#   2. Create with minimum attributes (AOS: name/type/source) -> real API
+#   3. Create AHV without checksum -> negative (Foundation requires checksum for AHV)
+#   4. Create with url -> negative (url only accepted on update)
+#   5. Create with missing required params (name/type/source) -> spec validation
+#   6. Invalid enum for type/source -> argument spec validation
+#   7. check_mode update with ALL attributes (asserts generated spec, no API call)
+#   8. Update name change -> negative (name cannot be modified)
+#   9. Info: get by ext_id (single entity)
+#  10. Info: list all (list of entities + total_available_results)
+#  11. Info: list with filter
+#  12. Info: list with limit
+#  13. Info: get with invalid ext_id -> negative
+#  14. Update with wrong ext_id -> negative
+#  15. Delete with wrong ext_id -> negative
+#  16. Delete missing ext_id -> negative
+#  17. check_mode delete
+#  18. Delete created images (cleanup)
+#
+# Note: Foundation Central enforces a strict API rate limit (~1 req/sec), so a
+# short pause is added between real API calls.
+
+- name: Start installer images tests
+  ansible.builtin.debug:
+    msg: Start installer images tests
+
+- name: Generate random names
+  ansible.builtin.set_fact:
+    random_name: "{{ query('community.general.random_string', numbers=false, special=false, length=12)[0] }}"
+    suffix_name: "ansible"
+    todelete: []
+
+- name: Set image names
+  ansible.builtin.set_fact:
+    image_name_min: "img_{{ suffix_name }}_{{ random_name }}_min"
+    image_name_ahv: "img_{{ suffix_name }}_{{ random_name }}_ahv"
+
+########################################################################################
+# Create Installer Image Tests
+########################################################################################
+
+- name: Generate spec for creating installer image using check mode with all attributes
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    name: "check_mode_image_full"
+    type: "AHV"
+    source: "REMOTE_URL"
+    url: "https://download.example.com/ahv/host-bundle.tar.gz"
+    metadata_download_url: "https://download.example.com/ahv/metadata.json"
+    certificate_chain: "cert-chain-data"
+    checksum:
+      sha256:
+        hex_digest: "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for creating installer image using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_image_full"
+      - result.response.type == "AHV"
+      - result.response.source == "REMOTE_URL"
+      - result.response.url == "https://download.example.com/ahv/host-bundle.tar.gz"
+      - result.response.metadata_download_url == "https://download.example.com/ahv/metadata.json"
+      - result.response.certificate_chain == "cert-chain-data"
+      - result.response.checksum.hex_digest == "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+    success_msg: "Spec for creating installer image using check mode with all attributes is generated successfully"
+    fail_msg: "Spec for creating installer image using check mode with all attributes is not generated successfully"
+
+- name: Generate spec for creating installer image using check mode with md5 checksum
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    name: "check_mode_image_md5"
+    type: "AHV"
+    source: "LOCAL"
+    checksum:
+      md5:
+        hex_digest: "0123456789abcdef0123456789abcdef"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for creating installer image using check mode with md5 checksum status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "check_mode_image_md5"
+      - result.response.type == "AHV"
+      - result.response.source == "LOCAL"
+      - result.response.checksum.hex_digest == "0123456789abcdef0123456789abcdef"
+    success_msg: "Spec for creating installer image using check mode with md5 checksum is generated successfully"
+    fail_msg: "Spec for creating installer image using check mode with md5 checksum is not generated successfully"
+
+- name: Create installer image with mutually exclusive md5 and sha256 checksum (should fail)
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    name: "img_both_checksum"
+    type: "AHV"
+    source: "LOCAL"
+    checksum:
+      md5:
+        hex_digest: "0123456789abcdef0123456789abcdef"
+      sha256:
+        hex_digest: "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90"
+  register: result
+  ignore_errors: true
+
+- name: Create installer image with mutually exclusive md5 and sha256 checksum status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'parameters are mutually exclusive: md5|sha256' in result.msg"
+    success_msg: "Create installer image with mutually exclusive checksum failed as expected"
+    fail_msg: "Create installer image with mutually exclusive checksum did not fail as expected"
+
+- name: Create installer image with minimum attributes
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    name: "{{ image_name_min }}"
+    type: "AOS"
+    source: "REMOTE_URL"
+  register: result
+  ignore_errors: true
+
+- name: Create installer image with minimum attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.failed == false
+      - result.ext_id is defined
+      - result.task_ext_id is defined
+      - result.response is defined
+      - result.response.name == "{{ image_name_min }}"
+      - result.response.type == "AOS"
+      - result.response.source == "REMOTE_URL"
+    success_msg: "Installer image with minimum attributes created successfully"
+    fail_msg: "Installer image with minimum attributes creation failed"
+
+- name: Add installer image to todelete list
+  ansible.builtin.set_fact:
+    todelete: "{{ todelete + [result.ext_id] }}"
+    image_min_ext_id: "{{ result.ext_id }}"
+
+- name: Pause to respect Foundation Central rate limit
+  ansible.builtin.pause:
+    seconds: 2
+
+########################################################################################
+# Negative Create Tests
+########################################################################################
+
+- name: Create AHV installer image without checksum (should fail)
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    name: "{{ image_name_ahv }}"
+    type: "AHV"
+    source: "REMOTE_URL"
+  register: result
+  ignore_errors: true
+
+- name: Create AHV installer image without checksum status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Checksum is required for AHV images' in (result.response | string)"
+    success_msg: "Create AHV installer image without checksum failed as expected"
+    fail_msg: "Create AHV installer image without checksum did not fail as expected"
+
+- name: Pause to respect Foundation Central rate limit
+  ansible.builtin.pause:
+    seconds: 2
+
+- name: Create installer image providing url (should fail, url only on update)
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    name: "img_with_url_{{ random_name }}"
+    type: "AOS"
+    source: "REMOTE_URL"
+    url: "https://download.example.com/aos/nutanix_installer_package.tar.gz"
+  register: result
+  ignore_errors: true
+
+- name: Create installer image providing url status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'ImageUrl can only be provided through the Update API' in (result.response | string)"
+    success_msg: "Create installer image providing url failed as expected"
+    fail_msg: "Create installer image providing url did not fail as expected"
+
+- name: Create installer image with missing name
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    type: "AOS"
+    source: "REMOTE_URL"
+  register: result
+  ignore_errors: true
+
+- name: Create installer image with missing name status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): name"
+    success_msg: "Create installer image with missing name failed as expected"
+    fail_msg: "Create installer image with missing name did not fail as expected"
+
+- name: Create installer image with missing type
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    name: "img_missing_type"
+    source: "REMOTE_URL"
+  register: result
+  ignore_errors: true
+
+- name: Create installer image with missing type status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): type"
+    success_msg: "Create installer image with missing type failed as expected"
+    fail_msg: "Create installer image with missing type did not fail as expected"
+
+- name: Create installer image with missing source
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    name: "img_missing_source"
+    type: "AOS"
+  register: result
+  ignore_errors: true
+
+- name: Create installer image with missing source status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - result.msg == "Missing required parameter(s): source"
+    success_msg: "Create installer image with missing source failed as expected"
+    fail_msg: "Create installer image with missing source did not fail as expected"
+
+- name: Create installer image with invalid type enum
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    name: "img_invalid_type"
+    type: "INVALID_TYPE"
+    source: "REMOTE_URL"
+  register: result
+  ignore_errors: true
+
+- name: Create installer image with invalid type enum status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'value of type must be one of' in result.msg"
+    success_msg: "Create installer image with invalid type enum failed as expected"
+    fail_msg: "Create installer image with invalid type enum did not fail as expected"
+
+- name: Create installer image with invalid source enum
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    name: "img_invalid_source"
+    type: "AOS"
+    source: "INVALID_SOURCE"
+  register: result
+  ignore_errors: true
+
+- name: Create installer image with invalid source enum status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'value of source must be one of' in result.msg"
+    success_msg: "Create installer image with invalid source enum failed as expected"
+    fail_msg: "Create installer image with invalid source enum did not fail as expected"
+
+########################################################################################
+# Update Installer Image Tests
+########################################################################################
+
+- name: Generate spec for updating installer image using check mode with all attributes
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    ext_id: "{{ image_min_ext_id }}"
+    name: "{{ image_name_min }}"
+    type: "AOS"
+    source: "REMOTE_URL"
+    url: "https://download.example.com/aos/nutanix_installer_package.tar.gz"
+    metadata_download_url: "https://download.example.com/aos/metadata.json"
+    certificate_chain: "updated-cert-chain"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Generate spec for updating installer image using check mode with all attributes status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.failed == false
+      - result.response is defined
+      - result.response.name == "{{ image_name_min }}"
+      - result.response.type == "AOS"
+      - result.response.source == "REMOTE_URL"
+      - result.response.url == "https://download.example.com/aos/nutanix_installer_package.tar.gz"
+      - result.response.metadata_download_url == "https://download.example.com/aos/metadata.json"
+      - result.response.certificate_chain == "updated-cert-chain"
+    success_msg: "Spec for updating installer image using check mode with all attributes is generated successfully"
+    fail_msg: "Spec for updating installer image using check mode with all attributes is not generated successfully"
+
+- name: Update installer image name (should fail, name cannot be modified)
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    ext_id: "{{ image_min_ext_id }}"
+    name: "{{ image_name_min }}_renamed"
+    type: "AOS"
+    source: "REMOTE_URL"
+  register: result
+  ignore_errors: true
+
+- name: Update installer image name status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'Image name cannot be modified' in (result.response | string)"
+    success_msg: "Update installer image name failed as expected"
+    fail_msg: "Update installer image name did not fail as expected"
+
+- name: Update installer image with wrong external ID
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: present
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+    name: "wrong_ext_id_image"
+    type: "AOS"
+    source: "REMOTE_URL"
+  register: result
+  ignore_errors: true
+
+- name: Update installer image with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Update installer image with wrong external ID failed as expected"
+    fail_msg: "Update installer image with wrong external ID did not fail as expected"
+
+########################################################################################
+# Info Module Tests - Get Single Installer Image
+########################################################################################
+
+- name: Fetch installer image using external ID
+  nutanix.ncp.ntnx_installer_images_info_v2:
+    ext_id: "{{ image_min_ext_id }}"
+  register: result
+  ignore_errors: true
+
+- name: Fetch installer image using external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.ext_id == "{{ image_min_ext_id }}"
+      - result.response.name == "{{ image_name_min }}"
+      - result.response.type == "AOS"
+      - result.response.source == "REMOTE_URL"
+    success_msg: "Fetch installer image using external ID passed"
+    fail_msg: "Fetch installer image using external ID failed"
+
+- name: Fetch installer image using wrong external ID
+  nutanix.ncp.ntnx_installer_images_info_v2:
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+  register: result
+  ignore_errors: true
+
+- name: Fetch installer image using wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Fetch installer image using wrong external ID failed as expected"
+    fail_msg: "Fetch installer image using wrong external ID did not fail as expected"
+
+########################################################################################
+# Info Module Tests - List Installer Images
+########################################################################################
+
+- name: List all installer images
+  nutanix.ncp.ntnx_installer_images_info_v2:
+  register: result
+  ignore_errors: true
+
+- name: List all installer images status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length >= 1
+      - result.total_available_results is defined
+      - result.total_available_results >= 1
+    success_msg: "List all installer images passed"
+    fail_msg: "List all installer images failed"
+
+- name: List installer images with filter
+  nutanix.ncp.ntnx_installer_images_info_v2:
+    filter: "name eq '{{ image_name_min }}'"
+  register: result
+  ignore_errors: true
+
+- name: List installer images with filter status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+      - result.response[0].name == "{{ image_name_min }}"
+    success_msg: "List installer images with filter passed"
+    fail_msg: "List installer images with filter failed"
+
+- name: List installer images with limit
+  nutanix.ncp.ntnx_installer_images_info_v2:
+    limit: 1
+  register: result
+  ignore_errors: true
+
+- name: List installer images with limit status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - result.response is defined
+      - result.response | length == 1
+    success_msg: "List installer images with limit passed"
+    fail_msg: "List installer images with limit failed"
+
+########################################################################################
+# Delete Installer Image Tests
+########################################################################################
+
+- name: Delete installer image with check mode
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: absent
+    ext_id: "{{ image_min_ext_id }}"
+  check_mode: true
+  register: result
+  ignore_errors: true
+
+- name: Delete installer image with check mode status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == false
+      - "'will be deleted' in result.msg"
+    success_msg: "Delete installer image with check mode passed"
+    fail_msg: "Delete installer image with check mode failed"
+
+- name: Delete installer image with missing external ID
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: Delete installer image with missing external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+      - "'state is absent but all of the following are missing: ext_id' in result.msg"
+    success_msg: "Delete installer image with missing external ID failed as expected"
+    fail_msg: "Delete installer image with missing external ID did not fail as expected"
+
+- name: Delete installer image with wrong external ID
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: absent
+    ext_id: "04595a7b-010c-4a89-58dd-060c94e9a1f0"
+  register: result
+  ignore_errors: true
+
+- name: Delete installer image with wrong external ID status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == false
+      - result.failed == true
+    success_msg: "Delete installer image with wrong external ID failed as expected"
+    fail_msg: "Delete installer image with wrong external ID did not fail as expected"
+
+- name: Delete all created installer images
+  nutanix.ncp.ntnx_installer_images_v2:
+    state: absent
+    ext_id: "{{ item }}"
+  register: result
+  ignore_errors: true
+  loop: "{{ todelete }}"
+
+- name: Deletion status
+  ansible.builtin.assert:
+    that:
+      - result is defined
+      - result.changed == true
+      - result.results | length == todelete | length
+      - result.msg == "All items completed"
+    success_msg: "All installer images are deleted successfully"
+    fail_msg: "Unable to delete all installer images"

--- a/tests/integration/targets/ntnx_installer_images_v2/tasks/main.yml
+++ b/tests/integration/targets/ntnx_installer_images_v2/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# NOTE: The LCM installer images APIs are served by Foundation Central (FCVM),
+# NOT by Prism Central. The module_defaults below therefore point to the
+# FCVM/Foundation endpoint variables (foundation_host / foundation_username /
+# foundation_password / foundation_port). These are provided via
+# tests/integration/integration_config.yml.
+- name: Set module defaults
+  module_defaults:
+    group/nutanix.ncp.ntnx:
+      nutanix_host: "{{ foundation_host }}"
+      nutanix_username: "{{ foundation_username | default(omit) }}"
+      nutanix_password: "{{ foundation_password | default(omit) }}"
+      nutanix_port: "{{ foundation_port | default(omit) }}"
+      validate_certs: "{{ validate_certs | default(false) }}"
+      nutanix_debug: "{{ nutanix_debug | default(omit) }}"
+      nutanix_log_file: "{{ nutanix_log_file | default(omit) }}"
+  block:
+    - name: Import installer_images.yml
+      ansible.builtin.import_tasks: installer_images.yml


### PR DESCRIPTION
## Summary

Auto-generated Ansible Collection modules for the **lifecycle** namespace, entity
**InstallerImages**, based on the inline SDK info. One PR per code-gen run.

- Modules generated: `ntnx_installer_images_v2` (CRUD), `ntnx_installer_images_info_v2` (info)
- API methods covered: 5 (`CreateImage`, `UpdateImageById`, `DeleteImageById`, `GetImageById`, `ListImages`)
- Fields in CRUD module spec: 9 input fields (`ext_id`, `name`, `type`, `source`, `url`, `metadata_download_url`, `certificate_chain`, `checksum` → `md5.hex_digest` / `sha256.hex_digest`)
- Fields in info module spec: 1 (`ext_id`)

### Endpoint awareness (important)

The LCM **InstallerImages** APIs are served by **Foundation Central (FCVM)**, **not**
Prism Central. This was verified live: `list_images` returns **404** on PC
(`/api/lifecycle/v4.x/config/images` not found) and **200** on the FCVM endpoint.
Accordingly:

- The modules reach the API through the standard `nutanix_host`/`nutanix_username`/
  `nutanix_password`/`nutanix_port` params, which callers must point at the FCVM
  endpoint. This is documented in both modules' `notes:`.
- The integration test target's `module_defaults` use dedicated
  `foundation_host`/`foundation_username`/`foundation_password`/`foundation_port`
  variables, and the example playbook documents the FCVM requirement.
- Async tasks returned by create/update/delete are Ergon tasks and are pollable via
  the Prism Tasks API on the same FCVM endpoint (verified live).

### Domain behavior verified against a live FCVM

- **Create** accepts only `name`, `type`, `source`. Providing `url` on create is
  rejected (`ImageUrl can only be provided through the Update API`).
- **AHV** images require a `checksum` (MD5 or SHA-256) — `Checksum is required for AHV images`.
- The image **name cannot be modified** on update (`Image name cannot be modified`).
- The task entity relation is `lifecycle:config:installer_image`.
- FCVM enforces a strict API rate limit (~1 req/sec); tests add small pauses.

### Domain knowledge (from Glean)

Glean MCP tools were **not available** in this environment, so no Glean query was
run. All domain behavior documented above was instead derived directly from the
inline SDK info and validated empirically against the live Foundation Central
endpoint during test/example execution.

## Files changed

- `plugins/modules/ntnx_installer_images_v2.py` (new — CRUD module)
- `plugins/modules/ntnx_installer_images_info_v2.py` (new — info module)
- `plugins/module_utils/v4/lcm/api_client.py` (add `get_installer_images_api_instance`)
- `plugins/module_utils/v4/lcm/helpers.py` (add `get_installer_image`)
- `plugins/module_utils/v4/constants.py` (add `INSTALLER_IMAGE` task rel)
- `meta/runtime.yml` (register both modules in `action_groups.ntnx`)
- `tests/integration/targets/ntnx_installer_images_v2/` (new — integration test target)
- `examples/lifecycle/InstallerImages/installer_images_v2.yml` (new — example playbook)
- `examples/lifecycle/InstallerImages/examples_run.log` (new — real playbook run output)
- `tests/integration/requirements.txt` (bump `ntnx-lifecycle-py-client` 4.2.2 → 4.3.1)
- `.gitignore` (ignore `tests/integration/integration_config.yml`)

## Test execution

| Metric        | Value                                                            |
|---------------|------------------------------------------------------------------|
| Command       | `ansible-test integration disabled/ntnx_installer_images_v2 --allow-disabled --python 3.12` |
| Total tasks   | 53 (23 module invocations + 23 assertions + setup)               |
| Passed        | 53 (ok)                                                          |
| Failed        | 0                                                                |
| Ignored       | 13 (expected-failure negative tests using `ignore_errors`)      |
| Changed       | 2 (real create + real delete on the live cluster)                |
| Cluster (FCVM)| 10.97.44.170:9440                                                |

### Analysis

No test failures. Coverage includes: check_mode create (all attrs, and MD5-checksum
variant), real minimal create, real delete, get-by-id, list-all, list with filter,
list with limit, and negative paths — create AHV without checksum, create with url,
create/update missing required fields, invalid `type`/`source` enum values,
mutually-exclusive `md5`/`sha256` checksum, update name change (rejected), and
wrong-ext_id get/update/delete. Every argument-spec field is asserted in at least
one test.

The example playbook was executed end-to-end against the live FCVM: create, get,
list and delete succeeded and their real responses were backfilled into the example
`sample:` blocks. The **update** task genuinely could not produce a success sample
because it triggers a real image download from the (placeholder) URL, which the
cluster cannot reach (`Metadata is not available for image ...`); that task is
marked `<Need to add sample>` in the example with an explanation.

### Test logs (tail)

<details>
<summary>tail -n 120 test_logs.log</summary>

```text
    "changed": false,
    "msg": "Create installer image with invalid source enum failed as expected"
}

TASK [ntnx_installer_images_v2 : Generate spec for updating installer image using check mode with all attributes] ***
ok: [testhost]

TASK [ntnx_installer_images_v2 : Generate spec for updating installer image using check mode with all attributes status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Spec for updating installer image using check mode with all attributes is generated successfully"
}

TASK [ntnx_installer_images_v2 : Update installer image name (should fail, name cannot be modified)] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "Bad Request", "msg": "Api Exception raised while updating installer image", "response": {"$dataItemDiscriminator": "lifecycle.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<lifecycle.v4.error.AppMessage>", "$objectType": "lifecycle.v4.error.ErrorResponse", "error": [{"$objectType": "lifecycle.v4.error.AppMessage", "argumentsMap": {"reason": "Image name cannot be modified"}, "code": "FC-10002", "errorGroup": "FC_INVALID_INPUT_ERROR", "locale": "en-US", "message": "Failed to perform the operation because input is invalid: Image name cannot be modified", "severity": "ERROR"}]}}, "status": 400}
...ignoring

TASK [ntnx_installer_images_v2 : Update installer image name status] ***********
ok: [testhost] => {
    "changed": false,
    "msg": "Update installer image name failed as expected"
}

TASK [ntnx_installer_images_v2 : Update installer image with wrong external ID] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "Not Found", "msg": "Api Exception raised while fetching installer image using external ID", "response": {"$dataItemDiscriminator": "lifecycle.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<lifecycle.v4.error.AppMessage>", "$objectType": "lifecycle.v4.error.ErrorResponse", "error": [{"$objectType": "lifecycle.v4.error.AppMessage", "argumentsMap": {"action": "get", "uuid": "04595a7b-010c-4a89-58dd-060c94e9a1f0"}, "code": "FC-10016", "errorGroup": "FC_RESOURCE_NOT_FOUND_ERROR", "locale": "en-US", "message": "Failed to perform get on image with extId 04595a7b-010c-4a89-58dd-060c94e9a1f0 because it does not exist", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_installer_images_v2 : Update installer image with wrong external ID status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Update installer image with wrong external ID failed as expected"
}

TASK [ntnx_installer_images_v2 : Fetch installer image using external ID] ******
ok: [testhost]

TASK [ntnx_installer_images_v2 : Fetch installer image using external ID status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch installer image using external ID passed"
}

TASK [ntnx_installer_images_v2 : Fetch installer image using wrong external ID] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "Not Found", "msg": "Api Exception raised while fetching installer image using external ID", "response": {"$dataItemDiscriminator": "lifecycle.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<lifecycle.v4.error.AppMessage>", "$objectType": "lifecycle.v4.error.ErrorResponse", "error": [{"$objectType": "lifecycle.v4.error.AppMessage", "argumentsMap": {"action": "get", "uuid": "04595a7b-010c-4a89-58dd-060c94e9a1f0"}, "code": "FC-10016", "errorGroup": "FC_RESOURCE_NOT_FOUND_ERROR", "locale": "en-US", "message": "Failed to perform get on image with extId 04595a7b-010c-4a89-58dd-060c94e9a1f0 because it does not exist", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_installer_images_v2 : Fetch installer image using wrong external ID status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Fetch installer image using wrong external ID failed as expected"
}

TASK [ntnx_installer_images_v2 : List all installer images] ********************
ok: [testhost]

TASK [ntnx_installer_images_v2 : List all installer images status] *************
ok: [testhost] => {
    "changed": false,
    "msg": "List all installer images passed"
}

TASK [ntnx_installer_images_v2 : List installer images with filter] ************
ok: [testhost]

TASK [ntnx_installer_images_v2 : List installer images with filter status] *****
ok: [testhost] => {
    "changed": false,
    "msg": "List installer images with filter passed"
}

TASK [ntnx_installer_images_v2 : List installer images with limit] *************
ok: [testhost]

TASK [ntnx_installer_images_v2 : List installer images with limit status] ******
ok: [testhost] => {
    "changed": false,
    "msg": "List installer images with limit passed"
}

TASK [ntnx_installer_images_v2 : Delete installer image with check mode] *******
ok: [testhost]

TASK [ntnx_installer_images_v2 : Delete installer image with check mode status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Delete installer image with check mode passed"
}

TASK [ntnx_installer_images_v2 : Delete installer image with missing external ID] ***
fatal: [testhost]: FAILED! => {"changed": false, "msg": "state is absent but all of the following are missing: ext_id"}
...ignoring

TASK [ntnx_installer_images_v2 : Delete installer image with missing external ID status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Delete installer image with missing external ID failed as expected"
}

TASK [ntnx_installer_images_v2 : Delete installer image with wrong external ID] ***
fatal: [testhost]: FAILED! => {"changed": false, "error": "Not Found", "msg": "Api Exception raised while fetching installer image using external ID", "response": {"$dataItemDiscriminator": "lifecycle.v4.error.ErrorResponse", "data": {"$errorItemDiscriminator": "List<lifecycle.v4.error.AppMessage>", "$objectType": "lifecycle.v4.error.ErrorResponse", "error": [{"$objectType": "lifecycle.v4.error.AppMessage", "argumentsMap": {"action": "get", "uuid": "04595a7b-010c-4a89-58dd-060c94e9a1f0"}, "code": "FC-10016", "errorGroup": "FC_RESOURCE_NOT_FOUND_ERROR", "locale": "en-US", "message": "Failed to perform get on image with extId 04595a7b-010c-4a89-58dd-060c94e9a1f0 because it does not exist", "severity": "ERROR"}]}}, "status": 404}
...ignoring

TASK [ntnx_installer_images_v2 : Delete installer image with wrong external ID status] ***
ok: [testhost] => {
    "changed": false,
    "msg": "Delete installer image with wrong external ID failed as expected"
}

TASK [ntnx_installer_images_v2 : Delete all created installer images] **********
changed: [testhost] => (item=e343d132-f49e-409f-a01c-741671e7bad1)

TASK [ntnx_installer_images_v2 : Deletion status] ******************************
ok: [testhost] => {
    "changed": false,
    "msg": "All installer images are deleted successfully"
}

PLAY RECAP *********************************************************************
testhost                   : ok=53   changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=13  
```

</details>

## How this was generated

- Triggered via the Nutanix headless code-gen flow.
- Modules mirror the existing `ntnx_virtual_switch_v2` / `ntnx_virtual_switches_info_v2`
  patterns and reuse shared `module_utils/v4` helpers.
